### PR TITLE
Make make-ova os agnostic

### DIFF
--- a/bin/make-ova
+++ b/bin/make-ova
@@ -1,8 +1,6 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
-
-# https://wiki.abiquo.com/display/ABI26/Guest+Operating+System+Definition+for+VMWare
-# debian64 OS identifier always seems to be 96
+# See docs/vmware-ova.md for info
 
 import argparse
 import os
@@ -13,31 +11,39 @@ import hashlib
 import tempfile
 import tarfile
 
-from mako.template import Template
+try:
+    from mako.template import Template
+except ImportError:
+    sys.exit("Mako Templates module not found")
 
-"""
-properties = {
+MIN_PYTHON = (3, 7)
+GUEST_OS = {
+    "debian10_64Guest": {
+        "definition": "96",
+        "description": "Garden Linux 64 (Debian 11)",
+        "hostname": "gardenlinux"
+    },
+    "sles15_64Guest": {
+        "definition": "85",
+        "description": "SUSE Linux Enterprise Server 15 SP2 (CHOST)",
+        "hostname": "sles15chost"
+    }
+}
+PROPERTIES = {
     "vmdkFilename": "",
     "vmdkFileSize": "",
     "vmdkFileCapacity": "",
     "virtualSystemId": "",
-    "osType": "debian10_64Guest",
-    "osDefinition": "96"
+    "osType": "",
+    "osDefinition": "",
+    "osDescription": "",
+    "applianceHostname": ""
 }
-"""
-properties = {
-    "vmdkFilename": "",
-    "vmdkFileSize": "",
-    "vmdkFileCapacity": "",
-    "virtualSystemId": "",
-    "osType": "debian10_64Guest",
-    "osDefinition": "96"
-}
+
 
 class OVAImageBuild:
-
-    def getInfo(sefl, filename):
-        result = subprocess.run(["qemu-img", "info", "--output", "json", filename], capture_output= True)
+    def getInfo(self, filename):
+        result = subprocess.run(["qemu-img", "info", "--output", "json", filename], capture_output=True)
         if result.returncode != 0:
             sys.exit("Error getting image info for " + filename + ": " + result.stdout)
 
@@ -46,12 +52,12 @@ class OVAImageBuild:
         virtualSize = doc["format-specific"]["data"]["extents"][0]["virtual-size"]
         return (fileSize, virtualSize)
 
-    def makeAttributes(self, properties):
+    def makeAttributes(self, PROPERTIES):
         class P:
-            pass        
+            pass
         p = P()
-        for k in properties:
-            setattr(p, k, properties[k])
+        for k in PROPERTIES:
+            setattr(p, k, PROPERTIES[k])
         return p
 
     def sha256(self, filename):
@@ -62,21 +68,21 @@ class OVAImageBuild:
             while len(fileBuffer) > 0:
                 sha.update(fileBuffer)
                 fileBuffer = file.read(blocksize)
-        
+
         return sha.hexdigest()
 
     def run(self, template):
-        vmdkFullFilename = properties["vmdkFullFilename"]
+        vmdkFullFilename = PROPERTIES["vmdkFullFilename"]
         vmdkPath = os.path.dirname(vmdkFullFilename)
-        vmdkFilename = os.path.basename(properties["vmdkFilename"])
+        vmdkFilename = os.path.basename(PROPERTIES["vmdkFilename"])
         ovaFilename = os.path.splitext(vmdkFilename)[0] + ".ova"
         ovaFullFilename = os.path.join(vmdkPath, ovaFilename)
         ovfFilename = os.path.splitext(vmdkFilename)[0] + ".ovf"
         print(ovaFullFilename)
-        fileSize, virtualSize = self.getInfo(properties["vmdkFullFilename"])
-        properties["vmdkFileSize"] = fileSize
-        properties["vmdkFileCapacity"] = virtualSize
-        p = self.makeAttributes(properties)
+        fileSize, virtualSize = self.getInfo(PROPERTIES["vmdkFullFilename"])
+        PROPERTIES["vmdkFileSize"] = fileSize
+        PROPERTIES["vmdkFileCapacity"] = virtualSize
+        p = self.makeAttributes(PROPERTIES)
         tmpl = Template(filename=template)
         ovf = tmpl.render(p=p)
         vmdkSha256 = self.sha256(vmdkFullFilename)
@@ -84,7 +90,7 @@ class OVAImageBuild:
 
             ovfFullFilename = os.path.join(tmpDir, ovfFilename)
             with open(ovfFullFilename, "w") as file:
