### PR TITLE
import gardenlinux key before building packages

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -54,7 +54,7 @@ pipeline: docker sign
 		--env BUILDIMAGE=$(BUILDIMAGE) \
 		--env DEBFULLNAME=$(DEBFULLNAME) \
 		--env DEBEMAIL=$(DEBEMAIL) \
-		$(BUILDIMAGE) make
+		$(BUILDIMAGE) bash -c "gpg --import /sign.pub; make"
 manual-kernel: docker-kernel
 	docker run --rm -ti --volume "$(POOLDIR)":/pool --volume "$(KERNELDIR)":/home/dev/manual \
 	       	--env BUILDTARGET="$(POOLDIR)" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area os
    /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind bug
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

This makes the default Makefile target in the `packages` subdirectory import the gardenlinux key before package build, so that the packages can be signed with it and the package building process does not error out.

**Which issue(s) this PR fixes**:

Fixes #234

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
