### PR TITLE
Small fixes/improvements

### DIFF
--- a/bin/garden-init
+++ b/bin/garden-init
@@ -227,16 +227,17 @@ if [ "${include_wget}" != "" ]; then
 fi
 set -x
 
+# INITRD="No" - really hackish solution to skip ramdisk generation
 [ "${include_aptfile}" != "" ] && 
 "$thisDir/garden-chroot" "$targetDir" bash -c '
 	cd '${tmp#$targetDir}'
-	apt-get install -y --allow-downgrades --no-install-recommends -f $1
+	INITRD="No" apt-get install -y --allow-downgrades --no-install-recommends -f $1
 ' -- "$include_aptfile"
 rm -rf $tmp
 
 [ "${include_aptversion}" != "" ] && 
 "$thisDir/garden-chroot" "$targetDir" bash -c '
-	apt-get install -y --allow-downgrades --no-install-recommends -f $1
+	INITRD="No" apt-get install -y --allow-downgrades --no-install-recommends -f $1
 ' -- "$include_aptversion"
 
 # fix ownership/permissions on / (otherwise "debootstrap" leaves them as-is which causes reproducibility issues)

--- a/bin/garden-init
+++ b/bin/garden-init
@@ -223,7 +223,7 @@ fi
 
 tmp=$(mktemp -d -p $targetDir)
 if [ "${include_wget}" != "" ]; then
-	wget -P$tmp $include_wget
+	wget --show-progress --progress=bar:force -P$tmp $include_wget
 fi
 set -x
 

--- a/features/khost/exec.config
+++ b/features/khost/exec.config
@@ -5,6 +5,8 @@ wget --show-progress --progress=bar:force -4 -P /usr/local/bin \
 	https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl} \
 	https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRI_VERSION}/crictl-v${CRI_VERSION}-linux-amd64.tar.gz 
 
+rm -f /root/.wget-hsts
+
 tar -C /usr/local/bin -xf /usr/local/bin/crictl-v${CRI_VERSION}-linux-amd64.tar.gz
 rm -f /usr/local/bin/crictl-v${CRI_VERSION}-linux-amd64.tar.gz
 

--- a/features/khost/exec.config
+++ b/features/khost/exec.config
@@ -1,10 +1,10 @@
 K8S_VERSION=1.21.0
 CRI_VERSION=1.21.0
 
-wget -4 -P /usr/local/bin \
+wget --show-progress --progress=bar:force -4 -P /usr/local/bin \
 	https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl} \
 	https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRI_VERSION}/crictl-v${CRI_VERSION}-linux-amd64.tar.gz 
-	
+
 tar -C /usr/local/bin -xf /usr/local/bin/crictl-v${CRI_VERSION}-linux-amd64.tar.gz
 rm -f /usr/local/bin/crictl-v${CRI_VERSION}-linux-amd64.tar.gz
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the build log a bit less verbose when downloading the custom files/debian packages.
Remove the .wget-hsts file as it breaks reproducibility. 
Introduce a hackish way of skipping the dracut generation in the garden-init stage in order to speed up the build process.