-               file.write(ovf)
+                file.write(ovf)
             ovfSha256 = self.sha256(ovfFullFilename)
 
             mfFilename = os.path.splitext(vmdkFilename)[0] + ".mf"
@@ -102,7 +108,6 @@ class OVAImageBuild:
 
     @classmethod
     def _argparse_register(cls, parser):
-
         parser.add_argument(
             '--vmdk',
             type=str,
@@ -111,9 +116,18 @@ class OVAImageBuild:
             required=True
         )
         parser.add_argument(
+            "--guest-id",
+            type=str,
+            dest='guest_id',
+            help='Guest operating system identifier',
+            choices=list(GUEST_OS.keys()),
+            required=True
+        )
+        parser.add_argument(
             "--template",
             type=str,
             dest='template',
+            help='OVF template file path (see ../templates for examples)',
             required=True
         )
 
@@ -123,11 +137,19 @@ class OVAImageBuild:
         cls._argparse_register(parser)
         args = parser.parse_args()
 
-        properties["vmdkFullFilename"] = args.vmdk
-        properties["vmdkFilename"] = os.path.basename(args.vmdk)
-        properties["virtualSystemId"] = os.path.splitext(os.path.basename(args.vmdk))[0]
+        if sys.version_info < MIN_PYTHON:
+            sys.exit("Python %s.%s or newer is required." % MIN_PYTHON)
+
+        PROPERTIES["vmdkFullFilename"] = args.vmdk
+        PROPERTIES["vmdkFilename"] = os.path.basename(args.vmdk)
+        PROPERTIES["virtualSystemId"] = os.path.splitext(os.path.basename(args.vmdk))[0]
+        PROPERTIES["osType"] = args.guest_id
+        PROPERTIES["osDefinition"] = GUEST_OS[args.guest_id]["definition"]
+        PROPERTIES["osDescription"] = GUEST_OS[args.guest_id]["description"]
+        PROPERTIES["applianceHostname"] = GUEST_OS[args.guest_id]["hostname"]
         oVAImageBuild = cls()
         oVAImageBuild.run(template=args.template)
- 
+
+
 if __name__ == '__main__':
     OVAImageBuild._main()

