### PR TITLE
Use Garden Linux version in motd

### DIFF
--- a/bin/garden-build.sh
+++ b/bin/garden-build.sh
@@ -188,6 +188,9 @@ fi
 	echo "GARDENLINUX_VERSION=$($debuerreotypeScriptsDir/garden-version)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$suite" >> rootfs/etc/os-release
+	if [ -f rootfs/etc/update-motd.d/05-logo ]; then
+		sed -i "s/@VERSION@/$(garden-version)/" rootfs/etc/update-motd.d/05-logo
+	fi
 
 	create_artifacts() {
 		local targetBase="$1"; shift

--- a/features/server/file.include/etc/update-motd.d/05-logo
+++ b/features/server/file.include/etc/update-motd.d/05-logo
@@ -5,5 +5,5 @@ echo ' / ___| __ _ _ __ __| | ___ _ __   | |    _ _ __  _   ___  __'
 echo '| |  _ / _` | '\''__/ _` |/ _ \ '\''_ \  | |   | | '\''_ \| | | \ \/ /'
 echo '| |_| | (_| | | | (_| |  __/ | | | | |___| | | | | |_| |>  < '
 echo ' \____|\__,_|_|  \__,_|\___|_| |_| |_____|_|_| |_|\__,_/_/\_\'
-echo 'Garden Linux 11 (based on Debian GNU/Linux 11)               '
+echo 'Garden Linux @VERSION@ (based on Debian GNU/Linux bookworm)      '
 echo


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind TODO
/area enhancement
/os garden-linux

**What this PR does / why we need it**:

Change the Garden Linux version displayed in motd from being the same as the corresponding
Debian testing version to the actual Garden Linux version from /etc/os-release.

Also bumps the Debian version it says it is based on from 10 to 11.