### PR TITLE
Start-vm - fetch files via http when pxebooting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,10 @@ kvm-dev: container-build cert/sign.pub
 	./build.sh --skip-build --features server,cloud,kvm,_dev $(BUILDDIR) $(VERSION)
 
 pxe: container-build cert/sign.pub
-	./build.sh --skip-build --features server,cloud,_pxe $(BUILDDIR) $(VERSION)
+	./build.sh --skip-build --features metal,server,_pxe $(BUILDDIR) $(VERSION)
 
 pxe-dev: container-build cert/sign.pub
-	./build.sh --skip-build --features server,cloud,_dev,_pxe $(BUILDDIR) $(VERSION)
+	./build.sh --skip-build --features metal,server,_dev,_pxe $(BUILDDIR) $(VERSION)
 
 anvil: container-build cert/sign.pub
 	./build.sh --skip-build --features server,cloud-anvil,kvm,_dev $(BUILDDIR) $(VERSION)

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -221,7 +221,8 @@ fi
 printf "Status:\n"
 printf "  starting VM(UUID:%s) with MAC:%s in %s\n" $uuid $macfull $targetDir
 [ $monitor ]	&& printf "  monitor: %s.monitor\tconnect: socat - UNIX-CONNECT:%s\n" $mac $targetDir/$mac.monitor
-[ $pxe ]	&& printf "  pxeboot: %.ipxe/\n" $mac
+[ $pxe ]	&& printf "  pxeboot: %s.ipxe\n" $mac
+[ $pxe ]	&& printf "  pxeboot: files served from %s\n" "$pxe"
 [ $bridge ]	&& printf "  interface: %s  bridged\n" $bridge
 [ $bridge ]	|| printf "  sshport: %s  unbridged\n" $port
 [ $vnc ] 	&& printf "  vncport: %s\n" $(( vncport + 5900 ))
@@ -233,6 +234,18 @@ done
 printf '%s ' "${virtOpts[@]}";printf "\n" ) | sed 's/ /!/g;s/!-/ -/g' | fold -s -w $(( $(tput cols) - 4 )) | sed 's/!/ /g;3,$ s|^|    |'
 [ $keypress ]	&& read -n 1 -r -s -p $'Press any key to continue...\n'
 
+# pxe helper container
+if [ $pxe ]; then
+	containerName=$(cat /proc/sys/kernel/random/uuid)
+	function stop(){
+		echo "stopping helper for pxe"
+		docker stop -t 0 $1
+		echo "everything stopped..."
+	}
+	trap 'stop $containerName' EXIT
+	echo "starting helper container"
+	docker run -it --rm -d -p 127.0.0.1:8888:80 --name ${containerName} -v ${pxe}:/usr/share/nginx/html:ro nginx
+fi
 
 ### from here on things are actually done!!!
 # modifying /etc/qemu/bridge.conf - would be good to be root!!!

--- a/examples/ipxe/start-vm.ipxe
+++ b/examples/ipxe/start-vm.ipxe
@@ -2,7 +2,8 @@
 
 set pxeserver IPADDRESSGOESHERE 
 set pxepath PATHGOESHERE 
+set port 8888
 
-kernel tftp://${pxeserver}/${pxepath}/rootfs.vmlinuz gl.url=tftp://${pxeserver}/root.squashfs gl.live=1 ip=dhcp console=ttyS0 gl.ovl=/:tmpfs
-initrd tftp://${pxeserver}/${pxepath}/rootfs.initrd
+kernel http://${pxeserver}:${port}/${pxepath}/rootfs.vmlinuz gl.url=http://${pxeserver}:${port}/root.squashfs gl.live=1 ip=dhcp console=ttyS0 gl.ovl=/:tmpfs
+initrd http://${pxeserver}:${port}/${pxepath}/rootfs.initrd
 boot


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
When using the start-vm script to test the pxe feature, we don't want to use tftp so we're spinning up a helper container in order to serve the needed files.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
