### PR TITLE
add cifs-utils package

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -1,5 +1,6 @@
 auditd
 ca-certificates
+cifs-utils
 dnsutils
 iproute2
 iptables


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cifs-utils package to make it possible to mount cifs volumes on the nodes.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
`cifs-utils` package is now part of the image
```
