### PR TITLE
Replace package rng-tools-debian with rng-tools5

### DIFF
--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -3,6 +3,7 @@ fdisk
 [${arch}=arm64] grub-cloud-arm64
 cloud-guest-utils
 libpam-cracklib
+rng-tools5
 
 main/l/linux-signed-amd64/linux-image-cloud-${arch}_5.10.38-1_${arch}.deb
 main/l/linux-signed-amd64/linux-image-5.10.0-8-cloud-${arch}_5.10.38-1_${arch}.deb

--- a/features/gcp/pkg.include
+++ b/features/gcp/pkg.include
@@ -1,4 +1,3 @@
-rng-tools-debian
 main/g/google-compute-image-packages/google-guest-agent_1:20210223.01-g1_amd64.deb
 main/g/google-compute-image-packages/google-compute-engine-oslogin_20191018.00-g1.1_amd64.deb
 main/g/google-compute-image-packages/google-compute-engine_20200113.00-g1.1_all.deb

--- a/features/kvm/pkg.include
+++ b/features/kvm/pkg.include
@@ -1,5 +1,4 @@
 dosfstools
-rng-tools-debian
 qemu-guest-agent
 kexec-tools
 grub-cloud-amd64


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind technical-debt
/area os
/os garden-linux

**What this PR does / why we need it**:

GCP and KVM features of Garden Linux install `rng-tools-debian` for gathering entropy from the hardware random generator provided by virtio-rng. As recommended in the package description of [rng-tools-debian](https://packages.debian.org/bullseye/rng-tools-debian) and [rng-tools](https://packages.debian.org/bullseye/rng-tools) this PR changes the package to rng-tools5.
It also fixes the cosmetic issue of systemd complaining about a missing unit file as rng-tools-debian still uses Sys-V init-scripts, rng-tools5 uses native systemd units.
Also adds the rng-tools5 packages to AWS and Azure feature sets to allow for faster collection of entropy on those platforms.

**Which issue(s) this PR fixes**:
Fixes #291

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- rng-tools-debian replaced by rng-tools5 for KVM and GCP features
- added rng-tools5 to Azure and AWS features for faster entropy collection on those platforms
```
