### PR TITLE
Use only centrally built packages during central image-build

### DIFF
--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -69,11 +69,10 @@ def render_task(
                 'value': '/cc/utils',
             })
 
-    # TODO: re-enable once all packages successfully build centrally
-    # env_vars.append({
-    #     'name': 'RUNNING_ON_CI',
-    #     'value': 'true',
-    # })
+    env_vars.append({
+        'name': 'RUNNING_ON_CI',
+        'value': 'true',
+    })
 
     base_build_task = tasks.base_image_build_task(
         volumes=volumes,


### PR DESCRIPTION
(Re)enable the `RUNNING_ON_CI` env-variable for the central build. Setting this variable causes the image-builds to use only packages provided by our package cache.