### PR TITLE
test(manual):  allow tests on prepared hosts

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -449,6 +449,46 @@ Run the tests (be sure you properly mounted the Garden Linux repository to the c
 
     pytest --iaas=ali --configfile=/config/mygcpconfig.yaml integration/
 
+
+### 2.6. Manual testing
+
+So for some reason, you do not want to test Garden Linux by using a tool that automatically sets up the testbed in a cloud environment for you.
+
+You rather want to set up a host running Garden Linux yourself, create a user in it, somehow slip in an SSH public key and have a hostname/ip-address you can use to connect. Now all you want is to have the tests run on that host. This section about _Manual testing_ is for you then.
+
+Use the following (very simple) test configuration:
+
+```yaml
+manual:
+    # mandatory, the hostname/ip-address of the host the tests should run on
+    host: 
+
+    # ssh related configuration for logging in to the VM (required)
+    ssh:
+        # path to the ssh private key file (required)
+        ssh_key_filepath: ~/.ssh/id_rsa_gardenlinux_test
+        # passphrase for a secured SSH key (optional)
+        passphrase:
+        # username
+        user: admin
+```
+
+#### 2.6.1 Running the tests
+
+Start docker container with dependencies:
+
+- mount Garden Linux repository to `/gardenlinux`
+- mount SSH keys to `/root/.ssh`
+- mount directory with configfile to `/config`
+
+```
+docker run -it --rm  -v `pwd`:/gardenlinux -v $HOME/.ssh:/root/.ssh -v ~/config:/config  gardenlinux/integration-test:`bin/garden-version` bash
+```
+
+Run the tests (be sure you properly mounted the Garden Linux repository to the container and you are in `/gardenlinux/tests`):
+
+    pytest --iaas=manual --configfile=/config/myconfig.yaml integration/
+
 ## 3. Misc
 
 ### auto-format using black

--- a/tests/integration/manual.py
+++ b/tests/integration/manual.py
@@ -1,0 +1,18 @@
+from .sshclient import RemoteClient
+
+class Manual:
+    """Handle Manual Instance"""
+
+    @classmethod
+    def fixture(cls, config):
+
+        try:
+            ssh = None
+            ssh = RemoteClient(
+                host=config["host"],
+                sshconfig=config["ssh"],
+            )
+            yield ssh
+        finally:
+            if ssh is not None:
+                ssh.disconnect()

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -14,6 +14,7 @@ from .aws import AWS
 from .gcp import GCP
 from .azure import AZURE
 from .openstackccee import OpenStackCCEE
+from .manual import Manual
 from .ali import ALI
 from .sshclient import RemoteClient
 
@@ -49,6 +50,8 @@ def client(request, config: dict, iaas) -> Iterator[RemoteClient]:
         yield from OpenStackCCEE.fixture(config["openstack_ccee"])
     elif iaas == "ali":
         yield from ALI.fixture(config["ali"])
+    elif iaas == "manual":
+        yield from Manual.fixture(config["manual"])
     else:
         raise ValueError(f"invalid {iaas=}")
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

The integration/platform tests we have so far create VMs in hyperscalers all automatically. In case this fails for whatever reasons or the tests should just run on an already built-up machine, the proper pytest fixtures were missing for that.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- test(manual):  allow tests on prepared hosts
```
