### PR TITLE
Fix for CVE https://security-tracker.debian.org/tracker/CVE-2020-13777

### DIFF
--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -21,6 +21,10 @@ chmod 0440 /etc/sudoers.d/wheel
 wget -P /tmp https://snapshot.debian.org/archive/debian/20200518T205044Z/pool/main/o/openldap/{libldap-2.4-2_2.4.50%2Bdfsg-1_amd64.deb,libldap-common_2.4.50%2Bdfsg-1_all.deb}
 dpkg -i /tmp/{libldap-2.4-2_2.4.50+dfsg-1_amd64.deb,libldap-common_2.4.50+dfsg-1_all.deb}
 
+# fix for CVE CVE-2020-13777
+wget -P /tmp https://snapshot.debian.org/archive/debian/20200607T205028Z/pool/main/g/gnutls28/libgnutls30_3.6.14-1_amd64.deb
+dpkg -i /tmp/libgnutls30_3.6.14-1_amd64.deb
+
 # removing berkelydb
 wget -P /tmp http://3.123.2.65/packages/{iproute2_5.6.0-1.1_amd64.deb,libpam-modules-bin_1.3.1-5.1_amd64.deb,libpam-modules_1.3.1-5.1_amd64.deb,libsasl2-modules-db_2.1.27+dfsg-2.1_amd64.deb,libsasl2-2_2.1.27+dfsg-2.1_amd64.deb,python3.8_3.8.3-1.1_amd64.deb,python3.8-minimal_3.8.3-1.1_amd64.deb,libpython3.8-minimal_3.8.3-1.1_amd64.deb,libpython3.8-stdlib_3.8.3-1.1_amd64.deb}
 


### PR DESCRIPTION
Add new version of gnutls

**What this PR does / why we need it**:

Fixes security issue CVE-2020-13777 in libgnutls

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

@gehoern  please review

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fix CVE-2020-13777 in gnutls
```
