### PR TITLE
PXE - set DefaultDependencies to no

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-get-squashfs.service
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-get-squashfs.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Download squashfs image
 
-After=basic.target network-online.target systemd-resolved.service
+After=network-online.target 
 Wants=network-online.target
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate
+DefaultDependencies=no
 
 [Service]
 Type=oneshot

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-overlay-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-overlay-setup.sh
@@ -32,7 +32,7 @@ if echo "$ovlconf" | grep -q '^/:\|,/:'; then
 		echo "[Unit]
 		Before=sysroot.mount
 		After=ignition-disks.service
-		DefaultDependencies=false
+		DefaultDependencies=no
 		Requires=systemd-fsck@${devescape}
 		After=systemd-fsck@${devescape}
 
@@ -50,7 +50,7 @@ if echo "$ovlconf" | grep -q '^/:\|,/:'; then
 	After=run-sysroot.ovl.mount
 	After=ignition-disks.service
 	Before=sysroot.mount
-	DefaultDependencies=false
+	DefaultDependencies=no
 
 	[Service]
 	Type=oneshot
@@ -63,7 +63,7 @@ if echo "$ovlconf" | grep -q '^/:\|,/:'; then
 	After=run-rootfs.mount
 	After=ignition-disks.service
 	After=create-mountpoints.service
-	DefaultDependencies=false
+	DefaultDependencies=no
 	Description=sysroot.mount
 	[Mount]
 	What=ovl_sysroot

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-sysroot-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-sysroot-generator.sh
@@ -18,9 +18,9 @@ GENERATOR_DIR="$1"
 
 cat >"${GENERATOR_DIR}/sysroot.mount" <<EOF
 [Unit]
-DefaultDependencies=false
 After=live-get-squashfs.service
 Before=initrd-root-fs.target
+DefaultDependencies=no
 
 [Mount]
 What=/run/root.squashfs

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
@@ -10,9 +10,9 @@ mkdir -p /run/rootfs
 
 cat >"${GENERATOR_DIR}/run-rootfs.mount" <<EOF
 [Unit]
-DefaultDependencies=false
 After=live-get-squashfs.service
 Before=initrd-root-fs.target
+DefaultDependencies=no
 
 [Mount]
 What=/run/root.squashfs


### PR DESCRIPTION
**What this PR does / why we need it**:
Early boot services, for live booting, have to receive `DefaultDependencies=no` for proper ordering. 
