### PR TITLE
fix v1.19 download link

### DIFF
--- a/features/chost/exec.config
+++ b/features/chost/exec.config
@@ -1,6 +1,6 @@
 wget -P /usr/local/bin \
 	https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/{kubeadm,kubelet,kubectl} \
-	https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.17.0/crictl-v1.17.0-linux-amd64.tar.gz 
+	https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-amd64.tar.gz 
 	
 tar -C /usr/local/bin -xf /usr/local/bin/crictl-v1.19.0-linux-amd64.tar.gz
 rm -f /usr/local/bin/crictl-v1.19.0-linux-amd64.tar.gz


### PR DESCRIPTION
Upgrade to kubernetes version 1.19 the download link for crictl was broken

