### PR TITLE
Dracut - 30-secureboot.conf keep during build only

### DIFF
--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -36,7 +36,9 @@ for kernel in /boot/vmlinuz-*; do
    --reproducible\
    "/boot/efi/Default/${kernel#*-}/linux"
 done
-   
+
+rm -f /etc/dracut.conf.d/30-secureboot.conf
+
 # fix path for the loader
 # needed because /boot/efi is not a mountpoint at this point
 sed 's/boot\/efi\///' -i /boot/efi/loader/entries/*.conf

--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -28,6 +28,8 @@ for kernel in /boot/vmlinuz-*; do
    "/boot/efi/Default/${kernel#*-}/linux"
 done
 
+rm -f /etc/dracut.conf.d/30-secureboot.conf
+
 # fix path for the loader
 # needed because /boot/efi is not a mountpoint at this point
 sed 's/boot\/efi\///' -i /boot/efi/loader/entries/*.conf

--- a/features/server/file.include/etc/dracut.conf.d/30-secureboot.conf
+++ b/features/server/file.include/etc/dracut.conf.d/30-secureboot.conf
@@ -1,2 +1,2 @@
-uefi_secureboot_cert="$([[ -f /etc/gl-sign.crt && /etc/gl-sign.key ]] && echo /etc/gl-sign.crt)"
-uefi_secureboot_key="$([[ -f /etc/gl-sign.crt && /etc/gl-sign.key ]] && echo /etc/gl-sign.key)"
+uefi_secureboot_cert="/etc/gl-sign.crt"
+uefi_secureboot_key="/etc/gl-sign.key"


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
30-secureboot.conf had some errors and the certs should not be handled like this anyway.
It should be used during the build process only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: