### PR TITLE
fix: delete all container images on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,23 @@ cert/sign.pub:
 docker:
 	make --directory=docker all
 
+.PHONY: docker-build
+docker-build:
+	make --directory=docker build-image
+
 all_prod: ali aws gcp azure metal openstack vmware kvm
 
 all_dev: ali-dev aws-dev gcp-dev azure-dev metal-dev openstack-dev vmware-dev kvm-dev
 
 ALI_IMAGE_NAME=$(IMAGE_BASENAME)-ali-$(VERSION)
-ali: docker cert/sign.pub
+ali: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,ali $(BUILDDIR)/ali $(VERSION)
 
 ali-upload:
 	aliyun oss cp $(BUILDDIR)/ali/$(SNAPSHOT_DATE)/rootfs.qcow2  oss://gardenlinux-development/gardenlinux/$(ALI_IMAGE_NAME).qcow2
 
 ALI_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-dev-ali-$(VERSION)
-ali-dev: docker cert/sign.pub
+ali-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,ali,_dev $(BUILDDIR)/ali-dev $(VERSION)
 
 ali-dev-upload:
@@ -37,42 +41,42 @@ ali-dev-upload:
 
 
 AWS_IMAGE_NAME=$(IMAGE_BASENAME)-aws-$(VERSION)
-aws: docker cert/sign.pub
+aws: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,aws $(BUILDDIR)/aws $(VERSION)
 
 aws-upload:
 	./bin/make-ec2-ami --bucket gardenlinux-testing --region eu-north-1 --image-name=$(AWS_IMAGE_NAME) $(BUILDDIR)/aws/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs.raw --permission-public "$(PUBLIC)" --distribute "$(AWS_DISTRIBUTE)"
 
 AWS_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-dev-aws-$(VERSION)
-aws-dev: docker cert/sign.pub
+aws-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,aws,_dev $(BUILDDIR)/aws-dev ${VERSION}
 
 aws-dev-upload:
 	./bin/make-ec2-ami --bucket ami-debian-image-test --region eu-north-1 --image-name=$(AWS_DEV_IMAGE_NAME) $(BUILDDIR)/aws-dev/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs.raw --permission-public "$(PUBLIC)" --distribute "$(AWS_DISTRIBUTE)"
 
 GCP_IMAGE_NAME=$(IMAGE_BASENAME)-gcp-$(VERSION)
-gcp: docker cert/sign.pub
+gcp: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,gcp $(BUILDDIR)/gcp $(VERSION)
 
 gcp-upload:
 	./bin/make-gcp-ami --bucket garden-linux-test --image-name $(GCP_IMAGE_NAME) --raw-image-path $(BUILDDIR)/gcp/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs-gcpimage.tar.gz --permission-public "$(PUBLIC)"
 
 GCP_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-dev-gcp-$(VERSION)
-gcp-dev: docker cert/sign.pub
+gcp-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,gcp,_dev $(BUILDDIR)/gcp-dev $(VERSION)
 
 gcp-dev-upload:
 	./bin/make-gcp-ami --bucket garden-linux-test --image-name $(GCP_DEV_IMAGE_NAME) --raw-image-path $(BUILDDIR)/gcp-dev/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs-gcpimage.tar.gz --permission-public "$(PUBLIC)"
 
 AZURE_IMAGE_NAME=$(IMAGE_BASENAME)-az-$(VERSION)
-azure: docker cert/sign.pub
+azure: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,azure $(BUILDDIR)/azure $(VERSION)
 
 azure-upload:
 	./bin/make-azure-ami --resource-group garden-linux --storage-account-name gardenlinux --image-path=$(BUILDDIR)/azure/$(SNAPSHOT_DATE)/amd64/bullseye/rootfs.vhd --image-name=$(AZURE_IMAGE_NAME)
 
 AZURE_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-dev-az-$(VERSION)
-azure-dev: docker cert/sign.pub
+azure-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,azure,_dev $(BUILDDIR)/azure-dev $(VERSION)
 
 azure-dev-upload:
@@ -80,59 +84,59 @@ azure-dev-upload:
 
 
 OPENSTACK_IMAGE_NAME=$(IMAGE_BASENAME)-openstack-$(VERSION)
-openstack: docker cert/sign.pub
+openstack: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,openstack $(BUILDDIR)/openstack $(VERSION)
 
 openstack-upload:
 	./bin/upload-openstack $(BUILDDIR)/openstack/$(SNAPSHOT_DATE)/rootfs.vmdk $(OPENSTACK_IMAGE_NAME)
 
 OPENSTACK_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-openstack-dev-$(VERSION)
