### PR TITLE
bug: fix wrong function call in make-ec2-ami

### DIFF
--- a/bin/make-ec2-ami
+++ b/bin/make-ec2-ami
@@ -356,7 +356,7 @@ class Ec2ImageBuild:
         self.tag_resource(snapshot_id, tag_specifications)
 
         tag_specifications = "Key='sec-by-def-public-image-exception',Value='enabled'"
-        self.tag_snapshot(ami_id, tag_specifications)
+        self.tag_resource(ami_id, tag_specifications)
 
         return ami_id
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
PR #389 (which I apparently approved a bit too quickly) introduced a non-working function call to make-ec2-ami. Fixed by this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
user: fixes internal bug in make-ec2-ami
```
