### PR TITLE
Use serial console as default output for cloud

### DIFF
--- a/features/cloud/file.include/etc/kernel/cmdline.d/00-default.cfg
+++ b/features/cloud/file.include/etc/kernel/cmdline.d/00-default.cfg
@@ -1,5 +1,5 @@
 # DO NOT CHANGE THIS FILE! USE /etc/kernel/cmdline.d
-CMDLINE_LINUX="ro console=ttyS0,115200 console=tty0 earlyprintk=ttyS0,115200 consoleblank=0"
+CMDLINE_LINUX="ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0"
 DEVICE="LABEL=ROOT"
 # WARNING! 0 disables the TIMEOUT
 TIMEOUT=1


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Cloud providers use serial console output as kind of a log, often even with write access.
However access to the graphical console is much less provided.
So we should make sure the serial console becomes default and gets the most information.

Making both more equal in information can be done with plymouth.