### PR TITLE
Clarify build result folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Building specific platform images:
     make kvm
     make metal
 
-See in `build/` folder for the outcome
+See in `.build/` folder for the outcome, there are subdirectories for the platform and the build date.
 
 ## Customize builds
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind doc
/area os
/os garden-linux

**What this PR does / why we need it**:

Clarifies that build results are put into `.build/` (hidden directory), not (as previously stated) `build/`