### PR TITLE
Unrestrict dmesg from non-root users

### DIFF
--- a/features/server/file.include/etc/sysctl.d/allow-nonroot-dmesg.conf
+++ b/features/server/file.include/etc/sysctl.d/allow-nonroot-dmesg.conf
@@ -1,0 +1,1 @@
+kernel.dmesg_restrict = 0


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows non-root users to use `dmesg`.

**Which issue(s) this PR fixes**:
Fixes #96 

**Special notes for your reviewer**:

**Release note**:

```improvement user
Non-root users can now use dmesg.
```
