### PR TITLE
create .packages folder

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,4 +1,4 @@
-POOLDIR=$(realpath ../.packages)
+POOLDIR=$$(mkdir -p ../.packages; realpath ../.packages)
 MANUALDIR=$(realpath manual)
 KERNELDIR=$(realpath kernel)
 CERTDIR=$(realpath ../cert)


### PR DESCRIPTION
.packages folder is not created. so all docker builds are in some docker volume