### PR TITLE
Add the version in the pretty name

### DIFF
--- a/bin/garden-build.sh
+++ b/bin/garden-build.sh
@@ -168,7 +168,7 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 	[ -z "${ports:-}" ] || sourcesListArgs+=( --ports )
 
 	#Brand it
-	sed -i "s/^PRETTY_NAME=.*$/PRETTY_NAME=\"Garden Linux\"/g" rootfs/etc/os-release
+	sed -i "s/^PRETTY_NAME=.*$/PRETTY_NAME=\"Garden Linux $(garden-version)\"/g" rootfs/etc/os-release
 	sed -i "s/^HOME_URL=.*$/HOME_URL=\"https:\/\/gardenlinux.io\/\"/g" rootfs/etc/os-release
 	sed -i "s/^SUPPORT_URL=.*$/SUPPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\"/g" rootfs/etc/os-release
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
@@ -191,7 +191,7 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 		if [ -n "${qemu:-}" ]; then
 			tarArgs+=( --exclude="./usr/bin/qemu-*-static" )
 		fi
-			
+
 		tarArgs+=( --include-dev )
 
 		if [ "$variant" != "sbuild" ]; then
@@ -255,7 +255,7 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 		for i in $(echo "base,$features" | tr ',' ' ' | sort -u); do
 			if [ -s $featureDir/$i/image ]; then
 				bash -c "$featureDir/$i/image $rootfs $targetBase"
-			else 
+			else
 				true
 			fi
 		done


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the version in the pretty name.
In this way the OS version will be visible via k8s 
Currently, it is 
```bash
$  k get node -o wide
NAME                                          STATUS   ROLES    AGE   VERSION    INTERNAL-IP     EXTERNAL-IP   OS-IMAGE       KERNEL-VERSION        CONTAINER-RUNTIME
ip-10-222-13-140.eu-west-1.compute.internal   Ready    <none>   35m   v1.17.12   10.222.13.140   <none>        Garden Linux   5.4.0-4-cloud-amd64   docker://19.3.7
```

After the change it will be something like 
```bash
 k get node -o wide
NAME                                          STATUS   ROLES    AGE   VERSION    INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION        CONTAINER-RUNTIME
ip-10-222-13-140.eu-west-1.compute.internal   Ready    <none>   35m   v1.17.12   10.222.13.140   <none>        Garden Linux 179.0   5.4.0-4-cloud-amd64   docker://19.3.7
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The image version is now injected in the `PRETTY_NAME` in /etc/os-release file.
```
