### PR TITLE
noninteractive pam-auth update

### DIFF
--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -9,9 +9,9 @@ sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 #session optional pam_umask.so
 #EOF
 
-pam-auth-update --remove cracklib
+DEBIAN_FRONTEND=noninteractive pam-auth-update --remove cracklib
 rm -f /usr/share/pam-configs/cracklib
-pam-auth-update
+DEBIAN_FRONTEND=noninteractive pam-auth-update
 
 for kernel in /boot/vmlinuz-*; do 
    dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown" --reproducible


### PR DESCRIPTION
**What this PR does / why we need it**:
For the DEBIAN_FRONTENT to noninteractive for the pam-auth-update commands.