### PR TITLE
fix wrong deb dracut packages

### DIFF
--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -3,6 +3,6 @@ curl
 dosfstools
 btrfs-progs
 xfsprogs
-main/d/dracut/dracut-core_051-1.1_${arch}.deb
-main/d/dracut/dracut_051-1.1_all.deb
-main/d/dracut/dracut-network_051-1.1_all.deb
+main/d/dracut/dracut-core_055-1gardenlinux1_{arch}.deb 
+main/d/dracut/dracut_055-1gardenlinux1_all.deb 
+main/d/dracut/dracut-network_055-1gardenlinux1_all.deb

--- a/features/chost/file.include/etc/modules-load.d/overlayfs.conf
+++ b/features/chost/file.include/etc/modules-load.d/overlayfs.conf
@@ -1,0 +1,1 @@
+options overlay metacopy=off redirect_dir=on


### PR DESCRIPTION
/area os
/os garden-linux


**Which issue(s) this PR fixes**:
Fixes # 
updated outdated debian package names for dracut gardenlinux


- category:       bugfix
- target_group:   dependency

