### PR TITLE
test(gcp): add test for correct ntp server on gcp

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -203,6 +203,7 @@ class GCP:
 
         :param image_name: name of the image
         """
+        logger.debug(f"Looking for {image_name=} in {project=}")
         try:
             response = (
                 self._compute.images().get(project=project, image=image_name,).execute()
@@ -211,6 +212,7 @@ class GCP:
             logger.info(f"{image=}")
             return image
         except:
+            logger.debug(f"failed to find image in {project=}")
             return None
 
     def _wait_for_operation(self, operation):

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -66,6 +66,11 @@ def aws(iaas):
         pytest.skip('test only supported on aws')
 
 @pytest.fixture(scope='module')
+def gcp(iaas):
+    if iaas != 'gcp':
+        pytest.skip('test only supported on gcp')
+
+@pytest.fixture(scope='module')
 def non_openstack(iaas):
     if iaas == 'openstack-ccee':
         pytest.skip('test not supported on openstack')
@@ -258,6 +263,11 @@ def test_correct_ntp(client, aws):
     (exit_code, output, error) = client.execute_command("grep -c ^NTP=169.254.169.123 /etc/systemd/timesyncd.conf")
     assert exit_code == 0, f"no {error=} expected"
     assert output.rstrip() == "1", "Expected NTP server to be configured to 169.254.169.123"
+
+def test_correct_ntp(client, gcp):
+    (exit_code, output, error) = client.execute_command("grep -c ^NTP=metadata.google.internal /etc/systemd/timesyncd.conf")
+    assert exit_code == 0, f"no {error=} expected"
+    assert output.rstrip() == "1", "Expected NTP server to be configured to metadata.google.internal"
 
 def test_nvme_kernel_parameter(client, aws):
     (exit_code, output, error) = client.execute_command("grep -c nvme_core.io_timeout=4294967295 /proc/cmdline")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Adds a test for correct NTP server setting in `timesyncd.conf` on GCP.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
test(gcp): add test for correct ntp server on gcp
```
