### PR TITLE
Gardener feature: add crictl and disabling containerd and docker

### DIFF
--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -1,18 +1,22 @@
 #!/bin/bash
 
 # set the default to iptalbes and deactivate nf_tables kernel modules
-#
 update-alternatives --set iptables /usr/sbin/iptables-legacy
 update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 update-alternatives --set arptables /usr/sbin/arptables-legacy
 update-alternatives --set ebtables /usr/sbin/ebtables-legacy
 
 # just to make sure there are no traces left
-#
 systemctl mask nftables.service
 
 # Disable docker and containerd, Gardener will have to enable the
 # one it uses
-#
-systemctl disable docker
-systemctl disable containerd
+systemctl disable docker.service
+systemctl disable docker.socket
+systemctl disable containerd.service
+
+# install crictl required for Gardener node bootstrapping of CRI enabled nodes
+VERSION="v1.18.0"
+wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+rm -f crictl-$VERSION-linux-amd64.tar.gz


### PR DESCRIPTION
**What this PR does / why we need it**:

Installs `crictl` as part of the Gardener feature.  Please see [here](https://github.com/gardener/gardener/issues/2719) for more information regarding the Gardener context.

Also fixes the disabling of containerd and docker systemd services. This would not have worked previously anyways, as Gardener currently always requires docker to be present - even when bootstrapping a containerd only node.

With this [PR](https://github.com/gardener/gardener/pull/2739), the Gardener will 
 - not require Docker any more to bootstrap CRI enabled nodes
- require `crictl` for the bootstrap of CRI enabled nodes

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Open as draft PR as the corresponding [PR in the Gardener repository](https://github.com/gardener/gardener/pull/2739) is not merged yet.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adding crictl to the Gardener feature. 
```
```improvement operator
Fixing a bug  that lead to not disabling the docker systemd service properly.
```
