### PR TITLE
Increase the memlock ulimit to 64Mib

### DIFF
--- a/features/gardener/file.include/etc/docker/daemon.json
+++ b/features/gardener/file.include/etc/docker/daemon.json
@@ -2,8 +2,8 @@
   "default-ulimits": {
       "memlock": {
           "name": "memlock",
-          "hard": 65536,
-          "soft": 65536
+          "hard": 67108864,
+          "soft": 67108864
       }
   }
 }


### PR DESCRIPTION
The original intent in #82 was to set the ulimit to 64Mib.

Unfortunately, #82 set the limit to 64Kib. This PR fixes that.

**What this PR does / why we need it**:

64Kib is the default for Docker without any additional configuration. 64Mib is high enough to solve the original problem.

**Which issue(s) this PR fixes**:
Fixes #81 correctly.

**Special notes for your reviewer**:

Can be verified by running `ulimit -l` in a container. The correct output should be:

```shell
$ ulimit -l
65536
```
The configuration file specifies the limit in bytes, while `ulimit` shows the limit in kilobytes.

**Release note**:

```improvement operator
Allows Golang 1.14 binaries to run correctly by increasing the default max memory lock ulimit size for Docker containers.
```
