### PR TITLE
Handle multiple paths for the kernel.full cert

### DIFF
--- a/packages/manual/linux-5.10
+++ b/packages/manual/linux-5.10
@@ -114,7 +114,13 @@ patch -p1 < $srcDir/series.patch
 echo "### setting certificate"
 # to make sure we do not take this accidently
 rm -f debian/certs/debian-uefi-certs.pem
-cp "${CERT_DIR}/kernel.full" debian/certs/gardenlinux-kernel-certs.pem
+if [ -e "${CERT_DIR}/kernel.full" ]; then
+	cp "${CERT_DIR}/kernel.full" debian/certs/gardenlinux-kernel-certs.pem
+elif [ -e "${CERT_DIR}/Kernel.sign.full" ]; then
+	cp "${CERT_DIR}/Kernel.sign.full" debian/certs/gardenlinux-kernel-certs.pem
+else
+	cp /kernel.full debian/certs/gardenlinux-kernel-certs.pem
+fi
 sed -i "s/debian-uefi-certs.pem/gardenlinux-kernel-certs.pem/" debian/config/config debian/config/featureset*/config
 CHANGELOG+="  * Replaced Debian signing certs with GardenLinux certs\n"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes absent cert-file for the central build

