### PR TITLE
Add OpenStack image build upload procedure

### DIFF
--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -596,3 +596,13 @@ def feature_by_name(feature_name: str):
         if feature.name == feature_name:
             return feature
     raise ValueError(feature_name)
+
+
+@dataclasses.dataclass(frozen=True)
+class OpenRC:
+    auth_url: str
+    domain: str
+    region: str
+    project_name: str
+    username: str
+    password: str

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -273,6 +273,13 @@ class GcpPublishedImage(PublishedImageBase):
 
 
 @dataclasses.dataclass(frozen=True)
+class OpenstackPublishedImage:
+    region_name: str
+    image_id: str
+    image_name: str
+
+
+@dataclasses.dataclass(frozen=True)
 class ReleaseManifest(ReleaseIdentifier):
     '''
     metadata for a gardenlinux release variant that can be (or was) published to a persistency
@@ -281,7 +288,7 @@ class ReleaseManifest(ReleaseIdentifier):
     build_timestamp: str
     paths: typing.Tuple[typing.Union[S3_ReleaseFile]]
     published_image_metadata: typing.Union[AlicloudPublishedImageSet,
-                                           AwsPublishedImageSet, GcpPublishedImage, None]
+                                           AwsPublishedImageSet, GcpPublishedImage, OpenstackPublishedImage, None]
 
     def path_by_suffix(self, suffix: str):
         for path in self.paths:
@@ -412,8 +419,25 @@ class AzurePublishCfg:
 
 
 @dataclasses.dataclass(frozen=True)
+class OpenstackEnviroment:
+    auth_url: str
+    domain: str
+    region: str
+    project_name: str
+    username: str
+    password: str
+
+
+@dataclasses.dataclass(frozen=True)
+class OpenstackPublishCfg:
+    openrc: OpenstackEnviroment
+    properties: dict
+
+
+@dataclasses.dataclass(frozen=True)
 class PublishCfg:
     azure: AzurePublishCfg
+    openstack: OpenstackPublishCfg
 
 
 @dataclasses.dataclass(frozen=True)
@@ -597,12 +621,3 @@ def feature_by_name(feature_name: str):
             return feature
     raise ValueError(feature_name)
 
-
-@dataclasses.dataclass(frozen=True)
-class OpenRC:
-    auth_url: str
-    domain: str
-    region: str
-    project_name: str
-    username: str
-    password: str

--- a/ci/glci/openstack_image.py
+++ b/ci/glci/openstack_image.py
@@ -1,82 +1,102 @@
-import os
-import time
-import argparse
-
-from glci.model import OpenRC
+import dataclasses
+import functools
+from datetime import datetime
+from time import sleep
 
 from openstack import connect
 
+import glci
+
 class OpenstackImageUploader:
-  '''OpenstackImageUploader is a client to upload images to Openstack Glance.'''
+    '''OpenstackImageUploader is a client to upload images to Openstack Glance.'''
 
-  def __init__(self, openrc: OpenRC):
-      self.conn = connect(
-          auth_url=openrc.auth_url,
-          project_name=openrc.project_name,
-          username=openrc.username,
-          password=openrc.password,
-          region_name=openrc.region,
-          user_domain_name=openrc.domain,
-          project_domain_name=openrc.domain,
-      )
+    def __init__(self, openrc: glci.model.OpenstackEnviroment):
+        self.openstack_env = openrc
 
-  def upload_image(self, name: str, path: str, meta: dict, timeout_seconds=86400):
-      '''Upload an image from filesystem to Openstack Glance.'''
+    @functools.lru_cache
+    def _get_connection(self):
+        return connect(
+            auth_url=self.openstack_env.auth_url,
+            project_name=self.openstack_env.project_name,
+            username=self.openstack_env.username,
+            password=self.openstack_env.password,
+            region_name=self.openstack_env.region,
+            user_domain_name=self.openstack_env.domain,
+            project_domain_name=self.openstack_env.domain,
+        )
 
-      image = self.conn.image.create_image(
-          name=name,
-          filename=path,
-          disk_format='vmdk',
-          container_format='bare',
-          visibility='community',
-          meta=meta,
-          timeout=timeout_seconds,
-      )
-      return image['id']
+    def upload_image_from_fs(self, name: str, path: str, meta: dict, timeout_seconds=86400):
+        '''Upload an image from filesystem to Openstack Glance.'''
 
-  def wait_image_ready(self, image_id: str, wait_interval_seconds=10):
-      '''Wait until an image get in ready state.'''
+        conn = self._get_connection()
+        image = conn.image.create_image(
+            name=name,
+            filename=path,
+            disk_format='vmdk',
+            container_format='bare',
+            visibility='community',
+            timeout=timeout_seconds,
+            **meta,
+        )
+        return image['id']
 
-      while True:
-          image = self.conn.image.get_image(image_id)
-          if image['status'] == 'queued' or image['status'] == 'saving':
-              time.sleep(wait_interval_seconds)
-              continue
-          if image['status'] == 'active':
-              return
-          RuntimeError(f"image upload to Glance failed due to image status {image['status']}")
+    def upload_image_from_url(self, name: str, url :str, meta: dict, timeout_seconds=86400):
+        '''Import an image from web url to Openstack Glance.'''
+
+        conn = self._get_connection()
+        image = conn.image.create_image(
+            name=name,
+            disk_format='vmdk',
+            container_format='bare',
+            visibility='community',
+            timeout=timeout_seconds,
+            **meta,
+        )
+        conn.image.import_image(image, method="web-download", uri=url)
+        return image['id']
+
+    def wait_image_ready(self, image_id: str, wait_interval_seconds=10, timeout=3600):
+        '''Wait until an image get in ready state.'''
+
+        conn = self._get_connection()
+        start_time = datetime.now()
+        while True:
+            if (datetime.now()-start_time).total_seconds() > timeout:
+                raise RuntimeError('Timeout for waiting image to get ready reached.')
+            image = conn.image.get_image(image_id)
+            if image['status'] == 'queued' or image['status'] == 'saving' or image['status'] == 'importing':
+                sleep(wait_interval_seconds)
+                continue
+            if image['status'] == 'active':
+                return
+            raise RuntimeError(f"image upload to Glance failed due to image status {image['status']}")
 
 
-def upload_image(image_name: str, image_path: str, build_number: str, openrc: OpenRC, architecture='x86_64'):
-    uploader = OpenstackImageUploader(openrc)
+def upload_and_publish_image(
+    s3_client,
+    cicd_cfg: glci.model.CicdCfg,
+    release: glci.model.OnlineReleaseManifest,
+) -> glci.model.OnlineReleaseManifest:
+    """Import an image from S3 into OpenStack Glance."""
+
+    image_name = f"gardenlinux-{release.version}"
     image_meta = {
-        'architecture': architecture,
-        'properties': {
-            'buildnumber': build_number,
-        },
+        'architecture': release.architecture.name,
+        'properties': cicd_cfg.publish.openstack.properties,
     }
-    image_id = uploader.upload_image(image_name, image_path, image_meta)
-    uploader.wait_image_ready(image_id)
-    return image_id
 
-
-def main():
-    openrc = OpenRC(
-        os.environ['OS_AUTH_URL'],
-        os.environ['OS_PROJECT_DOMAIN_NAME'],
-        os.environ['OS_REGION_NAME'],
-        os.environ['OS_PROJECT_NAME'],
-        os.environ['OS_USERNAME'],
-        os.environ['OS_PASSWORD'],
+    s3_image_url = s3_client.generate_presigned_url(
+        'get_object',
+        Params={'Bucket': release.s3_bucket, 'Key': release.s3_key},
     )
 
-    parser = argparse.ArgumentParser(description='Process some integers.')
-    parser.add_argument('--name', type=str, help='name of the image', required=True)
-    parser.add_argument('--path', type=str, help='path to image file', required=True)
-    parser.add_argument('--buildnumber', type=str, help='buildnumber of the image', required=True)
-    args = parser.parse_args()
+    uploader = OpenstackImageUploader(cicd_cfg.publish.openstack.openrc)
+    image_id = uploader.upload_image_from_url(image_name, s3_image_url, image_meta)
+    uploader.wait_image_ready(image_id)
 
-    upload_image(args.name, args.path, args.build_number, openrc)
-
-if __name__ == '__main__':
-    main()
+    published_image = glci.model.OpenstackPublishedImage(
+        region_name=cicd_cfg.publish.openstack.openrc.region,
+        image_id=image_id,
+        image_name=image_name,
+    )
+    return dataclasses.replace(release, published_image_metadata=published_image)

--- a/ci/glci/openstack_image.py
+++ b/ci/glci/openstack_image.py
@@ -1,0 +1,82 @@
+import os
+import time
+import argparse
+
+from glci.model import OpenRC
+
+from openstack import connect
+
+class OpenstackImageUploader:
+  '''OpenstackImageUploader is a client to upload images to Openstack Glance.'''
+
+  def __init__(self, openrc: OpenRC):
+      self.conn = connect(
+          auth_url=openrc.auth_url,
+          project_name=openrc.project_name,
+          username=openrc.username,
+          password=openrc.password,
+          region_name=openrc.region,
+          user_domain_name=openrc.domain,
+          project_domain_name=openrc.domain,
+      )
+
+  def upload_image(self, name: str, path: str, meta: dict, timeout_seconds=86400):
+      '''Upload an image from filesystem to Openstack Glance.'''
+
+      image = self.conn.image.create_image(
+          name=name,
+          filename=path,
+          disk_format='vmdk',
+          container_format='bare',
+          visibility='community',
+          meta=meta,
+          timeout=timeout_seconds,
+      )
+      return image['id']
+
+  def wait_image_ready(self, image_id: str, wait_interval_seconds=10):
+      '''Wait until an image get in ready state.'''
+
+      while True:
+          image = self.conn.image.get_image(image_id)
+          if image['status'] == 'queued' or image['status'] == 'saving':
+              time.sleep(wait_interval_seconds)
+              continue
+          if image['status'] == 'active':
+              return
+          RuntimeError(f"image upload to Glance failed due to image status {image['status']}")
+
+
+def upload_image(image_name: str, image_path: str, build_number: str, openrc: OpenRC, architecture='x86_64'):
+    uploader = OpenstackImageUploader(openrc)
+    image_meta = {
+        'architecture': architecture,
+        'properties': {
+            'buildnumber': build_number,
+        },
+    }
+    image_id = uploader.upload_image(image_name, image_path, image_meta)
+    uploader.wait_image_ready(image_id)
+    return image_id
+
+
+def main():
+    openrc = OpenRC(
+        os.environ['OS_AUTH_URL'],
+        os.environ['OS_PROJECT_DOMAIN_NAME'],
+        os.environ['OS_REGION_NAME'],
+        os.environ['OS_PROJECT_NAME'],
+        os.environ['OS_USERNAME'],
+        os.environ['OS_PASSWORD'],
+    )
+
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('--name', type=str, help='name of the image', required=True)
+    parser.add_argument('--path', type=str, help='path to image file', required=True)
+    parser.add_argument('--buildnumber', type=str, help='buildnumber of the image', required=True)
+    args = parser.parse_args()
+
+    upload_image(args.name, args.path, args.build_number, openrc)
+
+if __name__ == '__main__':
+    main()

--- a/ci/promote.py
+++ b/ci/promote.py
@@ -85,6 +85,8 @@ def publish_image(
         publish_function = _publish_aws_image
     elif release.platform == 'gcp':
         publish_function = _publish_gcp_image
+    elif release.platform == 'openstack':
+        publish_function = _publish_openstack_image
     else:
         print(f'do not know how to publish {release.platform=} yet')
         return release
@@ -141,6 +143,21 @@ def _publish_gcp_image(release: glci.model.OnlineReleaseManifest,
         gcp_project_name=gcp_cfg.project(),
         release=release,
         build_cfg=cicd_cfg.build,
+    )
+
+
+def _publish_openstack_image(release: glci.model.OnlineReleaseManifest,
+                       cicd_cfg: glci.model.CicdCfg,
+                       ) -> glci.model.OnlineReleaseManifest:
+    import glci.openstack_image
+    import ccc.aws
+    import ci.util
+
+    s3_client = ccc.aws.session(cicd_cfg.build.aws_cfg_name).client('s3')
+    return glci.openstack_image.upload_and_publish_image(
+        s3_client,
+        cicd_cfg=cicd_cfg,
+        release=release,
     )
 
 

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -10,3 +10,4 @@ google-api-python-client
 google-auth
 google-cloud-storage
 oss2==2.12.1
+openstacksdk==0.46.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Add procedure to upload gardenlinux images to OpenStack environments.

~~For each OpenStack environment we need to create a `Openrc` object with proper access information. This need to be passed for each environment to the function `upload_image()` together with the name of the image, builddate and the path to the image vmdk file in the local filesystem.~~

Updated the PR. For each OpenStack environment we need a `glci.model.CicdCfg` which contain internally an `glci.model.Openrc` object with access information and image properties. The image is now uploaded directly via web url (e.g. S3 object url) to Glance instead of uploading it from file system.
It's now also integrated with the publish process.

cc @ccwienk 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add image upload procedure for OpenStack environments.
```
