### PR TITLE
Make sure init scripts are not executed in /tmp

### DIFF
--- a/features/gcp/exec.config
+++ b/features/gcp/exec.config
@@ -1,6 +1,9 @@
 sed -i "s/^#NTP=/NTP=metadata.google.internal/g" /etc/systemd/timesyncd.conf
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
+# cannot execute startup script in /tmp, usr /var/tmp instead
+sed -i 's/^run_dir =\s*/run_dir = \/var\/tmp/g' /etc/default/instance_configs.cfg
+
 cat >>/etc/ssh/sshd_conf <<EOF
 
 # Needed for google oslogin

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 googleapiclient_logger = logging.getLogger("googleapiclient")
 googleapiclient_logger.setLevel(logging.ERROR)
 
+startup_script = """#!/bin/bash
+touch /tmp/startup-script-ok
+"""
 
 class GCP:
     """Handle resources in GCP"""
@@ -288,6 +291,10 @@ class GCP:
                     {
                         "key": "ssh-keys",
                         "value": self.user + ":" + self.get_public_key() 
+                    },
+                    {
+                        "key": "startup-script",
+                        "value" : startup_script
                     }
                 ]
             },

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -379,3 +379,8 @@ sys     0m0.108s
     m=re.search(p_real, error)
     duration = (int(m.group(1)) * 60) + int(m.group(2))
     assert duration < 5, "Expected the test to run in less than 5 seconds"
+
+def test_startup_script(client, gcp):
+    (exit_code, output, error) = client.execute_command("test -f /tmp/startup-script-ok")
+    assert exit_code == 0, f"no {error=} expected. Startup script did not run"
+


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Init scripts were not executed on GCP which led to nodes not joining the cluster. This PR reconfigures the google agent to run startup scripts from `/var/tmp` instead of `/tmp`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
