### PR TITLE
Small fix - getcap / sudoers permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN	apt-get update \
 		qemu-utils \
 		python3 \
 		python3-mako \
+		libcap2-bin \
      && rm -rf /var/lib/apt/lists/*
 
 # repo-root requires to be mounted at /debuerreotype

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -15,3 +15,4 @@ addgroup --system wheel
 ln -sf /bin/ip /usr/bin/ip
 sed -i "s/#RuntimeWatchdogSec=0/RuntimeWatchdogSec=20s/g" /etc/systemd/system.conf
 
+chmod 0440 /etc/sudoers.d/wheel


### PR DESCRIPTION
**What this PR does / why we need it**:
Add libcap2-bin to the Dockerfile so that getcap is available for the unit tests not running chrooted.

Change permissions for the wheel sudo rules as they get flagged by "visudo -c" and a lot of others that are based on that (e.g. tiger)

**Which issue(s) this PR fixes**:
**Special notes for your reviewer**:

**Release note**:
