### PR TITLE
Upgrade kubernetes and runtime interface

### DIFF
--- a/features/khost/exec.config
+++ b/features/khost/exec.config
@@ -1,9 +1,9 @@
-K8S_VERSION=1.21.1
-CRI_VERSION=1.21.0
+K8S_VERSION=1.22.2
+CRI_VERSION=1.22.0
 
 wget --show-progress --progress=bar:force -4 -P /usr/local/bin \
-	https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl} \
-	https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRI_VERSION}/crictl-v${CRI_VERSION}-linux-amd64.tar.gz 
+  https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl} \
+  https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRI_VERSION}/crictl-v${CRI_VERSION}-linux-amd64.tar.gz
 
 rm -f /root/.wget-hsts
 


### PR DESCRIPTION
  - upgrade k8s to v1.22.2

  - upgrade crictl to v1.22.0