### PR TITLE
Contribute detailed nginx cache config back to gardenlinux-repo

### DIFF
--- a/hack/nginx.conf
+++ b/hack/nginx.conf
@@ -14,7 +14,9 @@ server {
             proxy_cache                 STATIC;
             proxy_cache_lock            on;
             proxy_cache_lock_timeout    30s;
-            proxy_cache_valid           200  30d;
+            proxy_cache_valid           200 301 30d;
+            proxy_cache_valid           302 1h;
+            proxy_cache_valid           any 10m;
             proxy_cache_use_stale       error timeout invalid_header updating
                                         http_500 http_502 http_503 http_504;
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes the latest changes to the live nginx cache config, namely:
- 'OK' and 'moved permanently' responses (200 and 301) are valid for 30d
- 'moved temporarily' responses (302) are valid only for one hour
- any other response expires after ten minutes
