### PR TITLE
Remove 70-nvme.cfg from cloud

### DIFF
--- a/features/cloud/file.include/etc/kernel/cmdline.d/70-nvme.cfg
+++ b/features/cloud/file.include/etc/kernel/cmdline.d/70-nvme.cfg
@@ -1,3 +1,0 @@
-# Recommended to set by AWS support
-
-CMDLINE_LINUX="$CMDLINE_LINUX nvme_core.io_timeout=4294967295"


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Remove 70-nvme.cfg from cmdline.d, from the cloud feature as this is kernel command line parameter is AWS specific.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: