### PR TITLE
Make GCP images public by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SNAPSHOT_DATE=`date -d 'today' '+%Y%m%d'`
 IMAGE_BASENAME=garden-linux
 VERSION=40-2
+PUBLIC=
 
 all: all_dev all_prod
 
@@ -27,14 +28,14 @@ gcp:
 	./build.sh --features server,cloud,gardener,gcp .build/gcp bullseye $(SNAPSHOT_DATE)
 
 gcp-upload:
-	./bin/make-gcp-ami --bucket garden-linux-test --image-name $(GCP_IMAGE_NAME) --raw-image-path .build/gcp/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs-gcpimage.tar.gz
+	./bin/make-gcp-ami --bucket garden-linux-test --image-name $(GCP_IMAGE_NAME) --raw-image-path .build/gcp/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs-gcpimage.tar.gz --permission-public "$(PUBLIC)"
 
 GCP_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-dev-gcp-$(VERSION)
 gcp-dev:
 	./build.sh --features server,cloud,gardener,gcp,dev .build/gcp-dev bullseye $(SNAPSHOT_DATE)
 
 gcp-dev-upload:
-	./bin/make-gcp-ami --bucket garden-linux-test --image-name $(GCP_DEV_IMAGE_NAME) --raw-image-path .build/gcp-dev/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs-gcpimage.tar.gz
+	./bin/make-gcp-ami --bucket garden-linux-test --image-name $(GCP_DEV_IMAGE_NAME) --raw-image-path .build/gcp-dev/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs-gcpimage.tar.gz --permission-public "$(PUBLIC)"
 
 AZURE_IMAGE_NAME=$(IMAGE_BASENAME)-az-$(VERSION)
 azure:

--- a/bin/make-gcp-ami
+++ b/bin/make-gcp-ami
@@ -9,10 +9,11 @@ import time
 
 class GcpImageBuild:
 
-    def __init__(self, bucket, raw_image_path, image_name):
+    def __init__(self, bucket, raw_image_path, image_name, permission):
         self.bucket = bucket
         self.raw_image_path = raw_image_path
         self.image_name = image_name
+        self.permission = permission
 
     def logged_on_bucket_available(self, bucket):
         bucket_name = "gs://" + bucket
@@ -40,7 +41,14 @@ class GcpImageBuild:
         result = subprocess.run(["gcloud", "compute", "images", "create", image_name,
             "--source-uri", bucket_image ],
             capture_output=True)
-        print(result)
+        if result.returncode != 0:
+            print(result.stdout)
+            sys.exit("Unable to create image " + image_name+ ": " + str(result.stdout) + " " + str(result.stderr))
+        if self.permission == True:
+            result = subprocess.run(["gcloud", "compute", "images", "add-iam-policy-binding", image_name,
+                "--member", "allAuthenticatedUsers", "--role", "roles/compute.imageUser" ],
+                capture_output=True)
+            print(result)
 
     def run(self):
         self.logged_on_bucket_available(self.bucket)
@@ -67,6 +75,12 @@ class GcpImageBuild:
             type=str,
             help="Image name on GCP"
         )
+        parser.add_argument(
+            '--permission-public',
+            type=bool,
+            default=False,
+            help='Make snapshot and image public',
+        )
 
     @classmethod
     def _main(cls):
@@ -75,8 +89,8 @@ class GcpImageBuild:
         args = parser.parse_args()
         print(args)
 
-        gcp_img_build = cls(bucket=args.bucket, raw_image_path=args.raw_image_path, image_name=args.image_name)
+        gcp_img_build = cls(bucket=args.bucket, raw_image_path=args.raw_image_path, image_name=args.image_name, permission=args.permission_public)
         gcp_img_build.run()
- 
+
 if __name__ == '__main__':
     GcpImageBuild._main()


### PR DESCRIPTION
**What this PR does / why we need it**:
Make GCP images public by default

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://cloud.google.com/compute/docs/images/managing-access-custom-images#share-images-publicly

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The script uploading the GCP images is now making them available to all authenticated GCP users.
```
