### PR TITLE
for advanced Docker Proxy.

### DIFF
--- a/features/gardener/file.include/etc/docker/daemon.json
+++ b/features/gardener/file.include/etc/docker/daemon.json
@@ -1,4 +1,5 @@
-{ "live-restore": true, "storage-driver": "overlay2",
+{ "live-restore": true,
+  "storage-driver": "overlay2",
   "default-ulimits": {
       "memlock": {
           "name": "memlock",

--- a/features/gardener/file.include/etc/docker/daemon.json
+++ b/features/gardener/file.include/etc/docker/daemon.json
@@ -1,4 +1,4 @@
-{ "storage-driver": "overlay2",
+{ "live-restore": true, "storage-driver": "overlay2",
   "default-ulimits": {
       "memlock": {
           "name": "memlock",


### PR DESCRIPTION
I’m working with advanced Docker Proxy. 
This requires reconfiguration of Docker on every Node (/etc/systemd/system/docker.service.d/http-proxy.conf),
daemon-reload, and restart docker.service.
Restart – during bootstrapping - crashes already running container on the Node.
To prevent such crash, /etc/docker/daemon.json should have setting “live-restore: true”

