### PR TITLE
Sign centrally build packages

### DIFF
--- a/bin/.snapshot-url.sh
+++ b/bin/.snapshot-url.sh
@@ -25,6 +25,11 @@ t="$(date --date "$timestamp" '+%Y%m%dT%H%M%SZ')"
 # use caching proxy to avoid throttling, if available
 if wget -t1 -qO/dev/null http://localhost/$base/$archive/; then
 	echo "http://localhost/$base/$archive/$t"
+# try our central cache
+elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/; then
+	echo "https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/$t"
+elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/$base/$archive/; then
+	echo "https://snapshot-cache.ci.gardener.cloud/$base/$archive/$t"
 
 elif wget -t1 -qO/dev/null http://172.17.0.1/$base/$archive/; then
 	echo "http://172.17.0.1/$base/$archive/$t"
@@ -36,11 +41,6 @@ elif wget -t1 -qO/dev/null http://45.86.152.1/gardenlinux/$base/$archive/; then
 # this is for the gardenlinux-local packages ($base = gardenlinux/)
 elif wget -t1 -qO/dev/null http://45.86.152.1/$base/; then
 	echo "http://45.86.152.1/$base/"
-# try our central cache
-elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/; then
-	echo "https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/$t"
-elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/$base/$archive/; then
-	echo "https://snapshot-cache.ci.gardener.cloud/$base/$archive/$t"
 else
 	echo "https://snapshot.debian.org/$base/$archive/$t"
 fi

