### PR TITLE
Unpin docker version

### DIFF
--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -11,11 +11,6 @@ update-alternatives --set ebtables /usr/sbin/ebtables-legacy
 #
 systemctl mask nftables.service
 
-# Temporary mitigate https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=970525
-wget -P /tmp http://snapshot-cache.ci.gardener.cloud/archive/debian/20200927T083842Z/pool/main/d/docker.io/docker.io_19.03.13%2Bdfsg1-2_amd64.deb
-apt-get install -y -f /tmp/docker.io_19.03.13+dfsg1-2_amd64.deb
-rm -f /tmp/docker.io_19.03.13+dfsg1-2_amd64.deb
-
 # Disable docker and containerd, Gardener will have to enable the
 # one it uses
 #

--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -1,7 +1,7 @@
 apparmor
 containerd
 containernetworking-plugins
-#docker.io # Manually installed with a specific version to mitigate https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=970525
+docker.io
 ethtool
 ipvsadm
 socat


### PR DESCRIPTION
**What this PR does / why we need it**:
The fixed docker version has reached `testing` so we can unpin it now.

This reverts commit 93f71b332296185263adb026d15e1ebf1e59d87a.

**Which issue(s) this PR fixes**:
Fixes #138 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The docker version is no longer pinned to `19.03.13+dfsg1-2` but is regularly updated from the testing branch of Debian.
```
