### PR TITLE
Publish Built OCI-Images to GCR and Include Them in Component Descriptor

### DIFF
--- a/ci/promote.py
+++ b/ci/promote.py
@@ -218,17 +218,21 @@ def _publish_gcp_image(release: glci.model.OnlineReleaseManifest,
 def _publish_oci_image(
     release: glci.model.OnlineReleaseManifest,
     cicd_cfg: glci.model.CicdCfg,
+    release_build: bool = True,
 ) -> glci.model.OnlineReleaseManifest:
     import ccc.aws
     import glci.oci
-    import container.registry
+    import ccc.oci
+
+    oci_client = ccc.oci.oci_client()
     s3_client = ccc.aws.session(cicd_cfg.build.aws_cfg_name).client('s3')
 
     return glci.oci.publish_image(
         release=release,
         publish_cfg=cicd_cfg.publish.oci,
         s3_client=s3_client,
-        publish_oci_image_func=container.registry.publish_container_image,
+        oci_client=oci_client,
+        release_build=release_build,
     )
 
 

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -4,7 +4,7 @@ import typing
 
 import tkn.model
 
-IMAGE_VERSION = '1.1407.0'
+IMAGE_VERSION = '1.1477.0'
 DEFAULT_IMAGE = f'eu.gcr.io/gardener-project/cc/job-image:{IMAGE_VERSION}'
 KANIKO_IMAGE = f'eu.gcr.io/gardener-project/cc/job-image-kaniko:{IMAGE_VERSION}'
 

--- a/ci/steps/upload_results_step.py
+++ b/ci/steps/upload_results_step.py
@@ -9,6 +9,7 @@ import tarfile
 import glci.model
 import glci.util
 import glci.s3
+import promote
 
 '''
 this script is rendered into build-task from step.py/render_task.py
@@ -118,6 +119,15 @@ def upload_results_step(
       paths=uploaded_relpaths,
       published_image_metadata=None,
     )
+
+    # always publish oci image
+    if manifest.platform == 'oci':
+        release_build = glci.model.PublishingAction.RELEASE in publishing_actions
+        manifest = promote._publish_oci_image(
+            release=manifest,
+            cicd_cfg=cicd_cfg,
+            release_build=release_build,
+        )
 
     manifest_path_suffix = manifest.canonical_release_manifest_key_suffix()
     manifest_path = f'{glci.model.ReleaseManifest.manifest_key_prefix}/{manifest_path_suffix}'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area delivery
/os garden-linux

**What this PR does / why we need it**:
Image builds will always publish the created OCI images to GCR at `eu.gcr.io/gardenlinux/gardenlinux`. They will be tagged with `<version>-<canonical release manifest key suffix>` (e.g.: `535.0-oci-base--build-535.0-96be22`).
If a Component Descriptor is to be built, it will also include these published images as resources:
```
…
{
  'access': {
    'imageReference': 'eu.gcr.io/gardenlinux/gardenlinux:535.0-oci-base-535.0-96be22',
    'type': <AccessType.OCI_REGISTRY: 'ociRegistry'>
  },
  'extraIdentity': {},
  'labels': [{
    'name': 'gardener.cloud/gardenlinux/ci/build-metadata',
    'value': {
      'modifiers': ('_slim','base')
    }
  }],
  'name': 'gardenlinux',
  'relation': <ResourceRelation.LOCAL: 'local'>,
  'srcRefs': (),
  'type': <ResourceType.OCI_IMAGE: 'ociImage'>,
  'version': '535.0-96be229c824cb4efef14ba0fb8d6d278958c378e'
}, {
  'access': {
    'imageReference': 'eu.gcr.io/gardenlinux/gardenlinux:535.0-oci-base--build-535.0-96be22',
    'type': <AccessType.OCI_REGISTRY: 'ociRegistry'>
  },
  'extraIdentity': {},
  'labels': [{
    'name': 'gardener.cloud/gardenlinux/ci/build-metadata',
    'value': {
      'modifiers': ('_build','_slim','base')
    }
  }],
  'name': 'gardenlinux',
  'relation': <ResourceRelation.LOCAL: 'local'>,
  'srcRefs': (),
  'type': <ResourceType.OCI_IMAGE: 'ociImage'>,
  'version': '535.0-96be229c824cb4efef14ba0fb8d6d278958c378e'
},
…
```
The resulting oci-images are only supplied with a minimal default config. Only `PATH` and `CMD` are set by default.
