### PR TITLE
use cloud-init for VM provisioning on Azure

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-wget --quiet -P /tmp http://45.86.152.1/gardenlinux/pool/main/w/waagent_2.2.47-2.2_all.deb
-apt-get install -y -f /tmp/waagent_2.2.47-2.2_all.deb
-rm /tmp/waagent_2.2.47-2.2_all.deb
-
 sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf

--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/10_azure.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/10_azure.cfg
@@ -1,0 +1,5 @@
+reporting:
+  logging:
+    type: log
+  telemetry:
+    type: hyperv

--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
@@ -1,0 +1,1 @@
+network: {config: disabled}

--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,6 +1,10 @@
 # Azure images require waagent
-#waagent
+waagent
 # debootstrap does not pull python3-cffi-backend
-#python3-cffi-backend
-#
-#cloud-init
+python3-cffi-backend
+python3-cryptography
+python3-oauthlib
+cloud-init
+cloud-guest-utils
+hyperv-daemons
+isc-dhcp-client


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
The PR switches from using the waagent for VM provisioning to cloud-init. This makes the waagent compatible with Pyhton 3.9

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
* switch to cloud-init for VM provisioning on Azure
```
