### PR TITLE
fix: make sure build container is based on bullseye for 318 release branch

### DIFF
--- a/docker/needslim
+++ b/docker/needslim
@@ -6,23 +6,23 @@ VERSION="$(../bin/garden-version)"
 if [ "$(docker image ls gardenlinux/slim --format \"{{.Repository}}:{{.Tag}}\")" == "" ]; then
 	echo "WARNING: There is no gardenlinux/slim on this box. Since this is the builder script, it will pull no binary docker images from public repos."
 	echo
-	echo "Since gardenlinux/slim is needed for almost all images we pull debian/testing-slim and rename it to gardenlinux/slim so we avoid the Chicken-and-Egg problem temporarily"
+	echo "Since gardenlinux/slim is needed for almost all images we pull debian/bullseye-slim and rename it to gardenlinux/slim so we avoid the Chicken-and-Egg problem temporarily"
 	echo
 	echo "Please run 'make slim' afterwards"
 	echo
-	docker pull debian:testing-slim
-	docker tag  debian:testing-slim gardenlinux/slim
-	docker tag  debian:testing-slim gardenlinux/slim:$VERSION
-	docker tag  debian:testing-slim gardenlinux/slim:latest
+	docker pull debian:bullseye-slim
+	docker tag  debian:bullseye-slim gardenlinux/slim
+	docker tag  debian:bullseye-slim gardenlinux/slim:$VERSION
+	docker tag  debian:bullseye-slim gardenlinux/slim:latest
 else
 	if [ "$(docker image ls gardenlinux/slim:latest --format \"{{.ID}}\")" == \
-	     "$(docker image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
-		echo "WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:latest!"
+	     "$(docker image ls debian:bullseye-slim --format \"{{.ID}}\")" ]; then
+		echo "WARNING: You are still using a debian:bullseye-slim as a temporary replacement of gardenlinux/slim:latest!"
 		echo
 		echo "Please run 'make slim' to fix"
 	elif [ "$(docker image ls gardenlinux/slim:$VERSION --format \"{{.ID}}\")" == \
-	       "$(docker image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
-		echo "WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:$VERSION!"
+	       "$(docker image ls debian:bullseye-slim --format \"{{.ID}}\")" ]; then
+		echo "WARNING: You are still using a debian:bullseye-slim as a temporary replacement of gardenlinux/slim:$VERSION!"
 		echo
 		echo "Please run 'make slim' to fix"
 	fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind regression
/area os
/os garden-linux

**What this PR does / why we need it**:

Building a Garden Linux 318 release requires the build containers to come from Debian Bullseye (which 318 is based on). Having `debian:testing-slim` in our files will pull in `bookworm-slim` or newer nowadays which will cause the build to fail.

**Special notes for your reviewer**:

Do not merge to `main`! This PR must be merged to `rel-318`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
- fix: make sure build container is based on bullseye for 318 release branch
```
