### PR TITLE
Keep the order of features

### DIFF
--- a/bin/.constants.sh
+++ b/bin/.constants.sh
@@ -161,3 +161,7 @@ filter_if() {
         print $NF
       }'
 }
+norm_features() {
+    # remove duplicates without sorting, last entry "wins"
+    tac | awk '!seen[$0]++' | tac
+}

--- a/bin/garden-build.sh
+++ b/bin/garden-build.sh
@@ -181,7 +181,7 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 	sed -i "s/^HOME_URL=.*$/HOME_URL=\"https:\/\/gardenlinux.io\/\"/g" rootfs/etc/os-release
 	sed -i "s/^SUPPORT_URL=.*$/SUPPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\"/g" rootfs/etc/os-release
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
-	echo "GARDENLINUX_FEATURES=$(echo base,$features | tr "," "\n" | sort -u | paste -d"," -s)" >> rootfs/etc/os-release
+	echo "GARDENLINUX_FEATURES=$(echo base,$features | tr "," "\n" | norm_features | paste -d"," -s)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_VERSION=$($debuerreotypeScriptsDir/garden-version)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$suite" >> rootfs/etc/os-release
@@ -259,7 +259,7 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 
 		echo "#### features"
 		[ "$features" = "full" ] && features=$(ls $featureDir | paste -sd, -)
-		for i in $(echo "base,$features" | tr ',' '\n' | sort -u); do
+		for i in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 			if [ -s $featureDir/$i/image ]; then
 				bash -c "$featureDir/$i/image $rootfs $targetBase"
 			else
@@ -290,7 +290,7 @@ codename="$(awk -F ": " "\$1 == \"Codename\" { print \$2; exit }" "$outputDir/Re
 			# go over features and build the enabled/disabled lists
 			# a test with .disabled in a specific feature disables the test globally
 			# a test that is not executable is not enabled for the specific feature
-			for f in $(echo "base,$features" | tr ',' '\n' | sort -u); do
+			for f in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 				featureTest="${featureDir}/${f}/test/${test}"
 				if [ -f "${featureTest}.disable" ]; then
 					disabledBy=$(echo "${f} ${disabledBy}")

--- a/bin/garden-config
+++ b/bin/garden-config
@@ -30,21 +30,21 @@ targetDir="${1:-}"; shift || eusage 'missing target-dir'
 aptVersion="$("$thisDir/.apt-version.sh" "$targetDir")"
 
 [ "$features" = "full" ] && features=$(ls $featureDir | paste -sd, -)
-for i in $(echo "base,$features" | tr ',' '\n' | sort -u); do
+for i in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 	if [ -d "$featureDir/$i/file.include" ]; then
 		out=$(tar --owner=0 --group=0 -cC $featureDir/$i/file.include . | tar -xvC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  -)
 		echo "copying from $i: $out"
 	fi
 done
 
-for i in $(echo "base,$features" | tr ',' '\n' | sort -u); do
+for i in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 	if [ -f $featureDir/$i/exec.config ]; then
 		echo "executing from $i: exec.config"
 		$thisDir/garden-chroot "$targetDir" bash -c "$(cat $featureDir/$i/exec.config)"
 	fi
 done
 
-for i in $(echo "base,$features" | tr ',' '\n' | sort -u); do
+for i in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 	if [ -f "$featureDir/$i/file.exclude" ]; then
 		echo "deleting from $i: $(cat $featureDir/$i/file.exclude | paste -sd' '  -)"
 		for j in $(cat $featureDir/$i/file.exclude); do

--- a/bin/garden-init
+++ b/bin/garden-init
@@ -110,7 +110,7 @@ exclude="$(tr "," "\n" <<< $include)"$'\n'
 [ -s $thisDir/.init-includes ] && include+="$(cat $thisDir/.init-includes)"$'\n'
 [ -s $thisDir/.init-excludes ] && exclude+="$(cat $thisDir/.init-excludes)"$'\n'
 
-for i in $(echo "base,$features" | tr ',' '\n' | sort -u); do
+for i in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 	[ -s $featureDir/$i/pkg.include ] && include+="$(cat $featureDir/$i/pkg.include)"$'\n'
 	[ -s $featureDir/$i/pkg.exclude ] && exclude+="$(cat $featureDir/$i/pkg.exclude)"$'\n'
 done


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Keeping the order of the features is really important, when removing duplicate features, the list of features got sorted. This commit introduced this bug : https://github.com/gardenlinux/gardenlinux/commit/2893b35f12c737c3df74cf9d99eecd25892436d6