### PR TITLE
added kexec-tools to kvm feature

### DIFF
--- a/features/kvm/pkg.include
+++ b/features/kvm/pkg.include
@@ -1,6 +1,7 @@
 dosfstools
 rng-tools-debian
 qemu-guest-agent
+kexec-tools
 grub-cloud-amd64
 #fail2ban
 #ferm


### PR DESCRIPTION

/area os
/os garden-linux
/priority normal

**What this PR does / why we need it**:
kexec is needed in the kvm feature of gardenlinux, otherwise we can not install the os from ram to disk.

