### PR TITLE
ensure Azure image size is exactly 4GB

### DIFF
--- a/features/azure/image
+++ b/features/azure/image
@@ -2,5 +2,5 @@
 
 set -x
 
-makef.sh --read-only-usr --image-size 4G --grub-target bios --force $2 $2.tar.xz
+makef.sh --read-only-usr --image-size 4GB --grub-target bios --force $2 $2.tar.xz
 make-vhd -o subformat=fixed $2.raw $2.vhd


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the size of the built Azure image to exactly 4 GB