### PR TITLE
Overwrite waagent config after it is installed

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf
-
 wget --quiet -P /tmp http://45.86.152.1/gardenlinux/pool/main/w/waagent_2.2.47-2.2_all.deb
 apt-get install -y -f /tmp/waagent_2.2.47-2.2_all.deb
 rm /tmp/waagent_2.2.47-2.2_all.deb
+
+sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind bug
/area os
/os garden-linux
/priority 5

**What this PR does / why we need it**:
Overwrite waagent config after it is installed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
[Azure] Fix a bug that prevented the `waagent` to execute the user data of the VM.
```
