### PR TITLE
Ci: Move each branches pipelines to their own namespace

### DIFF
--- a/ci/cleanup_namespaces
+++ b/ci/cleanup_namespaces
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+own_dir="$(readlink -f "$(dirname "${0}")")"
+repo_root="${own_dir}/.."
+
+source "${own_dir}/lib.sh"
+
+install_kubectl
+install_tkn
+
+# retrieve and configure kubeconfig (sets KUBECONFIG env var)
+if [ -z ${KUBECONFIG:-} ] &&  [ -n ${SECRETS_SERVER_ENDPOINT:-} ]; then
+  kubecfg
+fi
+
+whitelisted_namespaces=("concourse" "kube-system" "kube-puplic" "kube-node-lease" "tekton-pipelines" "default")
+
+for namespace in $(kubectl get ns -ojsonpath={.items[*].metadata.name}); do
+
+  whitelisted="false"
+  for n in ${whitelisted_namespaces[*]}; do
+    if [ "${namespace}" == "${n}" ]; then
+      whitelisted="true"
+    fi
+  done
+  if [ "${whitelisted}" == "true" ]; then
+    echo "Namespace ${namespace} is whitelisted, skipping"
+    continue
+  fi
+
+  if [ $(kubectl get pipelineruns.tekton.dev -n $namespace | wc -l) -eq 0 ]; then
+    echo "No pipeline runs in namespace ${namespace}, skipping"
+    continue
+  fi
+  if [ $(days_since_last_pipeline_run ${namespace}) -gt 20 ]; then
+    echo "Found no run within the last 20 days in namespace ${namespace}, deleting"
+    kubectl delete ns $namespace
+  else
+    echo "Found run within the last 20 days in namespace ${namespace}, will not delete"
+  fi
+done

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -41,9 +41,9 @@ function kubecfg()  {
 }
 
 function export_env() {
-  export BRANCH_NAME="${BRANCH_NAME:-main}"
+  export BRANCH_NAME="${BRANCH_NAME:-${GARDENLINUX_BRANCH:-main}}"
+  export GARDENLINUX_TKN_WS="${GARDENLINUX_TKN_WS:-${GARDENLINUX_BRANCH:-gardenlinux}}"
   export FLAVOUR_SET="${FLAVOUR_SET:-all}"
-  export GARDENLINUX_TKN_WS="${GARDENLINUX_TKN_WS:-gardenlinux}"
   export GIT_URL="${GIT_URL:-https://github.com/gardenlinux/gardenlinux}"
   export OCI_PATH="${OCI_PATH:-eu.gcr.io/gardener-project/gardenlinux}"
   export PROMOTE_TARGET="${PROMOTE_TARGET:-snapshot}"

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -50,3 +50,17 @@ function export_env() {
   export BUILD_TARGETS="${BUILD_TARGETS:-build}"
   export PATH="${PATH}:${bin_dir}"
 }
+
+function seconds_since_epoch() {
+  timestamp="$1"
+  date '+%s' --date="${timestamp}"
+}
+
+function days_since_last_pipeline_run() {
+  namespace="$1"
+  oldest_run=$(kubectl get pipelineruns.tekton.dev -n ${namespace} \
+    --sort-by=.metadata.creationTimestamp -o jsonpath={.items[-1:].metadata.creationTimestamp})
+  now=$(date --iso-8601=seconds)
+  seconds=$(( $(seconds_since_epoch "${now}") - $(seconds_since_epoch "${oldest_run}") ))
+  echo $(( $seconds / (60*60*24) ))
+}

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -7,29 +7,39 @@ repo_root="${own_dir}/.."
 
 source "${own_dir}/lib.sh"
 
-install_kubectl
-install_tkn
+function sanitise_namespace_name {
+  namespace_name=$1
+  # sanitise given branch-name to k8s-namespace-name - k8s namespaces may contain only alphanumeric
+  # characters and dashes. Translate everything else to a dash.
+  # Note: they also must start and end with an alphanumeric character - if that isn't true for the
+  # branch name, this function will fail
+  echo -n ${namespace_name} | tr -c [:alnum:] -
+}
 
-# retrieve and configure kubeconfig (sets KUBECONFIG env var)
-if [ -z ${KUBECONFIG:-} ] &&  [ -n ${SECRETS_SERVER_ENDPOINT:-} ]; then
-  kubecfg
-fi
+function create_or_update_namespace {
+  namespace_name=$1
+  echo "Creating/Updating namespace with name: ${namespace_name}"
 
-# also handles default-values for env-vars
-export_env
+  # use kubectl to create a manifest for a namespace and apply it. Without the first step
+  # kubectl would complain if the namespace already exists.
+  # This will print a warning the first time this updates existing namespaces if they haven't been
+  # created with 'kubectl apply'
+  kubectl create ns "${namespace_name}" --dry-run=client -oyaml | kubectl apply -f -
+}
 
 function cleanup_pipelineruns {
-  echo "purging old pipelineruns"
+  namespace_name=$1
+  echo "purging old pipelineruns in namespace: ${namespace_name}"
   tkn \
-    -n "${GARDENLINUX_TKN_WS}" \
+    -n "${namespace_name}" \
     pipelineruns \
     delete \
     --force \
     --all \
     --keep 20
-  echo "purging old taskruns"
+  echo "purging old taskruns in namespace: ${namespace_name}"
     tkn \
-   -n "${GARDENLINUX_TKN_WS}" \
+   -n "${namespace_name}" \
     taskruns \
     delete \
     --force \
@@ -38,19 +48,33 @@ function cleanup_pipelineruns {
 }
 
 function create_credentials {
+  namespace_name=$1
   ci/render_credentials.py \
     --outfile "${credentials_outfile}"
 
-  if kubectl get secret -n "${GARDENLINUX_TKN_WS}" secrets &> /dev/null; then
-    kubectl delete secret -n "${GARDENLINUX_TKN_WS}" secrets
+  if kubectl get secret -n "${namespace_name}" secrets &> /dev/null; then
+    kubectl delete secret -n "${namespace_name}" secrets
   fi
 
-  echo "Creating secret"
+  echo "Creating secret in namespace: ${namespace_name}"
   kubectl create secret generic secrets \
-    -n "${GARDENLINUX_TKN_WS}" \
+    -n "${namespace_name}" \
     --from-file=config.json="${credentials_outfile}"
 }
 
+install_kubectl
+install_tkn
+
+# also handles default-values for env-vars
+export_env
+
+# retrieve and configure kubeconfig (sets KUBECONFIG env var)
+if [ -z ${KUBECONFIG:-} ] &&  [ -n ${SECRETS_SERVER_ENDPOINT:-} ]; then
+  kubecfg
+fi
+
+tekton_namespace="$(sanitise_namespace_name ${GARDENLINUX_TKN_WS})"
+create_or_update_namespace "${tekton_namespace}"
 
 echo "render pipelines"
 cd "${repo_root}"
@@ -77,7 +101,7 @@ if [ ! -z "${GARDENLINUX_BASE_IMAGE:-}" ]; then
 fi
 
 
-cleanup_pipelineruns
+cleanup_pipelineruns "${tekton_namespace}"
 
 # for local dev rendering use latest remote commit and no local one.
 if [ ! -z "${CC_CONFIG_DIR:-}" ]; then
@@ -120,8 +144,8 @@ if [ ! -z ${SECRETS_SERVER_ENDPOINT:-} ]; then
 else
   # secrets-server won't be available; create config from local files and put it as
   # k8s secret into cluster.
-  echo "create credentials"
-  create_credentials
+  echo "creating credentials in cluster"
+  create_credentials "${tekton_namespace}"
 fi
 
 ci/render_all.py \
@@ -163,20 +187,20 @@ done
 # --image-build calls triggering the pipeline run for image build
 if [ ${image_build} = true ] ; then
   echo "Build images"
-  kubectl apply -n "${GARDENLINUX_TKN_WS}" -f "${pipeline_run}"
+  kubectl apply -n "${tekton_namespace}" -f "${pipeline_run}"
   if [ ${wait} = true ] ; then
     echo "waiting for new pipelinerun ${pipeline_run}"
-    ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_run}" --namespace "${GARDENLINUX_TKN_WS}"
+    ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_run}" --namespace "${tekton_namespace}"
   fi
 fi
 
 # --package-build calls triggering the pipeline run for image build
 if [ ${package_build} = true ]; then
   echo "Build packages"
