### PR TITLE
make image shared hiddenly on Alicloud

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,5 @@
 aliyun-python-sdk-core==2.13.16
-aliyun-python-sdk-ecs==4.19.7
+aliyun-python-sdk-ecs==4.19.9
 azure-storage-blob==12.3.0
 boto3
 dacite==1.4.0 # bug in 1.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Share gardenlinux image to other accounts
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
GardenLinux images are built for all regions on Alicloud and are made shared with other accounts.
```
