### PR TITLE
Improve build-pipeline

### DIFF
--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -17,6 +17,7 @@ PipelineRun = tkn.model.PipelineRun
 PipelineRunSpec = tkn.model.PipelineRunSpec
 PipelineRunMetadata = tkn.model.PipelineRunMetadata
 PipelineMetadata = tkn.model.PipelineMetadata
+PodTemplate = tkn.model.PodTemplate
 TaskRef = tkn.model.TaskRef
 PipelineTask = tkn.model.PipelineTask
 NamedParam = tkn.model.NamedParam
@@ -41,9 +42,14 @@ def mk_pipeline_run(
                     value=committish,
                 )
             ],
-            pipelineRef= PipelineRef(
+            pipelineRef=PipelineRef(
                 name=pipeline_name,
             ),
+            podTemplate=PodTemplate(
+                nodeSelector={
+                    "worker.garden.sapcloud.io/group": "gl-build"
+                }
+            )
         ),
     )
     return plrun

--- a/ci/task.yaml
+++ b/ci/task.yaml
@@ -52,6 +52,11 @@ spec:
         print(git_helper.repo.git.show())
 
     - name: 'build-image'
+      resources:
+        requests:
+          memory: 1Gi
+        limits:
+          memory: 1.5Gi
       securityContext:
         privileged: true
         allowPrivilegeEscalation: true

--- a/ci/task.yaml
+++ b/ci/task.yaml
@@ -103,6 +103,8 @@ spec:
       volumeMounts:
       - mountPath: '/dev'
         name: 'dev'
+      - mountPath: '/build'
+        name: build
 
     - name: 'upload-results'
       image: 'eu.gcr.io/gardener-project/cc/job-image:1.612.0'
@@ -146,3 +148,6 @@ spec:
       hostPath:
         path: '/dev'
         type: 'Directory'
+    - name: build
+      emptyDir:
+        medium: "Memory"

--- a/ci/tkn/model.py
+++ b/ci/tkn/model.py
@@ -52,9 +52,15 @@ class PipelineRef:
 
 
 @dataclasses.dataclass
+class PodTemplate:
+    nodeSelector: dict
+
+
+@dataclasses.dataclass
 class PipelineRunSpec:
     params: typing.List[NamedParam]
     pipelineRef: PipelineRef
+    podTemplate: PodTemplate
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds an in-memory volume to the build pods (to be used to expedite builds later on)
- Adds memory-requests and -limits to the build pods due to the new in-memory volume
- Adds a node-selector to pods spawned by the pipeline-run to select machines that are more memory-optimised.