### PR TITLE
add default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ AWS_DISTRIBUTE=
 BUILDDIR=.build
 MAINTAINER_EMAIL="contact@gardenlinux.io"
 
+all: all_dev all_prod
+
 cert/sign.pub:
 	make --directory=cert MAINTAINER_EMAIL=$(MAINTAINER_EMAIL)
 	@gpg --list-secret-keys $(MAINTAINER_EMAIL) > /dev/null || echo "No secret key for $(MAINTAINER_EMAIL) exists, signing disabled" 
@@ -14,8 +16,6 @@ cert/sign.pub:
 .PHONY: docker
 docker:
 	make --directory=docker build-image
-
-all: all_dev all_prod
 
 all_prod: ali aws gcp azure openstack vmware kvm
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind cleanup
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

If i just run `make`, I get:

```
mbanck@lightning:~/hacking/git/gardenlinux$ make
make: 'cert/sign.pub' is up to date.
```

This PR moves the `all` target to be the first Makefile target, so instead then I get:

```
mbanck@lightning:~/hacking/git/gardenlinux$ make
make --directory=docker build-image
make[1]: Entering directory '/home/mbanck/hacking/git/gardenlinux/docker'
WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:latest!

Please run 'make slim' to fix
Sending build context to Docker daemon  4.608kB
Step 1/12 : FROM        gcr.io/kaniko-project/executor:latest as kaniko
[...]
```
**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add default make target
```
