### PR TITLE
fix: add security tags to make-ec2-ami

### DIFF
--- a/bin/make-ec2-ami
+++ b/bin/make-ec2-ami
@@ -342,6 +342,9 @@ class Ec2ImageBuild:
         tag_specifications = "Key='ami-id',Value='%s'" % ami_id
         self.tag_snapshot(snapshot_id, tag_specifications)
 
+        tag_specifications = "Key='sec-by-def-public-image-exception',Value='enabled'"
+        self.tag_snapshot(ami_id, tag_specifications)
+
         return ami_id
 
     def make_amis_public(self, amis):


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
Adds a tag to AWS AMI IDs in `make-ec2-ami` to trigger an exception of certain security scans in the Garden Linux AWS account where the images are published.

**Which issue(s) this PR fixes**:
Fixes #315

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix: add security tags to make-ec2-ami
```
