### PR TITLE
solves issue 471: CII badge added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 </p>
 <hr />
 
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3925/badge)](https://bestpractices.coreinfrastructure.org/projects/3925)
+
 Garden Linux is a [Debian](https://debian.org) derivate that aims to provide a small, auditable linux image for most Cloud Providers and Bare Metal.
 
 ## Features:


### PR DESCRIPTION
Garden Linux has passed the basic CII criteria and the respective badge is added to the README file by this PR.
/os garden-linux

Fixes #471 
