### PR TITLE
Adapt tekton task to integration test --iaas option

### DIFF
--- a/ci/integrationtest-run.yaml
+++ b/ci/integrationtest-run.yaml
@@ -1,11 +1,14 @@
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
-  generateName: it-test-
+  generateName: it-test-aws-
 spec:
   serviceAccountName: build-bot
   taskRef:
     name: integrationtest-gardenlinux-task
+  params:
+  - name: iaas
+    value: aws # or gcp
   resources:
     inputs:
     - name: repo

--- a/ci/integrationtest-task.yaml
+++ b/ci/integrationtest-task.yaml
@@ -4,6 +4,9 @@ kind: Task
 metadata:
   name: integrationtest-gardenlinux-task
 spec:
+  params:
+  - name: iaas
+    type: string
   resources:
     inputs:
     - name: repo
@@ -67,7 +70,7 @@ spec:
         pipenv install -dev
 
         echo "> Run tests"
-        pipenv run python __main__.py
+        pipenv run pytest --iaas=$(params.iaas) integration/
 
 ---
 apiVersion: tekton.dev/v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapts the tekton task for the integration tests to respect the newly introduced `--iaas` flag.
The taskrun now demonstrates the usage with the `aws` infrastructure.

Only when we integrate the tasks into a pipeline can we run e.g. an aws- and a gcp-task in parallel.