### PR TITLE
Configure recipients for azure publishing-notifications

### DIFF
--- a/ci/cicd.yaml
+++ b/ci/cicd.yaml
@@ -19,6 +19,7 @@ cicd_cfgs:
         plan_id: 'greatest'
         service_principal_cfg_name: 'shoot-operator-dev'
         storage_account_cfg_name: 'gardenlinux-dev'
+        notification_emails: [andreas.burger@sap.com, dominic.kistner@sap.com]
       openstack:
         environment_cfg_name: 'gardenlinux'
         image_properties_cfg_name: 'gardenlinux'

--- a/ci/glci/az.py
+++ b/ci/glci/az.py
@@ -5,6 +5,7 @@ from datetime import (
 )
 from enum import Enum
 import logging
+import typing
 
 import requests
 import version
@@ -467,6 +468,7 @@ def upload_and_publish_image(
     storage_account_cfg: glci.model.AzureStorageAccountCfg,
     marketplace_cfg: glci.model.AzureMarketplaceCfg,
     release: glci.model.OnlineReleaseManifest,
+    notification_emails: typing.List[str]
 ) -> glci.model.OnlineReleaseManifest:
     '''Copies an image from S3 to an Azure Storage Account, updates the corresponding
     Azure Marketplace offering and publish the offering.
@@ -491,7 +493,7 @@ def upload_and_publish_image(
         marketplace_cfg=marketplace_cfg,
         image_version=azure_version,
         image_url=image_url,
-        notification_recipients=(), # TODO Mail receipants
+        notification_recipients=notification_emails,
     )
 
     published_image = glci.model.AzurePublishedImage(

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -505,6 +505,7 @@ class AzurePublishCfg:
     plan_id: str
     service_principal_cfg_name: str
     storage_account_cfg_name: str
+    notification_emails: typing.List[str]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/ci/promote.py
+++ b/ci/promote.py
@@ -188,6 +188,7 @@ def _publish_azure_image(release: glci.model.OnlineReleaseManifest,
         storage_account_cfg=storage_account_cfg_serialized,
         marketplace_cfg=azure_marketplace_cfg,
         release=release,
+        notification_emails=cicd_cfg.publish.azure.notification_emails,
     )
 
 


### PR DESCRIPTION
In our most recent round of publishing we've received an error from Azure that indicates that a list of email-recipients to notify on status updates is missing.
This PR adds the config and passes it through to the azure build.