### PR TITLE
Fix openssl CVE-2021-23841 plus minor housekeeping

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest (release version will be `<epoch>.0` (e.g. 42.0))
-318.3
+318.4

--- a/bin/makef.sh
+++ b/bin/makef.sh
@@ -224,13 +224,14 @@ mv ${dir_name}/etc/grub.d/30_uefi-firmware~ ${dir_name}/etc/grub.d/30_uefi-firmw
 
 echo "### unmouting"
 umount -R ${dir_name}
-tune2fs -Q usrquota,grpquota,prjquota ${loopback}p4
-sync
 
 echo "### final fsck, just to be sure"
 fsck.vfat -f -a ${loopback}p2
 fsckExt4  ${loopback}p3
 fsckExt4  ${loopback}p4
+sync
+
+tune2fs -Q usrquota,grpquota,prjquota ${loopback}p4
 sync
 
 losetup -d $loopback

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -2,13 +2,13 @@
 
 #chown -R root.root /etc/initramfs-tools
 #update-initramfs -u
-wget -P /tmp http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/{linux-image-cloud-amd64_5.4.93-1,linux-image-5.4.0-6-cloud-amd64_5.4.93-1}_amd64.deb
+wget --quiet -P /tmp http://45.86.152.1/gardenlinux/pool/main/l/linux-signed-amd64/{linux-image-cloud-amd64_5.4.93-1,linux-image-5.4.0-6-cloud-amd64_5.4.93-1}_amd64.deb
 apt-get install -y -f /tmp/linux-image-5.4.0-6-cloud-amd64_5.4.93-1_amd64.deb /tmp/linux-image-cloud-amd64_5.4.93-1_amd64.deb
 rm -f /tmp/linux-image-5.4.0-6-cloud-amd64_5.4.93-1_amd64.deb /tmp/linux-image-cloud-amd64_5.4.93-1_amd64.deb
 apt-mark hold linux-image-cloud-amd64
 
 # WireGuard
-wget http://45.86.152.1/gardenlinux/pool/main/w/wireguard/wireguard-modules-5.4.0-6-cloud-amd64_1.0.20210124_amd64.deb -O /tmp/wireguard-modules-5.4.0-6-cloud-amd64_1.0.20210124_amd64.deb
+wget --quiet http://45.86.152.1/gardenlinux/pool/main/w/wireguard/wireguard-modules-5.4.0-6-cloud-amd64_1.0.20210124_amd64.deb -O /tmp/wireguard-modules-5.4.0-6-cloud-amd64_1.0.20210124_amd64.deb
 apt-get install -y -f /tmp/wireguard-modules-5.4.0-6-cloud-amd64_1.0.20210124_amd64.deb
 apt-get install -y wireguard-tools
 rm /tmp/wireguard-modules-5.4.0-6-cloud-amd64_1.0.20210124_amd64.deb

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -18,7 +18,7 @@ sed -i "s/#RuntimeWatchdogSec=0/RuntimeWatchdogSec=20s/g" /etc/systemd/system.co
 chmod 0440 /etc/sudoers.d/wheel
 
 # removing berkelydb
-wget -P /tmp http://45.86.152.1/gardenlinux/pool/main/{i/iproute2/iproute2_5.10.0-3.1,p/pam/libpam-modules-bin_1.4.0-4.1,p/pam/libpam-modules_1.4.0-4.1,p/pam/libpam-cracklib_1.4.0-4.1,p/pam/libpam0g_1.4.0-4.1,c/cyrus-sasl2/libsasl2-modules-db_2.1.27+dfsg-2.1,c/cyrus-sasl2/libsasl2-2_2.1.27+dfsg-2.1,p/python3.9/python3.9_3.9.1-4.1,p/python3.9/python3.9-minimal_3.9.1-4.1,p/python3.9/libpython3.9-minimal_3.9.1-4.1,p/python3.9/libpython3.9-stdlib_3.9.1-4.1,d/dracut/dracut-core_051-1.1}_amd64.deb http://45.86.152.1/gardenlinux/pool/main/{d/dracut/dracut_051-1.1,p/pam/libpam-runtime_1.4.0-4.1}_all.deb
+wget --quiet -P /tmp http://45.86.152.1/gardenlinux/pool/main/{i/iproute2/iproute2_5.10.0-3.1,p/pam/libpam-modules-bin_1.4.0-4.1,p/pam/libpam-modules_1.4.0-4.1,p/pam/libpam-cracklib_1.4.0-4.1,p/pam/libpam0g_1.4.0-4.1,c/cyrus-sasl2/libsasl2-modules-db_2.1.27+dfsg-2.1,c/cyrus-sasl2/libsasl2-2_2.1.27+dfsg-2.1,p/python3.9/python3.9_3.9.1-4.1,p/python3.9/python3.9-minimal_3.9.1-4.1,p/python3.9/libpython3.9-minimal_3.9.1-4.1,p/python3.9/libpython3.9-stdlib_3.9.1-4.1,d/dracut/dracut-core_051-1.1}_amd64.deb http://45.86.152.1/gardenlinux/pool/main/{d/dracut/dracut_051-1.1,p/pam/libpam-runtime_1.4.0-4.1}_all.deb
 
 apt-get install -y --allow-downgrades -f /tmp/libpam-modules-bin_1.4.0-4.1_amd64.deb /tmp/libpam-modules_1.4.0-4.1_amd64.deb /tmp/libpam-cracklib_1.4.0-4.1_amd64.deb /tmp/libpam0g_1.4.0-4.1_amd64.deb /tmp/libpam-runtime_1.4.0-4.1_all.deb
 apt-get install -y --allow-downgrades -f /tmp/iproute2_5.10.0-3.1_amd64.deb
@@ -36,3 +36,8 @@ chmod g-w / /etc/hosts
 
 # remove python's __pycache__
 find /usr/lib -type d -name __pycache__ -exec rm -rf {} +
+
+# CVE CVE-2021-23841
+wget --quiet -P /tmp http://snapshot-cache.ci.gardener.cloud/archive/debian/20210217T023442Z/pool/main/o/openssl/openssl_1.1.1j-1_amd64.deb
+apt-get install -y -f /tmp/openssl_1.1.1j-1_amd64.deb
+rm /tmp/openssl_1.1.1j-1_amd64.deb

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -27,3 +27,4 @@ less
 tcpdump
 vim-tiny
 quota
+netcat


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind security
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:
- Add openssl 1.1.1j-1 which resolves above mentioned CVE.
- quiet several uses of wget in scripts to reduce log cluttering
- add package netcat
**Which issue(s) this PR fixes**:
Fixes CVE-2021-23841 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix openssl CVE-2021-23841 
```
