### PR TITLE
docs: Conventional commits in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ You are welcome to contribute code to Garden Linux in order to fix a bug or to i
 The following rules govern code contributions:
 
 1. Contributions must be licensed under the MIT License.
-2. You need to sign the Developer Certificate of Origin.
+1. You need to sign the Developer Certificate of Origin.
 
 ## Contributing Documentation
 
@@ -38,7 +38,7 @@ You are welcome to contribute documentation to Garden Linux.
 The following rules govern documentation contributions:
 
 1. Contributions must be licensed under the Creative Commons Attribution 4.0 International License.
-2. You need to sign the Developer Certificate of Origin.
+1. You need to sign the Developer Certificate of Origin.
 
 ## Developer Certificate of Origin
 
@@ -48,20 +48,22 @@ Due to legal reasons, contributors will be asked to accept a Developer Certifica
 
 1. Branch from the master branch and, if needed, rebase to the current master branch before submitting your pull request. If it doesn’t merge cleanly with master you may be asked to rebase your changes.
 
-2. Commits should be as small as possible, while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).
+1. Commits should be as small as possible, while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).
 
-3. Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit and/or integration tests. If tested manually, provide information about the test scope in the PR description.
+1. Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification so that we automatically produce meaningful release notes.
 
-4. Create Work In Progress [WIP] pull requests only if you need a clarification or an explicit review before you can continue your work item.
+1. Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit and/or integration tests. If tested manually, provide information about the test scope in the PR description.
 
-5. If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review on our [mailing list](#Mailing-List).
+1. Create Work In Progress [WIP] pull requests only if you need a clarification or an explicit review before you can continue your work item.
 
-6. Post review:
+1. If your patch is not getting reviewed or you need a specific person to review it, you can @-reply a reviewer asking for a review in the pull request or a comment, or you can ask for a review on our [mailing list](#Mailing-List).
+
+1. Post review:
 
     1. If a review requires you to change your commit(s), please test the changes again. 
-    2. Amend the affected commit(s) and force push onto your branch.
-    3. Set respective comments in your GitHub review to resolved.
-    4. Create a general PR comment to notify the reviewers that your amendments are ready for another round of review.
+    1. Amend the affected commit(s) and force push onto your branch.
+    1. Set respective comments in your GitHub review to resolved.
+    1. Create a general PR comment to notify the reviewers that your amendments are ready for another round of review.
 
 
 ## Issues and Planning


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Includes the requirement to use Conventional Commits into the contribution guidelines (`CONTRIBUTING.md`). Also, leaves the numbering for a numbered list to the .md renderer.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
- docs: Conventional commits in contribution guidelines
```
