### PR TITLE
remove libdb from python2.7

### DIFF
--- a/hack/libdb/py27-remove-libdb.diff
+++ b/hack/libdb/py27-remove-libdb.diff
@@ -1,0 +1,20 @@
++++ python2.7-2.7.18/debian/control
+@@ -14,7 +14,7 @@
+   libsqlite3-dev, libffi-dev (>= 3.0.5) [!or1k !avr32],
+   libgpm2 [linux-any],
+   mime-support, netbase, net-tools, bzip2, time,
+-  libdb-dev (<< 1:6.0), libgdbm-dev, help2man,
++  libgdbm-dev, help2man,
+   xvfb <!nocheck>, xauth <!nocheck>
+ Build-Depends-Indep: python3-sphinx
+ Build-Conflicts: tcl8.4-dev, tk8.4-dev,
++++ python2.7-2.7.18/debian/rules
+@@ -324,7 +324,7 @@
+ 		--prefix=/usr \
+ 		--enable-ipv6 \
+ 		--enable-unicode=ucs4 \
+-		--with-dbmliborder=bdb:gdbm \
++		--with-dbmliborder=gdbm \
+ 		--with-system-expat \
+ 		--with-computed-gotos
+ 

--- a/hack/libdb/py27.sh
+++ b/hack/libdb/py27.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$(docker images -q gardenlinux:build 2> /dev/null)" == "" ]]; then
+	docker build -t gardenlinux:build .
+fi
+
+docker run --rm \
+	--volume $(readlink -f packages):/packages \
+	--volume $(readlink -f py27-remove-libdb.diff):/patch.diff \
+	-e DEBFULLNAME="GardenLinux Maintainers" \
+	-e DEBEMAIL="contact@gardenlinux.io" \
+	-ti gardenlinux:build \
+        bash -c "
+		set -euo pipefail
+		sudo apt-get update
+		sudo apt-get build-dep -y --no-install-recommends python2.7
+		sudo apt-get install -y --no-install-recommends devscripts # required for debuild
+		apt-get source python2.7
+		cd python2.7-*
+		patch -p1 < /patch.diff
+		dch -i 'remove libdb'
+		sudo apt-get remove -y --purge libdb5.3-dev
+		debuild -b -uc -us
+		mv ../*.deb /packages
+	"


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove Berkley DB from python2.7 packages.

**Which issue(s) this PR fixes**:
Fixes #