### PR TITLE
Downgrade cloud-init for AliCloud

### DIFF
--- a/features/ali/exec.config
+++ b/features/ali/exec.config
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash 
 
+# Workaround for https://bugs.launchpad.net/cloud-init/+bug/1917875 in 20.4.1
+wget --quiet http://ftp.de.debian.org/debian/pool/main/c/cloud-init/cloud-init_20.2-2~deb10u1_all.deb -O /tmp/cloud-init_20.2-2~deb10u1_all.deb
+apt-get install -y --allow-downgrades -f /tmp/cloud-init_20.2-2~deb10u1_all.deb
+rm /tmp/cloud-init_20.2-2~deb10u1_all.deb
+
 # Ali DNS does not support DNSSEC
 sed -i 's/^#DNSSEC=allow-downgrade/DNSSEC=false/g' /etc/systemd/resolved.conf
 
@@ -7,3 +12,4 @@ sed -i 's/^#DNSSEC=allow-downgrade/DNSSEC=false/g' /etc/systemd/resolved.conf
 mv /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak
 cat /etc/cloud/cloud.cfg.bak | grep -v "^ - growpart$" | grep -v "^ - resizefs$" | grep -v "^ - ntp$" >/etc/cloud/cloud.cfg  
 rm /etc/cloud/cloud.cfg.bak
+

--- a/flavours.yaml
+++ b/flavours.yaml
@@ -3,20 +3,8 @@ flavour_sets:
   - name: 'all'
     flavour_combinations:
       - architectures: [ 'amd64' ]
-        platforms: [ metal ]
-        modifiers: [ [ gardener, _prod ] , [ chost, _prod ] , [ vhost, _prod ], [] ]
-        fails: [ unit, integration ]
-      - architectures: [ 'amd64' ]
-        modifiers: [ [], [ '_build' ] ]
-        platforms: [ oci ]
-        fails: [ unit, integration ]
-      - architectures: [ 'amd64' ]
-        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
+        platforms: [ ali ]
         modifiers: [ [ gardener, _prod ] ]
-        fails: [ unit, integration ]
-      - architectures: [ 'amd64' ]
-        platforms: [ kvm ]
-        modifiers: [ [], ['_prod', 'chost'], ['_prod', 'gardener'] ]
         fails: [ unit, integration ]
   - name: 'testing'
     flavour_combinations:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind bug
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

Downgrade cloud-init from 20.4 to 20.2 due to a bug in cloud-init on alicloud. The cloud-init bug has been reported: 
https://bugs.launchpad.net/cloud-init/+bug/1917875. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Downgrade cloud-init from 20.4 to 20.2 due to a bug in cloud-init on alicloud. cloud-init downgrade is only for alicloud.
```
