### PR TITLE
Azure clock source

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -7,3 +7,7 @@ rm /tmp/waagent_2.2.47-2.2_all.deb
 sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf
 
 sed -i '/^ExecStart=\/usr\/sbin\/waagent -daemon/a ExecStartPost=\/bin\/systemctl try-restart systemd-networkd.service' /lib/systemd/system/walinuxagent.service
+
+# On Azure we use chrony and ptp to set the time
+apt-get remove systemd-timesyncd
+apt-get install -y chrony

--- a/features/azure/file.include/etc/chrony/chrony.conf
+++ b/features/azure/file.include/etc/chrony/chrony.conf
@@ -1,0 +1,50 @@
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+
+# Include configuration files found in /etc/chrony/conf.d.
+#confdir /etc/chrony/conf.d
+
+# Use Debian vendor zone.
+#pool 2.debian.pool.ntp.org iburst
+
+# Use time sources from DHCP.
+#sourcedir /run/chrony-dhcp
+
+# Use NTP sources found in /etc/chrony/sources.d.
+#sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+#leapsectz right/UTC
+
+# Azure provides a PTP Clock Source
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0

--- a/features/azure/file.include/etc/udev/rules.d/60-udev-hyperv.rules
+++ b/features/azure/file.include/etc/udev/rules.d/60-udev-hyperv.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Azure recommends in https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync to use PTP. As systemd-timesyncd does not support PTP so it is deinstalled and chrony is being used as proposed in the linked document.

As there might be multiple /dev/ptp devices a udev role has been added to create a stable symlink /dev/ptp_hyperv.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
This PR changes way VMs on Azure acquire their time from NTP to PTP.
```
