### PR TITLE
Set correct clocksource for aws according to hypervisor

### DIFF
--- a/features/aws/file.include/usr/lib/dracut/modules.d/98gardenlinux/clocksource-setup.sh
+++ b/features/aws/file.include/usr/lib/dracut/modules.d/98gardenlinux/clocksource-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if grep -q "clocksource=" /proc/cmdline; then
+        exit 0
+fi
+
+hypervisor=$(systemd-detect-virt)
+available_clock_sources=$(cat /sys/devices/system/clocksource/clocksource0/available_clocksource)
+case $hypervisor in
+kvm)
+ if [[ "$available_clock_sources" =~ "kvm-clock" ]] ; then
+   echo "Detected hypervisor KVM, setting clocksource kvm-clock" | systemd-cat -p info -t clocksource-setup
+   echo kvm-clock > /sys/devices/system/clocksource/clocksource0/current_clocksource
+ fi
+ ;;
+xen)
+ if [[ "$available_clock_sources" =~ "tsc" ]] ; then
+   echo "Detected hypervisor XEN, setting clocksource tsc" | systemd-cat -p info -t clocksource-setup
+   echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource
+ fi
+ ;;
+esac
+

--- a/features/cloud/file.include/usr/lib/dracut/modules.d/98gardenlinux/module-setup.sh
+++ b/features/cloud/file.include/usr/lib/dracut/modules.d/98gardenlinux/module-setup.sh
@@ -11,7 +11,7 @@ depends() {
 }
 
 install() {
-    inst_multiple grep sfdisk growpart udevadm awk mawk sed rm readlink
+    inst_multiple grep sfdisk growpart udevadm awk mawk sed rm readlink systemd-detect-virt systemd-cat
    
     # grow root
     if [ -f "$moddir/growroot.sh" ]; then
@@ -27,5 +27,8 @@ install() {
         systemctl -q --root "$initdir" add-wants initrd-fs.target usr-mount.service
         systemctl -q --root "$initdir" add-wants initrd-fs.target sysroot-usr-fsck.service 
         systemctl -q --root "$initdir" add-wants initrd-fs.target sysroot-usr.mount 
+    fi
+    if [ -f "$moddir/clocksource-setup.sh" ]; then
+        inst_hook pre-pivot 00 "$moddir/clocksource-setup.sh"
     fi
 }


### PR DESCRIPTION
This is according to https://aws.amazon.com/de/premiumsupport/knowledge-center/manage-ec2-linux-clock-source/#:~:text=The%20recommended%20clock%20source%20for,Nitro%20Hypervisor%20is%20kvm%2Dclock

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind enhancement
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
set correct clocksource on AWS according to hypervisor
```
