### PR TITLE
Add systemd-timesyncd to server

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -19,6 +19,7 @@ sysstat
 systemd
 systemd-coredump
 systemd-cron
+systemd-timesyncd
 traceroute
 wget
 less


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
systemd-timesyncd should be included via the server feature.