### PR TITLE
library backport for sphinx

### DIFF
--- a/packages/manual/cyrus-sasl2
+++ b/packages/manual/cyrus-sasl2
@@ -9,7 +9,10 @@ sudo rm -f /etc/dpkg/dpkg.cfg.d/docker
 sudo apt-get build-dep -y --no-install-recommends $src
 sudo apt-get install -y libgdbm-dev
 
-wget -P /tmp https://snapshot.debian.org/archive/debian-ports/20200409T204941Z/pool/main/s/sphinx/{libjs-sphinxdoc_1.8.5-9_all.deb,python3-sphinx_1.8.5-9_all.deb,sphinx-common_1.8.5-9_all.deb} 
+wget -P /tmp https://snapshot.debian.org/archive/debian/20210413T152040Z/pool/main/p/python-docutils/{docutils-common_0.16%2Bdfsg-4_all.deb,python3-docutils_0.16%2Bdfsg-4_all.deb}
+wget -P /tmp https://snapshot.debian.org/archive/debian-ports/20200409T204941Z/pool/main/s/sphinx/{libjs-sphinxdoc_1.8.5-9_all.deb,python3-sphinx_1.8.5-9_all.deb,sphinx-common_1.8.5-9_all.deb}
+sudo dpkg -i /tmp/docutils-common_0.16+dfsg-4_all.deb
+sudo dpkg -i /tmp/python3-docutils_0.16+dfsg-4_all.deb
 sudo dpkg -i /tmp/libjs-sphinxdoc_1.8.5-9_all.deb
 sudo dpkg -i /tmp/sphinx-common_1.8.5-9_all.deb
 sudo dpkg -i /tmp/python3-sphinx_1.8.5-9_all.deb


### PR DESCRIPTION
cyrus-sasl2 did not compile anymore: it depends on sphinx 1.8.5 or better < 3.0.0. but since debian upgraded to sphinx 4.x now it even changes now more packages in the dependency tree: python-docutils so we down pinned this to make it compile again.

Since both packages are only related to document creation, I see no security risk.