### PR TITLE
tests - allow for uninitialized machine-id

### DIFF
--- a/features/server/test/machine_id
+++ b/features/server/test/machine_id
@@ -22,9 +22,18 @@ fi
 
 echo "checking the machine-id"
 
-if [[ -f ${rootfsDir}/etc/machine-id && ! -s ${rootfsDir}/etc/machine-id ]]; then
-	echo "OK - machine-id is as expected"
-	rc=0
+if [[ -f ${rootfsDir}/etc/machine-id ]]; then
+	if [[ ! -s ${rootfsDir}/etc/machine-id ]]; then
+		echo "OK - machine-id is as expected (blank)"
+		rc=0
+	elif [[ $(cat ${rootfsDir}/etc/machine-id) == "uninitialized" ]]; then
+		echo "OK - machine-id is as expected (uninitialized)"
+		rc=0
+	else	
+		echo "FAIL - machine-id is not blank or \"uninitialized\""
+		rc=1
+	fi
+
 else
 	echo "FAIL - machine-id doesn't exist or is not empty!"
 	rc=1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind TODO
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
