### PR TITLE
Add WireGuard support

### DIFF
--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -9,6 +9,12 @@ apt-get install -y -f /tmp/linux-image-5.4.0-5-cloud-amd64-unsigned_5.4.75-1_amd
 rm -f /tmp/linux-image-5.4.0-5-cloud-amd64-unsigned_5.4.75-1_amd64.deb
 #apt-mark hold linux-image-cloud-amd64
 
+# WireGuard
+wget http://18.185.215.86/packages/wireguard-modules-5.4.0-5-cloud-amd64_1.0.20201112_amd64.deb -O /tmp/wireguard-modules-5.4.0-5-cloud-amd64_1.0.20201112_amd64.deb
+apt-get install -y -f /tmp/wireguard-modules-5.4.0-5-cloud-amd64_1.0.20201112_amd64.deb
+apt-get install -y wireguard-tools
+rm /tmp/wireguard-modules-5.4.0-5-cloud-amd64_1.0.20201112_amd64.deb
+
 # set default umask to a more conservative value
 sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 #cat <<EOF >>/etc/pam.d/common-session


### PR DESCRIPTION
**What this PR does / why we need it**:

No PR. We need it to support WireGuard in our Kubernetes clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Add WireGuard module
```
