### PR TITLE
Always upload component-descriptor (if configured)

### DIFF
--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -131,10 +131,10 @@ def build_component_descriptor(
         f'{pprint.pformat(dataclasses.asdict(component_descriptor))}'
     )
 
-    if glci.model.PublishingAction.RELEASE_CANDIDATE in publishing_actions:
-        product.v2.upload_component_descriptor_v2_to_oci_registry(
-            component_descriptor_v2=component_descriptor,
-        )
+    product.v2.upload_component_descriptor_v2_to_oci_registry(
+        component_descriptor_v2=component_descriptor,
+        on_exist=product.v2.UploadMode.OVERWRITE,
+    )
 
     if snapshot_repo_base_url:
         if base_url != snapshot_repo_base_url:


### PR DESCRIPTION
Previously, the component-descriptor publication was limited even if configured - first to releases, then to release-candidates. This PR finally removes this limitation, as our consumers downstream have been configured to react only to releases.