### PR TITLE
Use secure URLs if possible for accessing mirrors

### DIFF
--- a/bin/.snapshot-url.sh
+++ b/bin/.snapshot-url.sh
@@ -26,8 +26,8 @@ if wget -t1 -qO/dev/null http://localhost/archive/debian/; then
 	echo "http://localhost/archive/$archive/$t"
 elif wget -t1 -qO/dev/null http://172.17.0.1/archive/debian/; then	
 	echo "http://172.17.0.1/archive/$archive/$t"
-elif wget -t1 -qO/dev/null http://snapshot-cache.ci.gardener.cloud/archive/debian/; then
-	echo "http://snapshot-cache.ci.gardener.cloud/archive/$archive/$t"
+elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/archive/debian/; then
+	echo "https://snapshot-cache.ci.gardener.cloud/archive/$archive/$t"
 else
-	echo "http://snapshot.debian.org/archive/$archive/$t"
+	echo "https://snapshot.debian.org/archive/$archive/$t"
 fi

--- a/bin/debuerreotype-debian-sources-list
+++ b/bin/debuerreotype-debian-sources-list
@@ -35,23 +35,23 @@ suite="${1:-}"; shift || eusage 'missing suite'
 epoch="$(< "$targetDir/debuerreotype-epoch")"
 
 if [ -z "$ports" ]; then
-	standardMirror='http://deb.debian.org/debian'
+	standardMirror='https://deb.debian.org/debian'
 	snapshotStandardMirrors=( "$("$thisDir/.snapshot-url.sh" "@$epoch")" )
 else
-	standardMirror='http://deb.debian.org/debian-ports'
+	standardMirror='https://deb.debian.org/debian-ports'
 	snapshotStandardMirrors=( "$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-ports')" )
 fi
 
-securityMirror='http://security.debian.org/debian-security'
+securityMirror='https://security.debian.org/debian-security'
 snapshotSecurityMirrors=( "$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-security')" )
 
 if [ -n "$eol" ]; then
 	archiveSnapshotMirror="$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-archive')"
 
-	standardMirror='http://archive.debian.org/debian'
+	standardMirror='https://archive.debian.org/debian'
 	snapshotStandardMirrors=( "$archiveSnapshotMirror/debian" "${snapshotStandardMirrors[@]}" )
 
-	securityMirror='http://archive.debian.org/debian-security'
+	securityMirror='https://archive.debian.org/debian-security'
 	snapshotSecurityMirrors=( "$archiveSnapshotMirror/debian-security" "${snapshotSecurityMirrors[@]}" )
 fi
 
@@ -72,7 +72,7 @@ deb() {
 
 	local found= mirror
 	for mirror in "${snapshotMirrors[@]}"; do
-		# http://snapshot.debian.org/archive/debian-archive/20160314T000000Z/debian/dists/squeeze-updates/main/binary-amd64/Packages.gz
+		# https://snapshot.debian.org/archive/debian-archive/20160314T000000Z/debian/dists/squeeze-updates/main/binary-amd64/Packages.gz
 		if \
 			wget --quiet --spider -O /dev/null -o /dev/null "$mirror/dists/$suite/$comp/binary-$arch/Packages.xz" \
 			|| wget --quiet --spider -O /dev/null -o /dev/null "$mirror/dists/$suite/$comp/binary-$arch/Packages.gz" \

--- a/ci/glci/alicloud.py
+++ b/ci/glci/alicloud.py
@@ -82,7 +82,7 @@ class AlicloudImageMaker:
             )
             bucket = oss2.Bucket(
                 self.oss2_auth,
-                f"http://oss-{self.region}.aliyuncs.com",
+                f"https://oss-{self.region}.aliyuncs.com",
                 self.bucket_name,
             )
             bucket.put_object(self.image_oss_key, tfh)

