### PR TITLE
Fix url of waagent package

### DIFF
--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,3 +1,3 @@
 # Azure images require waagent
-main/w/waagent_2.2.47-2gardenlinux1_all.deb
+main/w/waagent/waagent_2.2.47-2gardenlinux1_all.deb
 chrony


### PR DESCRIPTION
The current content of the `azure`-features pkg.include results in an erroneous URL when requested from our cache.
This PR fixes the content of the pkg.include.