### PR TITLE
[rel-318] Automated cherry pick of #243: Overwrite waagent config after it is installed

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf
-
 wget --quiet -P /tmp http://45.86.152.1/gardenlinux/pool/main/w/waagent_2.2.47-2.2_all.deb
 apt-get install -y -f /tmp/waagent_2.2.47-2.2_all.deb
 rm /tmp/waagent_2.2.47-2.2_all.deb
+
+sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf


### PR DESCRIPTION
Cherry pick of #243 on rel-318.

#243: Overwrite waagent config after it is installed

**Release Notes:**
```bugfix user
[Azure] Fix a bug that prevented the `waagent` to execute the user data of the VM.
```