### PR TITLE
PXE bug fixes

### DIFF
--- a/bin/.boot.pxe
+++ b/bin/.boot.pxe
@@ -3,6 +3,6 @@
 set pxeserver IPADDRESSGOESHERE 
 set pxepath PATHGOESHERE 
 
-kernel http://${pxeserver}/${pxepath}/rootfs.vmlinuz gl.url=http://${pxeserver}/root.squashfs gl.live=1 ip=dhcp console=ttyS0
-initrd http://${pxeserver}/${pxepath}/rootfs.initrd
+kernel tftp://${pxeserver}/${pxepath}/rootfs.vmlinuz gl.url=tftp://${pxeserver}/root.squashfs gl.live=1 ip=dhcp console=ttyS0
+initrd tftp://${pxeserver}/${pxepath}/rootfs.initrd
 boot

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -99,7 +99,7 @@ if [ "$pxe" -o "$pxeLocal" ]; then
 		cp "$pxeLocal/"{rootfs.initrd,rootfs.vmlinuz} "$tempDir/"
 		cp "$pxeLocal/root.squashfs" "$tempDir/"
 		cp "$thisDir/.boot.pxe" "$tempDir/boot.pxe"
-		cp "$thisDir/*.ign" "$tempDir/"
+		cp "$thisDir/*.ign" "$tempDir/" || true
 		# modify the boot.pxe to load the proper kernel and initramfs
 		sed -i "s/PATHGOESHERE//" "${tempDir}/boot.pxe" 
 		sed -i "s/IPADDRESSGOESHERE/10.0.2.2/" "${tempDir}/boot.pxe" 

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -103,7 +103,6 @@ if [ "$pxe" -o "$pxeLocal" ]; then
 		# modify the boot.pxe to load the proper kernel and initramfs
 		sed -i "s/PATHGOESHERE//" "${tempDir}/boot.pxe" 
 		sed -i "s/IPADDRESSGOESHERE/10.0.2.2/" "${tempDir}/boot.pxe" 
-		sed -i "s/http/tftp/" "${tempDir}/boot.pxe" 
 	else
 		# copy the kernel image and initramfs to be able to be booted from PXE
 		cp "$pxe/{rootfs.initrd,rootfs.vmlinuz}" "$thisDir/../hack/pxe/$rand/"

--- a/features/_pxe/exec.config
+++ b/features/_pxe/exec.config
@@ -2,18 +2,16 @@
 
 set -e
 
-wget -P /tmp http://18.185.215.86/packages/dracut-core_050+65-2_amd64.deb 
-wget -P /tmp http://18.185.215.86/packages/{dracut-network_050+65-2,dracut_050+65-2}_all.deb
-wget -P /tmp http://18.185.215.86/packages/ignition-2.7.0.tar.gz
-wget -P /tmp http://18.185.215.86/packages/dracut.tar.gz 
+wget -nv -P /tmp http://18.185.215.86/packages/dracut-core_050+65-2_amd64.deb 
+wget -nv -P /tmp http://18.185.215.86/packages/{dracut-network_050+65-2,dracut_050+65-2}_all.deb
+wget -nv -P /tmp http://18.185.215.86/packages/ignition-2.7.0.tar.gz
+wget -nv -P /tmp http://18.185.215.86/packages/dracut.tar.gz 
 
 apt-get install -y --allow-downgrades -f /tmp/*.deb
 
 cd /tmp
 tar pzxf /tmp/ignition-2.7.0.tar.gz -C /
 tar zxf /tmp/dracut.tar.gz 
-
-ls -la /
 
 cp -ar /tmp/dracut-050/modules.d/45url-lib /usr/lib/dracut/modules.d/
 cp -ar /tmp/dracut-050/modules.d/90qemu /usr/lib/dracut/modules.d/
@@ -37,7 +35,7 @@ echo "" > /etc/dracut.conf.d/11-ifcfg.conf
 
 # rebuild the initramfs
 for kernel in /boot/vmlinuz-*; do 
-   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown systemd-networkd gardenlinux-live ignition"
+   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown systemd-networkd gardenlinux-live ignition" -o "gardenlinux"
 done
 
 exit 0

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-get-squashfs.service
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-get-squashfs.service
@@ -1,11 +1,8 @@
 [Unit]
 Description=Download squashfs image
-#DefaultDependencies=false
 
-After=basic.target network-online.target
+After=basic.target network-online.target systemd-resolved.service
 Wants=network-online.target
-#After=systemd-networkd-wait-online.service network-online.target
-#After=dracut-initqueue.service
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate
@@ -13,6 +10,5 @@ OnFailureJobMode=isolate
 [Service]
 Type=oneshot
 TimeoutStartSec=600
-OOMScoreAdjust=-1000
 RemainAfterExit=yes
 ExecStart=/sbin/live-get-squashfs

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/sd-module-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/sd-module-setup.sh
@@ -34,6 +34,10 @@ install() {
         $systemdsystemunitdir/systemd-network-generator.service \
         $systemdsystemunitdir/systemd-resolved.service \
         $systemdsystemunitdir/systemd-networkd.socket \
+        $systemdsystemunitdir/network-online.target \
+        $systemdsystemunitdir/network-pre.target \
+        $systemdsystemunitdir/network.target \
+        $systemdsystemunitdir/systemd-resolved.service.d/resolvconf.conf \
         $systemdutildir/network/99-default.link \
         networkctl ip
 
@@ -55,8 +59,12 @@ install() {
 
     grep '^systemd-network:' $dracutsysrootdir/etc/passwd 2>/dev/null >> "$initdir/etc/passwd"
     grep '^systemd-network:' $dracutsysrootdir/etc/group >> "$initdir/etc/group"
+    grep '^systemd-resolve:' $dracutsysrootdir/etc/passwd 2>/dev/null >> "$initdir/etc/passwd"
+    grep '^systemd-resolve:' $dracutsysrootdir/etc/group >> "$initdir/etc/group"
     # grep '^systemd-timesync:' $dracutsysrootdir/etc/passwd 2>/dev/null >> "$initdir/etc/passwd"
     # grep '^systemd-timesync:' $dracutsysrootdir/etc/group >> "$initdir/etc/group"
+
+    ln -s /run/systemd/resolve/resolv.conf "$initdir/etc/resolv.conf" 
 
     _arch=${DRACUT_ARCH:-$(uname -m)}
     inst_libdir_file {"tls/$_arch/",tls/,"$_arch/",}"libnss_dns.so.*" \
@@ -69,9 +77,11 @@ install() {
         systemd-networkd.service \
         systemd-network-generator.service \
         systemd-resolved.service \
-        systemd-networkd.socket
 #       systemd-timesyncd.service
     do
         systemctl -q --root "$initdir" enable "$i"
     done
+
+    # resolved - name resolution in dracut
+    systemctl -q --root "$initdir" add-wants network-online.target systemd-resolved.service
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Omit gardenlinux dracut module if included by other feature(s) when live booting.
Properly start systemd-resolved in dracut.