### PR TITLE
Fix metal feature / gl dracut module

### DIFF
--- a/features/cloud/file.include/usr/lib/dracut/modules.d/98gardenlinux/module-setup.sh
+++ b/features/cloud/file.include/usr/lib/dracut/modules.d/98gardenlinux/module-setup.sh
@@ -11,7 +11,8 @@ depends() {
 }
 
 install() {
-    inst_multiple grep sfdisk growpart udevadm awk mawk sed rm readlink systemd-detect-virt systemd-cat
+    # FIXME: remove tr, base should include it
+    inst_multiple tr grep sfdisk growpart udevadm awk mawk sed rm readlink systemd-detect-virt systemd-cat
    
     # grow root
     if [ -f "$moddir/growroot.sh" ]; then

--- a/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/module-setup.sh
+++ b/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/module-setup.sh
@@ -11,7 +11,7 @@ depends() {
 }
 
 install() {
-    inst_multiple grep sfdisk growpart udevadm awk mawk sed rm readlink
+    inst_multiple tr grep sfdisk growpart udevadm awk mawk sed rm readlink systemd-detect-virt systemd-cat
    
     # grow root
     if [ -f "$moddir/growroot.sh" ]; then
@@ -21,7 +21,14 @@ install() {
     # handle usr mounting
     if [[ -f "$moddir/usr-mount.service" ]] && [[ -f "$moddir/usr-mount.sh" ]]; then
         inst_simple "$moddir/usr-mount.service" ${systemdsystemunitdir}/usr-mount.service
+        inst_simple "$moddir/sysroot-usr-fsck.service" ${systemdsystemunitdir}/sysroot-usr-fsck.service
+        inst_simple "$moddir/sysroot-usr.mount" ${systemdsystemunitdir}/sysroot-usr.mount
         inst_script "$moddir/usr-mount.sh" /bin/usr-mount.sh
-        systemctl -q --root "$initdir" add-wants initrd-root-fs.target usr-mount.service
+        systemctl -q --root "$initdir" add-wants initrd-fs.target usr-mount.service
+        systemctl -q --root "$initdir" add-wants initrd-fs.target sysroot-usr-fsck.service 
+        systemctl -q --root "$initdir" add-wants initrd-fs.target sysroot-usr.mount 
+    fi
+    if [ -f "$moddir/clocksource-setup.sh" ]; then
+        inst_hook pre-pivot 00 "$moddir/clocksource-setup.sh"
     fi
 }

--- a/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/sysroot-usr-fsck.service
+++ b/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/sysroot-usr-fsck.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Filesystem check for the device used for /usr
+DefaultDependencies=no
+After=usr-mount.service  
+Before=sysroot-usr.mount
+Requisite=usr-mount.service
+
+[Service]
+EnvironmentFile=/run/systemd/sysroot-usr.env
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/lib/systemd/systemd-fsck ${DEVICE} 
+TimeoutSec=0

--- a/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/sysroot-usr.mount
+++ b/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/sysroot-usr.mount
@@ -1,0 +1,12 @@
+[Unit]
+After=sysroot.mount
+After=usr-mount.service
+Before=initrd-fs.target
+Requisite=usr-mount.service
+
+[Mount]
+EnvironmentFile=/run/systemd/sysroot-usr.env
+Where=/sysroot/usr
+What=${DEVICE}
+Options=${OPTIONS}
+Type=${FSTYPE}

--- a/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/usr-mount.sh
+++ b/features/metal/file.include/usr/lib/dracut/modules.d/98gardenlinux/usr-mount.sh
@@ -1,29 +1,12 @@
 #!/bin/sh
 
-#
-# FIXME
-#
 mountUnit="/sysroot/etc/systemd/system/usr.mount"
 
 FSTYPE=$(awk -F= '/^Type=/ { print $2}' "$mountUnit")
 DEVICE=$(awk -F= '/^What=/ { print $2}' "$mountUnit")
 OPTIONS=$(awk -F= '/^Options=/ { print $2}' "$mountUnit") 
 
-DEVNAME=$(systemd-escape -p "$DEVICE")
-# create the mount unit in ramdisk
-{
-echo "[Unit]"
-echo "Before=initrd-root-fs.target"
-echo "Requires=systemd-fsck@${DEVNAME}.service"
-echo "After=sysroot.mount"
-echo "After=systemd-fsck@${DEVNAME}.service"
-echo "After=blockdev@${DEVNAME}.target"
-echo "[Mount]"
-echo "Where=/sysroot/usr"
-echo "What=$DEVICE"
-echo "Options=$OPTIONS"
-echo "Type=$FSTYPE"
-} > /etc/systemd/system/sysroot-usr.mount
-
-mkdir -p /etc/systemd/system/initrd-fs.target.wants
-ln -s /etc/systemd/system/sysroot-usr.mount /etc/systemd/system/initrd-fs.target.wants/sysroot-usr.mount
+echo "FSTYPE=${FSTYPE}
+DEVICE=${DEVICE}
+OPTIONS=${OPTIONS}
+DEVNAME=${DEVNAME}" > /run/systemd/sysroot-usr.env


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Sync the gardenlinux dracut module used in the metal feature with the one from the cloud feature. Add "tr" to the module setup as this is missing from base/dracut-systemd and is going to break the rootfs generator.