### PR TITLE
Tests - skip tests when building

### DIFF
--- a/bin/garden-build.sh
+++ b/bin/garden-build.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
-	--flags 'no-build,debug,suite:,gardenversion:,timestamp:' \
+	--flags 'no-build,debug,skip-tests,suite:,gardenversion:,timestamp:' \
 	--flags 'eol,ports,arch:,qemu,features:,commitid:' \
 	--flags 'suffix:,prefix:' \
 	--
@@ -28,6 +28,7 @@ while true; do
 		--suffix) suffix="$1"; shift ;; # target name prefix
 		--prefix) prefix="$1"; shift ;; # target name suffix
 		--commitid) commitid="$1"; shift ;; # build commit hash
+		--skip-tests) notests=1 shift ;; # skip tests
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -264,7 +265,10 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 		testcounter=0
 		failcounter=0
 		for i in $(echo "base,$features" | tr ',' ' ' | sort -u); do
-			if [ -d $featureDir/$i/test ]; then
+			if [ "$notests" = 1 ]; then
+				echo "skipping tests for $i feature"
+				continue
+			elif [ -d $featureDir/$i/test ]; then
 				for j in $(ls $featureDir/$i/test); do
 					if [ -x $featureDir/$i/test/$j ]; then
 					        let "testcounter=testcounter+1"

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,10 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/bin/.constants.sh" \
-	--flags 'no-build,debug,lessram,manual' \
+	--flags 'no-build,debug,lessram,manual,skip-tests' \
 	--flags 'arch:,qemu,features:,suite:,ports' \
 	-- \
-	'[--no-build] [--lessram] [--debug] [--manual] [--arch=<arch>] [--qemu] <output-dir> <version/timestamp>' \
+	'[--no-build] [--lessram] [--debug] [--manual] [--arch=<arch>] [--qemu] [--skip-tests] <output-dir> <version/timestamp>' \
 	'output stretch 2017-05-08T00:00:00Z
 --eol output squeeze 2016-03-14T00:00:00Z
 --eol --arch i386 output sarge 2016-03-14T00:00:00Z' 
@@ -21,6 +21,7 @@ qemu=
 features=
 suite="bullseye"
 suiteports=
+notests=0
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
@@ -33,7 +34,8 @@ while true; do
 		--qemu) 	qemu=1 ;;	# for using "qemu-debootstrap" and "start-vm"
 		--features) 	features="$1"; shift ;; # adding featurelist
 		--suite) 	suite="$1"; shift ;; # adding suite
-		--ports)        suiteports=1 ;;      # enables "debian-ports" support for suite
+		--ports)        suiteports=1 ; shift ;;      # enables "debian-ports" support for suite
+		--skip-tests)   notests=1 ;;    # skip running tests 
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -56,6 +58,7 @@ envArgs=(
 	arch="$arch" 
 	features="$features"
 	version="$version"
+	notests="$notests"
 )
 
 securityArgs=( 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add --skip-tests flag to skip running the tests when building.
