### PR TITLE
Do not enable missing irqbalance

### DIFF
--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -2,7 +2,6 @@ apt-mark hold linux-image-amd64
 
 systemctl enable haveged
 systemctl enable ipmievd
-systemctl enable irqbalance
 
 update-kernel-cmdline
 mkdir -p /boot/efi/Default


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Should not enable missing units as it will break the build.