### PR TITLE
add support for a second mirror that serves gardlinux-specific packages.

### DIFF
--- a/bin/.snapshot-url.sh
+++ b/bin/.snapshot-url.sh
@@ -17,23 +17,26 @@ while true; do
 done
 
 timestamp="${1:-}"; shift || eusage 'missing timestamp'
-archive="${1:-debian}"
+archive="${1:-debian}"; shift || true
+base="${1:-archive}"
 
 t="$(date --date "$timestamp" '+%Y%m%dT%H%M%SZ')"
 
 # use caching proxy to avoid throttling, if available
-if wget -t1 -qO/dev/null http://localhost/archive/$archive/; then
-	echo "http://localhost/archive/$archive/$t"
-elif wget -t1 -qO/dev/null http://172.17.0.1/archive/$archive/; then
-	echo "http://172.17.0.1/archive/$archive/$t"
-elif wget -t1 -qO/dev/null http://192.168.10.1/gardenlinux/archive/$archive/; then
-	echo "http://192.168.10.1/gardenlinux/archive/$archive/$t"
+if wget -t1 -qO/dev/null http://localhost/$base/$archive/; then
+	echo "http://localhost/$base/$archive/$t"
+elif wget -t1 -qO/dev/null http://172.17.0.1/$base/$archive/; then
+	echo "http://172.17.0.1/$base/$archive/$t"
 #elif wget -t1 -qO/dev/null http://repo.gardenlinux.io/gardenlinux/archive/$archive/; then
 #	echo "http://repo.gardenlinux.io/gardenlinux/archive/$archive/$t"
-elif wget -t1 -qO/dev/null http://45.86.152.1/gardenlinux/archive/$archive/; then
-	echo "http://45.86.152.1/gardenlinux/archive/$archive/$t"
-elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/archive/$archive/; then
-	echo "https://snapshot-cache.ci.gardener.cloud/archive/$archive/$t"
+# this is for the snapshot cache ($base = archive)
+elif wget -t1 -qO/dev/null http://45.86.152.1/gardenlinux/$base/$archive/; then
+	echo "http://45.86.152.1/gardenlinux/$base/$archive/$t"
+# this is for the gardenlinux-local packages ($base = gardenlinux/)
+elif wget -t1 -qO/dev/null http://45.86.152.1/$base/; then
+	echo "http://45.86.152.1/$base/"
+elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/$base/$archive/; then
+	echo "https://snapshot-cache.ci.gardener.cloud/$base/$archive/$t"
 else
-	echo "https://snapshot.debian.org/archive/$archive/$t"
+	echo "https://snapshot.debian.org/$base/$archive/$t"
 fi

--- a/bin/garden-init
+++ b/bin/garden-init
@@ -98,8 +98,16 @@ if [ -z "$nonDebian" ]; then
 	fi
 fi
 
+# setup mirror_pool, i.e. the archive where the gardenlinux-local packages are kept
 mirror_host="$(sed "s/^\(.*\/\/[^\/]*\)\/.*/\1/" <<< $mirror)"
 mirror_pool="${mirror_host}/gardenlinux/pool/"
+
+if ! wget -t1 -qO/dev/null ${mirror_pool}; then
+	# there are gardenlinux-local packages on the main snapshot mirror, try
+	# snapshot-url.sh again for a gardenlinux-specific one
+	mirror_host=$("$thisDir/.snapshot-url.sh" "@$epoch" "gardenlinux" "gardenlinux" | sed "s/^\(.*\/\/[^\/]*\)\/.*/\1/")
+	mirror_pool="${mirror_host}/gardenlinux/pool/"
+fi
 
 #featurelist=$(getFeatures $features)
 [ "$features" = "full" ] && features=$(ls $featureDir | paste -sd, -)


### PR DESCRIPTION
This adds support for a "gardenlinux" archive base in snapshot-url, as well as
a check in garden-init whether the gardenlinux-specific packages are present in
the selected snapshot mirror. If they are not, the new above "gardenlinux"
archive base is queried via snapshot-url and this one used instead.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind enhancement
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #237

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
