### PR TITLE
Add metal/metal-dev to add_prod/all_dev targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ cert/sign.pub:
 docker:
 	make --directory=docker all
 
-all_prod: ali aws gcp azure openstack vmware kvm
+all_prod: ali aws gcp azure metal openstack vmware kvm
 
-all_dev: ali-dev aws-dev gcp-dev azure-dev openstack-dev vmware-dev kvm-dev
+all_dev: ali-dev aws-dev gcp-dev azure-dev metal-dev openstack-dev vmware-dev kvm-dev
 
 ALI_IMAGE_NAME=$(IMAGE_BASENAME)-ali-$(VERSION)
 ali: docker cert/sign.pub


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:

Add the metal/metal-dev platform to the `all_prod/all_dev` Makefile targets
