### PR TITLE
Remove features from /tmp

### DIFF
--- a/bin/garden-config
+++ b/bin/garden-config
@@ -56,7 +56,7 @@ for i in $(echo "base,$features" | tr ',' '\n' | norm_features); do
 		$thisDir/garden-chroot $targetDir /tmp/$(basename $featureDir)/$i/exec.config | indent
 	fi
 done
-rm -rf $targetDir/tmp/$featureDir
+rm -r "$targetDir/tmp/$(basename $featureDir)"
 
 printf "## deleting file.exclude\n"
 set -o noglob


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
When running the exec.config scripts, the features are copied to /tmp, but they weren't properly removed afterwards.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
