### PR TITLE
Ci: also notify via slack for build failures.

### DIFF
--- a/ci/cicd.yaml
+++ b/ci/cicd.yaml
@@ -30,3 +30,6 @@ cicd_cfgs:
         image_prefix: 'eu.gcr.io/gardenlinux/gardenlinux'
     notify:
       email_cfg_name: 'ses_gardener_cloud_sap'
+      slack_cfg_name: 'ti_workspace'
+      slack_channel: 'GURQBS34Z'
+      branches: ['main']

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -608,6 +608,9 @@ class PublishCfg:
 @dataclasses.dataclass(frozen=True)
 class NotificationCfg:
     email_cfg_name: str
+    slack_cfg_name: str
+    slack_channel: str
+    branches: typing.Tuple[str, ...]
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
With this pull-request, failing pipeline-builds on `main` (configurable) will also try to post to our internal `gardenlinux-dev` (configurable) channel. A link to the tekton-dashboard will be included, and if a build-log is available it will also be attached.