### PR TITLE
Add step publishing Component Descriptor

### DIFF
--- a/ci/glci/alicloud.py
+++ b/ci/glci/alicloud.py
@@ -61,9 +61,12 @@ class AlicloudImageMaker:
 
     # copy image from S3 to OSS
     def cp_image_from_s3(self, s3_client):
-        s3_bucket_key = self.release.path_by_suffix("rootfs.qcow2").s3_key
-        s3_bucket_name = self.release.path_by_suffix(
-            "rootfs.qcow2").s3_bucket_name
+
+        ali_release_artifact = glci.util.virtual_image_artifact_for_platform('ali')
+        ali_release_artifact_path = self.release.path_by_suffix(ali_release_artifact)
+
+        s3_bucket_key = ali_release_artifact_path.s3_key
+        s3_bucket_name = ali_release_artifact_path.s3_bucket_name
 
         with tempfile.TemporaryFile() as tfh:
             # TODO: use streaming
@@ -159,7 +162,7 @@ class AlicloudImageMaker:
                         did_raise = True
                         continue
                     raise
-        
+
         if did_raise:
             raise
 

--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -9,6 +9,7 @@ import typing
 import botocore.client
 
 import glci.model
+import glci.util
 
 
 logger = logging.getLogger(__name__)
@@ -329,9 +330,12 @@ def upload_and_register_gardenlinux_image(
 
     target_image_name = target_image_name_for_release(release=release)
 
+    aws_release_artifact = glci.util.virtual_image_artifact_for_platform('aws')
+    aws_release_artifact_path = release.path_by_suffix(aws_release_artifact)
+
     # TODO: check path is actually S3_ReleaseFile
-    raw_image_key = release.path_by_suffix('rootfs.raw').s3_key
-    bucket_name = release.path_by_suffix('rootfs.raw').s3_bucket_name
+    raw_image_key = aws_release_artifact_path.s3_key
+    bucket_name = aws_release_artifact_path.s3_bucket_name
 
     snapshot_task_id = import_snapshot(
         ec2_client=ec2_client,

--- a/ci/glci/az.py
+++ b/ci/glci/az.py
@@ -8,6 +8,7 @@ import logging
 import typing
 
 import requests
+from glci import util
 import version
 from msal import ConfidentialClientApplication
 from azure.storage.blob import (
@@ -474,13 +475,16 @@ def upload_and_publish_image(
     Azure Marketplace offering and publish the offering.
     '''
 
+    azure_release_artifact = util.virtual_image_artifact_for_platform('azure')
+    azure_release_artifact_path = release.path_by_suffix(azure_release_artifact)
+
     # Copy image from s3 to Azure Storage Account
     target_blob_name = f"gardenlinux-az-{release.version}.vhd"
     image_url = copy_image_from_s3_to_az_storage_account(
         storage_account_cfg=storage_account_cfg,
         s3_client=s3_client,
-        s3_bucket_name=release.path_by_suffix('rootfs.vhd').s3_bucket_name,
-        s3_object_key=release.path_by_suffix('rootfs.vhd').s3_key,
+        s3_bucket_name=azure_release_artifact_path.s3_bucket_name,
+        s3_object_key=azure_release_artifact_path.s3_key,
         target_blob_name=target_blob_name,
     )
 

--- a/ci/glci/gcp.py
+++ b/ci/glci/gcp.py
@@ -6,6 +6,7 @@ import logging
 import google.cloud.storage.blob
 import google.cloud.storage.client
 import glci.model
+import glci.util
 
 
 logger = lambda: logging.getLogger(__name__)
@@ -17,9 +18,13 @@ def upload_image_to_gcp_store(
     release: glci.model.OnlineReleaseManifest,
     build_cfg: glci.model.BuildCfg,
 ) -> google.cloud.storage.blob.Blob:
+
+    gcp_release_artifact = glci.util.virtual_image_artifact_for_platform('gcp')
+    gcp_release_artifact_path = release.path_by_suffix(gcp_release_artifact)
+    raw_image_key = gcp_release_artifact_path.s3_key
+    s3_bucket_name = gcp_release_artifact_path.s3_bucket_name
+
     image_blob_name = f'gardenlinux-{release.version}.tar.gz'
-    raw_image_key = release.path_by_suffix('rootfs-gcpimage.tar.gz').s3_key
-    s3_bucket_name = release.path_by_suffix('rootfs-gcpimage.tar.gz').s3_bucket_name
 
     # XXX: rather do streaming
     with tempfile.TemporaryFile() as tfh:

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -35,6 +35,7 @@ class FeatureType(enum.Enum):
     MODIFIER = 'modifier'
 
 
+# TODO: Check feasibility of using proper enum(s)
 Platform = str  # see `features/*/info.yaml` / platforms() for allowed values
 Modifier = str  # see `features/*/info.yaml` / modifiers() for allowed values
 

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -18,10 +18,11 @@ repo_root = os.path.abspath(os.path.join(
 
 
 class PublishingAction(enum.Enum):
-    MANIFESTS = 'manifests'
-    IMAGES = 'images'
-    RELEASE = 'release'
     BUILD_ONLY = 'build_only'
+    COMPONENT_DESCRIPTOR = 'component_descriptor'
+    IMAGES = 'images'
+    MANIFESTS = 'manifests'
+    RELEASE = 'release'
 
 
 class FeatureType(enum.Enum):

--- a/ci/glci/openstack_image.py
+++ b/ci/glci/openstack_image.py
@@ -75,7 +75,7 @@ class OpenstackImageUploader:
 
 def upload_and_publish_image(
     s3_client,
-    openstack_environments_cfgs :typing.Tuple[glci.model.OpenstackEnvironment],
+    openstack_environments_cfgs: typing.Tuple[glci.model.OpenstackEnvironment],
     image_properties: dict,
     release: glci.model.OnlineReleaseManifest,
 ) -> glci.model.OnlineReleaseManifest:
@@ -87,12 +87,15 @@ def upload_and_publish_image(
         'properties': image_properties,
     }
 
+    openstack_release_artifact = glci.util.virtual_image_artifact_for_platform('openstack')
+    openstack_release_artifact_path = release.path_by_suffix(openstack_release_artifact)
+
     s3_image_url = s3_client.generate_presigned_url(
         'get_object',
         ExpiresIn=1200*len(openstack_environments_cfgs), # 20min validity for each openstack enviroment/region
         Params={
-            'Bucket': release.path_by_suffix('rootfs.vmdk').s3_bucket_name,
-            'Key': release.path_by_suffix('rootfs.vmdk').s3_key,
+            'Bucket': openstack_release_artifact_path.s3_bucket_name,
+            'Key': openstack_release_artifact_path.s3_key,
         },
     )
 

--- a/ci/glci/util.py
+++ b/ci/glci/util.py
@@ -475,3 +475,26 @@ class EnumValueYamlDumper(yaml.SafeDumper):
         if isinstance(data, enum.Enum):
             return self.represent_data(data.value)
         return super().represent_data(data)
+
+
+def virtual_image_artifact_for_platform(platform: glci.model.Platform) -> str:
+    # map each platform to the suffix/object that is of interest.
+
+    platform_to_artifact_mapping = {
+        'ali': 'rootfs.qcow2',
+        'aws': 'rootfs.raw',
+        'azure': 'rootfs.vhd',
+        'gcp': 'rootfs-gcpimage.tar.gz',
+        'kvm': 'rootfs.raw',
+        'metal': 'rootfs.tar.xz',
+        'oci': 'rootfs.tar.xz',
+        'openstack': 'rootfs.vmdk',
+        'vmware': 'rootfs.ova',
+    }
+
+    if not platform in platform_to_artifact_mapping:
+        raise NotImplementedError(
+            f"No information about release artifacts available for platform '{platform}'"
+        )
+
+    return platform_to_artifact_mapping[platform]

--- a/ci/promote.py
+++ b/ci/promote.py
@@ -107,6 +107,7 @@ def _publish_alicloud_image(release: glci.model.OnlineReleaseManifest,
     maker.cp_image_from_s3(s3_client)
     return maker.make_image()
 
+
 def _clean_alicloud_image(release: glci.model.OnlineReleaseManifest,
                             cicd_cfg: glci.model.CicdCfg,
 ) -> glci.model.OnlineReleaseManifest:
@@ -123,6 +124,7 @@ def _clean_alicloud_image(release: glci.model.OnlineReleaseManifest,
         oss_auth, acs_client, release, cicd_cfg.build)
 
     return maker.delete_images()
+
 
 def _publish_aws_image(release: glci.model.OnlineReleaseManifest,
                        cicd_cfg: glci.model.CicdCfg,

--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -226,7 +226,7 @@ def mk_pipeline_run(
     snapshot_timestamp = glci.model.snapshot_date(gardenlinux_epoch=gardenlinux_epoch)
 
     flavour_count = len(list(flavour_set.flavours()))
-    
+
     if flavour_count == 0:
         flavour_count = 1  # at least one workspace must be created
 

--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -44,6 +44,8 @@ def mk_pipeline_name(
             return 'imgs'
         elif publishing_action is glci.model.PublishingAction.MANIFESTS:
             return 'man'
+        elif publishing_action is glci.model.PublishingAction.COMPONENT_DESCRIPTOR:
+            return 'cd'
 
     # add last 4 seconds of time since epoch (to avoid issues with identical pipeline names for
     # repeated builds of the same commit)

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -113,7 +113,7 @@ done
 image_build=false
 package_build=false
 wait=false
-for arg in "$@" 
+for arg in "$@"
 do
     echo "Found arg $arg";
     if [ $arg ==  "--image-build" ]; then

--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -108,6 +108,17 @@ def main():
     )
     raw_build_task = dataclasses.asdict(build_task)
 
+    ctx_repository_config_name = NamedParam(
+        name='ctx_repository_config_name',
+        default='gardener-dev',
+        description='Name of the component-descriptor repository-context config to use',
+    )
+    snapshot_ctx_repository_config_name = NamedParam(
+        name='snapshot_ctx_repository_config_name',
+        default='gardener-dev',
+        description='Name of the snapshot component-descriptor repository-context config to use',
+    )
+
     promote_task = tasks.promote_task(
         branch=NamedParam(name='branch'),
         cicd_cfg_name=NamedParam(name='cicd_cfg_name'),
@@ -117,6 +128,8 @@ def main():
         publishing_actions=NamedParam(name='publishing_actions'),
         snapshot_timestamp=NamedParam(name='snapshot_timestamp'),
         version=NamedParam(name='version'),
+        ctx_repository_config_name=ctx_repository_config_name,
+        snapshot_ctx_repository_config_name=snapshot_ctx_repository_config_name,
         env_vars=env_vars,
         volumes=volumes,
         volume_mounts=volume_mounts,

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -4,7 +4,7 @@ import typing
 
 import tkn.model
 
-IMAGE_VERSION = '1.1388.0'
+IMAGE_VERSION = '1.1399.0'
 DEFAULT_IMAGE = f'eu.gcr.io/gardener-project/cc/job-image:{IMAGE_VERSION}'
 KANIKO_IMAGE = f'eu.gcr.io/gardener-project/cc/job-image-kaniko:{IMAGE_VERSION}'
 

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -576,7 +576,7 @@ def notify_step(
     namespace: tkn.model.NamedParam,
     only_recipients: tkn.model.NamedParam,
     pipeline_name: tkn.model.NamedParam,
-    pipeline_run_name: tkn.model.NamedParam,    
+    pipeline_run_name: tkn.model.NamedParam,
     repo_dir: tkn.model.NamedParam,
     status_dict_str: tkn.model.NamedParam,
     env_vars: typing.List[typing.Dict] = [],

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -568,6 +568,43 @@ def build_base_image_step(
     )
 
 
+def create_component_descriptor_step(
+    repo_dir: tkn.model.NamedParam,
+    branch: tkn.model.NamedParam,
+    version: tkn.model.NamedParam,
+    committish: tkn.model.NamedParam,
+    cicd_cfg_name: tkn.model.NamedParam,
+    gardenlinux_epoch: tkn.model.NamedParam,
+    ctx_repository_config_name: tkn.model.NamedParam,
+    snapshot_ctx_repository_config_name: tkn.model.NamedParam,
+    publishing_actions: tkn.model.NamedParam,
+    env_vars: typing.List[typing.Dict] = [],
+    volume_mounts: typing.List[typing.Dict] = [],
+):
+    return tkn.model.TaskStep(
+        name='component-descriptor',
+        image=DEFAULT_IMAGE,
+        script=task_step_script(
+            path=os.path.join(steps_dir, 'component_descriptor.py'),
+            script_type=ScriptType.PYTHON3,
+            callable='build_component_descriptor',
+            repo_path_param=repo_dir,
+            params=[
+                branch,
+                cicd_cfg_name,
+                committish,
+                ctx_repository_config_name,
+                gardenlinux_epoch,
+                publishing_actions,
+                snapshot_ctx_repository_config_name,
+                version,
+            ],
+        ),
+        volumeMounts=volume_mounts,
+        env=env_vars,
+    )
+
+
 def notify_step(
     additional_recipients: tkn.model.NamedParam,
     cicd_cfg_name: tkn.model.NamedParam,

--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -1,0 +1,215 @@
+import dataclasses
+import datetime
+import sys
+import timezone
+
+import yaml
+import glci
+import glci.util
+
+import gci.componentmodel as cm
+import glci.model
+import glci.s3
+import version as version_util
+import product.v2
+
+import ctx
+
+
+def _resolve_ctx_repository_config(cfg_name):
+    f = ctx.cfg_factory()
+    cfg = f.ctx_repository(cfg_name)
+    return cfg.base_url()
+
+
+def _virtual_image_packages(release_manifest, cicd_cfg):
+    s3_client = glci.s3.s3_client(cicd_cfg)
+    manifest_file_path = release_manifest.path_by_suffix('rootfs.manifest')
+    resp = s3_client.get_object(
+        Bucket=manifest_file_path.s3_bucket_name,
+        Key=manifest_file_path.s3_key,
+    )
+    for line in resp['Body'].iter_lines():
+        yield line.decode('utf-8')
+
+
+def build_component_descriptor(
+    version: str,
+    committish: str,
+    cicd_cfg_name: str,
+    gardenlinux_epoch: str,
+    publishing_actions: str,
+    ctx_repository_config_name: str,
+    branch: str,
+    snapshot_ctx_repository_config_name: str = None,
+):
+    publishing_actions = [
+        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
+    ]
+    if glci.model.PublishingAction.COMPONENT_DESCRIPTOR not in publishing_actions:
+        print(
+            f'publishing action {glci.model.PublishingAction.COMPONENT_DESCRIPTOR} not specified '
+            'exiting now'
+        )
+        sys.exit(0)
+    if glci.model.PublishingAction.BUILD_ONLY in publishing_actions:
+        print(
+            f'publishing action {glci.model.PublishingAction.BUILD_ONLY=} specified - exiting now'
+        )
+        sys.exit(0)
+
+    cicd_cfg = glci.util.cicd_cfg(cfg_name=cicd_cfg_name)
+    flavour_set = glci.util.flavour_set(flavour_set_name='all')
+
+    find_releases = glci.util.preconfigured(
+        func=glci.util.find_releases,
+        cicd_cfg=cicd_cfg,
+    )
+
+    releases = tuple(find_releases(
+        flavour_set=flavour_set,
+        version=version,
+        build_committish=committish,
+        gardenlinux_epoch=int(gardenlinux_epoch),
+        prefix=glci.model.ReleaseManifest.manifest_key_prefix,
+        )
+    )
+
+    if glci.model.PublishingAction.RELEASE not in publishing_actions:
+      version = version_util.process_version(
+        version_str=version,
+        operation=version_util.SET_PRERELEASE,
+        prerelease=committish,
+      )
+
+    base_url = _resolve_ctx_repository_config(ctx_repository_config_name)
+    if snapshot_ctx_repository_config_name:
+        snapshot_repo_base_url = _resolve_ctx_repository_config(snapshot_ctx_repository_config_name)
+
+    component_descriptor = _base_component_descriptor(
+        version=version,
+        branch=branch,
+        commit=committish,
+        ctx_repository_base_url=base_url
+    )
+
+    component_descriptor.component.resources.extend([
+        virtual_machine_image_resource(release_manifest, cicd_cfg)
+        for release_manifest in releases
+    ])
+
+    product.v2.upload_component_descriptor_v2_to_oci_registry(
+      component_descriptor_v2=component_descriptor,
+    )
+
+    if snapshot_repo_base_url:
+        if base_url != snapshot_repo_base_url:
+            repo_ctx = cm.OciRepositoryContext(
+                baseUrl=snapshot_repo_base_url,
+                type=cm.AccessType.OCI_REGISTRY,
+            )
+            component_descriptor.component.repositoryContexts.append(repo_ctx)
+
+        # upload obeys the appended repo_ctx
+        product.v2.upload_component_descriptor_v2_to_oci_registry(
+            component_descriptor_v2=component_descriptor,
+            on_exist=product.v2.UploadMode.OVERWRITE,
+        )
+
+
+def virtual_machine_image_resource(
+    release_manifest,
+    cicd_cfg,
+):
+    resource_type = 'virtual_machine_image'
+    image_file_suffix = glci.util.virtual_image_artifact_for_platform(release_manifest.platform)
+    image_file_path = release_manifest.path_by_suffix(image_file_suffix)
+
+    bucket_name = cicd_cfg.build.s3_bucket_name
+
+    labels = [
+        cm.Label(
+          name='gardener.cloud/gardenlinux/ci/build-metadata',
+          value={
+              'modifiers': release_manifest.modifiers,
+              'buildTimestamp': release_manifest.build_timestamp,
+              'debianPackages': [p for p in _virtual_image_packages(release_manifest, cicd_cfg)],
+          }
+        ),
+    ]
+
+    if (published_image_metadata := release_manifest.published_image_metadata):
+        labels.append(
+            cm.Label(
+                name='gardener.cloud/gardenlinux/ci/published-image-metadata',
+                value=published_image_metadata,
+            ),
+        )
+
+    resource_access = cm.S3Access(
+        type=cm.AccessType.S3,
+        bucketName=bucket_name,
+        objectKey=image_file_path.s3_key,
+    )
+
+    return cm.Resource(
+        name='gardenlinux',
+        version=release_manifest.version,
+        extraIdentity={
+            'featureFlags': ','.join(release_manifest.modifiers),
+            'architecture': release_manifest.architecture,
+            'platform': release_manifest.platform,
+        },
+        type=resource_type,
+        labels=labels,
+        access=resource_access,
+    )
+
+
+def _base_component_descriptor(
+    version: str,
+    ctx_repository_base_url: str,
+    commit: str,
+    branch: str,
+    component_name: str='github.com/gardenlinux/gardenlinux',
+):
+    parsed_version = version_util.parse_to_semver(version)
+    if parsed_version.finalize_version() == parsed_version:
+        # "final" version --> there will be a tag, later
+        src_ref = f'refs/tags/{version}'
+    else:
+        src_ref = f'refs/heads/{branch}'
+
+    # logical names must not contain slashes or dots
+    logical_name = component_name.replace('/', '_').replace('.', '_')
+
+    base_descriptor_v2 = cm.ComponentDescriptor(
+        meta=cm.Metadata(schemaVersion=cm.SchemaVersion.V2),
+        component=cm.Component(
+            name=component_name,
+            version=version,
+            repositoryContexts=[
+                cm.OciRepositoryContext(
+                    baseUrl=ctx_repository_base_url,
+                    type=cm.AccessType.OCI_REGISTRY,
+                )
+            ],
+            provider=cm.Provider.INTERNAL,
+            sources=[
+                cm.ComponentSource(
+                    name=logical_name,
+                    type=cm.SourceType.GIT,
+                    access=cm.GithubAccess(
+                        type=cm.AccessType.GITHUB,
+                        repoUrl=component_name,
+                        ref=src_ref,
+                        commit=commit,
+                    ),
+                    version=version,
+                )
+            ],
+            componentReferences=[],
+            resources=[], # added later
+        ),
+    )
+    return base_descriptor_v2

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -1,4 +1,3 @@
-from os import name
 import steps
 import tkn.model
 

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -21,6 +21,8 @@ def promote_task(
     publishing_actions: NamedParam,
     snapshot_timestamp: NamedParam,
     version: NamedParam,
+    ctx_repository_config_name: NamedParam,
+    snapshot_ctx_repository_config_name: NamedParam,
     env_vars=[],
     giturl: NamedParam = _giturl,
     name='promote-gardenlinux-task',
@@ -59,9 +61,25 @@ def promote_task(
         volume_mounts=volume_mounts,
     )
 
+    build_cd_step = steps.create_component_descriptor_step(
+        branch=branch,
+        repo_dir=_repodir,
+        committish=committish,
+        version=version,
+        gardenlinux_epoch=gardenlinux_epoch,
+        ctx_repository_config_name=ctx_repository_config_name,
+        snapshot_ctx_repository_config_name=snapshot_ctx_repository_config_name,
+        env_vars=env_vars,
+        publishing_actions=publishing_actions,
+        volume_mounts=volume_mounts,
+        cicd_cfg_name=cicd_cfg_name,
+    )
+
     params = [
         branch,
         cicd_cfg_name,
+        ctx_repository_config_name,
+        snapshot_ctx_repository_config_name,
         committish,
         flavourset,
         gardenlinux_epoch,
@@ -78,6 +96,7 @@ def promote_task(
             params=params,
             steps=[
                 clone_step,
+                build_cd_step,
                 promote_step,
                 release_step,
             ],


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds another step to the promote task of the image-build-pipeline that builds and publishes a Component Descriptor for the current build, if configured.

**Special notes for your reviewer**:
The required publishing-action is not (yet) set by default, so merging this should be super safe.
For an example, see [this](https://github.com/gardenlinux/gardenlinux/files/6939055/example-cd.txt) descriptor.
