### PR TITLE
Prepare pipeline for tekton-upgrade

### DIFF
--- a/ci/render_task.py
+++ b/ci/render_task.py
@@ -73,6 +73,10 @@ def render_task(
         'name': 'RUNNING_ON_CI',
         'value': 'true',
     })
+    env_vars.append({
+        'name': 'HOME',
+        'value': '/workspace/tekton_home',
+    })
 
     base_build_task = tasks.base_image_build_task(
         volumes=volumes,

--- a/ci/steps/build_kernel_package.sh
+++ b/ci/steps/build_kernel_package.sh
@@ -62,7 +62,7 @@ build_kernel_package(){
     for package in "${packages[@]}"
     do
     echo "Building now ${package}"
-    pkg_build_script_path="manual/${package}"
+    pkg_build_script_path="${repo_dir}/packages/manual/${package}"
     echo "pkg_build_script_path: ${pkg_build_script_path}"
 
     if [ ! -f "${pkg_build_script_path}" ]; then

--- a/ci/steps/build_package.sh
+++ b/ci/steps/build_package.sh
@@ -45,7 +45,7 @@ build_package() {
     # originally this is called on docker startup
     gpg --import ${CERTDIR}/sign.pub
 
-    pkg_build_script_path="manual/${pkg_name}"
+    pkg_build_script_path="${repo_dir}/packages/manual/${pkg_name}"
     echo "pkg_build_script_path: ${pkg_build_script_path}"
 
     if [ ! -f "${pkg_build_script_path}" ]; then

--- a/ci/steps/build_package.sh
+++ b/ci/steps/build_package.sh
@@ -34,9 +34,7 @@ build_package() {
     ls -l ${CERTDIR}
     ln -s ${MANUALDIR} /workspace/manual
     ln -s /../Makefile.inside /workspace/Makefile
-    echo "$(gpgconf --list-dir agent-socket)"
-    mkdir -p /workspace/.gnupg
-    ln -s $(gpgconf --list-dir agent-socket) /workspace/.gnupg/S.gpg-agent
+
     ln -s ${CERTDIR}/sign.pub /sign.pub
     ln -s ${CERTDIR}/Kernel.sign.full /kernel.full
     ln -s ${CERTDIR}/Kernel.sign.crt /kernel.crt

--- a/ci/steps/build_package.sh
+++ b/ci/steps/build_package.sh
@@ -2,11 +2,11 @@ build_package() {
     set -e
     set -x
 
-    repodir=$1
+    repo_dir=$1
     pkg_name=$2
 
     if [ -z "$SOURCE_PATH" ]; then
-    SOURCE_PATH="$(readlink -f ${repodir})"
+    SOURCE_PATH="$(readlink -f ${repo_dir})"
     fi
 
     if [ -z "${pkg_name}" ]; then
@@ -16,14 +16,14 @@ build_package() {
 
     echo $(pwd)
 
-    MANUALDIR=$(realpath $repodir/packages/manual)
-    KERNELDIR=$(realpath $repodir/packages/kernel)
+    MANUALDIR=$(realpath ${repo_dir}/packages/manual)
+    KERNELDIR=$(realpath ${repo_dir}/packages/kernel)
 
     export DEBFULLNAME="Garden Linux Maintainers"
     export DEBEMAIL="contact@gardenlinux.io"
     export BUILDIMAGE="gardenlinux/build-deb"
     export BUILDKERNEL="gardenlinux/build-kernel"
-    export CERTDIR=$(realpath $repodir/cert)
+    export CERTDIR=$(realpath ${repo_dir}/cert)
     echo "MANUALDIR: ${MANUALDIR}"
     echo "KERNELDIR: ${KERNELDIR}"
     echo "CERTDIR: ${CERTDIR}"

--- a/ci/steps/clone_repo_step.py
+++ b/ci/steps/clone_repo_step.py
@@ -61,6 +61,12 @@ def clone_and_checkout_anonymously(
     return repo.head.commit.message, repo.head.commit.hexsha
 
 
+def prepare_home_dir():
+    if home_dir := os.environ.get('HOME'):
+        print(f"Preparing HOME at '{home_dir}'")
+        os.makedirs(os.path.abspath(home_dir), exist_ok=True)
+
+
 def clone_and_copy(
     giturl: str,
     committish: str,
@@ -88,6 +94,8 @@ def clone_and_copy(
             )
         else:
             raise RuntimeError(f"Unable to clone {giturl}")
+
+    prepare_home_dir()
 
     print(f'cloned to {repo_dir=} {commit_hash=}')
     print(f'Commit Message: {commit_msg}')

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -137,6 +137,7 @@ def nokernel_package_task(
 ):
     package_build_step, step_params = steps.build_package_step(
             params=all_params,
+            env_vars=env_vars,
     )
     return _package_task(
         task_name='build-packages',
@@ -156,6 +157,7 @@ def kernel_package_task(
 ):
     package_build_step, step_params = steps.build_kernel_package_step(
             params=all_params,
+            env_vars=env_vars,
     )
     return _package_task(
         task_name='build-kernel-packages',


### PR DESCRIPTION
With Tekton version `v0.24.0` (we use `v0.21.0`, most recent is `v0.29.0`) some overrides that we currently rely on are removed. This PR prepares our pipelines for upgrades of Tekton past `v0.24.0`.

The necessary changes are actually rather small:
- explicitly set `HOME` to a directory in the shared `\workspace` (currently `\workspace\tekton_home`) and make sure it exists.
- adjust scripts to use absoulte paths where necessary (as the default working dir of `\workspace` is no longer provided and the image-default is used instead).

Also tested with the current version of Tekton.