-openstack-dev: docker cert/sign.pub
+openstack-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,openstack,_dev $(BUILDDIR)/openstack-dev $(VERSION)
 
 openstack-dev-upload: 
 	./bin/upload-openstack $(BUILDDIR)/openstack-dev/$(SNAPSHOT_DATE)/rootfs.vmdk $(OPENSTACK_DEV_IMAGE_NAME)
 
-openstack-qcow2: docker cert/sign.pub
+openstack-qcow2: docker-build cert/sign.pub
 	./build.sh --features server,cloud,gardener,openstack-qcow2 $(BUILDDIR)/openstack-qcow2 $(VERSION)
 
 VMWARE_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-vmware-dev-$(VERSION)
-vmware-dev: docker cert/sign.pub
+vmware-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,vmware,_dev $(BUILDDIR)/vmware-dev $(VERSION)
 
 VMWARE_VMOPERATOR_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-vmware-vmoperator-dev-$(VERSION)
-vmware-vmoperator-dev: docker cert/sign.pub
+vmware-vmoperator-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,vmware-vmoperator,_dev $(BUILDDIR)/vmware-vmoperator-dev $(VERSION)
 
-vmware: docker cert/sign.pub
+vmware: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,gardener,vmware $(BUILDDIR)/vmware $(VERSION)
 
-cloud: docker cert/sign.pub
+cloud: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud $(BUILDDIR)/cloud $(VERSION)
 
-kvm: docker cert/sign.pub
+kvm: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,kvm $(BUILDDIR)/kvm $(VERSION)
 
-kvm-dev: docker cert/sign.pub
+kvm-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,kvm,_dev $(BUILDDIR)/kvm-dev $(VERSION)
 
-pxe: docker cert/sign.pub
+pxe: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,_pxe $(BUILDDIR)/pxe $(VERSION)
 
-pxe-dev: docker cert/sign.pub
+pxe-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud,_dev,_pxe $(BUILDDIR)/pxe-dev $(VERSION)
 
-anvil: docker cert/sign.pub
+anvil: docker-build cert/sign.pub
 	./build.sh --no-build --features server,cloud-anvil,kvm,_dev $(BUILDDIR)/anvil $(VERSION)
 
 onmetal: metal
-metal: docker cert/sign.pub
+metal: docker-build cert/sign.pub
 	./build.sh --no-build --features server,metal $(BUILDDIR)/metal $(VERSION)
 
-metal-dev: docker cert/sign.pub
+metal-dev: docker-build cert/sign.pub
 	./build.sh --no-build --features server,metal,_dev $(BUILDDIR)/metal-dev $(VERSION)
 
-metalk: docker cert/sign.pub
+metalk: docker-build cert/sign.pub
 	./build.sh --no-build --features server,metal,chost,khost,_pxe $(BUILDDIR)/metalk $(SNAPSHOT_DATE)
 
 clean:
@@ -140,6 +144,8 @@ clean:
 	@rm -rf $(BUILDDIR)/*
 	@echo "deleting all containers running gardenlinux/build-image"
 	@-docker container rm $$(docker container ls -a | awk '{ print $$1,$$2 }' | grep gardenlinux/build-image: | awk '{ print $$1 }') 2> /dev/null || true
-	@echo "deleting all images of gardenlinux/build-image"
-	@-docker image rm --force $$(docker image ls -a | awk '{ print $$1,$$3 }' | grep gardenlinux/build-image | awk '{ print $$2 }' | sort -u) 2> /dev/null || true
+	@echo "deleting all containers running gardenlinux/integration-test"
+	@-docker container rm $$(docker container ls -a | awk '{ print $$1,$$2 }' | grep gardenlinux/integration-test: | awk '{ print $$1 }') 2> /dev/null || true
 
+distclean: clean
+	make --directory=docker clean


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
Make clean would delete all containers coming from gardenlinux/build-image
and the image itself, all other container images however would remain.
By calling the clean target of the Makefile within the docker directory,
all container images that were built during a Garden Linux build will be
removed.

Building a Garden Linux release would build both, the build-image and
the integration test image (and others). With this change to the Make
file, only the build container image is created, speeding up the process
significantly. The integration test container image is only built on
demand.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix: delete all container images on make clean
```
