### PR TITLE
docs: clearly mention OpenStack reference implementation

### DIFF
--- a/docs/openstack.md
+++ b/docs/openstack.md
@@ -1,4 +1,12 @@
-# Create OpenStack Image for CC EE
+# GardenLinux for OpenStack
+
+A word of **WARNING**: Since OpenStack is an open environment, we can only provide a reference implementation at this point.
+
+Our reference implementation goes by the name _CC EE_ and uses OpenStack with VMware ESXi as hypervisor (which is why you will find `open-vm-tools` in `features/openstack/pkg.include` and why the code snippet below deals with `vmdk`-files).
+
+If you want to run Garden Linux on OpenStack, chances are high that you will have to create your own feature set that matches your environment and your hypervisor.
+
+## Create OpenStack Image for CC EE
 
 Create scsi geometry image (default would be openstack)
 ```

--- a/features/openstack/README.md
+++ b/features/openstack/README.md
@@ -1,0 +1,6 @@
+# GardenLinux for OpenStack
+
+A word of **WARNING**: Since OpenStack is an open environment, we can only provide a reference implementation at this point.
+This particular feature set for Garden Linux on OpenStack is for an OpenStack landscape that uses VMware ESXi as hypervisor (which is why you will find `open-vm-tools` in `pkg.include`).
+
+If you want to run Garden Linux on OpenStack, you will most likely have to create your own feature set that matches your environment and hypervisor.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind documentation
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds some documentation which clearly mentions that the current OpenStack feature set is a reference
implementation that is designed for the (not so common) CCEE setup with ESXi as hypervisor.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
docs: clearly mention OpenStack reference implementation
```
