### PR TITLE
Set DEBIAN_FRONTEND to noninteractive in Debian docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN	go get -u golang.org/x/lint/golint \
      && make
 
 FROM 	debian:testing-slim
+ENV     DEBIAN_FRONTEND noninteractive
 RUN	apt-get update \
      && apt-get install -y --no-install-recommends \
 		debian-ports-archive-keyring \

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -1,5 +1,7 @@
 FROM	debian:testing-slim
 
+ENV     DEBIAN_FRONTEND noninteractive
+
 RUN	mkdir /etc/sudoers.d \
      &&	echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel \
      && echo "deb-src http://deb.debian.org/debian testing main" >> /etc/apt/sources.list \

--- a/repository/Dockerfile
+++ b/repository/Dockerfile
@@ -1,5 +1,7 @@
 FROM	debian:testing-slim
 
+ENV     DEBIAN_FRONTEND noninteractive
+
 RUN	apt-get update \
      &&	apt-get install -y reprepro gpg libgpgme11 \
      &&	gpg --list-keys \

--- a/snapshot/Dockerfile
+++ b/snapshot/Dockerfile
@@ -1,5 +1,7 @@
 FROM	debian:stable-slim
 
+ENV     DEBIAN_FRONTEND noninteractive
+
 RUN	apt-get update \
      &&	apt-get install debian-archive-keyring \
      &&	echo "deb http://archive.debian.org/debian/ sarge main [trusted=yes]" >> /etc/apt/sources.list.d/damnold.list \


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@23technologies.cloud>