### PR TITLE
remove ftparchive from apt-utils/py27 patch update

### DIFF
--- a/hack/libdb/apt-remove-libdb.diff
+++ b/hack/libdb/apt-remove-libdb.diff
@@ -1,0 +1,33 @@
++++ pam-2.1.2/debian/control
+@@ -15,7 +15,6 @@
+                gettext (>= 0.12),
+                googletest <!nocheck> | libgtest-dev <!nocheck>,
+                libbz2-dev,
+-               libdb-dev,
+                libgnutls28-dev (>= 3.4.6),
+                libgcrypt20-dev,
+                liblz4-dev (>= 0.0~r126),
+@@ -140,8 +139,6 @@
+  .
+   * apt-extracttemplates is used by debconf to prompt for configuration
+     questions before installation.
+-  * apt-ftparchive is used to create Packages and other index files
+-    needed to publish an archive of Debian packages
+   * apt-sortpkgs is a Packages/Sources file normalizer.
+ 
+ Package: apt-transport-https
++++ pam-2.1.2/debian/apt-utils.install
+@@ -1,13 +1,10 @@
+ usr/bin/apt-extracttemplates
+-usr/bin/apt-ftparchive
+ usr/bin/apt-sortpkgs
+ usr/lib/apt/planners/
+ usr/lib/apt/solvers/
+ usr/share/doc/apt-utils
+ usr/share/locale/*/*/apt-utils.mo
+ usr/share/man/*/*/apt-extracttemplates.*
+-usr/share/man/*/*/apt-ftparchive.*
+ usr/share/man/*/*/apt-sortpkgs.*
+ usr/share/man/*/apt-extracttemplates.*
+-usr/share/man/*/apt-ftparchive.*
+ usr/share/man/*/apt-sortpkgs.*

--- a/hack/libdb/apt.sh
+++ b/hack/libdb/apt.sh
@@ -8,21 +8,19 @@ fi
 
 docker run --rm \
 	--volume $(readlink -f packages):/packages \
-	--volume $(readlink -f py27-remove-libdb.diff):/patch.diff \
+	--volume $(readlink -f apt-remove-libdb.diff):/patch.diff \
 	-e DEBFULLNAME="GardenLinux Maintainers" \
 	-e DEBEMAIL="contact@gardenlinux.io" \
 	-ti gardenlinux:build \
         bash -c "
 		set -euo pipefail
 		sudo apt-get update
-		sudo apt-get build-dep -y --no-install-recommends python2.7
+		sudo apt-get build-dep -y --no-install-recommends apt-utils 
 		sudo apt-get install -y --no-install-recommends devscripts # required for debuild
-		sudo apt-get install -y libgdbm-compat-dev
-		apt-get source python2.7
-		cd python2.7-*
+		apt-get source apt-utils 
+		cd apt-*
 		patch -p1 < /patch.diff
-		dch -i 'remove _bsddb module'
-		sudo apt-get remove -y --purge libdb-dev libdb5.3-dev
+		dch -i 'remove ftparchive/libdb'
 		debuild -b -uc -us
 		sudo mv ../*.deb /packages
 	"

--- a/hack/libdb/py27-remove-libdb.diff
+++ b/hack/libdb/py27-remove-libdb.diff
@@ -8,6 +8,26 @@
    xvfb <!nocheck>, xauth <!nocheck>
  Build-Depends-Indep: python3-sphinx
  Build-Conflicts: tcl8.4-dev, tk8.4-dev,
++++ python2.7-2.7.18/setup.py
+@@ -1309,7 +1309,7 @@
+             if dbm_args:
+                 dbm_order = [arg.split('=')[-1] for arg in dbm_args][-1].split(":")
+             else:
+-                dbm_order = "ndbm:gdbm:bdb".split(":")
++                dbm_order = "ndbm:gdbm".split(":")
+             dbmext = None
+             for cand in dbm_order:
+                 if cand == "ndbm":
++++ python2.7-2.7.18/debian/control.in
+@@ -14,7 +14,7 @@
+   libsqlite3-dev, libffi-dev (>= 3.0.5) [!or1k !avr32],
+   libgpm2 [linux-any],
+   mime-support, netbase, net-tools, bzip2, time,
+-  libdb-dev (<< 1:6.0), libgdbm-dev, help2man,
++  libgdbm-dev, help2man,
+   xvfb <!nocheck>, xauth <!nocheck>
+ Build-Depends-Indep: python3-sphinx
+ Build-Conflicts: tcl8.4-dev, tk8.4-dev,
 +++ python2.7-2.7.18/debian/rules
 @@ -324,7 +324,7 @@
  		--prefix=/usr \
@@ -18,3 +38,12 @@
  		--with-system-expat \
  		--with-computed-gotos
  
+@@ -804,7 +804,7 @@
+ 	-find $(d)/usr/lib/python$(VER) -name '*_failed*.so'
+ 	find $(d)/usr/lib/python$(VER) -name '*_failed*.so' | xargs -r rm -f
+ 
+-	test -f $(d)/usr/lib/python$(VER)/lib-dynload/_bsddb.so
++	#test -f $(d)/usr/lib/python$(VER)/lib-dynload/_bsddb.so
+ 
+ 	for i in $(d)/$(scriptdir)/lib-dynload/*.so; do \
+ 	  b=$$(basename $$i .so); \


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove ftparchive from apt-utils so BerkeleyDB is no longer needed for apt. 
Update for the python 2.7 patch getting rid of the _bsddb module.

**Which issue(s) this PR fixes**:
Fixes #
