### PR TITLE
Ci: do not set RUNNING_ON_CI for the time being

### DIFF
--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -69,10 +69,11 @@ def render_task(
                 'value': '/cc/utils',
             })
 
-    env_vars.append({
-        'name': 'RUNNING_ON_CI',
-        'value': 'true',
-    })
+    # TODO: re-enable once all packages successfully build centrally
+    # env_vars.append({
+    #     'name': 'RUNNING_ON_CI',
+    #     'value': 'true',
+    # })
 
     base_build_task = tasks.base_image_build_task(
         volumes=volumes,


### PR DESCRIPTION
Setting it causes central builds to fail until all packages are built by the central pipeline successfully.

