### PR TITLE
PXE support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN	apt-get update \
 		qemu-user-static \
 		qemu-utils \
 		xz-utils \
+		cpio \
      && rm -rf /var/lib/apt/lists/*
 
 # repo-root requires to be mounted at /debuerreotype

--- a/bin/.boot.pxe
+++ b/bin/.boot.pxe
@@ -1,0 +1,9 @@
+#!ipxe
+
+set pxeserver IPADDRESSGOESHERE 
+set pxepath PATHGOESHERE 
+
+kernel http://${pxeserver}/${pxepath}/rootfs.vmlinuz initrd=rootfs.initrd console=ttyS0 boot=live bootfrom=/
+initrd http://${pxeserver}/${pxepath}/rootfs.initrd
+boot
+

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -7,8 +7,10 @@ thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'cpu:,mem:,disk:,bridge:' \
 	--flags 'daemonize' \
+	--flags 'pxelocal:' \
+	--flags 'pxe:' \
 	-- \
-	'[--cpu:3] [--mem:16384] [--disk:3G] [--daemonize] <image file>' \
+	'[--cpu:3] [--mem:16384] [--disk:3G] [--daemonize] [--pxe:dir] [--pxelocal] <image file>' \
 	'example'
 
 eval "$dgetopt"
@@ -17,6 +19,9 @@ memory=2048
 disk=-1
 bridge=
 daemonize=
+pxe=
+pxeConfig=
+pxeLocal=
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
@@ -27,10 +32,13 @@ while true; do
 						shift ;;
 		--daemonize) 	daemonize=1; 	;;
 		--bridge ) 	bridge="$1";  	shift ;;
+		--pxe )         pxe="$1";       shift ;;
+		--pxelocal)     pxeLocal="$1";  shift ;;
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
 done
+
 imagefile="${1:-}";     shift || eusage 'missing image file to start'
 [ ! -s $imagefile ] && ( echo "file does not exist"; exit 1; )
 
@@ -77,14 +85,45 @@ virtOpts+=(
         -drive format=$imageext,if=none,discard=unmap,aio=native,cache.direct=on,id=drive0,file=$imagefile
 	)
 
+# pxe
+# TODO : a disk image is not needed when booting via pxe
+
+if [ "$pxe" -o "$pxeLocal" ]; then
+	tempDir=$(mktemp -d)
+	rand=$(uuidgen)
+	mkdir -p "$thisDir/../hack/pxe/$rand"
+	trap 'echo "Cleaning up ..."; rm -rf "$tempDir"; rm -rf "$thisDir/../hack/pxe/$rand"' EXIT
+
+	if [ "$pxeLocal" ]; then
+		# copy the kernel image and initramfs to be able to be booted from PXE
+		cp "$pxeLocal/"{rootfs.initrd,rootfs.vmlinuz} "$tempDir/"
+		cp "$thisDir/.boot.pxe" "$tempDir/boot.pxe"
+		
+		# modify the boot.pxe to load the proper kernel and initramfs
+		sed -i "s/PATHGOESHERE//" "${tempDir}/boot.pxe" 
+		sed -i "s/IPADDRESSGOESHERE/10.0.2.2/" "${tempDir}/boot.pxe" 
+		sed -i "s/http/tftp/" "${tempDir}/boot.pxe" 
+	else
+		# copy the kernel image and initramfs to be able to be booted from PXE
+		cp "$pxe/{rootfs.initrd,rootfs.vmlinuz}" "$thisDir/../hack/pxe/$rand/"
+		cp "$thisDir/.boot.pxe" "$tempDir/boot.pxe"
+
+		# modify the boot.pxe to load the proper kernel and initramfs
+		# TODO : get ip as parameter or load from config or something else
+		sed -i "s/PATHGOESHERE/pxe\/${rand}/" "${tempDir}/boot.pxe" 
+		sed -i "s/IPADDRESSGOESHERE/172.31.31.177/" "${tempDir}/boot.pxe" 
+	fi
+	pxeConfig=",tftp=$tempDir,bootfile=/boot.pxe"
+
+fi
 # network
 macaddr="$(printf '02:%02X:%02X:%02X:%02X:%02X' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))"
 if [ $bridge ]; then
 	echo "allow $bridge" >> /etc/qemu/bridge.conf
 	cat /etc/qemu/bridge.conf | sort -u > /etc/qemu/bridge.conf
-	virtOpts+=( -netdev bridge,id=net0,br=mgmt )
+	virtOpts+=( -netdev bridge,id=net0,br=mgmt"$pxeConfig" )
 else
-	virtOpts+=( -netdev user,id=net0,hostfwd=tcp::2223-:22,hostname=garden )
+	virtOpts+=( -netdev user,id=net0,hostfwd=tcp::2223-:22,hostname=garden"$pxeConfig" )
 fi
 virtOpts+=( -device virtio-net-pci,netdev=net0,mac=$macaddr )
 

--- a/features/_pxe/exec.config
+++ b/features/_pxe/exec.config
@@ -1,0 +1,1 @@
+update-initramfs -ck all

--- a/features/_pxe/image
+++ b/features/_pxe/image
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+rootfs=$1
+targetBase=$2
+targetBaseDir=$(dirname "$targetBase")
+
+# extract kernel image and initramfs
+cp "$rootfs/boot/"vmlinuz* "$targetBase.vmlinuz"
+cp "$rootfs/boot/"initrd* "$targetBase.initrd"
+
+mkdir "$targetBaseDir/live"
+
+# create the squashfs to include the fully generate image, excluding /boot of course as it's not needed
+mksquashfs "$rootfs" "$targetBaseDir/live/root.squashfs" -e boot
+
+# create a cpio archive from the squashfs and append to the initramfs
+(cd "$targetBaseDir"; echo -e ".\n./live\n./live/root.squashfs" | cpio -H newc -o | gzip -9 >> rootfs.initrd)
+
+# clean-up
+rm -rf "$targetBaseDir/live"
+rm -rf "$targetBaseDir/root.squashfs"

--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -1,0 +1,1 @@
+live-boot

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -8,4 +8,5 @@ services:
       - "./nginx.conf:/etc/nginx/conf.d/default.conf"
       - "./reprepro/repository:/repository/debian"
       - "../packages:/packages/packages"
+      - "./pxe:/pxe/pxe"
     restart: always

--- a/hack/nginx.conf
+++ b/hack/nginx.conf
@@ -24,4 +24,7 @@ server {
         location /packages/ {
 	    root /packages;
 	}
+        location /pxe/ {
+	    root /pxe;
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Modified the _pxe feature in order to add the live-boot package and tweak the image (script) as to create a proper Initrd containing the complete image (without /boot) as squashfs. 

The start-vm script has also been modified so that it can start a live gardenlinux setup and boot from PXE. It can also load the needed files via http for better performance. (use --pxe)(needs the local nginx started)

start-vm can now be used to boot via pxe and get a live gardenlinux setup:
e.g.
./start-vm --pxelocal ../.build/gcp/20200616/amd64/bullseye/ disk_stuff.raw

Yes, a disk/image still needs to be provided, but can be blank, this must be improved.

**Which issue(s) this PR fixes**:
Fixes #94

**Special notes for your reviewer**:
