### PR TITLE
Change dns server in resolv.conf to point to local revolver

### DIFF
--- a/features/openstack/file.include/etc/systemd/system/systemd-resolved.service.d/resolv.conf
+++ b/features/openstack/file.include/etc/systemd/system/systemd-resolved.service.d/resolv.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPre=+/bin/rm /etc/resolv.conf
+ExecStartPost=+/bin/ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Our CC EE colleagues recommend the following options in /etc/resolv.conf:

```
options rotate timeout:1
```

Unfortunately there is no obvious way to configure systemd-resolved to do that, however the systemd-resovled has this functionality built in. This PR changes the symbolic link from /etc/resolv.conf to point to the /run/systemd/resolve/stub-resolv.conf file. 

**Which issue(s) this PR fixes**:
Fixes #326

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Configure openstack image according to the recommendations of our CC EE colleagues.
```
