### PR TITLE
Remove containerd config

### DIFF
--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -16,3 +16,6 @@ systemctl mask nftables.service
 #
 systemctl disable docker
 systemctl disable containerd
+
+# Delete the default containerd config file. Let Gardener create it.
+rm -rf /etc/containerd/config.toml


### PR DESCRIPTION
**What this PR does / why we need it**:

By installing the debian package containerd, Gardenlinux already contains the file containerd config file in /etc/containerd/config.toml.
Gardener does not override an existing containerd config, and as a consequence does not generate the default configuration file.

This is currently not a problem, but could become one in the future, when Gardener adds support for containerd configuration via the Shoot.yaml.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I tested `containerd` running successfully with `gardenlinux` using a  version of the Gardener that [includes this fix](https://github.com/gardener/gardener/commit/6886fbe56daebba7d7537e13d710747149deb85b)  together with [this PR version of the `os-gardenlinux`](https://github.com/gardener/gardener-extension-os-gardenlinux/pull/5)  extension.
Also `gvisor` seemed to have no issues.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
