### PR TITLE
CI: Don't build cfssl from scratch for every build

### DIFF
--- a/cert/Makefile
+++ b/cert/Makefile
@@ -67,11 +67,11 @@ define BASH_BUILD
 git clone https://github.com/cloudflare/cfssl.git
 cd cfssl
 make
-mv bin/* /build 
+mv bin/* /build
 endef
 export BASH_BUILD
 
-all: Kernel.sign.crt sign.pub 
+all: Kernel.sign.crt sign.pub
 test:
 	echo "$(INTERNAL_HOSTNAME)"
 
@@ -98,7 +98,7 @@ $(SIGN_CA).crt: $(SIGN_CA).key
 
 .PRECIOUS: %.ca.crt
 %.ca.crt: %.ca.key $(SIGN_CA).crt
-	@echo "Signing CA $(@:.ca.crt=) by $(SIGN_CA)" 
+	@echo "Signing CA $(@:.ca.crt=) by $(SIGN_CA)"
 	$(eval tmpfile := $(shell mktemp))
 	@echo "$$profile" > $(tmpfile)
 	@cfssl/cfssl sign -ca $(SIGN_CA).crt -ca-key $(SIGN_CA).key -config $(tmpfile) -profile ca $(<:.key=.csr) | cfssl/cfssljson -bare -stdout | ./rename $(@:.crt=) $(SIGN_CA)
@@ -116,7 +116,7 @@ $(SIGN_CA).crt: $(SIGN_CA).key
 
 .PRECIOUS: %.sign.crt
 %.sign.crt: %.sign.key $(SIGN_CERT).crt
-	@echo "Signing Signature Certificate $(@:.sign.crt=) by $(SIGN_CERT)" 
+	@echo "Signing Signature Certificate $(@:.sign.crt=) by $(SIGN_CERT)"
 	$(eval tmpfile := $(shell mktemp))
 	@echo "$$profile" > $(tmpfile)
 	@cfssl/cfssl sign -ca $(SIGN_CERT).crt -ca-key $(SIGN_CERT).key -config $(tmpfile) -profile=sign $(<:.key=.csr) | cfssl/cfssljson -bare -stdout | ./rename $(@:.crt=) $(SIGN_CERT)
@@ -134,7 +134,7 @@ $(SIGN_CA).crt: $(SIGN_CA).key
 
 .PRECIOUS: %.client.crt
 %.client.crt: %.client.key $(SIGN_CERT).crt
-	@echo "Signing Signature Certificate $(@:.client.crt=) by $(SIGN_CERT)" 
+	@echo "Signing Signature Certificate $(@:.client.crt=) by $(SIGN_CERT)"
 	$(eval tmpfile := $(shell mktemp))
 	@echo "$$profile" > $(tmpfile)
 	@cfssl/cfssl sign -ca $(SIGN_CERT).crt -ca-key $(SIGN_CERT).key -config $(tmpfile) -profile=client $(<:.key=.csr) | cfssl/cfssljson -bare -stdout | ./rename $(@:.crt=) $(SIGN_CERT)
@@ -153,7 +153,7 @@ $(SIGN_CA).crt: $(SIGN_CA).key
 .PRECIOUS: %.server.crt
 %.server.crt: %.server.key $(SIGN_CERT).crt
 	@echo "Signing Server Certificate $(@:.server.crt=) by $(SIGN_CERT)"
-	@find . -lname $@ -exec rm -rf {} \;	
+	@find . -lname $@ -exec rm -rf {} \;
 	$(eval tmpfile := $(shell mktemp))
 	@echo "$$profile" > $(tmpfile)
 	@cfssl/cfssl sign -ca $(SIGN_CERT).crt -ca-key $(SIGN_CERT).key -config $(tmpfile) -profile=server $(INTERNAL_HOSTNAME)  $(<:.key=.csr) | cfssl/cfssljson -bare -stdout | ./rename $(@:.crt=) $(SIGN_CERT)
@@ -172,7 +172,7 @@ $(SIGN_CA).crt: $(SIGN_CA).key
 .PRECIOUS: %.peer.crt
 %.peer.crt: %.peer.key $(SIGN_CERT).crt
 	@echo "Signing Server Certificate $(@:.peer.crt=) by $(SIGN_CERT)"
-	@find . -lname $@ -exec rm -rf {} \;	
+	@find . -lname $@ -exec rm -rf {} \;
 	$(eval tmpfile := $(shell mktemp))
 	@echo "$$profile" > $(tmpfile)
 	@cfssl/cfssl sign -ca $(SIGN_CERT).crt -ca-key $(SIGN_CERT).key -config $(tmpfile) -profile=peer $(INTERNAL_HOSTNAME)  $(<:.key=.csr) | cfssl/cfssljson -bare -stdout | ./rename $(@:.crt=) $(SIGN_CERT)
@@ -206,4 +206,3 @@ clean:
 PHONY: superclean
 superclean: clean
 	rm -rf cfssl
-

--- a/ci/params.py
+++ b/ci/params.py
@@ -32,10 +32,10 @@ class AllParams:
         default='/workspace/cfssl',
         description='git wokring dir to clone and build cfssl',
     )
-    cfssl_fastpath = NamedParam(
-        name='cfssl_fastpath',
-        default='false',
-        description='bypass cfssl build and copy binaries from github (set to true/false)',
+    skip_cfssl_build = NamedParam(
+        name='skip_cfssl_build',
+        default='False',
+        description='bypass cfssl build, use binaries from base-image',
     )
     cfssl_committish = NamedParam(
         name='cfssl_committish',

--- a/ci/render_all.py
+++ b/ci/render_all.py
@@ -26,11 +26,13 @@ def main():
     # for tasks:
     parser.add_argument('--use-secrets-server', action='store_true')
     parser.add_argument('--outfile-tasks', default='tasks.yaml')
+    parser.add_argument('--skip-cfssl-build', action='store_true')
 
     parsed = parser.parse_args()
 
     # Render tasks:
     all_tasks = render_task.render_task(
+        skip_cfssl_build=parsed.skip_cfssl_build,
         use_secrets_server=parsed.use_secrets_server,
         outfile_tasks=parsed.outfile_tasks,
     )

--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -241,6 +241,7 @@ def main():
         help='the gardenlinux epoch defining the snapshot timestamp to build against',
     )
     parser.add_argument('--cicd-cfg', default='default')
+    parser.add_argument('--skip-cfssl-build', action='store_true')
     parser.add_argument('--pipeline-cfg', default=paths.flavour_cfg_path)
     parser.add_argument('--outfile', default='pipeline_run.yaml')
     parser.add_argument('--outfile-packages', default='pipeline_package_run.yaml')

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -121,6 +121,7 @@ else
 fi
 
 ci/render_all.py \
+  --skip-cfssl-build \
   --pipeline_cfg "${pipeline_cfg}" \
   --flavour-set "${FLAVOUR_SET}" \
   --outfile-pipeline-main "${outfile_pipeline_main}" \

--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -27,6 +27,7 @@ def multiline_str_presenter(dumper, data):
 def render_task(
     use_secrets_server: bool,
     outfile_tasks: str,
+    skip_cfssl_build: bool,
 ):
     if not use_secrets_server:
         env_vars = [{
@@ -82,6 +83,7 @@ def render_task(
     raw_base_build_task = dataclasses.asdict(base_build_task)
 
     package_task = tasks.nokernel_package_task(
+        skip_cfssl_build=skip_cfssl_build,
         env_vars=env_vars,
         volumes=volumes,
         volume_mounts=volume_mounts,
@@ -89,6 +91,7 @@ def render_task(
     raw_package_task = dataclasses.asdict(package_task)
 
     kernel_package_task = tasks.kernel_package_task(
+        skip_cfssl_build=skip_cfssl_build,
         env_vars=env_vars,
         volumes=volumes,
         volume_mounts=volume_mounts,
@@ -96,6 +99,7 @@ def render_task(
     raw_kernel_package_task = dataclasses.asdict(kernel_package_task)
 
     build_task = tasks.build_task(
+        skip_cfssl_build=skip_cfssl_build,
         env_vars=env_vars,
         volumes=volumes,
         volume_mounts=volume_mounts,
@@ -161,6 +165,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--use-secrets-server', action='store_true')
     parser.add_argument('--outfile-tasks', default='tasks.yaml')
+    parser.add_argument('--skip_cfssl_build', action='store_true')
 
     parsed = parser.parse_args()
     render_task(

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -10,7 +10,7 @@ import tkn.model
 IMAGE_VERSION = '1.1477.0'
 DEFAULT_IMAGE = f'eu.gcr.io/gardener-project/cc/job-image:{IMAGE_VERSION}'
 KANIKO_IMAGE = f'eu.gcr.io/gardener-project/cc/job-image-kaniko:{IMAGE_VERSION}'
-CACHED_PATCH: str  = None
+CACHED_PATCH: str = None
 
 own_dir = os.path.abspath(os.path.dirname(__file__))
 scripts_dir = os.path.join(own_dir)

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -340,7 +340,6 @@ def build_cfssl_step(
     step_params = [
         # !DO NOT CHANGE ORDER!
         params.repo_dir,
-        params.cfssl_fastpath,
         params.cfssl_dir,
     ]
     step = tkn.model.TaskStep(
@@ -386,15 +385,23 @@ def write_key_step(
 
 def build_cert_step(
     params: params.AllParams,
+    use_build_image: bool = True,
     env_vars: typing.List[typing.Dict] = [],
     volume_mounts: typing.List[typing.Dict] = [],
 ):
     step_params = [
         params.repo_dir,
     ]
+
+    if use_build_image:
+        image = '$(params.gardenlinux_build_deb_image)'
+        step_params.append(params.gardenlinux_build_deb_image)
+    else:
+        image = 'golang:latest'
+
     step = tkn.model.TaskStep(
         name='build-cert',
-        image='golang:latest',
+        image=image,
         script=task_step_script(
             path=os.path.join(steps_dir, 'build_cert.sh'),
             script_type=ScriptType.BOURNE_SHELL,

--- a/ci/steps/build_cert.sh
+++ b/ci/steps/build_cert.sh
@@ -1,5 +1,6 @@
 build_cert() {
     repo_dir=$1
+    build_cfssl=$2
 
     key_file="${repo_dir}/cert/private.key"
     cert_dir="${repo_dir}/cert"
@@ -9,5 +10,14 @@ build_cert() {
     fi
 
     pushd "${cert_dir}"
+
+    # in order to prevent downloading/building cfssl if it's already present
+    # in the build image, create links to expected files before calling make
+    if [[ "$(which cfssl)" ]] && [[ "$(which cfssljson)" ]]; then
+        mkdir -p "cfssl/"
+        ln -s "$(which cfssl)" "${cert_dir}/cfssl/cfssl"
+        ln -s "$(which cfssljson)" "${cert_dir}/cfssl/cfssljson"
+    fi
+
     make
 }

--- a/ci/steps/build_cfssl.sh
+++ b/ci/steps/build_cfssl.sh
@@ -1,8 +1,7 @@
 
 build_cfssl() {
     repo_dir=$1
-    cfssl_fastpath=$2
-    cfssl_dir=$3
+    cfssl_dir=$2
 
     key_file="/workspace/gardenlinux_git/cert/private.key"
 
@@ -11,34 +10,9 @@ build_cfssl() {
     fi
 
     mkdir -p "${repo_dir}/cert/cfssl"
-    if [ "${cfssl_fastpath}" != "true" ]; then
-    # slow-path build CFSSL from github:
     pushd "${cfssl_dir}"
     make
     mv bin/* "${repo_dir}/cert/cfssl"
-    else
-    mkdir -p "${repo_dir}/bin"
-    pushd "${repo_dir}/bin"
-    # fast-path copy binaries from CFSSL github release:
-    cfssl_files=( cfssl-bundle_1.5.0_linux_amd64 \\
-        cfssl-certinfo_1.5.0_linux_amd64 \\
-        cfssl-newkey_1.5.0_linux_amd64 \\
-        cfssl-scan_1.5.0_linux_amd64 \\
-        cfssljson_1.5.0_linux_amd64 \\
-        cfssl_1.5.0_linux_amd64 \\
-        mkbundle_1.5.0_linux_amd64 \\
-        multirootca_1.5.0_linux_amd64 \\
-    )
-
-    len2=`expr length _1.5.0_linux_amd64`
-    for file in "${cfssl_files[@]}"; do
-        len=`expr length $file`
-        outname=${file:0:`expr $len - $len2`}
-        wget --no-verbose -O $outname https://github.com/cloudflare/cfssl/releases/download/v1.5.0/${file}
-        chmod +x $outname
-    done
-    mv * "${repo_dir}/cert/cfssl"
-    fi
     # cleanup workspace to safe some valuable space
     popd
     rm -rf "${cfssl_dir}"

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -19,7 +19,7 @@ def promote_task(
     volume_mounts=[],
 ):
     params = []
-    clone_step, params_step  = steps.clone_step(
+    clone_step, params_step = steps.clone_step(
         params=all_params,
         env_vars=env_vars,
         volume_mounts=volume_mounts,

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,3 +1,6 @@
+FROM	$build_base_image as downloader
+
+
 ARG build_base_image=gardenlinux/slim
 FROM	$build_base_image
 
@@ -10,7 +13,7 @@ RUN	mkdir /etc/sudoers.d \
      && echo "#deb-src https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
      && echo "APT::Install-Recommends false;\nAPT::Install-Suggests false;\nApt::AutoRemove::SuggestsImportant false;\n" > /etc/apt/apt.conf.d/no-recommends \
      &&	echo "progress=bar:force:noscroll" >> /etc/wgetrc \
-     &&	echo "force-confold\nforce-confdef" > /etc/dpkg/dpkg.cfg.d/forceold 
+     &&	echo "force-confold\nforce-confdef" > /etc/dpkg/dpkg.cfg.d/forceold
 
 ARG	BUILDARCH=amd64
 
@@ -29,6 +32,9 @@ RUN	apt-get update \
      &&	addgroup --system wheel \
      &&	adduser dev --disabled-password --gecos dev \
      &&	adduser dev wheel
+
+COPY install-cfssl.sh /setup/
+RUN  /setup/install-cfssl.sh
 
 USER	dev
 WORKDIR	/home/dev

--- a/docker/build/install-cfssl.sh
+++ b/docker/build/install-cfssl.sh
@@ -1,0 +1,25 @@
+#!usr/bin/env bash
+
+# This script downloads cfssl binaries and moves them to /usr/bin/ (in PATH).
+# With cfssl installed, our central build can just refer to the existing
+# binaries instead of performing a fresh build every time.
+
+cfssl_version="1.5.0"
+
+cfssl_files=( \
+    cfssl-bundle \
+    cfssl-certinfo \
+    cfssl-newkey \
+    cfssl-scan \
+    cfssljson \
+    cfssl \
+    mkbundle \
+    multirootca \
+)
+
+for file in "${cfssl_files[@]}"; do
+    outname="/usr/bin/${file}"
+    url="https://github.com/cloudflare/cfssl/releases/download/v${cfssl_version}/${file}_${cfssl_version}_linux_amd64"
+    wget --no-verbose -O "${outname}" "${url}"
+    chmod +x "${outname}"
+done


### PR DESCRIPTION
Instead of building cfssl once in every task that needs it, this PR changes it so that a version of cfssl is included in the build-image. This version is then used during the central build process, if configured.