### PR TITLE
Take another shot at the azure image upload

### DIFF
--- a/features/azure/image
+++ b/features/azure/image
@@ -2,5 +2,5 @@
 
 set -x
 
-makef.sh --read-only-usr --image-size 4GB --grub-target bios --force $2 $2.tar.xz
-make-vhd -o subformat=fixed $2.raw $2.vhd
+makef.sh --read-only-usr --image-size 4G --grub-target bios --force $2 $2.tar.xz
+make-vhd -o subformat=fixed,force_size $2.raw $2.vhd


### PR DESCRIPTION
First, revert previous change as Azure is calculating in GiB, thus the previous size param resulted in exactly the right size as per local testing.
Second, use the force_size option as suggested by the Azure documentation.

For more information, see
https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic#resizing-vhds