--- a/hack/nginx.conf
+++ b/hack/nginx.conf
@@ -8,7 +8,7 @@ server {
 	server_name _;
 
         location /archive {
-            proxy_pass                  http://snapshot.debian.org/archive;
+            proxy_pass                  https://snapshot.debian.org/archive;
             proxy_set_header            Host snapshot.debian.org;
             proxy_buffering             on;
             proxy_cache                 STATIC;

--- a/hack/raspbian.sh
+++ b/hack/raspbian.sh
@@ -61,7 +61,7 @@ docker run \
 	bash -Eeuo pipefail -c '
 		set -x
 
-		mirror="http://archive.raspbian.org/raspbian"
+		mirror="https://archive.raspbian.org/raspbian"
 
 		dpkgArch="armhf"
 

--- a/hack/steamos.sh
+++ b/hack/steamos.sh
@@ -21,7 +21,7 @@ while true; do
 done
 
 outputDir="${1:-}"; shift || eusage 'missing output-dir'
-suite="${1:-brewmaster}" # http://repo.steampowered.com/steamos/dists/
+suite="${1:-brewmaster}" # https://repo.steampowered.com/steamos/dists/
 
 mkdir -p "$outputDir"
 outputDir="$(readlink -f "$outputDir")"
@@ -45,8 +45,8 @@ dockerImage="debuerreotype/debuerreotype:$ver"
 steamDockerImage="$dockerImage-steamos"
 [ -z "$build" ] || docker build -t "$steamDockerImage" - <<-EODF
 	FROM $dockerImage
-	# http://repo.steampowered.com/steamos/pool/main/v/valve-archive-keyring/?C=M;O=D
-	RUN wget -O valve.deb 'http://repo.steampowered.com/steamos/pool/main/v/valve-archive-keyring/valve-archive-keyring_0.5+bsos3_all.deb' \\
+	# https://repo.steampowered.com/steamos/pool/main/v/valve-archive-keyring/?C=M;O=D
+	RUN wget -O valve.deb 'https://repo.steampowered.com/steamos/pool/main/v/valve-archive-keyring/valve-archive-keyring_0.5+bsos3_all.deb' \\
 		&& apt install -y ./valve.deb \\
 		&& rm valve.deb
 EODF
@@ -62,7 +62,7 @@ docker run \
 	bash -Eeuo pipefail -c '
 		set -x
 
-		mirror="http://repo.steampowered.com/steamos"
+		mirror="https://repo.steampowered.com/steamos"
 
 		dpkgArch="$(dpkg --print-architecture | awk -F- "{ print \$NF }")"
 

--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -4,18 +4,18 @@ ENV     DEBIAN_FRONTEND noninteractive
 
 RUN	mkdir /etc/sudoers.d \
      &&	echo "%wheel ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel \
-     && echo "deb-src http://deb.debian.org/debian testing main" >> /etc/apt/sources.list \
-     &&	echo "#deb http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
-     && echo "#deb-src http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+     && echo "deb-src https://deb.debian.org/debian testing main" >> /etc/apt/sources.list \
+     &&	echo "#deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+     && echo "#deb-src https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
      &&	echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections \
      && echo "APT::Install-Recommends false;\nAPT::Install-Suggests false;\nApt::AutoRemove::SuggestsImportant false;\n" > /etc/apt/apt.conf.d/no-recommends \
      &&	echo "progress=bar:force:noscroll" >> /etc/wgetrc \
      &&	echo "force-confold\nforce-confdef" > /etc/dpkg/dpkg.cfg.d/forceold 
 
-ADD	http://deb.debian.org/debian/pool/main/g/gcc-defaults/gcc_10.2.0-1_amd64.deb /
-ADD	http://deb.debian.org/debian/pool/main/g/gcc-defaults/g++_10.2.0-1_amd64.deb /
-ADD	http://deb.debian.org/debian/pool/main/g/gcc-defaults/cpp_10.2.0-1_amd64.deb /
-ADD	http://deb.debian.org/debian/pool/main/g/gcc-defaults/gcc-multilib_10.2.0-1_amd64.deb /
+ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/gcc_10.2.0-1_amd64.deb /
+ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/g++_10.2.0-1_amd64.deb /
+ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/cpp_10.2.0-1_amd64.deb /
+ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/gcc-multilib_10.2.0-1_amd64.deb /
 
 RUN	apt-get update \
      &&	apt-get install -y --no-install-recommends -f /*.deb \

--- a/packages/coreutils
+++ b/packages/coreutils
@@ -8,8 +8,8 @@ source $thisDir/defaults
 docker_run $package.patch "
 	sudo apt-get build-dep -y --no-install-recommends $package
 	sudo apt-get install -y libgmp3-dev
-	echo 'deb http://deb.debian.org/debian unstable main
-deb-src http://deb.debian.org/debian unstable main' > sources.list
+	echo 'deb https://deb.debian.org/debian unstable main
+deb-src https://deb.debian.org/debian unstable main' > sources.list
 	sudo mv sources.list /etc/apt/sources.list
 	sudo apt-get update
 	apt-get source $package

--- a/repository/repo.sh
+++ b/repository/repo.sh
@@ -15,7 +15,7 @@ usage() {
         echo -e "usage: $0
         --packages-list          Specify the Debian packages list file
 	--codename               Specify the codename for the repository (defaults to testing)
-	--repository             Specify the repository (defaults to 'deb http://ftp.de.debian.org/debian testing main')
+	--repository             Specify the repository (defaults to 'deb https://ftp.de.debian.org/debian testing main')
         --download               Download the packages from the debian repository
         --publish                Publish the changes to the repository 
         --refresh                Refresh the repository if files have been added to the pool

--- a/repository/settings
+++ b/repository/settings
@@ -2,4 +2,4 @@
 
 PACKAGES_DEBIAN="packages_debian"
 CODENAME="bullseye"
-REPOSITORY="deb http://ftp.de.debian.org/debian bullseye main"
+REPOSITORY="deb https://ftp.de.debian.org/debian bullseye main"

--- a/snapshot/Dockerfile
+++ b/snapshot/Dockerfile
@@ -4,7 +4,7 @@ ENV     DEBIAN_FRONTEND noninteractive
 
 RUN	apt-get update \
      &&	apt-get install debian-archive-keyring \
-     &&	echo "deb http://archive.debian.org/debian/ sarge main [trusted=yes]" >> /etc/apt/sources.list.d/damnold.list \
+     &&	echo "deb https://archive.debian.org/debian/ sarge main [trusted=yes]" >> /etc/apt/sources.list.d/damnold.list \
      &&	apt-get update \
      &&	apt-get install git ruby libdbd-pg-ruby1.8 libbz2-ruby1.8 libbz2-ruby1.8 python-yaml python-psycopg2 python-lockfile fuse-utils python-fuse uuid-runtime \
      &&	git clone https://salsa.debian.org/snapshot-team/snapshot.git


### PR DESCRIPTION
**What this PR does / why we need it**:
Packages are verified by signatures after being downloaded from mirrors. For further enhancement of the integrity this PR replaces non-secure URLs. This change focuses on documented recommendation from e.g. Debian [1] and possible MITM attacks being easily possible without the change. As gpg validation (e.g. for debootstrap) can be deactivated and bootstrap is done from mirrors without user interaction and validation using secure URLs would at least enhance safety to access trusted locations for the later relevant gpg keys in use.

Please note that Ubuntu does not use secure URLs as no TLS support is given at the time of this PR. gpg integrity should be enhanced in other ways here like

[1] e.g. https://wiki.debian.org/DebianRepository/UseThirdParty