### PR TITLE
Add test to make sure wireguard is installed

### DIFF
--- a/features/cloud/test/packages
+++ b/features/cloud/test/packages
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rootfsDir=$1
+thisDir=$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")
+rootfsDir=$(readlink -e "$rootfsDir")
+
+source "${thisDir}/helpers"
+
+run_in_chroot ${rootfsDir} packages.validate

--- a/features/cloud/test/packages.validate
+++ b/features/cloud/test/packages.validate
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -u
+
+rc=0
+
+echo "checking for wireguard packages"
+count=$(dpkg -l | grep wireguard | wc -l)
+
+if [[ ${count} -ne 2 ]] ; then
+    rc=1
+    echo "Not all wireguard packages installed, expected wireguard-modules and wireguard-tools but got"
+    out=$(dpkg -l | grep wireguard)
+    if [ "g${out}" == "g" ] ; then
+       echo "-- empty output --"
+    else 
+       echo ${out}
+    fi
+fi
+
+if [[ ${rc} -eq 0 ]]; then
+    echo "OK - all required packages installed"
+    exit 0
+else
+    echo "FAIL - not all required packages installed"
+    exit 1
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind TODO
/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
