### PR TITLE
Do not use various other caches in central build

### DIFF
--- a/bin/.snapshot-url.sh
+++ b/bin/.snapshot-url.sh
@@ -22,25 +22,37 @@ base="${1:-archive}"
 
 t="$(date --date "$timestamp" '+%Y%m%dT%H%M%SZ')"
 
-# use caching proxy to avoid throttling, if available
-if wget -t1 -qO/dev/null http://localhost/$base/$archive/; then
-	echo "http://localhost/$base/$archive/$t"
-elif wget -t1 -qO/dev/null http://172.17.0.1/$base/$archive/; then
-	echo "http://172.17.0.1/$base/$archive/$t"
-# elif wget -t1 -qO/dev/null http://repo.gardenlinux.io/gardenlinux/archive/$archive/; then
-# 	echo "http://repo.gardenlinux.io/gardenlinux/archive/$archive/$t"
-# this is for the snapshot cache ($base = archive)
-elif wget -t1 -qO/dev/null http://45.86.152.1/gardenlinux/$base/$archive/; then
-	echo "http://45.86.152.1/gardenlinux/$base/$archive/$t"
-# this is for the gardenlinux-local packages ($base = gardenlinux/)
-elif wget -t1 -qO/dev/null http://45.86.152.1/$base/; then
-	echo "http://45.86.152.1/$base/"
-# try our central cache
-elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/; then
-	echo "https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/$t"
-elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/$base/$archive/; then
-	echo "https://snapshot-cache.ci.gardener.cloud/$base/$archive/$t"
+if [[ -z "${RUNNING_ON_CI:-}" ]]; then
+	# use caching proxy to avoid throttling, if available
+	if wget -t1 -qO/dev/null http://localhost/$base/$archive/; then
+		echo "http://localhost/$base/$archive/$t"
+	elif wget -t1 -qO/dev/null http://172.17.0.1/$base/$archive/; then
+		echo "http://172.17.0.1/$base/$archive/$t"
+	# elif wget -t1 -qO/dev/null http://repo.gardenlinux.io/gardenlinux/archive/$archive/; then
+	# 	echo "http://repo.gardenlinux.io/gardenlinux/archive/$archive/$t"
+	# this is for the snapshot cache ($base = archive)
+	elif wget -t1 -qO/dev/null http://45.86.152.1/gardenlinux/$base/$archive/; then
+		echo "http://45.86.152.1/gardenlinux/$base/$archive/$t"
+	# this is for the gardenlinux-local packages ($base = gardenlinux/)
+	elif wget -t1 -qO/dev/null http://45.86.152.1/$base/; then
+		echo "http://45.86.152.1/$base/"
+	# try our central cache
+	elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/; then
+		echo "https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/$t"
+	elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/$base/$archive/; then
+		echo "https://snapshot-cache.ci.gardener.cloud/$base/$archive/$t"
 
+	else
+		echo "https://snapshot.debian.org/$base/$archive/$t"
+	fi
 else
-	echo "https://snapshot.debian.org/$base/$archive/$t"
+	# use central cache alone when running on CI.
+	if wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/; then
+		echo "https://snapshot-cache.ci.gardener.cloud/gardenlinux/$base/$archive/$t"
+	elif wget -t1 -qO/dev/null https://snapshot-cache.ci.gardener.cloud/$base/$archive/; then
+		echo "https://snapshot-cache.ci.gardener.cloud/$base/$archive/$t"
+
+	else
+		echo "https://snapshot.debian.org/$base/$archive/$t"
+	fi
 fi

--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -69,6 +69,11 @@ def render_task(
                 'value': '/cc/utils',
             })
 
+    env_vars.append({
+        'name': 'RUNNING_ON_CI',
+        'value': 'true',
+    })
+
     base_build_task = tasks.base_image_build_task(
         volumes=volumes,
         volume_mounts=volume_mounts,


### PR DESCRIPTION
If `RUNNING_ON_CI` env var is set, use central cache _only_. Otherwise, apply previous cache-hierarchy.
This env-var is set by default on rendered pipelines.