### PR TITLE
repositories - remove https for repos that don't have it

### DIFF
--- a/bin/garden-debian-sources-list
+++ b/bin/garden-debian-sources-list
@@ -45,16 +45,16 @@ else
 	snapshotStandardMirrors=( "$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-ports')" )
 fi
 
-securityMirror='https://security.debian.org/debian-security'
+securityMirror='http://security.debian.org/debian-security'
 snapshotSecurityMirrors=( "$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-security')" )
 
 if [ -n "$eol" ]; then
 	archiveSnapshotMirror="$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-archive')"
 
-	standardMirror='https://archive.debian.org/debian'
+	standardMirror='http://archive.debian.org/debian'
 	snapshotStandardMirrors=( "$archiveSnapshotMirror/debian" "${snapshotStandardMirrors[@]}" )
 
-	securityMirror='https://archive.debian.org/debian-security'
+	securityMirror='http://archive.debian.org/debian-security'
 	snapshotSecurityMirrors=( "$archiveSnapshotMirror/debian-security" "${snapshotSecurityMirrors[@]}" )
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The following repositories security.debian.org/debian-security and archive.debian.org/security and archive.debian.org/debian-security don't provide https access.

**Which issue(s) this PR fixes**:
Fixes #