-  kubectl apply -n "${GARDENLINUX_TKN_WS}" -f "${pipeline_package_run}"
+  kubectl apply -n "${tekton_namespace}" -f "${pipeline_package_run}"
   if [ ${wait} = true ]; then
     echo "waiting for new pipelinerun ${pipeline_package_run}"
-    ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_package_run}" --namespace "${GARDENLINUX_TKN_WS}"
+    ci/wait_for_pipelinerun.py --pipelinerun-file "${pipeline_package_run}" --namespace "${tekton_namespace}"
   fi
 fi
 

--- a/ci/render_pipelines_and_trigger_job
+++ b/ci/render_pipelines_and_trigger_job
@@ -46,7 +46,7 @@ function create_credentials {
   fi
 
   echo "Creating secret"
-  $(which kubectl) create secret generic secrets \
+  kubectl create secret generic secrets \
     -n "${GARDENLINUX_TKN_WS}" \
     --from-file=config.json="${credentials_outfile}"
 }
@@ -140,7 +140,7 @@ for manifest in \
   "${outfile_pipeline_packages}"
 do
   echo "Apply of ${manifest}"
-  $(which kubectl) apply -n "${GARDENLINUX_TKN_WS}" -f "${manifest}"
+  kubectl apply -n "${tekton_namespace}" -f "${manifest}"
 done
 
 image_build=false


### PR DESCRIPTION
Moves the pipelines created by each Git-branch to their own k8s-namespace. The name of the namespace is derived from the branch-name by replacing all non-alphanumeric characters with `-` (Note: This will still fail if the branch starts/ends with a non-alphanumerical character, but at least the error message should be self-explanatory).

Also provides a script that can autmatically clean-up namespaces that did not see any testrun within the last 20 days (not yet added to pipeline-def)