### PR TITLE
Install the hard-coded cloud-init version

### DIFF
--- a/features/ali/exec.config
+++ b/features/ali/exec.config
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash 
+#!/usr/bin/env bash
 
 # Workaround for https://bugs.launchpad.net/cloud-init/+bug/1917875 in 20.4.1
-wget --quiet http://snapshot.debian.org/archive/debian/20200520T032945Z/pool/main/c/cloud-init/cloud-init_20.2-2_all.deb /tmp/cloud-init_20.2-2_all.deb
+wget --quiet http://snapshot.debian.org/archive/debian/20200520T032945Z/pool/main/c/cloud-init/cloud-init_20.2-2_all.deb -O /tmp/cloud-init_20.2-2_all.deb
 apt-get install -y --allow-downgrades -f /tmp/cloud-init_20.2-2_all.deb
 rm /tmp/cloud-init_20.2-2_all.deb
 
@@ -10,6 +10,6 @@ sed -i 's/^#DNSSEC=allow-downgrade/DNSSEC=false/g' /etc/systemd/resolved.conf
 
 # growpart is done in initramfs, growroot by systemd
 mv /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak
-cat /etc/cloud/cloud.cfg.bak | grep -v "^ - growpart$" | grep -v "^ - resizefs$" | grep -v "^ - ntp$" >/etc/cloud/cloud.cfg  
+cat /etc/cloud/cloud.cfg.bak | grep -v "^ - growpart$" | grep -v "^ - resizefs$" | grep -v "^ - ntp$" >/etc/cloud/cloud.cfg
 rm /etc/cloud/cloud.cfg.bak
 

--- a/features/ali/pkg.include
+++ b/features/ali/pkg.include
@@ -1,4 +1,4 @@
 python3-cffi-backend
 python3-boto
-cloud-init
+#cloud-init
 dmidecode

--- a/flavours.yaml
+++ b/flavours.yaml
@@ -3,7 +3,7 @@ flavour_sets:
   - name: 'all'
     flavour_combinations:
       - architectures: [ 'amd64' ]
-        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
+        platforms: [ ali ]
         modifiers: [ [ gardener, _prod ] ]
         fails: [ unit, integration ]
   - name: 'testing'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind bug
/area os
/os garden-linux
/priority 1
/platform alicloud

**What this PR does / why we need it**:
Fix the cloud-init installation for Alicloud, as with the latest version the VMs cannot be initialized properly

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
