### PR TITLE
Include non-transitional netcat-openbsd

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -25,6 +25,7 @@ less
 tcpdump
 vim-tiny
 quota
+netcat-openbsd
 nvme-cli
 selinux-basics
 selinux-policy-default


### PR DESCRIPTION
The netcat transitional package have been removed from Debian after
Bullseye.  Just use netcat-openbsd instead.

/kind bug
/area os
/os garden-linux