### PR TITLE
Proper sftp-server path in sshd_config

### DIFF
--- a/features/server/file.include/etc/ssh/sshd_config
+++ b/features/server/file.include/etc/ssh/sshd_config
@@ -33,7 +33,7 @@ PrintMotd no
 AcceptEnv LANG
 
 # override default of no subsystems
-Subsystem sftp  /usr/lib/ssh/sftp-server -f AUTHPRIV -l INFO
+Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO
 
 # autologout inactive users after 10 minutes
 ClientAliveInterval 600

--- a/features/server/test/sshd.d/ssh_expected
+++ b/features/server/test/sshd.d/ssh_expected
@@ -16,7 +16,7 @@ AuthenticationMethods publickey
 LogLevel VERBOSE
  
 # Log sftp level file access (read/write/etc.) that would not be easily logged otherwise - be aware that the path has to be adapted to the Distribution installed.
-Subsystem sftp /usr/lib/ssh/sftp-server -f AUTHPRIV -l INFO
+Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO
  
 # Root login is not allowed for auditing reasons. This is because it's difficult to track which process belongs to which root user:
 #


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
sftp-server in the sshd_config is using the wrong path.

**Which issue(s) this PR fixes**:
Part of #516 

**Special notes for your reviewer**:

**Release note**:

