### PR TITLE
ci[aws]: add tags for image security scanning

### DIFF
--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -140,6 +140,18 @@ def register_image(
         VirtualizationType='hvm', # | paravirtual
     )
 
+    ec2_client.create_tags(
+        Resources=[
+            result['ImageId'],
+        ],
+        Tags=[
+            {
+                'Key': 'sec-by-def-public-image-exception',
+                'Value': 'enabled',
+            },
+        ]
+    )
+
     # XXX need to wait until image is available (before publishing)
     return result['ImageId']
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind technical-debt
/area os
/os garden-linux

**What this PR does / why we need it**:
Adds a tag to AWS AMI IDs to trigger an exception of certain security scans in the Garden Linux AWS account where the images are published.

**Which issue(s) this PR fixes**:
Fixes #315 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
ci[aws]: add tags for image security scanning
```
