### PR TITLE
Reduce git cloning download size during kernel package build

### DIFF
--- a/packages/manual/linux-5.10
+++ b/packages/manual/linux-5.10
@@ -22,12 +22,9 @@ xz -dc linux-$KERNEL_VERSION.tar.xz      | gpg --verify linux-$KERNEL_VERSION.ta
 xz -dc patches-$KERNEL_RT_VERSION.tar.xz | gpg --verify patches-$KERNEL_RT_VERSION.tar.sign -
 
 echo "### cloning the latest and greatest debian release environment to linux"
-git clone https://salsa.debian.org/kernel-team/linux.git $src
-echo "### checkingout the old kernel to linux-$KERNEL_DEBIAN"
-cp -R $src linux-$KERNEL_DEBIAN
-cd linux-$KERNEL_DEBIAN
-git -c advice.detachedHead=false checkout debian/$KERNEL_DEBIAN
-cd ..
+git clone --depth 1 https://salsa.debian.org/kernel-team/linux.git $src
+echo "### cloning the old kernel to linux-$KERNEL_DEBIAN"
+git clone --depth 1 --single --branch debian/$KERNEL_DEBIAN https://salsa.debian.org/kernel-team/linux.git linux-$KERNEL_DEBIAN
 
 echo "### pulling aufs5 from upstream not from debian" 
 git clone https://github.com/sfjro/aufs5-standalone.git

--- a/packages/manual/linux-5.10
+++ b/packages/manual/linux-5.10
@@ -14,7 +14,7 @@ gpg --tofu-policy good 514B0EDE3C387F944FB3799329E574109AEBFAAA
 echo "### updating package repsitory"
 sudo apt-get update
 echo "### installing minimal create requirements"
-sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git
+sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git quilt
 echo "### pulling kernel and rt-patches" 
 wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-$KERNEL_VERSION.tar.{sign,xz}
 wget https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/$(cut -d. -f-2 <<< ${KERNEL_BASE})/older/patches-$KERNEL_RT_VERSION.tar.{sign,xz}

--- a/packages/manual/linux-5.10
+++ b/packages/manual/linux-5.10
@@ -11,6 +11,8 @@ gpg --tofu-policy good 647F28654894E3BD457199BE38DBBDC86092693E
 gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 514B0EDE3C387F944FB3799329E574109AEBFAAA
 gpg --tofu-policy good 514B0EDE3C387F944FB3799329E574109AEBFAAA
 	
+echo "### updating package repsitory"
+sudo apt-get update
 echo "### installing minimal create requirements"
 sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git
 echo "### pulling kernel and rt-patches" 

--- a/packages/manual/linux-5.10
+++ b/packages/manual/linux-5.10
@@ -74,10 +74,10 @@ EOF
 
 cd ..
 # checking out linux stable to have the whole changelog from the kernel readable for debian/bin/stable-update 
-git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+git clone --single --branch linux-$(echo $KERNEL_BASE | sed s/0$/y/) --bare https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 cd $src
 
-debian/bin/stable-update ../linux-stable $KERNEL_VERSION
+debian/bin/stable-update ../linux-stable.git $KERNEL_VERSION
 cat debian/changelog debian/changelog.tmp > debian/changelog.new
 mv debian/changelog.new debian/changelog
 rm debian/changelog.tmp

--- a/packages/manual/linux-5.4
+++ b/packages/manual/linux-5.4
@@ -84,10 +84,10 @@ EOF
 
 cd ..
 # checking out linux stable to have the whole changelog from the kernel readable for debian/bin/stable-update 
-git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+git clone --single --branch linux-$(echo $KERNEL_BASE | sed s/0$/y/) --bare https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 cd $src
 
-debian/bin/stable-update ../linux-stable $KERNEL_VERSION
+debian/bin/stable-update ../linux-stable.git $KERNEL_VERSION
 cat debian/changelog debian/changelog.tmp > debian/changelog.new
 mv debian/changelog.new debian/changelog
 rm debian/changelog.tmp

