### PR TITLE
Add support for local credentials to example integration-test-framework

### DIFF
--- a/integration_tests/azure/readme.md
+++ b/integration_tests/azure/readme.md
@@ -1,0 +1,17 @@
+### Azure Integration Tests
+
+This directory contains two files:
+1. `azure_test.py`: contains the test-cases for `Azure`
+2. `conftest.py`: contains the `Azure`-specific pytest-fixtures
+
+### Usage
+
+The integration tests can be started by running
+
+> pytest .
+
+from within this directory. By default, this will use our central credentials management to obtain the credentials to use to authenticate against `Azure`. You can use pre-existing local Credentials by calling
+
+> pytest . --local
+
+instead. __Note__: This requires a __successful__ login to the `Azure CLI` (e.g. using `az login`) before running the tests.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -62,3 +62,13 @@ def s3_bucket(test_params) -> S3Info:
         target_image_name=f'integration-test-image-{test_params.committish}',
     )
 
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--local',
+        action='store_true',
+        help=(
+            "run test using local authentication (requires successful authentication prior to "
+            " execution, e.g.: 'gcloud auth application-default login' or 'az login')"
+        ),
+    )

--- a/integration_tests/gcp/gcp_test.py
+++ b/integration_tests/gcp/gcp_test.py
@@ -1,11 +1,12 @@
 def test_gcp_instances(gcp_cfg, compute_client):
-    zones = compute_client.zones().list(project=gcp_cfg.project_id).execute()
+    # TODO/FIXME: gcp_cfg.project() requires access to central config
+    zones = compute_client.zones().list(project=gcp_cfg.project()).execute()
     print('Getting all zones for this project:')
     for zone in zones['items']:
         print(f"Zone: {zone['name']=}, {zone['id']=}, {zone['status']}")
 
     zone = 'europe-west2-a'
-    result = compute_client.instances().list(project=gcp_cfg.project_id, zone=zone).execute()
+    result = compute_client.instances().list(project=gcp_cfg.project(), zone=zone).execute()
     assert(len(result) != 0)
     instances =  result['items'] if 'items' in result else []
     print(f'Getting instances for zone {zone}:')

--- a/integration_tests/gcp/readme.md
+++ b/integration_tests/gcp/readme.md
@@ -1,0 +1,17 @@
+### GCP Integration Tests
+
+This directory contains two files:
+1. `gcp_test.py`: contains the test-cases for `GCP`
+2. `conftest.py`: contains the `GCP`-specific pytest-fixtures
+
+### Usage
+
+The integration tests can be started by running
+
+> pytest .
+
+from within this directory. By default, this will use our central credentials management to obtain the credentials to use to authenticate against `GCP`. You can use pre-existing local credentials by calling
+
+> pytest . --local
+
+instead. __Note__: This requires a __successful__ login to the `Google Cloud SDK` using `gcloud auth application-default login` before running the tests.

--- a/integration_tests/readme.md
+++ b/integration_tests/readme.md
@@ -1,0 +1,18 @@
+### Integration Tests
+
+This directory contains the files that make up the integration test suites for the various providers.
+
+### Usage
+
+All existing integration tests can be started by simply running
+
+> pytest
+
+from within this directory. By default, this will use our central credentials management to obtain the necessary credentials to authenticate against the individual cloud providers. You can use pre-existing local credentials (where supported) by calling
+
+> pytest --local
+
+instead. __Note__: This requires a __successful__ login to the respective cloud provider's CLI (e.g. `Google Cloud SDK`) before running the tests.
+Instead of running all tests at once, they can also be run individually by provider by simply passing the directory as argument to pytest, e.g.:
+
+> pytest azure --local


### PR DESCRIPTION
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Adapts the existing exemplary integration-test framework so that it _optionally_ supports authentication using local credentials in a way that is transparent to the test-author. Also adds small readme.mds to document usage.
For this PR this was only done for GCP and Azure, as there were some uncertainties with handling this using pytest. These changes should provide an example for doing similar work on the other cloud provider integration tests.

**Special notes for your reviewer**:
It might be worth thinking about merging this into your dev-branches instead of merging into main. Either way, rebasing should not be much of an issue.

