### PR TITLE
remove -ti from all docker runs except for manual builds

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -15,7 +15,7 @@ export BASH_BUILD
 all: garden-feat
 
 garden-feat: *.go
-	docker run -v $(SCRIPTDIR):/go/src -ti golang:latest bash -c "$$BASH_BUILD"
+	docker run -v $(SCRIPTDIR):/go/src golang:latest bash -c "$$BASH_BUILD"
 	rm -f go.mod go.sum
 
 .PHONY: clean

--- a/cert/Makefile
+++ b/cert/Makefile
@@ -79,7 +79,7 @@ test:
 cfssl/cfssl cfssl/cfssljson:
 	@echo "Building cfssl / cfssljson"
 	@mkdir -p cfssl
-	@docker run --volume "$$(realpath cfssl):/build" --rm -ti golang:latest bash -c "$$BASH_BUILD"
+	@docker run --volume "$$(realpath cfssl):/build" --rm golang:latest bash -c "$$BASH_BUILD"
 
 #### CA
 .PHONY: %.ca

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -44,9 +44,9 @@ manual: docker sign
 		--env DEBEMAIL=$(DEBEMAIL) \
 		--env WORKDIR="/home/dev" \
 		$(BUILDIMAGE) bash -c "manual/.docker; bash"
-.PHONY: pipeline 
+.PHONY: pipeline
 pipeline: docker sign
-	docker run --rm -ti \
+	docker run --rm \
 		--volume $(POOLDIR):/pool \
 		--volume $(MANUALDIR):/home/dev/manual \
 		--volume $(MANUALDIR)/../Makefile.inside:/home/dev/Makefile \
@@ -64,7 +64,7 @@ pipeline: docker sign
 		--env WORKDIR="/home/dev" \
 		$(BUILDIMAGE) bash -c "gpg --import /sign.pub; make"
 manual-kernel: docker-kernel
-	docker run --rm -ti --volume "$(POOLDIR)":/pool --volume "$(KERNELDIR)":/home/dev/manual \
+	docker run --rm --volume "$(POOLDIR)":/pool --volume "$(KERNELDIR)":/home/dev/manual \
 	       	--env BUILDTARGET="$(POOLDIR)" \
 		--env BUILDIMAGE="$(BUILDKERNEL)" \
 		--env BUILDVERSION=$(BUILDVERSION) \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Removes `-ti` arg from all docker run commands except for manual builds.

**Which issue(s) this PR fixes**:

Currently running make with multiple jobs (`make -j $(nproc)`) in a clean repo fails with `the input device is not a TTY`.
This is because make does not allocate a pty as stdin for job subprocesses &rArr; `docker run -ti` does not work.
