### PR TITLE
bin/start-vm: minor fix

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -191,7 +191,7 @@ if [ $uefi ]; then
 	[ -r $uefiCode ] || eusage "Missing ueficode at $ueficode.\n Run: apt-get install ovmf"
 	[ -r $uefiVars ] || eusage "Missing uefivars at $uefiVars.\n Run: apt-get install ovmf"
 
-	[ -e $targetDir/$mac.vars ] || $uefiVars $targetDir/$mac.vars
+	[ -e $targetDir/$mac.vars ] || cp $uefiVars $targetDir/$mac.vars
 
 	virtOpts+=(	"-machine q35,smm=on"
 			"-global driver=cfi.pflash01,property=secure,value=on"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
fix minor bug in `bin/start-vm` where `$uefiVars` was attempted to be executed rather than copied.
