### PR TITLE
Small tests updates

### DIFF
--- a/features/cloud/test/tmout
+++ b/features/cloud/test/tmout
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e 
+
+echo "testing auto-logout settings"
+rootfsDir=$1
+absPath=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+
+if [[ -z ${absPath} || ! -d ${absPath} ]]; then
+	echo "FATAL - can't determine working directory"
+	exit 1
+fi
+
+source ${absPath}/helpers
+
+if ! check_rootdir "${rootfsDir}"; then
+	exit 1
+fi
+
+if [[ "$UID" -ne 0 ]]; then
+	echo "FATAL - must be run as root"
+	exit 1
+else
+	run_in_chroot ${rootfsDir} "tmout.chroot"
+fi
+

--- a/features/cloud/test/tmout.chroot
+++ b/features/cloud/test/tmout.chroot
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+tmout=$(su - root -c "env | grep TMOUT")
+tmout_ro=$(su - root -c "unset TMOUT 2> /dev/null; echo \$?")
+
+if [[ "$tmout" == "TMOUT=600" ]] && [[ "$tmout_ro" == "1" ]]; then
+	echo "OK - auto-logout is properly configured"	
+	exit 0
+else
+	echo "FAIL - auto-logout is not properly configured - check /etc/profile.d"
+	exit 1
+fi

--- a/features/cloud/test/umask
+++ b/features/cloud/test/umask
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "testing default umask"
+
+rootfsDir=$1
+thisDir=$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")
+rootfsDir=$(readlink -e "$rootfsDir")
+
+source "${thisDir}/helpers"
+
+check_rootdir "${rootfsDir}" || exit 1
+
+if grep -qP '^UMASK\s+027$' "${rootfsDir}/etc/login.defs"; then
+       echo "OK - umask defaults to 027"       
+       exit 0
+else
+	echo "FAIL - umask doesn't default to 027"
+	exit 1
+fi

--- a/features/server/test/debsums.chroot
+++ b/features/server/test/debsums.chroot
@@ -3,6 +3,8 @@
 export TZ="UTC"
 export LC_ALL="C"
 
+exec 2> /dev/null
+
 DEBIAN_FRONTEND=noninteractive apt-get update > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends debsums apt-utils > /dev/null
 

--- a/features/server/test/packages_musthave.list
+++ b/features/server/test/packages_musthave.list
@@ -1,1 +1,2 @@
 libpam-cracklib:amd64
+auditd

--- a/features/server/test/systemctl_enabled.list
+++ b/features/server/test/systemctl_enabled.list
@@ -1,1 +1,2 @@
 systemd-networkd.service
+auditd.service

--- a/features/server/test/user_groups.list
+++ b/features/server/test/user_groups.list
@@ -1,1 +1,2 @@
-wheel:dev
+wheel:
+root:


### PR DESCRIPTION
**What this PR does / why we need it**:
Small output fix for the debsums test - removing a debconf warning.
Adding a test for the presence of TMOUT.
Adding auditd to be checked if package is installed and if the service is enabled.
Updating groups for the user_groups test. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
NONE
