### PR TITLE
Enable project quotas on the ROOT filesystem

### DIFF
--- a/bin/makef.sh
+++ b/bin/makef.sh
@@ -104,7 +104,7 @@ mkfs.ext4 -L ROOT -O quota -E lazy_itable_init=0,lazy_journal_init=0,quotatype=u
 #tune2fs -c 0 -i 0 ${loopback}p3
 
 echo "### mounting filesystems"
-mkdir -p ${dir_name}          && mount ${loopback}p4 -o prjquota ${dir_name}
+mkdir -p ${dir_name}          && mount ${loopback}p4 ${dir_name}
 mkdir -p ${dir_name}/boot/efi && mount ${loopback}p2 ${dir_name}/boot/efi
 mkdir -p ${dir_name}/usr      && mount ${loopback}p3 ${dir_name}/usr
 

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -25,3 +25,4 @@ traceroute
 wget
 tcpdump
 vim-tiny
+quota


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables project quotas on the ROOT filesystem for GardenLinux images.

**Which issue(s) this PR fixes**:
Fixes #62 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
GardenLinux now supports enabling the kubelet `LocalStorageCapacityIsolationFSQuotaMonitoring` feature gate. 
```
