### PR TITLE
Enable user namespaces for non-root users

### DIFF
--- a/features/server/file.include/etc/sysctl.d/enable-unprivileged-user-namespaces.conf
+++ b/features/server/file.include/etc/sysctl.d/enable-unprivileged-user-namespaces.conf
@@ -1,0 +1,1 @@
+kernel.unprivileged_userns_clone = 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes it possible for non-root users to use user namespaces.

**Special notes for your reviewer**:

User namespaces are used by rootless container tools. For example, [buildah](https://github.com/containers/buildah/), [img](https://github.com/genuinetools/img/), [rootless podman](https://github.com/containers/libpod), and more. 

Most distributions have this support automatically enabled - the Debian project disables this in their kernel builds. Enabling this will restore parity with CoreOS and SuSE.

**Release note**:

```improvement user
User namespaces are enabled for non-root users.
```