--- a/packages/manual/linux-5.4
+++ b/packages/manual/linux-5.4
@@ -22,12 +22,9 @@ xz -dc linux-$KERNEL_VERSION.tar.xz      | gpg --verify linux-$KERNEL_VERSION.ta
 xz -dc patches-$KERNEL_RT_VERSION.tar.xz | gpg --verify patches-$KERNEL_RT_VERSION.tar.sign -
 
 echo "### cloning the latest and greatest debian release environment to linux"
-git clone https://salsa.debian.org/kernel-team/linux.git $src
-echo "### checkingout the old kernel to linux-$KERNEL_DEBIAN"
-cp -R $src linux-$KERNEL_DEBIAN
-cd linux-$KERNEL_DEBIAN
-git -c advice.detachedHead=false checkout debian/$KERNEL_DEBIAN
-cd ..
+git clone --depth 1 https://salsa.debian.org/kernel-team/linux.git $src
+echo "### cloning the old kernel to linux-$KERNEL_DEBIAN"
+git clone --depth 1 --single --branch debian/$KERNEL_DEBIAN https://salsa.debian.org/kernel-team/linux.git linux-$KERNEL_DEBIAN
 
 echo "### pulling aufs5 from upstream not from debian" 
 git clone https://github.com/sfjro/aufs5-standalone.git

--- a/packages/manual/linux-5.4
+++ b/packages/manual/linux-5.4
@@ -14,7 +14,7 @@ gpg --tofu-policy good 514B0EDE3C387F944FB3799329E574109AEBFAAA
 echo "### updating package repsitory"
 sudo apt-get update
 echo "### installing minimal create requirements"
-sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git
+sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git quilt
 echo "### pulling kernel and rt-patches" 
 wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-$KERNEL_VERSION.tar.{sign,xz}
 wget https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/$(cut -d. -f-2 <<< ${KERNEL_BASE})/older/patches-$KERNEL_RT_VERSION.tar.{sign,xz}

--- a/packages/manual/linux-5.4
+++ b/packages/manual/linux-5.4
@@ -11,6 +11,8 @@ gpg --tofu-policy good 647F28654894E3BD457199BE38DBBDC86092693E
 gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 514B0EDE3C387F944FB3799329E574109AEBFAAA
 gpg --tofu-policy good 514B0EDE3C387F944FB3799329E574109AEBFAAA
 	
+echo "### updating package repsitory"
+sudo apt-get update
 echo "### installing minimal create requirements"
 sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git
 echo "### pulling kernel and rt-patches" 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind enhancement
/area performance
/os garden-linux
/priority normal

**What this PR does / why we need it**:

This PR enhances kernel package building. It does the following:

* improve git cloning for both Debian kernel package repo and the linux-stable repo

The Debian kernel repo (previously 800-900 MB download) is switched to two shallow clones (2 and 7 MB download)

The linux-stable kernel is needed for the changelog, so cannot be switched to a shallow clone, but at least (as only commit information is needed, no actual source code) can be switched to a bare repository and only the branch in question needs to be cloned. This improves required bandwidth from around 3.5 GB to 1.8 GB. 

In my testing, the functionality as far as the kernel package build needs it was not impacted for both.

Minor other changes:

* add `quilt` to the list of installed packages

Without this, I get a build error:

```
### generating a debian conform orig file and install
Using source name linux, version 5.10.26, dfsg 0
[...]
QUILT_PATCHES='/home/dev/linux-5.10/debian/patches' QUILT_PC=.pc quilt push --quiltrc - -a -q --fuzz=0
sh: 1: quilt: not found
make[1]: *** [debian/rules:55: orig] Error 127
```

* Update the package list before installing packages

As we track testing, otherwise, the base image might be out of date and needs to be rebuilt - this might be something that has been left out by design?

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduce git cloning download size during kernel package build 
```
