### PR TITLE
fix user/group ownership of file.include files

### DIFF
--- a/bin/debuerreotype-config
+++ b/bin/debuerreotype-config
@@ -29,7 +29,7 @@ aptVersion="$("$thisDir/.apt-version.sh" "$targetDir")"
 [ "$features" = "full" ] && features=$(ls $featureDir | paste -sd, -)
 for i in $(echo "base,$features" | tr ',' ' ' | sort -u); do
 	if [ -d "$featureDir/$i/file.include" ]; then
-		out=$(tar -cC $featureDir/$i/file.include . | tar -xvC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  -)
+		out=$(tar --owner=0 --group=0 -cC $featureDir/$i/file.include . | tar -xvC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  -)
 		echo "copying from $i: $out"
 	fi
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
All the included files in the final image from the file.include directory (from features) are going to have wrong owners depending on which user cloned the repository.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4#issuecomment-620411860

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
NONE
-->
