### PR TITLE
adding kexec to server

### DIFF
--- a/features/kvm/pkg.include
+++ b/features/kvm/pkg.include
@@ -1,7 +1,5 @@
 dosfstools
 qemu-guest-agent
-kexec-tools
-#grub-cloud-amd64
 #fail2ban
 #ferm
 #python3-systemd

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -4,12 +4,10 @@ fdisk
 lvm2
 dosfstools
 efibootmgr
-kexec-tools
 haveged
 ipmitool
 #grub-cloud-amd64
 cloud-guest-utils
-kexec-tools
 #irqbalance
 pciutils
 usbutils

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -5,6 +5,7 @@ dracut
 iproute2
 iptables
 iputils-ping
+kexec-tools
 libnss-resolve
 libnss-systemd
 libpam-systemd


### PR DESCRIPTION
bugfix

currently kexec is only available for kvm and metal because it is heavily used there in ignition. since it is configured in server it actually needs to be there and therefore being available everywhere.