### PR TITLE
Fix bug in cd-generation

### DIFF
--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -177,7 +177,7 @@ def oci_image_resources(
                         }
                     ),
                 ]
-            ),
+            )
 
 
 def virtual_machine_image_resource(


### PR DESCRIPTION
An erroneous comma results in a generator yielding tuples instead of Resources.

A future PR will validate the CD before uploading it.