### PR TITLE
GCP exec.config docker.sock remove change

### DIFF
--- a/features/gcp/exec.config
+++ b/features/gcp/exec.config
@@ -1,4 +1,3 @@
-sed -i "s/^ListenStream=\/var\/run\/docker.sock/ListenStream=\/run\/docker.sock/g" /lib/systemd/system/docker.socket
 sed -i "s/^#NTP=/NTP=metadata.google.internal/g" /etc/systemd/timesyncd.conf
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
GCP's exec.config fails because of wrong path for the unit file. This should be handled by a drop-in anyway, but the ListenStream is set to /run/docker.sock now anyway (in the unit provided by the package) so just removing it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: