### PR TITLE
Ci publishing action onstable

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -18,7 +18,7 @@ gardenlinux:
           - --image-build
           vars:
             PROMOTE_TARGET: "'snapshot'"
-            PUBLISHING_ACTIONS: "'manifests,component_descriptor'"
+            BUILD_TARGETS: "'manifest,component_descriptor'"
     build-packages:
       repo:
         trigger: false
@@ -29,4 +29,4 @@ gardenlinux:
           - --package-build
           vars:
             PROMOTE_TARGET: "'snapshot'"
-            PUBLISHING_ACTIONS: "'manifests'"
+            BUILD_TARGETS: "'manifest'"

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,5 +1,5 @@
 # Introduction
-The following section describes how Garden Linux can be built using a pipeline. 
+The following section describes how Garden Linux can be built using a pipeline.
 The open source project [Tekton](https://github.com/tektoncd/pipeline) is used as environment to run the build. The build pipeline is fully containerized and requires a Kubernetes cluster.
 
 ## Overview About The Build
@@ -32,7 +32,7 @@ tekton-cli (installed automatically from script)
 ```
 
 ### Set Limits
-The build machine requires a certain amount of resources usually not available by default. Apply the 
+The build machine requires a certain amount of resources usually not available by default. Apply the
 following limits:
 
 ```
@@ -55,7 +55,7 @@ spec:
       ephemeral-storage: 20Gi
       memory: 4G
       cpu: 1.0
-    
+
 ```
 
 ### Grant API Permissions To Script User
@@ -114,15 +114,15 @@ The build uses two pipelines: One to build the packages and one to build the VM 
 Build variants:
 The build can handle various variants of build artifacts. These are configured by a flavour set. The flavours are defined in the file flavours.yaml in the root directory of th Git repository. By default there is one set in this file named "all". You can add more sets according to your needs.
 
-Publishing action:
-There are options how the build artifacts are handled after build. This is set in the environment variable PUBLISHING_ACTIONS (see also class PublishingAction in ci/glci/model.py). Currently there are four variants supported:
+Build-Target:
+There are options how the build artifacts are handled after build. This is set in the environment variable BUILD_TARGETS (see also class BuildTarget in ci/glci/model.py). Currently there are four variants supported:
 
- - `manifests`
- - `images`
+ - `build`
+ - `manifest`
  - `release`
- - `build_only`
+ - `publish`
 
-If the variable is not set it defaults to "`build-only`" 
+If the variable is not set it defaults to "`build`"
 
 The flavour set build by the pipeline is contained in the environment variable FLAVOUR_SET and defaults to "all" if not set.
 
@@ -146,7 +146,7 @@ The script to generate the pipeline definitions reads various environment variab
 # Namespace where pipelines are deployed defaults to "gardenlinux":
 export GARDENLINUX_TKN_WS=gardenlinux
 # type of artifacts to be built:
-export PUBLISHING_ACTIONS=manifests
+export BUILD_TARGETS=manifests
 # build variant: defaults to "all"
 export FLAVOUR_SET=all
 # Git branch to build, defaults to "main"
@@ -180,7 +180,7 @@ Example:
 
 ### Credential Handling
 
-The build pipeline can be used with a central server managing configuration and secrets. As an alternative all credentials can be read from a Kubernetes secret named "secrets" in the corresponding namespace. This secret will be automatically generated from configuration files. The switch between central server and a Kubernetes secret is done by an environment variable named `SECRET_SERVER_ENDPOINT`. If it is not set the secret will be generated and applied. At minimum there need to be two secrets: One for uploading the artifacts to an S3-like Object store and one to upload container images to an OCI registry. Example files are provided in the folder `ci/cfg`. 
+The build pipeline can be used with a central server managing configuration and secrets. As an alternative all credentials can be read from a Kubernetes secret named "secrets" in the corresponding namespace. This secret will be automatically generated from configuration files. The switch between central server and a Kubernetes secret is done by an environment variable named `SECRET_SERVER_ENDPOINT`. If it is not set the secret will be generated and applied. At minimum there need to be two secrets: One for uploading the artifacts to an S3-like Object store and one to upload container images to an OCI registry. Example files are provided in the folder `ci/cfg`.
 
 Edit the files cfg/cfg_types.yaml. Each top-level entry refers to another file
 containing the credentials. Examples with templates are provided. A second entry is for uploading the base-image and to an OCI registry. Additional configuration information is found in [cicd.yaml](cicd.yaml)
@@ -221,4 +221,4 @@ kubectl apply -f ./ci/integrationtest-task.yaml
 # run the actual test as taskrun
 kubectl create -f ./ci/it-run.yaml
 ```
-Running the integration tests is work-in-progress. 
+Running the integration tests is work-in-progress.

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import dataclasses
 import datetime
 import dateutil.parser
@@ -17,14 +18,18 @@ repo_root = os.path.abspath(os.path.join(
     own_dir, os.path.pardir, os.path.pardir))
 
 
-class PublishingAction(enum.Enum):
-    BUILD_ONLY = 'build_only'
-    COMPONENT_DESCRIPTOR = 'component_descriptor'
-    IMAGES = 'images'
-    MANIFESTS = 'manifests'
-    RELEASE_CANDIDATE = 'release_candidate'
-    RELEASE = 'release'
-    RUN_TESTS = 'run_tests'
+class BuildTarget(enum.Enum):
+    BUILD = 'build'                                # compile, link, create arifacts local
+    MANIFEST = 'manifest'                          # upload artifacts to S3, create manifest
+    COMPONENT_DESCRIPTOR = 'component-descriptor'  # create and upload component descr
+    TESTS = 'tests'                                # run gardenlinux integration tests
+    PUBLISH = 'publish'                            # upload images to cloud providers
+    FREEZE_VERSION = 'freeze-version'              # use version epoch.y.z instead of epoch-commit
+    GITHUB_RELEASE = 'github-release'              # create a github release (branch, tag, release)
+
+    @staticmethod
+    def set_from_str(comma_separated: str) -> typing.Set[BuildTarget]:
+        return {BuildTarget(action.strip()) for action in comma_separated.split(',')}
 
 
 class FeatureType(enum.Enum):

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -19,17 +19,43 @@ repo_root = os.path.abspath(os.path.join(
 
 
 class BuildTarget(enum.Enum):
-    BUILD = 'build'                                # compile, link, create arifacts local
-    MANIFEST = 'manifest'                          # upload artifacts to S3, create manifest
-    COMPONENT_DESCRIPTOR = 'component-descriptor'  # create and upload component descr
-    TESTS = 'tests'                                # run gardenlinux integration tests
-    PUBLISH = 'publish'                            # upload images to cloud providers
-    FREEZE_VERSION = 'freeze-version'              # use version epoch.y.z instead of epoch-commit
-    GITHUB_RELEASE = 'github-release'              # create a github release (branch, tag, release)
+    # compile, link, create arifacts local
+    BUILD = 'build', {}
+    # upload artifacts to S3, create manifest
+    MANIFEST = 'manifest', {'build', }
+    # create and upload component descr
+    COMPONENT_DESCRIPTOR = 'component-descriptor', {'build', }
+    # run gardenlinux integration tests
+    TESTS = 'tests', {'build', }
+    # upload images to cloud providers
+    PUBLISH = 'publish', {'build', 'manifest', 'component-descriptor'}
+    # use version epoch.y.z instead of epoch-commit
+    FREEZE_VERSION = 'freeze-version', {'build', 'manifest', 'component-descriptor'}
+    # create a github release (branch, tag, release)
+    GITHUB_RELEASE = 'github-release', {'build', 'manifest', 'component-descriptor', 'freeze-version'}
+
+    def __new__(cls, value, requires=None):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj._requires_ = requires
+        return obj
 
     @staticmethod
     def set_from_str(comma_separated: str) -> typing.Set[BuildTarget]:
-        return {BuildTarget(action.strip()) for action in comma_separated.split(',')}
+        targets = {BuildTarget(action.strip()) for action in comma_separated.split(',')}
+        BuildTarget.check_requirements(targets)
+        return targets
+
+    @staticmethod
+    def check_requirements(bt_set: typing.Set[BuildTarget]) :
+        for e in bt_set:
+            missing = set()
+            for r in e._requires_:
+                target = BuildTarget(r)
+                if not target in bt_set:
+                    missing.add(r)
+            if missing:
+                raise ValueError(f' {e.value}: missing required build target(s): {missing}')
 
 
 class FeatureType(enum.Enum):

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -47,6 +47,6 @@ function export_env() {
   export GIT_URL="${GIT_URL:-https://github.com/gardenlinux/gardenlinux}"
   export OCI_PATH="${OCI_PATH:-eu.gcr.io/gardener-project/gardenlinux}"
   export PROMOTE_TARGET="${PROMOTE_TARGET:-snapshot}"
-  export PUBLISHING_ACTIONS="${PUBLISHING_ACTIONS:-build_only}"
+  export BUILD_TARGETS="${BUILD_TARGETS:-build}"
   export PATH="${PATH}:${bin_dir}"
 }

--- a/ci/params.py
+++ b/ci/params.py
@@ -125,10 +125,10 @@ class AllParams:
         name='platform',
         description='the target platform (aws, gcp, metal, kvm, ..)',
     )
-    publishing_actions = NamedParam(
-        name='publishing_actions',
+    build_targets = NamedParam(
+        name='build_targets',
         default='manifests',
-        description='how artifacts should be published (glci.model.PublishingAction)',
+        description='how artifacts should be published (glci.model.BuildTarget)',
     )
     pytest_cfg = NamedParam(
         name='pytest_cfg',

--- a/ci/promote.py
+++ b/ci/promote.py
@@ -29,10 +29,10 @@ def parse_args():
     parser.add_argument('--committish')
     parser.add_argument('--gardenlinux-epoch', type=int)
     parser.add_argument(
-      '--publishing-action',
+      '--build-target',
       action='append',
-      type=glci.model.PublishingAction,
-      dest='publishing_actions',
+      type=glci.model.BuildTarget,
+      dest='build_targets',
     )
     parser.add_argument('--version', required=True)
     parser.add_argument('--source', default='snapshots')
@@ -280,13 +280,13 @@ def promote(
     build_committish: str,
     gardenlinux_epoch: int,
     version_str: str,
-    publishing_actions: typing.Sequence[glci.model.PublishingAction],
+    build_targets: typing.Set[glci.model.BuildTarget],
     cicd_cfg: glci.model.CicdCfg,
     flavour_set: glci.model.GardenlinuxFlavourSet,
     build_type: glci.model.BuildType,
 ):
 
-    if glci.model.PublishingAction.IMAGES in publishing_actions:
+    if glci.model.BuildTarget.BUILD in build_targets:
         executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=len(releases))
         _publish_img = functools.partial(publish_image, cicd_cfg=cicd_cfg)
@@ -297,7 +297,7 @@ def promote(
         for release in releases:
             print(release.published_image_metadata)
 
-        if glci.model.PublishingAction.MANIFESTS in publishing_actions:
+        if glci.model.BuildTarget.MANIFEST in build_targets:
             upload_release_manifest_set = glci.util.preconfigured(
                 func=glci.util.upload_release_manifest_set,
                 cicd_cfg=cicd_cfg,
@@ -373,7 +373,7 @@ def main():
             parsed.target.value,
         ),
         version_str=version,
-        publishing_actions=parsed.publishing_actions,
+        build_targets=parsed.build_targets,
         cicd_cfg=cicd_cfg,
         flavour_set=flavour_set,
         build_type=parsed.target,

--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -177,6 +177,9 @@ def mk_pipeline_run(
         committish=args.committish,
     )
 
+    # check if build-targets are correct (exit early)
+    glci.model.BuildTarget.check_requirements(args.build_targets)
+
     plrun = PipelineRun(
         metadata=tkn.model.Metadata(
             name=run_name,

--- a/ci/render_pipeline_run.py
+++ b/ci/render_pipeline_run.py
@@ -30,33 +30,35 @@ VolumeClaimTemplateSpec = tkn.model.VolumeClaimTemplateSpec
 # k8s only allows dns names / leng restriction applies
 def mk_pipeline_name(
     pipeline_name: str,
-    publishing_actions: typing.Sequence[glci.model.PublishingAction],
+    build_targets: typing.Set[glci.model.BuildTarget],
     version: str,
     committish: str,
 ):
-    def _publishing_action_shorthand(publishing_action):
-        if publishing_action is glci.model.PublishingAction.RELEASE:
-            return 'rel'
-        elif publishing_action is glci.model.PublishingAction.RELEASE_CANDIDATE:
-            return 'rc'
-        elif publishing_action is glci.model.PublishingAction.BUILD_ONLY:
-            return 'bo'
-        elif publishing_action is glci.model.PublishingAction.IMAGES:
-            return 'imgs'
-        elif publishing_action is glci.model.PublishingAction.MANIFESTS:
-            return 'man'
-        elif publishing_action is glci.model.PublishingAction.COMPONENT_DESCRIPTOR:
-            return 'cd'
-        elif publishing_action is glci.model.PublishingAction.RUN_TESTS:
-            return 'tst'
+    def _build_targets_shorthand(build_targets):
+        result = ''
+        if glci.model.BuildTarget.BUILD in build_targets:
+            result += 'b'
+        if glci.model.BuildTarget.MANIFEST in build_targets:
+            result += 'm'
+        if glci.model.BuildTarget.COMPONENT_DESCRIPTOR in build_targets:
+            result += 'c'
+        if glci.model.BuildTarget.TESTS in build_targets:
+            result += 't'
+        if glci.model.BuildTarget.PUBLISH in build_targets:
+            result += 'p'
+        if glci.model.BuildTarget.FREEZE_VERSION in build_targets:
+            result += 'v'
+        if glci.model.BuildTarget.GITHUB_RELEASE in build_targets:
+            result += 'g'
+        return result
 
     # add last 4 seconds of time since epoch (to avoid issues with identical pipeline names for
     # repeated builds of the same commit)
     build_ts = str(int(time.time()))[-4:]
-    if publishing_actions:
+    if build_targets:
         name_parts = (
             pipeline_name[:11],
-            '-'.join([_publishing_action_shorthand(a) for a in publishing_actions]),
+            _build_targets_shorthand(build_targets),
             version.replace('.', '-'),
             committish[:6],
             build_ts,
@@ -147,8 +149,8 @@ def get_common_parameters(
         get_param_from_arg(args, 'oci_path'),
         get_param_from_arg(args, 'only_recipients'),
         NamedParam(
-            name='publishing_actions',
-            value=','.join(a.value for a in args['publishing_actions'])
+            name='build_targets',
+            value=','.join(a.value for a in args['build_targets'])
         ),
         NamedParam(
             name='snapshot_timestamp',
@@ -170,7 +172,7 @@ def mk_pipeline_run(
 ):
     run_name = mk_pipeline_name(
         pipeline_name=pipeline_name,
-        publishing_actions=args.publishing_actions,
+        build_targets=args.build_targets,
         version=get_version(vars(args)),
         committish=args.committish,
     )
@@ -272,16 +274,16 @@ def main():
         default=glci.model.BuildType.SNAPSHOT,
     )
     parser.add_argument(
-        '--publishing-action',
-        type=lambda x: (glci.model.PublishingAction(v) for v in x.split(',')),
+        '--build-targets',
+        type=lambda x: (glci.model.BuildTarget(v) for v in x.split(',')),
         action='extend',
-        dest='publishing_actions',
-        default=[glci.model.PublishingAction.MANIFESTS],
+        dest='build_targets',
+        # default=[glci.model.BuildTarget.MANIFEST],
     )
     parser.add_argument('--gardenlinux-base-image')
 
     parsed = parser.parse_args()
-    parsed.publishing_actions = set(parsed.publishing_actions)
+    parsed.build_targets = set(parsed.build_targets)
 
     pipeline_run = mk_pipeline_packages_run(
         args=parsed,

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -70,8 +70,12 @@ if [ ! -z "${ONLY_RECIPIENTS:-}" ]; then
   EXTRA_ARGS="${EXTRA_ARGS} --only-recipients=${ONLY_RECIPIENTS}"
 fi
 if [ ! -z "${PYTEST_CFG:-}" ]; then
-  EXTRA_ARGS="${PYTEST_CFG} --pytest-cfg={PYTEST_CFG}"
+  EXTRA_ARGS="${EXTRA_ARGS} --pytest-cfg=${PYTEST_CFG}"
 fi
+if [ ! -z "${GARDENLINUX_BASE_IMAGE:-}" ]; then
+  EXTRA_ARGS="${EXTRA_ARGS} --gardenlinux-base-image=${GARDENLINUX_BASE_IMAGE}"
+fi
+
 
 cleanup_pipelineruns
 

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -104,7 +104,7 @@ ci/render_pipeline_run.py $EXTRA_ARGS \
   --git-url "${GIT_URL}" \
   --promote-target "${PROMOTE_TARGET}" \
   --oci-path "${OCI_PATH}" \
-  --publishing-action "${PUBLISHING_ACTIONS}" \
+  --build-targets "${BUILD_TARGETS}" \
   --outfile "${pipeline_run}" \
   --outfile-packages "${pipeline_package_run}"
 

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -516,6 +516,8 @@ def build_base_image_step(
     volume_mounts: typing.List[typing.Dict] = [],
 ):
     step_params = [
+        params.build_image,
+        params.gardenlinux_build_deb_image,
         params.oci_path,
         params.repo_dir,
         params.version_label,

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -165,7 +165,7 @@ def upload_results_step(
         params.modifiers,
         params.outfile,
         params.platform,
-        params.publishing_actions,
+        params.build_targets,
         params.version,
     ]
     step = tkn.model.TaskStep(
@@ -196,7 +196,7 @@ def promote_single_step(
         params.gardenlinux_epoch,
         params.modifiers,
         params.platform,
-        params.publishing_actions,
+        params.build_targets,
         params.version,
     ]
     step = tkn.model.TaskStep(
@@ -226,7 +226,7 @@ def promote_step(
         params.flavourset,
         params.gardenlinux_epoch,
         params.promote_target,
-        params.publishing_actions,
+        params.build_targets,
         params.version,
     ]
     step = tkn.model.TaskStep(
@@ -257,7 +257,7 @@ def pre_build_step(
         params.gardenlinux_epoch,
         params.modifiers,
         params.platform,
-        params.publishing_actions,
+        params.build_targets,
         params.version,
     ]
     step = tkn.model.TaskStep(
@@ -285,7 +285,7 @@ def release_step(
         params.committish,
         params.gardenlinux_epoch,
         params.giturl,
-        params.publishing_actions,
+        params.build_targets,
     ]
     step = tkn.model.TaskStep(
         name='release-step',
@@ -549,7 +549,7 @@ def create_component_descriptor_step(
         params.committish,
         params.ctx_repository_config_name,
         params.gardenlinux_epoch,
-        params.publishing_actions,
+        params.build_targets,
         params.snapshot_ctx_repository_config_name,
         params.version,
     ]
@@ -642,7 +642,7 @@ def pre_check_tests_step(
         params.gardenlinux_epoch,
         params.modifiers,
         params.platform,
-        params.publishing_actions,
+        params.build_targets,
         params.version,
     ]
     step = tkn.model.TaskStep(
@@ -673,7 +673,7 @@ def test_step(
         params.gardenlinux_epoch,
         params.modifiers,
         params.platform,
-        params.publishing_actions,
+        params.build_targets,
         params.repo_dir,
         params.snapshot_timestamp,
         params.suite,
@@ -708,7 +708,7 @@ def upload_test_results_step(
         params.gardenlinux_epoch,
         params.modifiers,
         params.platform,
-        params.publishing_actions,
+        params.build_targets,
         params.repo_dir,
         params.version,
     ]
@@ -735,6 +735,7 @@ def attach_log_step(
     ):
     step_params = [
         params.architecture,
+        params.build_targets,
         params.cicd_cfg_name,
         params.committish,
         params.gardenlinux_epoch,

--- a/ci/steps/attach_logs.py
+++ b/ci/steps/attach_logs.py
@@ -70,6 +70,7 @@ def _upload_package_file(
 
 def _attach_and_upload_logs(
     architecture: str,
+    build_targets: str,
     cicd_cfg_name: str,
     committish: str,
     gardenlinux_epoch: str,
@@ -89,6 +90,11 @@ def _attach_and_upload_logs(
         print("No file found with log files, won't upload.")
         print("Exiting with failure, see logs from previous steps")
         return False
+
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
+    if not glci.model.BuildTarget.MANIFEST in build_target_set:
+        print(f'build target {glci.model.BuildTarget.MANIFEST=} not specified - skip upload')
+        return True
 
     manifest_available = True
     if not platform.strip() or not modifiers.strip():
@@ -160,6 +166,7 @@ def _attach_and_upload_logs(
 
 def upload_logs(
     architecture: str,
+    build_targets: str,
     cicd_cfg_name: str,
     committish: str,
     gardenlinux_epoch: str,
@@ -182,6 +189,7 @@ def upload_logs(
     if ok:
         _attach_and_upload_logs(
             architecture=architecture,
+            build_targets=build_targets,
             cicd_cfg_name=cicd_cfg_name,
             committish=committish,
             gardenlinux_epoch=gardenlinux_epoch,

--- a/ci/steps/build_base_image.py
+++ b/ci/steps/build_base_image.py
@@ -4,10 +4,22 @@ import build_kaniko as builder
 
 
 def build_base_image(
+    build_image: str,
+    gardenlinux_build_deb_image: str,
     repo_dir: str,
     oci_path: str,
     version_label: str,
 ):
+    # check if build is configured to use an existing (older) base-image
+    # if yes skip building base images otherwise build base images for commit
+    targeted_build_deb_image = f'{oci_path}/gardenlinux-build-deb:{version_label}'
+    targeted_build_image = f'{oci_path}/gardenlinux-build-image:{version_label}'
+
+    if gardenlinux_build_deb_image != targeted_build_deb_image and build_image != targeted_build_image:
+        print(f'Build will use (older) base images {gardenlinux_build_deb_image}, {build_image}'
+            ' skip step.')
+        return
+
     dockerfile_relpath = os.path.join(repo_dir, "docker", "build-image", "Dockerfile")
     print(f'repo_dir is: {repo_dir}')
 
@@ -16,7 +28,7 @@ def build_base_image(
     for docker_dir in docker_dirs:
         dockerfile_relpath = os.path.join(repo_dir, "docker", docker_dir, "Dockerfile")
         print(f'---Building now {dockerfile_relpath}')
-        build_base_image = 'debian:testing-slim'
+
         if docker_dir == 'build-deb':
             build_base_image = f'{oci_path}/gardenlinux-build:{version_label}'
         else:

--- a/ci/steps/pre_build_step.py
+++ b/ci/steps/pre_build_step.py
@@ -5,6 +5,12 @@ import glci.util
 import glci.s3
 
 
+def _write_not_build_marker_file(reason: str):
+    with open('/workspace/skip_build', 'w') as f:
+        f.write('skip build (already done or build not in build_targets)')
+    print(f'build skipped: {reason} - telling next step to skip (/workspace/skip_build touched)')
+
+
 def pre_build_step(
     cicd_cfg_name: str,
     modifiers: str,
@@ -13,15 +19,11 @@ def pre_build_step(
     gardenlinux_epoch: str,
     architecture: str,
     platform: str,
-    publishing_actions: str,
+    build_targets: str,
 ):
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
-    if glci.model.PublishingAction.BUILD_ONLY in publishing_actions:
-        print(
-            f'publishing action {glci.model.PublishingAction.BUILD_ONLY=} specified - exiting now'
-        )
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
+    if not glci.model.BuildTarget.BUILD in build_target_set:
+        _write_not_build_marker_file('build not in build-targets')
         sys.exit(0)
 
     cicd_cfg = glci.util.cicd_cfg(cfg_name=cicd_cfg_name)
@@ -31,23 +33,20 @@ def pre_build_step(
     modifiers = tuple([m for m in modifiers.split(',') if m])
 
     release_identifier = glci.model.ReleaseIdentifier(
-      build_committish=committish,
-      version=version,
-      gardenlinux_epoch=int(gardenlinux_epoch),
-      architecture=glci.model.Architecture(architecture),
-      platform=platform,
-      modifiers=modifiers,
+        build_committish=committish,
+        version=version,
+        gardenlinux_epoch=int(gardenlinux_epoch),
+        architecture=glci.model.Architecture(architecture),
+        platform=platform,
+        modifiers=modifiers,
     )
 
     if glci.util.find_release(
-      s3_client=s3_client,
-      bucket_name=s3_bucket_name,
-      release_identifier=release_identifier,
-      prefix=glci.model.ReleaseManifest.manifest_key_prefix,
+        s3_client=s3_client,
+        bucket_name=s3_bucket_name,
+        release_identifier=release_identifier,
+        prefix=glci.model.ReleaseManifest.manifest_key_prefix,
     ):
-      with open('/workspace/skip_build', 'w') as f:
-          f.write('skip build (already done)')
-      print('build already done - telling next step to skip (/workspace/skip_build touched)')
-      # check if tests have been run and create a marker file
+        _write_not_build_marker_file('already done')
     else:
-      print('no matching build results found - will perform build')
+        print('no matching build results found - will perform build')

--- a/ci/steps/pre_check_tests.py
+++ b/ci/steps/pre_check_tests.py
@@ -11,13 +11,12 @@ def pre_check_tests(
     gardenlinux_epoch: str,
     architecture: str,
     platform: str,
-    publishing_actions: str,
+    build_targets: str,
 ):
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
-    if not glci.model.PublishingAction.RUN_TESTS in publishing_actions:
-        print('publishing action "run_tests" not specified - skipping tests')
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
+
+    if not glci.model.BuildTarget.TESTS in build_target_set:
+        print('build target "tests" not specified - skipping tests')
         return True
 
     cicd_cfg = glci.util.cicd_cfg(cfg_name=cicd_cfg_name)

--- a/ci/steps/promote_step.py
+++ b/ci/steps/promote_step.py
@@ -18,17 +18,13 @@ def promote_single_step(
     gardenlinux_epoch: parsable_to_int,
     modifiers: str,
     version: str,
-    publishing_actions: str,
+    build_targets: str,
 ):
     cicd_cfg = glci.util.cicd_cfg(cfg_name=cicd_cfg_name)
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
-    if glci.model.PublishingAction.RELEASE_CANDIDATE not in publishing_actions:
-        print(
-            f'publishing action {glci.model.PublishingAction.RELEASE_CANDIDATE=} not specified'
-            ' - exiting now'
-        )
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
+
+    if glci.model.BuildTarget.PUBLISH not in build_target_set:
+        print(f'build target {glci.model.BuildTarget.PUBLISH=} not specified - exiting now')
         sys.exit(0)
 
     find_release = glci.util.preconfigured(
@@ -114,7 +110,7 @@ def promote_single_step(
 def promote_step(
     cicd_cfg_name: str,
     flavourset: str,
-    publishing_actions: str,
+    build_targets: str,
     gardenlinux_epoch: parsable_to_int,
     committish: str,
     version: str,
@@ -124,14 +120,10 @@ def promote_step(
     flavour_set = glci.util.flavour_set(flavourset)
     flavours = tuple(flavour_set.flavours())
     build_type: glci.model.BuildType = glci.model.BuildType(promote_target)
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
 
-    if glci.model.PublishingAction.BUILD_ONLY in publishing_actions:
-        print(
-            f'publishing action {glci.model.PublishingAction.BUILD_ONLY=} specified - exiting now'
-        )
+    if glci.model.BuildTarget.MANIFEST not in build_target_set:
+        print(f'build target {glci.model.BuildTarget.MANIFEST=} not specified - exiting now')
         sys.exit(0)
 
     find_releases = glci.util.preconfigured(
@@ -152,10 +144,10 @@ def promote_step(
     # ensure all previous tasks really were successful
     is_complete = len(releases) == len(flavours)
     if not is_complete:
-        print('release was not complete - will not promote (this indicates a bug!)')
+        print('release was not complete - will not publish (this indicates a bug!)')
         sys.exit(1)  # do not signal an error
 
-    print(publishing_actions)
+    print(build_target_set)
 
     # if this line is reached, the release has been complete
     # now create and publish manifest-set

--- a/ci/steps/release_step.py
+++ b/ci/steps/release_step.py
@@ -8,14 +8,12 @@ def release_step(
     giturl: str,
     committish: str,
     gardenlinux_epoch: parsable_to_int,
-    publishing_actions: str,
+    build_targets: str,
 ):
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
 
-    if not glci.model.PublishingAction.RELEASE in publishing_actions:
-      print(f'{publishing_actions=} - will not perform release')
+    if not glci.model.BuildTarget.GITHUB_RELEASE in build_target_set:
+      print(f'{build_target_set=} - will not perform release')
       return
 
     release.ensure_target_branch_exists(

--- a/ci/steps/run_tests.py
+++ b/ci/steps/run_tests.py
@@ -22,7 +22,7 @@ class TestRunParameters:
         gardenlinux_epoch: str,
         modifiers: str,
         platform: str,
-        publishing_actions: str,
+        build_targets: str,
         repo_dir: str,
         suite: str,
         snapshot_timestamp: str,
@@ -34,7 +34,7 @@ class TestRunParameters:
         self.gardenlinux_epoch = gardenlinux_epoch
         self.modifiers = modifiers
         self.platform = platform
-        self.publishing_actions = publishing_actions
+        self.build_targets = build_targets
         self.repo_dir = repo_dir
         self.suite = suite
         self.snapshot_timestamp = snapshot_timestamp
@@ -88,7 +88,7 @@ def run_tests(
     gardenlinux_epoch: str,
     modifiers: str,
     platform: str,
-    publishing_actions: str,
+    build_targets: str,
     repo_dir: str,
     suite: str,
     snapshot_timestamp: str,
@@ -97,14 +97,13 @@ def run_tests(
     pytest_cfg: str = None,
 ):
     print(f'run_test with: {architecture=}, {cicd_cfg_name=}, {gardenlinux_epoch=}')
-    print(f'   : {modifiers=}, {platform=}, {publishing_actions=}, {repo_dir=}')
+    print(f'   : {modifiers=}, {platform=}, {build_targets=}, {repo_dir=}')
     print(f'   : {suite=}, {snapshot_timestamp=}, {version=}')
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
-
-    if not glci.model.PublishingAction.RUN_TESTS in publishing_actions:
-        print('publishing action "run_tests" not specified - skipping tests')
+    build_targets = (
+        glci.model.BuildTarget(action.strip()) for action in build_targets.split(',')
+    )
+    if not glci.model.BuildTarget.TESTS in build_targets:
+        print('build target "tests" not specified - skipping tests')
         return True
 
     if os.path.exists('/workspace/skip_tests'):
@@ -119,7 +118,7 @@ def run_tests(
         gardenlinux_epoch=gardenlinux_epoch,
         modifiers=modifiers,
         platform=platform,
-        publishing_actions=publishing_actions,
+        build_targets=build_targets,
         repo_dir=repo_dir,
         suite=suite,
         snapshot_timestamp=snapshot_timestamp,

--- a/ci/steps/upload_results_step.py
+++ b/ci/steps/upload_results_step.py
@@ -4,7 +4,6 @@ import hashlib
 import os
 import pprint
 import sys
-import tarfile
 
 import glci.model
 import glci.util
@@ -63,15 +62,12 @@ def upload_results_step(
     modifiers: str,
     version: str,
     outfile: str,
-    publishing_actions: str,
+    build_targets: str,
 ):
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
-    if glci.model.PublishingAction.BUILD_ONLY in publishing_actions:
-        print(
-            f'publishing action {glci.model.PublishingAction.BUILD_ONLY=} specified - exiting now'
-        )
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
+
+    if not glci.model.BuildTarget.MANIFEST in build_target_set:
+        print(f'build target {glci.model.BuildTarget.MANIFEST=} not specified - exiting now')
         sys.exit(0)
 
     if os.path.isfile('/workspace/skip_build'):
@@ -122,7 +118,7 @@ def upload_results_step(
 
     # always publish oci image
     if manifest.platform == 'oci':
-        release_build = glci.model.PublishingAction.RELEASE_CANDIDATE in publishing_actions
+        release_build = glci.model.BuildTarget.FREEZE_VERSION in build_target_set
         manifest = promote._publish_oci_image(
             release=manifest,
             cicd_cfg=cicd_cfg,

--- a/ci/steps/upload_test_results.py
+++ b/ci/steps/upload_test_results.py
@@ -15,16 +15,19 @@ def upload_test_results(
     gardenlinux_epoch: str,
     modifiers: str,
     platform: str,
-    publishing_actions: str,
+    build_targets: str,
     repo_dir: str,
     version: str,
 ):
-    publishing_actions = [
-        glci.model.PublishingAction(action.strip()) for action in publishing_actions.split(',')
-    ]
-    if not glci.model.PublishingAction.RUN_TESTS in publishing_actions:
-        print('publishing action "run_tests" not specified - skipping tests')
-        return True
+    build_target_set = glci.model.BuildTarget.set_from_str(build_targets)
+
+    if not glci.model.BuildTarget.TESTS in build_target_set:
+        print('build target "tests" not specified - nothing to upload')
+        sys.exit(0)
+
+    if not glci.model.BuildTarget.MANIFEST in build_target_set:
+        print('build target "manifest" not specified - skipping uploads')
+        sys.exit(0)
 
     if os.path.exists('/workspace/skip_tests'):
         print('Tests already uploaded in previous run, skipping upload step')


### PR DESCRIPTION

/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
* CI: replace publishing action by buils-targets
* CI: add option to use an existing base image during build (env var: GARDENLINUX_BASE_IMAGE)

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
