### PR TITLE
rm python2 from azure build

### DIFF
--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,7 +1,5 @@
 # Azure images require waagent 
 waagent
-# Some waagent extensions still need python2.7, and break when it is not present
-python
 # debootstrap does not pull python3-cffi-backend
 #python3-cffi-backend
 #


### PR DESCRIPTION
After cursory testing The Microsoft Azure Linux-Agent does not seem to depend on python2 anymore. My current best guess for the required python version is 3.8+, as given by https://github.com/Azure/WALinuxAgent/blob/develop/requirements.txt
