### PR TITLE
Refactor integrationtests tekton

### DIFF
--- a/ci/integrationtests/pipeline.yaml
+++ b/ci/integrationtests/pipeline.yaml
@@ -1,0 +1,39 @@
+# Pipeline that runs the integrationtests for all iaas providers in parallel
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: integrationtests-all
+spec:
+  params:
+  - name: ami_id
+    type: string
+  - name: gcp_image_name
+    type: string
+  resources:
+  - name: source-repo
+    type: git
+  tasks:
+  - name: integrationtest-aws
+    taskRef:
+      name: integrationtest-gardenlinux-task
+    params:
+    - name: iaas
+      value: aws
+    - name: ami_id
+      value: $(params.ami_id)
+    resources:
+      inputs:
+      - name: repo
+        resource: source-repo
+  - name: integrationtest-gcp
+    taskRef:
+      name: integrationtest-gardenlinux-task
+    params:
+    - name: iaas
+      value: gcp
+    - name: gcp_image_name
+      value: $(params.gcp_image_name)
+    resources:
+      inputs:
+        - name: repo
+          resource: source-repo

--- a/ci/integrationtests/pipelineresource.yaml
+++ b/ci/integrationtests/pipelineresource.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: gardenlinux-repo
+spec:
+  type: git
+  params:
+    - name: revision
+      value: refactor-it-tekton
+    - name: url
+      value: https://github.com/gardenlinux/gardenlinux.git

--- a/ci/integrationtests/pipelinerun.yaml
+++ b/ci/integrationtests/pipelinerun.yaml
@@ -1,0 +1,18 @@
+# Demo PiplineRun showing the invocation of the integration tests pipeline
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: integrationtests-all-
+spec:
+  pipelineRef:
+    name: integrationtests-all
+  params:
+  # TODO: replace with values from some "component descriptor"-style thing
+  - name: ami_id
+    value: ami-06458801dbaec803b # eu-west-1
+  - name: gcp_image_name
+    value: garden-linux-gcp-29-2
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: gardenlinux-repo

--- a/ci/integrationtests/task.yaml
+++ b/ci/integrationtests/task.yaml
@@ -60,6 +60,7 @@ spec:
           service_account_json:
           service_account_json_path: /tmp/serviceaccount.json
           machine_type: n1-standard-1
+          image_project: sap-se-gcp-gardenlinux
           image_name: $(params.gcp_image_name)
           # user and ssh key used to connect to the vm
           user: admin

--- a/ci/integrationtests/task.yaml
+++ b/ci/integrationtests/task.yaml
@@ -7,6 +7,12 @@ spec:
   params:
   - name: iaas
     type: string
+  - name: ami_id
+    type: string
+    default: replaceme_aws
+  - name: gcp_image_name
+    type: string
+    default: replaceme_gcp
   resources:
     inputs:
     - name: repo
@@ -40,7 +46,7 @@ spec:
           access_key_id: %s
           secret_access_key: %s
           # which AMI to use for creating an ec2 instance
-          ami_id: ami-0e7e5773a975f0aea
+          ami_id: $(params.ami_id)
           ssh_key_filepath: /tmp/id_rsa
           # user and ssh key used to connect to the ec2 instance
           user: admin
@@ -54,7 +60,7 @@ spec:
           service_account_json:
           service_account_json_path: /tmp/serviceaccount.json
           machine_type: n1-standard-1
-          image_name: garden-linux-dev-gcp-38
+          image_name: $(params.gcp_image_name)
           # user and ssh key used to connect to the vm
           user: admin
           ssh_key_filepath: /tmp/id_rsa
@@ -71,23 +77,3 @@ spec:
 
         echo "> Run tests"
         pipenv run pytest --iaas=$(params.iaas) integration/
-
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: gardenlinux-repo
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/gardenlinux/gardenlinux.git
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: build-bot
-secrets:
-  - name: github-com-user

--- a/ci/integrationtests/taskrun.yaml
+++ b/ci/integrationtests/taskrun.yaml
@@ -1,3 +1,4 @@
+# Demo TaskRun showing how to invoke the integration-test Task "standalone" for aws, without a pipeline
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
@@ -8,7 +9,9 @@ spec:
     name: integrationtest-gardenlinux-task
   params:
   - name: iaas
-    value: aws # or gcp
+    value: aws
+  - name: ami_id
+    value: ami-0e7e5773a975f0aea
   resources:
     inputs:
     - name: repo

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -54,6 +54,7 @@ class GCP:
         self.project = config["project"]
         self.zone = config["zone"]
         self.image_name = self.config["image_name"]
+        self.image_project = self.config["image_project"]
         self.machine_type = self.config["machine_type"]
         self.ssh_key_filepath = path.expanduser(self.config["ssh_key_filepath"])
         self.user = self.config["user"]
@@ -130,7 +131,7 @@ class GCP:
 
         :returns: instance to enable cleanup
         """
-        image = self._get_image(self.project, self.image_name)
+        image = self._get_image(self.image_project, self.image_name)
 
         machine_type = f"zones/{self.zone}/machineTypes/{self.machine_type}"
         time = datetime.now().strftime("%Y-%m-%dt%H-%M-%S")

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -18,6 +18,7 @@ gcp:
     service_account_json:
     service_account_json_path: ~/.config/gcloud/sap-se-gcp-scp-k8s-dev-133a7fdc3563.json
     image_name: garden-linux-dev-gcp-41
+    image_project: sap-se-gcp-scp-k8s-dev
     machine_type: n1-standard-1
     # user and ssh key used to connect to the vm
     user: gardenlinux


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors the tekton part of the integration tests by making parameters like image name configurable and adding an example pipeline.

Additionally this PR allows to have a different gcp image project than the project used to create the test VM.

Currently contains @msohn IPv6 test fixes plus working pipenv fixes, but maybe these will go into another PR...

