### PR TITLE
Small PAM and test improvements

### DIFF
--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -19,9 +19,10 @@ sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 # Allow umask to be changed
 #session optional pam_umask.so
 #EOF
+
 pam-auth-update --remove cracklib
-pam-auth-update --enable garden
-pam-auth-update --enable garden-extra
+rm -f /usr/share/pam-configs/cracklib
+pam-auth-update
 
 for kernel in /boot/vmlinuz-*; do 
    dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown" --reproducible

--- a/features/cloud/file.include/usr/share/pam-configs/garden-extra
+++ b/features/cloud/file.include/usr/share/pam-configs/garden-extra
@@ -1,7 +1,6 @@
 Name: Garden Linux pam policies faillock
 Default: yes
 Priority: 128
-Depends: garden
 Auth-Type: Primary
 Auth:
 	[default=die] pam_faillock.so authfail silent audit deny=5 unlock_time=900

--- a/features/server/test/debsums_exclude.list
+++ b/features/server/test/debsums_exclude.list
@@ -1,1 +1,2 @@
 /lib/systemd/system/dbus.socket
+/usr/share/pam-configs/cracklib

--- a/features/server/test/dev
+++ b/features/server/test/dev
@@ -24,13 +24,13 @@ if ! check_rootdir "${rootfsDir}"; then
 fi
 
 echo "testing /dev contents"
-nr_files=$(wc -l ${thisDir}/dev_files | cut -d " " -f 1)
+nr_files=$(grep -v "^#" ${thisDir}/dev_files | wc -l | cut -d " " -f 1)
 nr_dev=$(shopt -s nullglob dotglob; f=(${rootfsDir}/dev/*); echo ${#f[@]})
 
 # check if the number of files in /dev is the same as in dev_files
 if [[ "$nr_files" -ne "$nr_dev" ]]; then
 	echo "FAIL -  number of dev files do not match!"
-	echo "        expects: $(awk -F, '{ printf "%s ",$1}' ${thisDir}/dev_files)"
+	echo "        expects: $(awk -F, '!/^#/{ printf "%s ",$1}' ${thisDir}/dev_files)"
 	echo "        got:     $(echo ${rootfsDir}/dev/* | tr ' ' '\n' | xargs -L 1 basename | tr '\n' ' ')"  
 	rc=1
 	exit 1
@@ -50,7 +50,7 @@ while read -r line; do
 		echo "       expects: ${line}"
 		echo "       got:     ${to_test}"
 	fi
-done < ${thisDir}/dev_files
+done <<< $(grep -v "^#" ${thisDir}/dev_files)
 
 if [[ "$rc" -eq 0 ]]; then
 	echo "OK - all /dev devices match"

--- a/features/server/test/dev_files
+++ b/features/server/test/dev_files
@@ -1,8 +1,8 @@
 console,0,0,character special file,5,1,console
 fd,0,0,symbolic link,0,0,/proc/self/fd
 full,0,0,character special file,1,7,full
-mapper,0,0,directory,0,0,mapper
 null,0,0,character special file,1,3,null
+#mapper,0,0,directory,0,0,mapper
 ptmx,0,0,character special file,5,2,ptmx
 pts,0,0,directory,0,0,pts
 random,0,0,character special file,1,8,random

--- a/features/server/test/password_hashes
+++ b/features/server/test/password_hashes
@@ -12,10 +12,13 @@ source "${thisDir}/helpers"
 
 check_rootdir "${rootfsDir}" || exit 1
 
-if grep -qP '^password\s+\[\s?success=1\s+default=ignore\s?]\s+pam_unix\.so\s+obscure\s+use_authtok\s+try_first_pass\s+sha512\s?$' "${rootfsDir}/etc/pam.d/common-password"; then
-       echo "OK - password hashes as expected"       
+if grep -qP '^password\s+\[\s?success=1\s+default=ignore\]\s+pam_unix.so\s+obscure\s+sha512\s?$' "${rootfsDir}/etc/pam.d/common-password"; then
+       echo "OK - password hashes as expected - sha512"       
        exit 0
+elif grep -qP '^password\s+\[\s?success=1\s+default=ignore\]\s+pam_unix.so\s+obscure\s+use_authtok\s+try_first_pass\s+yescrypt\s?$' "${rootfsDir}/etc/pam.d/common-password"; then
+	echo "OK - password hashes as expected - yesscrypt"
+	exit 0
 else
-	echo "FAIL - password hashes do not default to sha512"
+	echo "FAIL - password hashes do not default to sha512 or yesscrypt"
 	exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Add test for yescrypt password hashes.
Improve dev test from server feature.
Remove /usr/share/pam-configs/cracklib to remove any warnings.
