### PR TITLE
Connect ci and Azure publishing procedure

### DIFF
--- a/ci/cicd.yaml
+++ b/ci/cicd.yaml
@@ -18,6 +18,6 @@ cicd_cfgs:
         publisher_id: 'sap'
         plan_id: 'greatest'
         service_principal_cfg_name: 'shoot-operator-dev'
-        storage_account_cfg_name: 'gardelinux-dev'
+        storage_account_cfg_name: 'gardenlinux-dev'
     notify:
       email_cfg_name: 'ses_gardener_cloud_sap'

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -436,6 +436,7 @@ class BuildCfg:
     alicloud_region: str
     alicloud_cfg_name: str
 
+
 @dataclasses.dataclass(frozen=True)
 class AzureMarketplaceCfg:
     offer_id: str
@@ -452,7 +453,7 @@ class AzureServicePrincipalCfg:
 
 @dataclasses.dataclass(frozen=True)
 class AzureStorageAccountCfg:
-    name: str
+    storage_account_name: str
     container_name: str
     access_key: str
 

--- a/ci/promote.py
+++ b/ci/promote.py
@@ -110,13 +110,30 @@ def _publish_azure_image(release: glci.model.OnlineReleaseManifest,
                        cicd_cfg: glci.model.CicdCfg,
                        ) -> glci.model.OnlineReleaseManifest:
     import glci.az
+    import glci.model
     import ccc.aws
     import ci.util
 
     s3_client = ccc.aws.session(cicd_cfg.build.aws_cfg_name).client('s3')
+    cfg_factory = ci.util.ctx().cfg_factory()
+
+    service_principal_cfg = cfg_factory.azure_service_principal(cicd_cfg.publish.azure.service_principal_cfg_name)
+    service_principal_cfg_serialized = glci.model.AzureServicePrincipalCfg(**service_principal_cfg.raw)
+
+    storage_account_cfg = cfg_factory.azure_storage_account(cicd_cfg.publish.azure.storage_account_cfg_name)
+    storage_account_cfg_serialized = glci.model.AzureStorageAccountCfg(**storage_account_cfg.raw)
+
+    azure_marketplace_cfg = glci.model.AzureMarketplaceCfg(
+        publisher_id=cicd_cfg.publish.azure.publisher_id,
+        offer_id=cicd_cfg.publish.azure.offer_id,
+        plan_id=cicd_cfg.publish.azure.plan_id,
+    )
+
     return glci.az.upload_and_publish_image(
         s3_client,
-        cicd_cfg=cicd_cfg,
+        service_principal_cfg=service_principal_cfg_serialized,
+        storage_account_cfg=storage_account_cfg_serialized,
+        marketplace_cfg=azure_marketplace_cfg,
         release=release,
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The ci fetch now the configuration for the Azure publishing procedure from SecretServer correctly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```NONE

```