--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -98,6 +98,7 @@ def mk_pipeline_packages_run(
     gardenlinux_epoch: int,
     git_url: str,
     pipeline_name: str,
+    key_config_name: str,
     publishing_actions: typing.Sequence[glci.model.PublishingAction],
     oci_path: str,
     version: str,
@@ -177,6 +178,10 @@ def mk_pipeline_packages_run(
                     name='gardenlinux_build_deb_image',
                     value=build_deb_image,
                 ),
+                NamedParam(
+                    name='key_config_name',
+                    value=key_config_name,
+                )
             ],
             pipelineRef=PipelineRef(
                 name=pipeline_name,
@@ -367,6 +372,7 @@ def main():
         git_url=parsed.git_url,
         oci_path=parsed.oci_path,
         pipeline_name='gl-packages-build',
+        key_config_name='gardenlinux',
         publishing_actions=parsed.publishing_actions,
         version=version,
         additional_recipients=parsed.additional_recipients,

--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -73,12 +73,16 @@ def main():
     raw_base_build_task = dataclasses.asdict(base_build_task)
 
     package_task = tasks.nokernel_package_task(
+        package_name=NamedParam(name='pkg_name'),
+        repo_dir=NamedParam('repo_dir'),
         env_vars=env_vars,
         volume_mounts=volume_mounts,
     )
     raw_package_task = dataclasses.asdict(package_task)
 
     kernel_package_task = tasks.kernel_package_task(
+        repo_dir=NamedParam('repo_dir'),
+        package_names=NamedParam('pkg_names'),
         env_vars=env_vars,
         volume_mounts=volume_mounts,
     )

--- a/ci/steps/build_cert.sh
+++ b/ci/steps/build_cert.sh
@@ -1,0 +1,21 @@
+build_cert() {
+    repo_dir=$1
+    # cfssl_fastpath=$2
+    # cfssl_dir=$3
+
+    key_file="${repo_dir}/cert/private.key"
+
+    if [[ -f "${key_file}" ]]; then
+        gpg --import "${key_file}"
+    fi
+
+    pushd "${repo_dir}/cert"
+    make
+    mkdir -p "${repo_dir}/certdir"
+    cp --verbose Kernel.sign.full "${repo_dir}/certdir/kernel.full"
+    cp --verbose Kernel.sign.crt "${repo_dir}/certdir/kernel.crt"
+    cp --verbose Kernel.sign.key "${repo_dir}/certdir/kernel.key"
+    cp --verbose sign.pub "${repo_dir}/certdir/sign.pub"
+    cp --verbose root.ca.crt "${repo_dir}/certdir/root.ca.crt"
+    cp --verbose root.ca.key "${repo_dir}/certdir/root.ca.crt"
+}

--- a/ci/steps/build_cert.sh
+++ b/ci/steps/build_cert.sh
@@ -1,21 +1,13 @@
 build_cert() {
     repo_dir=$1
-    # cfssl_fastpath=$2
-    # cfssl_dir=$3
 
     key_file="${repo_dir}/cert/private.key"
+    cert_dir="${repo_dir}/cert"
 
     if [[ -f "${key_file}" ]]; then
         gpg --import "${key_file}"
     fi
 
-    pushd "${repo_dir}/cert"
+    pushd "${cert_dir}"
     make
-    mkdir -p "${repo_dir}/certdir"
-    cp --verbose Kernel.sign.full "${repo_dir}/certdir/kernel.full"
-    cp --verbose Kernel.sign.crt "${repo_dir}/certdir/kernel.crt"
-    cp --verbose Kernel.sign.key "${repo_dir}/certdir/kernel.key"
-    cp --verbose sign.pub "${repo_dir}/certdir/sign.pub"
-    cp --verbose root.ca.crt "${repo_dir}/certdir/root.ca.crt"
-    cp --verbose root.ca.key "${repo_dir}/certdir/root.ca.crt"
 }

--- a/ci/steps/build_cfssl.sh
+++ b/ci/steps/build_cfssl.sh
@@ -1,0 +1,45 @@
+
+build_cfssl() {
+    repo_dir=$1
+    cfssl_fastpath=$2
+    cfssl_dir=$3
+
+    key_file="/workspace/gardenlinux_git/cert/private.key"
+
+    if [[ -f "${key_file}" ]]; then
+        gpg --import "${key_file}"
+    fi
+
+    mkdir -p "${repo_dir}/cert/cfssl"
+    if [ "${cfssl_fastpath}" != "true" ]; then
+    # slow-path build CFSSL from github:
+    pushd "${cfssl_dir}"
+    make
+    mv bin/* "${repo_dir}/cert/cfssl"
+    else
+    mkdir -p "${repo_dir}/bin"
+    pushd "${repo_dir}/bin"
+    # fast-path copy binaries from CFSSL github release:
+    cfssl_files=( cfssl-bundle_1.5.0_linux_amd64 \\
+        cfssl-certinfo_1.5.0_linux_amd64 \\
+        cfssl-newkey_1.5.0_linux_amd64 \\
+        cfssl-scan_1.5.0_linux_amd64 \\
+        cfssljson_1.5.0_linux_amd64 \\
+        cfssl_1.5.0_linux_amd64 \\
+        mkbundle_1.5.0_linux_amd64 \\
+        multirootca_1.5.0_linux_amd64 \\
+    )
+
+    len2=`expr length _1.5.0_linux_amd64`
+    for file in "${cfssl_files[@]}"; do
+        len=`expr length $file`
+        outname=${file:0:`expr $len - $len2`}
+        wget --no-verbose -O $outname https://github.com/cloudflare/cfssl/releases/download/v1.5.0/${file}
+        chmod +x $outname
+    done
+    mv * "${repo_dir}/cert/cfssl"
+    fi
+    # cleanup workspace to safe some valuable space
+    popd
+    rm -rf "${cfssl_dir}"
+}

--- a/ci/steps/build_kernel_package.sh
+++ b/ci/steps/build_kernel_package.sh
@@ -22,18 +22,17 @@ build_kernel_package(){
 
     MANUALDIR=$(realpath $repo_dir/packages/manual)
     KERNELDIR=$(realpath $repo_dir/packages/kernel)
-    CERTDIR=$(realpath $repo_dir/cert)
 
     export DEBFULLNAME="Garden Linux Maintainers"
     export DEBEMAIL="contact@gardenlinux.io"
     export BUILDIMAGE="gardenlinux/build-deb"
     export BUILDKERNEL="gardenlinux/build-kernel"
     export WORKDIR="/workspace"
+    export CERTDIR=$(realpath $repo_dir/cert)
     echo "MANUALDIR: ${MANUALDIR}"
     echo "KERNELDIR: ${KERNELDIR}"
     echo "CERTDIR: ${CERTDIR}"
     echo "WORKDIR: ${WORKDIR}"
-    ls -l ${CERTDIR}
 
     # original makefile uses mounts, replace this by linking required dirs
     # to the expexted locations:

--- a/ci/steps/build_kernel_package.sh
+++ b/ci/steps/build_kernel_package.sh
@@ -1,0 +1,80 @@
+build_kernel_package(){
+    set -ex
+
+    repo_dir=$1
+    pkg_names=$2
+
+    # split string into an array
+    echo "Input: ${pkg_names}"
+    IFS=', ' read -r -a packages <<< "${pkg_names}"
+    echo "Building kernel dependent packages: ${packages[@]}"
+
+    if [ -z "$SOURCE_PATH" ]; then
+    SOURCE_PATH="$(readlink -f ${repo_dir})"
+    fi
+
+    if [ -z "${packages}" ]; then
+    echo "ERROR: no package name given"
+    exit 1
+    fi
+
+    echo $(pwd)
+
+    MANUALDIR=$(realpath $repo_dir/packages/manual)
+    KERNELDIR=$(realpath $repo_dir/packages/kernel)
+    CERTDIR=$(realpath $repo_dir/cert)
+
+    export DEBFULLNAME="Garden Linux Maintainers"
+    export DEBEMAIL="contact@gardenlinux.io"
+    export BUILDIMAGE="gardenlinux/build-deb"
+    export BUILDKERNEL="gardenlinux/build-kernel"
+    export WORKDIR="/workspace"
+    echo "MANUALDIR: ${MANUALDIR}"
+    echo "KERNELDIR: ${KERNELDIR}"
+    echo "CERTDIR: ${CERTDIR}"
+    echo "WORKDIR: ${WORKDIR}"
+    ls -l ${CERTDIR}
+
+    # original makefile uses mounts, replace this by linking required dirs
+    # to the expexted locations:
+    # original: mount <gardenlinuxdir>/.packages but this does not exist so just create
+    ln -s ${MANUALDIR} /workspace/manual
+    ln -s /../Makefile.inside /workspace/Makefile
+    echo "$(gpgconf --list-dir agent-socket)"
+    mkdir -p /workspace/.gnupg
+    ln -s $(gpgconf --list-dir agent-socket) /workspace/.gnupg/S.gpg-agent
+    ln -s ${CERTDIR}/sign.pub /sign.pub
+    ln -s ${CERTDIR}/Kernel.sign.full /kernel.full
+    ln -s ${CERTDIR}/Kernel.sign.crt /kernel.crt
+    ln -s ${CERTDIR}/Kernel.sign.key /kernel.key
+
+    # originally this is called on docker startup
+    gpg --import ${CERTDIR}/sign.pub
+
+    echo "Checking disk begin end of kernel-packages build:"
+    df -h
+    sudo apt-get install --no-install-recommends -y wget quilt vim less
+
+    export BUILDTARGET="${OUT_PATH:-/workspace/pool}"
+    if [ ! -f "$BUILDTARGET" ]; then
+    mkdir "$BUILDTARGET"
+    fi
+
+    for package in "${packages[@]}"
+    do
+    echo "Building now ${package}"
+    pkg_build_script_path="manual/${package}"
+    echo "pkg_build_script_path: ${pkg_build_script_path}"
+
+    if [ ! -f "${pkg_build_script_path}" ]; then
+        echo "ERROR: Don't know how to build ${package}"
+        exit 1
+    fi
+
+    pushd "/workspace"
+    ${pkg_build_script_path}
+    popd
+    done
+    echo "Checking disk usage end of kernel-packages build:"
+    df -h
+}

--- a/ci/steps/build_package.sh
+++ b/ci/steps/build_package.sh
@@ -18,12 +18,12 @@ build_package() {
 
     MANUALDIR=$(realpath $repodir/packages/manual)
     KERNELDIR=$(realpath $repodir/packages/kernel)
-    CERTDIR=$(realpath $repodir/cert)
 
     export DEBFULLNAME="Garden Linux Maintainers"
     export DEBEMAIL="contact@gardenlinux.io"
     export BUILDIMAGE="gardenlinux/build-deb"
     export BUILDKERNEL="gardenlinux/build-kernel"
+    export CERTDIR=$(realpath $repodir/cert)
     echo "MANUALDIR: ${MANUALDIR}"
     echo "KERNELDIR: ${KERNELDIR}"
     echo "CERTDIR: ${CERTDIR}"

--- a/ci/steps/write_key.py
+++ b/ci/steps/write_key.py
@@ -1,0 +1,20 @@
+import os
+
+import ctx
+
+
+def write_key_to_file(
+    target_file_path: str,
+    key_config_name: str,
+):
+    cfg_factory = ctx.cfg_factory()
+    key_config = cfg_factory._cfg_element(cfg_type_name='gpg_key', cfg_name=key_config_name)
+    with open(target_file_path, 'w') as f:
+        f.write(key_config.raw['private'])
+
+
+def write_key(repo_dir, key_config_name):
+    write_key_to_file(
+        os.path.join(repo_dir, 'cert', 'private.key'),
+        key_config_name,
+    )

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -219,6 +219,9 @@ def _package_task(
     )
 
     cfssl_build_step = steps.build_cfssl_step(
+        repo_dir=repodir,
+        cfssl_fastpath=cfssl_fastpath,
+        cfssl_dir=cfssl_dir,
         env_vars=env_vars,
         volume_mounts=volume_mounts,
     )
@@ -253,12 +256,17 @@ def _package_task(
 
 
 def nokernel_package_task(
+    package_name,
+    repo_dir,
     env_vars,
     volume_mounts,
 ):
     return _package_task(
         task_name='build-packages',
-        package_build_step=steps.build_package_step(),
+        package_build_step=steps.build_package_step(
+            repo_dir=repo_dir,
+            package_name=package_name,
+        ),
         is_kernel_task=False,
         env_vars=env_vars,
         volume_mounts=volume_mounts,
@@ -266,12 +274,17 @@ def nokernel_package_task(
 
 
 def kernel_package_task(
+    repo_dir,
+    package_names,
     env_vars,
     volume_mounts,
 ):
     return _package_task(
         task_name='build-kernel-packages',
-        package_build_step=steps.build_kernel_package_step(),
+        package_build_step=steps.build_kernel_package_step(
+            repo_dir=repo_dir,
+            package_names=package_names,
+        ),
         is_kernel_task=True,
         env_vars=env_vars,
         volume_mounts=volume_mounts,

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -1,3 +1,4 @@
+from os import name
 import steps
 import tkn.model
 
@@ -184,16 +185,22 @@ def _package_task(
         description='cfssl git url to clone',
         default='https://github.com/cloudflare/cfssl.git'
     )
+    key_config_name = NamedParam(
+        name='key_config_name',
+        description='config name of the key to use for signing the packages',
+        default='gardenlinux',
+    )
 
     params = [
-        cfssl_committish,
         cfss_git_url,
+        cfssl_committish,
         cfssl_dir,
         cfssl_fastpath,
         cicd_cfg_name,
         committish,
         gardenlinux_build_deb_image,
         giturl,
+        key_config_name,
         pkg_name,
         repodir,
         s3_package_path,
@@ -218,6 +225,13 @@ def _package_task(
         volume_mounts=volume_mounts,
     )
 
+    write_key_step = steps.write_key_step(
+        key_config_name=key_config_name,
+        repo_dir=repodir,
+        env_vars=env_vars,
+        volume_mounts=volume_mounts,
+    )
+
     cfssl_build_step = steps.build_cfssl_step(
         repo_dir=repodir,
         cfssl_fastpath=cfssl_fastpath,
@@ -225,7 +239,7 @@ def _package_task(
         env_vars=env_vars,
         volume_mounts=volume_mounts,
     )
-    make_certs_step = steps.build_make_cert_step(
+    build_certs_step = steps.build_cert_step(
         repo_dir=repodir,
         env_vars=env_vars,
         volume_mounts=volume_mounts,
@@ -245,8 +259,9 @@ def _package_task(
             steps=[
                 clone_step_gl,
                 clone_step_cfssl,
+                write_key_step,
                 cfssl_build_step,
-                make_certs_step,
+                build_certs_step,
                 package_build_step,
                 s3_upload_packages_step,
             ],

--- a/packages/manual/linux-5.10
+++ b/packages/manual/linux-5.10
@@ -4,18 +4,20 @@ set -euox pipefail
 . $(dirname $0)/.helper
 . ${srcDir}/VERSION
 
+CERT_DIR="${CERTDIR:-}"
+
 echo "### getting the keys of the maintainers"
 gpg --locate-keys torvalds@kernel.org gregkh@kernel.org
 gpg --tofu-policy good 647F28654894E3BD457199BE38DBBDC86092693E
 # Steven Rostedt <rostedt@goodmis.org>
 gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 514B0EDE3C387F944FB3799329E574109AEBFAAA
 gpg --tofu-policy good 514B0EDE3C387F944FB3799329E574109AEBFAAA
-	
+
 echo "### updating package repsitory"
 sudo apt-get update
 echo "### installing minimal create requirements"
 sudo apt-get install --no-install-recommends -y equivs kernel-wedge python3-debian rsync libdistro-info-perl git quilt
-echo "### pulling kernel and rt-patches" 
+echo "### pulling kernel and rt-patches"
 wget -nc https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-$KERNEL_VERSION.tar.sign
 wget -nc https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/$(cut -d. -f-2 <<< ${KERNEL_BASE})/older/patches-$KERNEL_RT_VERSION.tar.sign
 while ! $(xz -dc linux-$KERNEL_VERSION.tar.xz | gpg --verify linux-$KERNEL_VERSION.tar.sign -); do
@@ -30,7 +32,7 @@ done
 echo "### cloning the latest and greatest debian release environment to linux"
 if [ -d $src ]; then
 	cd $src; git checkout master; git pull --tags; cd ..
-else 
+else
 	# find better way of doing this
 	git clone https://salsa.debian.org/kernel-team/linux.git $src
 fi
@@ -44,11 +46,11 @@ cd $src
 mv debian/changelog debian/changelog.org
 cd ..
 
-if $(dpkg --compare-versions $KERNEL_DEBIAN lt $KERNEL_VERSION); then 
+if $(dpkg --compare-versions $KERNEL_DEBIAN lt $KERNEL_VERSION); then
 	echo "### cloning the old kernel to linux-$KERNEL_DEBIAN"
 	git clone --depth 1 --single --branch debian/$KERNEL_DEBIAN https://salsa.debian.org/kernel-team/linux.git linux-$KERNEL_DEBIAN
 	KERNEL_VERSION="$KERNEL_VERSION-1"
-	echo "### pulling aufs5 from upstream not from debian" 
+	echo "### pulling aufs5 from upstream not from debian"
 	git clone https://github.com/sfjro/aufs5-standalone.git
 	cd aufs5-standalone
 	git -c advice.detachedHead=false checkout aufs$(cut -d. -f-2 <<< ${KERNEL_BASE})
@@ -68,7 +70,7 @@ if $(dpkg --compare-versions $KERNEL_DEBIAN lt $KERNEL_VERSION); then
 	debian/bin/genpatch-aufs ../aufs5-standalone
 	cd ..
 
-	# checking out linux stable to have the whole changelog from the kernel readable for debian/bin/stable-update 
+	# checking out linux stable to have the whole changelog from the kernel readable for debian/bin/stable-update
 	git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 
 	cd $src
@@ -100,7 +102,7 @@ $(cat $srcDir/changelog)
 EOF
 
 cd ..
-# checking out linux stable to have the whole changelog from the kernel readable for debian/bin/stable-update 
+# checking out linux stable to have the whole changelog from the kernel readable for debian/bin/stable-update
 git clone --single --branch linux-$(echo $KERNEL_BASE | sed s/0$/y/) --bare https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 cd $src
 
@@ -111,7 +113,7 @@ rm -f debian/changelog.new debian/changelog.newkernel debian/changelog.org
 echo "### setting certificate"
 # to make sure we do not take this accidently
 rm -f debian/certs/debian-uefi-certs.pem
-cp /kernel.full debian/certs/gardenlinux-kernel-certs.pem
+cp "${CERT_DIR}/kernel.full" debian/certs/gardenlinux-kernel-certs.pem
 sed -i "s/debian-uefi-certs.pem/gardenlinux-kernel-certs.pem/" debian/config/config debian/config/featureset*/config
 
 echo "### generating a debian conform orig file and install"

--- a/packages/manual/linux-5.10-signed
+++ b/packages/manual/linux-5.10-signed
@@ -4,11 +4,13 @@ set -euo pipefail
 . $(dirname $0)/.helper
 . $(dirname $0)/linux-5.10.d/VERSION
 
+CERT_DIR="${CERTDIR:-}"
+
 sudo apt-get install -y --no-install-recommends vim less equivs pesign
 
-mkdir -p certdir
-openssl pkcs12 -export -out kernel.p12 -inkey /kernel.key -in /kernel.crt -passout pass:""
-pk12util -i kernel.p12 -d certdir -W "" -K ""
+mkdir -p "${CERT_DIR}"
+openssl pkcs12 -export -out kernel.p12 -inkey "${CERT_DIR}/kernel.key" -in "${CERT_DIR}/kernel.crt" -passout pass:""
+pk12util -i "${CERT_DIR}/kernel.p12" -d "${CERT_DIR}" -W "" -K ""
 
 if $(dpkg --compare-versions $KERNEL_DEBIAN lt $KERNEL_VERSION); then
 	KERNEL_VERSION="$KERNEL_VERSION-1"

--- a/packages/manual/linux-5.10.d/sign-helper
+++ b/packages/manual/linux-5.10.d/sign-helper
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CERT_DIR="${WORKDIR}/certdir"
+CERT_DIR=${CERTDIR:-${WORKDIR}/certdir}
 CERT_NAME="Garden Linux Kernel Signature - SAP SE"
 LINUX_SIGNFILE=/usr/lib/linux-kbuild-5.10/scripts/sign-file
 
@@ -20,7 +20,7 @@ while read filename; do
 		pesign -i "/${filename}" --export-signature "${out_dir}/$kernel/${filename}.sig" --sign -d sha256 -n "${CERT_DIR}" -c "${CERT_NAME}"
 		;;
 	    *.ko)
-		sudo "$LINUX_SIGNFILE" -dp sha256 "/kernel.key" "/kernel.crt" "/$filename"
+		sudo "$LINUX_SIGNFILE" -dp sha256 "${CERT_DIR}/kernel.key" "${CERT_DIR}/kernel.crt" "/$filename"
 		sudo mv "/$filename.p7s" "$out_dir/$kernel/$filename.sig"
 		sudo chown dev "$out_dir/$kernel/$filename.sig"
 		;;


### PR DESCRIPTION
Adjust the existing build-scripts so that centrally built packages are now also signed and used.
Also includes some refactoring to the ci-gear to remove the last inlined build-scripts.