--- a/docs/vmware-ova.md
+++ b/docs/vmware-ova.md
@@ -1,0 +1,153 @@
+# VMware OVA
+
+Building an ova can be done with `bin/make-ova`.
+
+Requirements:
+* Python `3.7` minimum is required
+* Mako python module must also be installed
+* `qemu-tools (qemu-img)` must be installed
+* VMDK image file must be in type `streamOptimized`,
+see below how to convert if necessary
+
+## Add new os
+
+1. Retrieve OS ID
+
+There is a list available here in the [wiki from abiquo](https://wiki.abiquo.com/display/ABI26/Guest+Operating+System+Definition+for+VMWare).
+
+This can also be retrieved when exporting an `ovf` from a Virtual Machine.
+
+2. In `bin/make-ova` add new OS in `GUEST_OS`
+
+## Convert VMDK
+
+> OVA requires stream optimized disk image file (.vmdk) so that it can
+be easily streamed over a network link. This tool can convert flat disk image
+or sparse disk image to stream optimized disk image, and then create OVA with
+the converted stream optimized disk image by using an OVF descriptor template.
+
+1. Check the type of the disk image
+
+```bash
+qemu-img info --output json my-disk-image.vmdk | jq '.["format-specific"].data["create-type"]'
+```
+
+If the output is `streamOptimized`, you can skip the next step.
+
+If the output is something like `monolithicSparse` of `monolithicFlat`,
+a conversion is required.
+
+2. Convert
+
+```bash
+qemu-img convert -p -f vmdk my-disk-image.vmdk -O vmdk my-disk-image-stream-optimized.vmdk -o subformat=streamOptimized
+```
+
+## Make ova
+
+Specify the `vmdk`, the full path to the `template`
+and the `guest-id` of the OS.
+
+```bash
+$ ./make-ova --vmdk garden-linux-27.1.0.vmdk \
+           --template /gardenlinux/templates/vmware.ovf.template \
+           --guest-id debian10_64Guest
+garden-linux-27.1.0.ova
+```
+
+## Upload template
+
+### via UI
+
+Navigate to the directory target, right click: `Deploy OVF template`
+
+### with `govc`
+
+Export the minimum required environment variables
+for authentication:
+
+```bash
+GOVC_URL=vCenter-instance
+GOVC_USERNAME=my-user
+GOVC_PASSWORD=my-password
+```
+
+Create options file that will be used for import:
+
+```bash
+$ touch ova-import-options.json
+$ govc import.spec garden-linux-27.1.0.ova | jq '.' | tee ova-import-options.json
+{
+  "DiskProvisioning": "flat",
+  "IPAllocationPolicy": "dhcpPolicy",
+  "IPProtocol": "IPv4",
+  "PropertyMapping": [
+    {
+      "Key": "instance-id",
+      "Value": "id-ovf"
+    },
+    {
+      "Key": "hostname",
+      "Value": "gardenlinux"
+    },
+    {
+      "Key": "seedfrom",
+      "Value": ""
+    },
+    {
+      "Key": "public-keys",
+      "Value": ""
+    },
+    {
+      "Key": "user-data",
+      "Value": ""
+    },
+    {
+      "Key": "password",
+      "Value": ""
+    }
+  ],
+  "NetworkMapping": [
+    {
+      "Name": "VM Network",
+      "Network": ""
+    }
+  ],
+  "MarkAsTemplate": false,
+  "PowerOn": false,
+  "InjectOvfEnv": false,
+  "WaitForIP": false,
+  "Name": null
+}
+```
+
+Minimum requirement in `ova-import-options.json`:
+* configure `DiskProvisioning` if required
+* set `MarkAsTemplate` to `true`
+* replace the empty network field with the appropriate
+value based on your environment
+
+Import the `.ova`:
+
+```bash
+$ govc import.ova -name garden-linux-27.1.0 \
+    -dc MY_DATACENTER \
+    -ds MY_DATASTORE \
+    -pool MY_POOL \
+    -folder MY_FOLDER \
+    -options ./ova-import-options.json \
+    garden-linux-27.1.0.ova 
+
+```
+
+The Warning :warning: can be ignored.
+
+The following environement variables can be exported
+to avoid specifying some of the command line flags:
+
+```bash
+GOVC_DATACENTER
+GOVC_DATASTORE
+GOVC_RESOURCE_POOL
+GOVC_FOLDER
+```

--- a/features/vmware/image
+++ b/features/vmware/image
@@ -4,4 +4,4 @@ set -x
 
 makef.sh --read-only-usr --grub-target bios --force $2 $2.tar.xz
 qemu-img convert -o subformat=streamOptimized -o adapter_type=lsilogic -f raw -O vmdk $2.raw $2.vmdk
-make-ova --vmdk $2.vmdk --template "${REPO_ROOT}/templates/gardenlinux.ovf.template"
+make-ova --vmdk $2.vmdk --guest-id debian10_64Guest --template "${REPO_ROOT}/templates/vmware.ovf.template"

--- a/templates/vmware.ovf.template
+++ b/templates/vmware.ovf.template
@@ -18,17 +18,17 @@
     <Name>${p.virtualSystemId}</Name>
     <OperatingSystemSection ovf:id="${p.osDefinition}" vmw:osType="${p.osType}">
       <Info>The kind of installed guest operating system</Info>
-      <Description>Garden Linux 64-bit (Debian 11)</Description>
+      <Description>"${p.osDescription}"</Description>
     </OperatingSystemSection>
 
     <ProductSection ovf:required="false">
       <Info>Cloud-Init customization</Info>
-      <Product>Garden Linux 64 (Debian 11)</Product>
+      <Product>"${p.osDescription}"</Product>
       <Property ovf:key="instance-id" ovf:type="string" ovf:userConfigurable="true" ovf:value="id-ovf">
           <Label>A Unique Instance ID for this instance</Label>
           <Description>Specifies the instance id.  This is required and used to determine if the machine should take "first boot" actions</Description>
       </Property>
-      <Property ovf:key="hostname" ovf:type="string" ovf:userConfigurable="true" ovf:value="gardenlinux">
+      <Property ovf:key="hostname" ovf:type="string" ovf:userConfigurable="true" ovf:value="${p.applianceHostname}">
           <Description>Specifies the hostname for the appliance</Description>
       </Property>
       <Property ovf:key="seedfrom" ovf:type="string" ovf:userConfigurable="true">


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows make-ova to be used with different OS.

This also adds support for SUSE CHOST 15 SP2.

**Special notes for your reviewer**:

I'm not sure this is the right place in the script to add the GUEST_OS since the repo is for `gardenlinux`.

**Release note**: 
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
