### PR TITLE
ci: Concourse split build and disable notifications

### DIFF
--- a/.ci/clean_build_result_repositories
+++ b/.ci/clean_build_result_repositories
@@ -2,7 +2,7 @@
 
 own_dir="$(readlink -f "$(dirname "${0}")")"
 
-source "${own_dir}/lib.sh"
+source "${own_dir}/../ci/lib.sh"
 
 export_env
 

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,12 +3,32 @@ gardenlinux:
     repo:
       name: 'GARDENLINUX'
       cfg_name: 'github_com'
+    traits:
+      notifications:
+        default:
+          on_error:
+            triggering_policy: 'never'
 
   jobs:
     on-head-update:
       steps:
         render_pipelines_and_trigger_job:
-          execute: '../ci/render_pipelines_and_trigger_job'
+          execute: 
+          - '../ci/render_pipelines_and_trigger_job'
+          - --image-build
+          - --wait
+          vars:
+            PROMOTE_TARGET: "'snapshot'"
+            PUBLISHING_ACTIONS: "'manifests'"
+    build-packages:
+      repo:
+        trigger: false
+      steps:
+        render_pipelines_and_trigger_job:
+          execute: 
+          - '../ci/render_pipelines_and_trigger_job'
+          - --package-build
+          - --wait
           vars:
             PROMOTE_TARGET: "'snapshot'"
             PUBLISHING_ACTIONS: "'manifests'"

--- a/.ci/run_integration_tests
+++ b/.ci/run_integration_tests
@@ -2,7 +2,7 @@
 
 own_dir="$(readlink -f "$(dirname "${0}")")"
 
-source "${own_dir}/lib.sh"
+source "${own_dir}/../ci/lib.sh"
 
 install_kubectl
 install_tkn

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -2,13 +2,6 @@ own_dir="$(readlink -f "$(dirname "${0}")")"
 repo_root="$(readlink -f "${own_dir}/..")"
 bin_dir="${repo_root}/bin"
 
-shootcluster_cfg_name="$(gardener-ci \
-  config attribute \
-   --cfg-type cfg_set \
-   --cfg-name gardenlinux \
-   --key kubernetes.default \
-)"
-
 function install_kubectl() {
   if which kubectl &>/dev/null; then
     return 0
@@ -30,6 +23,13 @@ function install_tkn() {
 }
 
 function kubecfg()  {
+  shootcluster_cfg_name="$(gardener-ci \
+    config attribute \
+     --cfg-type cfg_set \
+     --cfg-name gardenlinux \
+     --key kubernetes.default \
+  )"
+
   # retrieve kubeconfig
   gardener-ci config model_element \
     --cfg-type kubernetes \

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 set -x
 
 own_dir="$(readlink -f "$(dirname "${0}")")"
 repo_root="${own_dir}/.."
 
-source "${repo_root}/.ci/lib.sh"
+source "${own_dir}/lib.sh"
 
 install_kubectl
 install_tkn
 
 # retrieve and configure kubeconfig (sets KUBECONFIG env var)
-kubecfg
+if [ ! -z ${SECRETS_SERVER_ENDPOINT:-} ]; then
+  kubecfg
+fi
 
 # also handles default-values for env-vars
 export_env
@@ -35,6 +37,7 @@ function create_credentials {
     kubectl delete secret -n "${GARDENLINUX_TKN_WS}" secrets
   fi
 
+  echo "Creating secret"
   $(which kubectl) create secret generic secrets \
     -n "${GARDENLINUX_TKN_WS}" \
     --from-file=config.json="${credentials_outfile}"
@@ -48,6 +51,7 @@ pipeline_cfg="${repo_root}/flavours.yaml"
 outfile='rendered_pipeline.yaml'
 outfile_packages='rendered_pipeline_packages.yaml'
 
+EXTRA_ARGS=
 if [ ! -z "${VERSION:-}" ]; then
   EXTRA_ARGS="--version=${VERSION}"
 fi
@@ -81,11 +85,13 @@ ci/render_pipelines.py \
   --outfile "${outfile}" \
   --outfile-packages "${outfile_packages}"
 
-if [ ! -z $SECRETS_SERVER_ENDPOINT ]; then
+RENDER_TASK_EXTRA_ARGS=
+if [ ! -z ${SECRETS_SERVER_ENDPOINT:-} ]; then
   RENDER_TASK_EXTRA_ARGS="--use-secrets-server"
 else
   # secrets-server won't be available; create config from local files and put it as
   # k8s secret into cluster.
+  echo "create credentials"
   create_credentials
 fi
 
@@ -98,14 +104,47 @@ ci/render_task.py \
 for manifest in \
   "${rendered_task}" \
   "${outfile}" \
-  "${outfile_packages}" \
-  "${pipeline_package_run}" \
-  "${pipeline_run}"
+  "${outfile_packages}"
 do
+  echo "Skip apply of ${manifest}"
   $(which kubectl) apply -n "${GARDENLINUX_TKN_WS}" -f "${manifest}"
 done
 
-echo 'done: refreshed pipeline(s) and created a new pipeline-run for current commit'
+image_build=false
+package_build=false
+wait=false
+for arg in "$@" 
+do
+    echo "Found arg $arg";
+    if [ $arg ==  "--image-build" ]; then
+      image_build=true
+    fi
+    if [ $arg ==  "--package-build" ]; then
+      package_build=true
+    fi
+    if [ $arg ==  "--wait" ]; then
+      wait=true
+    fi
+done
 
-echo 'will wait for new pipelinerun'
-ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_run}" --namespace "${GARDENLINUX_TKN_WS}"
+# --image-build calls triggering the pipeline run for image build
+if [ ${image_build} = true ] ; then
+  echo "Build images"
+  kubectl apply -n "${GARDENLINUX_TKN_WS}" -f "${pipeline_run}"
+  if [ ${wait} = true ] ; then
+    echo "waiting for new pipelinerun ${pipeline_run}"
+    ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_run}" --namespace "${GARDENLINUX_TKN_WS}"
+  fi
+fi
+
+# --package-build calls triggering the pipeline run for image build
+if [ ${package_build} = true ]; then
+  echo "Build packages"
+  kubectl apply -n "${GARDENLINUX_TKN_WS}" -f "${pipeline_package_run}"
+  if [ ${wait} = true ]; then
+    echo "waiting for new pipelinerun ${pipeline_package_run}"
+    ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_package_run}" --namespace "${GARDENLINUX_TKN_WS}"
+  fi
+fi
+
+echo 'done: refreshed pipeline(s) for current commit'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind TODO
/area os
/os garden-linux

**What this PR does / why we need it**:
* Do not build packages on every commit (manual triggering)
* Disable notifications from Concourse (avoid double notifications)

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
NONE

