### PR TITLE
docker/Makefile: no longer depending on host having dpkg

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@ build-image: needslim
 
 .PHONY: build
 build: needslim
-	@docker build --build-arg BUILDARCH="$$(dpkg --print-architecture | awk -F- "{ print \$$NF }")" -t gardenlinux/build $(ALTNAME_INTERNAL) build
+	@docker build --build-arg BUILDARCH="$$([ "$$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64")" -t gardenlinux/build $(ALTNAME_INTERNAL) build
 
 .PHONY: build-deb
 build-deb: build


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

`docker/Makefile` currently depends on `dpkg` being available on the host to determine BUILDARCH env for build container.
This breaks if the build system is not debian or debian based.
This PR should fix it by only using `uname`.
