### PR TITLE
Disable bash history

### DIFF
--- a/features/server/file.include/etc/profile.d/50-nohistory.sh
+++ b/features/server/file.include/etc/profile.d/50-nohistory.sh
@@ -1,0 +1,3 @@
+HISTFILE=/dev/null
+readonly HISTFILE
+export HISTFILE

--- a/features/server/test/history
+++ b/features/server/test/history
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e 
+
+echo "testing settings for shell history"
+rootfsDir=$1
+absPath=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
+
+if [[ -z ${absPath} || ! -d ${absPath} ]]; then
+	echo "FATAL - can't determine working directory"
+	exit 1
+fi
+
+source ${absPath}/helpers
+
+if ! check_rootdir "${rootfsDir}"; then
+	exit 1
+fi
+
+if [[ "$UID" -ne 0 ]]; then
+	echo "FATAL - must be run as root"
+	exit 1
+else
+	run_in_chroot ${rootfsDir} "history.chroot"
+fi
+

--- a/features/server/test/history.chroot
+++ b/features/server/test/history.chroot
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+histfile=$(su - root -c "env | grep HISTFILE")
+histfile_ro=$(su - root -c "unset HISTFILE 2> /dev/null; echo \$?")
+
+if [[ "$histfile" == "HISTFILE=/dev/null" ]] && [[ "$histfile_ro" == "1" ]]; then
+	echo "OK - history is disabled and variable is read-only"	
+	exit 0
+else
+	echo "FAIL - the history is not properly disabled - check /etc/profile.d"
+	exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is going to disable the bash history. This is a SAP Security requirement.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
Bash history is disabled.