### PR TITLE
Reproducibility fixes

### DIFF
--- a/features/_pxe/exec.config
+++ b/features/_pxe/exec.config
@@ -35,7 +35,7 @@ echo "" > /etc/dracut.conf.d/11-ifcfg.conf
 
 # rebuild the initramfs
 for kernel in /boot/vmlinuz-*; do 
-   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown systemd-networkd gardenlinux-live ignition" -o "gardenlinux"
+   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown systemd-networkd gardenlinux-live ignition" -o "gardenlinux" --reproducible
 done
 
 exit 0

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -24,9 +24,13 @@ sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 pam-auth-update --remove cracklib
 pam-auth-update --enable garden
 
+# /etc/iscsi/initiatorname.iscsi is breaking the reproducibility - reverting to GenerateName=yes so that the iqn gets generated on daemon start
+# will be generated only once
+echo "GenerateName=yes" > /etc/iscsi/initiatorname.iscsi
+
 systemctl disable iscsid
 systemctl disable open-iscsi
 
 for kernel in /boot/vmlinuz-*; do 
-   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"
+   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown" --reproducible
 done

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -35,3 +35,5 @@ apt-get autoremove --purge -y libdb5.3
 chmod u-s /sbin/mount.nfs /sbin/mount.cifs /bin/umount /bin/mount
 chmod g-w / /etc/hosts
 
+# remove python's __pycache__
+find /usr/lib -type d -name __pycache__ -exec rm -rf {} +

--- a/features/server/file.include/etc/dracut.conf.d/general.conf
+++ b/features/server/file.include/etc/dracut.conf.d/general.conf
@@ -1,2 +1,3 @@
 do_strip="no"
 compress="xz"
+reproducible="yes"


### PR DESCRIPTION
**What this PR does / why we need it**:
Reproducibility was/is broken for multiple reasons:

1. timestamps of files included in the initramfs
timestamps will be based on dracut-functions.sh which is coming from the dracut packages

2. /etc/iscsi/initiatorname.iscsi containing an ID generated on first start
reverting to GenerateName=yes - iqn will be generated on first daemon start and once set it won't be regenerated

3. remove __pycache__ from /usr/lib/python3.8 
generation of .pyc files is not reproducible - step takes place in the post install step of the python3.8 package

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

