### PR TITLE
Change Docker cgroup driver back to cgroupfs

### DIFF
--- a/features/gardener/file.include/etc/docker/daemon.json
+++ b/features/gardener/file.include/etc/docker/daemon.json
@@ -1,5 +1,6 @@
 { "live-restore": true,
   "storage-driver": "overlay2",
+  "exec-opts": ["native.cgroupdriver=cgroupfs"],
   "default-ulimits": {
       "memlock": {
           "name": "memlock",


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind TODO
/area os
/os garden-linux
/priority high

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Docker 20 has changed the default cgroup driver to systemd which
breaks the kubelet. This commit is chaning this back to cgroupfs.
```
