### PR TITLE
Ci: report pipeline-status to commit

### DIFF
--- a/ci/glci/github.py
+++ b/ci/glci/github.py
@@ -1,0 +1,31 @@
+import enum
+
+import ccc.github
+
+
+class GitHubStatus(enum.Enum):
+    ERROR = 'error'
+    FAILURE = 'failure'
+    PENDING = 'pending'
+    SUCCESS = 'success'
+
+
+def post_github_status(
+    github_cfg,
+    committish: str,
+    state: GitHubStatus,
+    target_url: str = None,
+    description: str = None,
+    context: str = "tekton-pipelines",
+
+):
+    github_api = ccc.github.github_api(github_cfg)
+
+    repo = github_api.repository(owner='gardenlinux', repository='gardenlinux')
+    repo.create_status(
+        sha=committish,
+        state=state.value,
+        target_url=target_url,
+        description=description,
+        context=context,
+    )

--- a/ci/render_pipelines.py
+++ b/ci/render_pipelines.py
@@ -79,11 +79,18 @@ def mk_pipeline_base_build_task(
     all_tasks: typing.Sequence[tkn.model.Task]
 ):
     name = "build-baseimage"
-    params = _get_passed_parameters(name=name, all_tasks=all_tasks)
+    params = _get_passed_parameters(
+        name=name,
+        all_tasks=all_tasks,
+        overrides={
+            NamedParam(name='pipeline_run_name', value='$(context.pipelineRun.name)'),
+            NamedParam(name='namespace', value='$(context.pipelineRun.namespace)'),
+        },
+    )
     return PipelineTask(
         name=name,
         taskRef=TaskRef(name=name),
-        params=params,
+        params=tuple(params),
         runAfter=None,
     )
 
@@ -230,7 +237,6 @@ def mk_pipeline_notify_task(
             NamedParam(name='platform', value=platform),
             NamedParam(name='pipeline_run_name', value='$(context.pipelineRun.name)'),
             NamedParam(name='pipeline_name', value='$(context.pipeline.name)'),
-            NamedParam(name='pipeline_run_name', value='$(context.pipelineRun.name)'),
             NamedParam(name='namespace', value='$(context.pipelineRun.namespace)'),
             NamedParam(name='status_dict_str', value=status_str),
         }
@@ -389,8 +395,8 @@ def mk_pipeline(
     params.remove(all_params.modifiers)
     params.remove(all_params.namespace)
     params.remove(all_params.platform)
-    params.remove(all_params.pipeline_name)
     params.remove(all_params.pipeline_run_name)
+    params.remove(all_params.pipeline_name)
 
     # convert to list as set is not rendered to yaml
     params = tuple(params)

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -152,6 +152,35 @@ def clone_step(
     return step, step_params
 
 
+def status_step(
+    params: params.AllParams,
+    env_vars: typing.List[typing.Dict] = [],
+    volume_mounts: typing.List[typing.Dict] = [],
+):
+    step_params = [
+        params.committish,
+        params.giturl,
+        params.pipeline_run_name,
+        params.namespace,
+    ]
+
+    step = tkn.model.TaskStep(
+        name='update-status-step',
+        image=DEFAULT_IMAGE,
+        script=task_step_script(
+            path=os.path.join(steps_dir, 'update_status.py'),
+            script_type=ScriptType.PYTHON3,
+            callable='update_status',
+            params=step_params,
+            repo_path_param=params.repo_dir,
+        ),
+        volumeMounts=volume_mounts,
+        env=env_vars,
+    )
+
+    return step, step_params
+
+
 def upload_results_step(
     params: params.AllParams,
     env_vars: typing.List[typing.Dict] = [],

--- a/ci/steps/update_status.py
+++ b/ci/steps/update_status.py
@@ -1,0 +1,28 @@
+import urllib.parse
+
+import ccc.github
+import glci.github
+
+
+def update_status(
+    giturl: str,
+    committish: str,
+    namespace: str,
+    pipeline_run_name: str,
+):
+    dashboard_url = (
+        f'https://tekton-dashboard.gardenlinux.io/#/namespaces/{namespace}'
+        f'/pipelineruns/{pipeline_run_name}'
+    )
+    repo_url = urllib.parse.urlparse(giturl)
+    github_cfg = ccc.github.github_cfg_for_hostname(
+        repo_url.hostname,
+    )
+
+    glci.github.post_github_status(
+        github_cfg=github_cfg,
+        committish=committish,
+        target_url=dashboard_url,
+        state=glci.github.GitHubStatus.PENDING,
+        description='Pipeline run started',
+    )

--- a/ci/tasks.py
+++ b/ci/tasks.py
@@ -330,6 +330,13 @@ def base_image_build_task(env_vars, volumes, volume_mounts):
     )
     params += params_step
 
+    update_status_step, params_step = steps.status_step(
+        params=all_params,
+        env_vars=env_vars,
+        volume_mounts=volume_mounts,
+    )
+    params += params_step
+
     build_base_image_step, params_step = steps.build_base_image_step(
         params=all_params,
         env_vars=env_vars,
@@ -344,6 +351,7 @@ def base_image_build_task(env_vars, volumes, volume_mounts):
             params=params,
             steps=[
                 clone_repo_step,
+                update_status_step,
                 build_base_image_step,
             ],
             volumes=volumes,


### PR DESCRIPTION
Will report a 'pending' to the commit being built once the pipeline starts running (immediately after checking
out) and a final 'success' or 'failure' after the pipeline's outcome can be determined.
The status contains a dashboard-link to the corresponding tekton-pipeline

ToDo: Figure out the best way to achieve the same for pull requests
