### PR TITLE
Enable again aws, azure, gcp, openstack and vmware flavours

### DIFF
--- a/flavours.yaml
+++ b/flavours.yaml
@@ -3,7 +3,7 @@ flavour_sets:
   - name: 'all'
     flavour_combinations:
       - architectures: [ 'amd64' ]
-        platforms: [ ali ]
+        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
         modifiers: [ [ gardener, _prod ] ]
         fails: [ unit, integration ]
   - name: 'testing'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

-->
/kind cleanup
/area os
/os garden-linux
/priority 3

**What this PR does / why we need it**:
Enable again all flavours after #264

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
