### PR TITLE
Add security=selinux kernel parameter

### DIFF
--- a/features/server/file.include/etc/kernel/cmdline.d/90-selinux.cfg
+++ b/features/server/file.include/etc/kernel/cmdline.d/90-selinux.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX security=selinux"


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Add security=selinux to enable selinux (permissive mode, as default in /etc/selinux/config).

**Which issue(s) this PR fixes**:
Fixes #333 