### PR TITLE
remove resolv.conf symlink from openstack

### DIFF
--- a/features/openstack/file.include/etc/resolv.conf
+++ b/features/openstack/file.include/etc/resolv.conf
@@ -1,1 +1,0 @@
-/run/systemd/resolve/stub-resolv.conf


### PR DESCRIPTION
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Remove the /etc/resolv.conf symlink pointing to /run/systemd/resolve/stub-resolv.conf. Keep the default pointing to /run/systemd/resolve/resolv.conf coming from the server feature.