### PR TITLE
PXE verify hash of squashfs

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
@@ -11,7 +11,7 @@ depends() {
 
 install() {
     #inst_multiple grep sfdisk growpart udevadm awk mawk sed rm readlink
-    inst_multiple curl grep sfdisk awk mawk file
+    inst_multiple curl grep sfdisk awk mawk file sha256sum
    
     inst_simple "$moddir/live-get-squashfs.service" ${systemdsystemunitdir}/live-get-squashfs.service
     inst_script "$moddir/live-get-squashfs.sh" /sbin/live-get-squashfs

--- a/features/_pxe/image
+++ b/features/_pxe/image
@@ -11,11 +11,8 @@ cp "$rootfs/boot/"vmlinuz* "$targetBase.vmlinuz"
 cp "$rootfs/boot/"initrd* "$targetBase.initrd"
 
 # create the squashfs to include the fully generate image, excluding /boot of course as it's not needed
-mksquashfs "$rootfs" "$targetBaseDir/root.squashfs" -e boot
+mksquashfs "$rootfs" "$targetBaseDir/root.squashfs" -e boot -comp xz
 
-# create a cpio archive from the squashfs and append to the initramfs
-# (cd "$targetBaseDir"; echo -e ".\n./live\n./live/root.squashfs" | cpio -H newc -o | gzip -9 >> rootfs.initrd)
+(cd "$targetBaseDir"; sha256sum root.squashfs | awk '{ print $1 }' > root.squashfs.sha256sum)
 
-# clean-up
-# rm -rf "$targetBaseDir/live"
-# rm -rf "$targetBaseDir/root.squashfs"
+(cd "$targetBaseDir"; echo -e "root.squashfs.sha256sum" | cpio -H newc -o | xz --check=crc32 >> rootfs.initrd) 


### PR DESCRIPTION
**What this PR does / why we need it**:
Calculate the hash of the squashfs, "bake" it into the initrd so that it can be verified while PXE booting.