### PR TITLE
Fix NTP server for GCP

### DIFF
--- a/features/gcp/exec.config
+++ b/features/gcp/exec.config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 sed -i "s/^ListenStream=\/var\/run\/docker.sock/ListenStream=\/run\/docker.sock/g" /lib/systemd/system/docker.socket
-sed -i "s/^#NTP=/NTP=metadata.google.internal/g" /etc/systemd/system.conf
+sed -i "s/^#NTP=/NTP=metadata.google.internal/g" /etc/systemd/timesyncd.conf
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
 cat >>/etc/ssh/sshd_conf <<EOF


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

On GCP the wrong file was edited for the correct NTP server. This patch fixes it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Garden Linux on GCP now uses the Google NTP server.
```
