### PR TITLE
Fix build problem if build directory .build does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BUILDDIR=.build
 BUILDKEY="contact@gardenlinux.io"
 
 sign.pub:
+	@mkdir -p .build
 	@gpg --list-secret-keys $(BUILDKEY) > /dev/null || echo "No secret key for $(BUILDKEY) exists, signing disabled" 
 	@gpg --export --armor $(BUILDKEY) > $(BUILDDIR)/sign.pub
 	@diff $(BUILDDIR)/sign.pub gardenlinux.pub || echo "Not using the official key"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix build error if .build directory does not exist.

**Which issue(s) this PR fixes**:
Fixes #152 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fix build error if .build directory does not exist.
```
