### PR TITLE
Remove hardcoded path for /boot/efi

### DIFF
--- a/features/cloud/file.include/etc/kernel/postinst.d/zz-kernel-install
+++ b/features/cloud/file.include/etc/kernel/postinst.d/zz-kernel-install
@@ -35,4 +35,3 @@ fi
 echo "kernel-install: installing kernel ${version}" 
 /usr/bin/kernel-install remove "${version}" 
 /usr/bin/kernel-install add "${version}" "${kernel}" "zzz-skip-initrd"
-dracut --uefi -f "/boot/efi/Default/${kernel#*-}/linux" ${kernel#*-} --reproducible --kernel-cmdline "$(cat /etc/kernel/cmdline)"

--- a/features/cloud/file.include/usr/lib/kernel/install.d/95-unified.install
+++ b/features/cloud/file.include/usr/lib/kernel/install.d/95-unified.install
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+
+if [ "$COMMAND" = remove ]; then
+    exit 0
+fi
+
+if [ "$COMMAND" != add ]; then
+    echo "Invalid command $COMMAND" >&2
+    exit 1
+fi
+
+if [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ]; then
+	echo "Generating unified image for ${KERNEL_VERSION}"
+	stdlog=4
+fi
+
+dracut \
+--force \
+--kver "${KERNEL_VERSION}" \
+--uefi \
+--stdlog ${stdlog-1} \
+--kernel-cmdline "$(cat /etc/kernel/cmdline)" \
+"${BOOT_DIR_ABS}/linux"
+
+exit 0

--- a/features/metal/file.include/etc/kernel/postinst.d/zz-kernel-install
+++ b/features/metal/file.include/etc/kernel/postinst.d/zz-kernel-install
@@ -35,4 +35,3 @@ fi
 echo "kernel-install: installing kernel ${version}" 
 /usr/bin/kernel-install remove "${version}" 
 /usr/bin/kernel-install add "${version}" "${kernel}" "zzz-skip-initrd"
-dracut --uefi -f "/boot/efi/Default/${kernel#*-}/linux" ${kernel#*-} --reproducible --kernel-cmdline "$(cat /etc/kernel/cmdline)"

--- a/features/metal/file.include/usr/lib/kernel/install.d/95-unified.install
+++ b/features/metal/file.include/usr/lib/kernel/install.d/95-unified.install
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+COMMAND="$1"
+KERNEL_VERSION="$2"
+BOOT_DIR_ABS="$3"
+
+if [ "$COMMAND" = remove ]; then
+    exit 0
+fi
+
+if [ "$COMMAND" != add ]; then
+    echo "Invalid command $COMMAND" >&2
+    exit 1
+fi
+
+if [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ]; then
+	echo "Generating unified image for ${KERNEL_VERSION}"
+	stdlog=4
+fi
+
+dracut \
+--force \
+--kver "${KERNEL_VERSION}" \
+--uefi \
+--stdlog ${stdlog-1} \
+--kernel-cmdline "$(cat /etc/kernel/cmdline)" \
+"${BOOT_DIR_ABS}/linux"
+
+exit 0


### PR DESCRIPTION
**How to categorize this PR?**

/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
We've been using a hardcoded path for the unified image, in the post install kernel scripts - ```"/boot/efi/Default/${kernel#*-}/linux"```
This is having unexpected effects when the ESP partition is mounted on a different path, e.g. /efi

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

