### PR TITLE
reenabling netcat for debugging

### DIFF
--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -15,3 +15,4 @@ jq
 ipvsadm
 cifs-utils
 nfs-common
+netcat-openbsd


### PR DESCRIPTION
netcat was deprecated in Debian. We use anyhow most of the time socat, but some SRE requesting netcat to be present in Gardener environments.