### PR TITLE
Add cache-lock to hack/nginx.conf

### DIFF
--- a/hack/nginx.conf
+++ b/hack/nginx.conf
@@ -8,12 +8,14 @@ server {
 	server_name _;
 
         location /archive {
-            proxy_pass             http://snapshot.debian.org/archive;
-            proxy_set_header       Host snapshot.debian.org;
-            proxy_buffering        on;
-            proxy_cache            STATIC;
-            proxy_cache_valid      200  30d;
-            proxy_cache_use_stale  error timeout invalid_header updating
-                                   http_500 http_502 http_503 http_504;
+            proxy_pass                  http://snapshot.debian.org/archive;
+            proxy_set_header            Host snapshot.debian.org;
+            proxy_buffering             on;
+            proxy_cache                 STATIC;
+            proxy_cache_lock            on;
+            proxy_cache_lock_timeout    30s;
+            proxy_cache_valid           200  30d;
+            proxy_cache_use_stale       error timeout invalid_header updating
+                                        http_500 http_502 http_503 http_504;
         }
 }


### PR DESCRIPTION
only one request will be allowed to populate a new cache-element, i.e. other requests that hit the same cache-entry have to wait until the first request has updated the cache.
After the timeout (currently `30s`), they will nonetheless bypass the cache **without** updating it.
