### PR TITLE
test(aws): parameter and key generation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -29,26 +29,26 @@ Use the following configuration file:
 aws:
     # region in which all test resources will be created (required)
     region: eu-central-1
-    # machine/instance type of the test VM - not all machines are available in all regions (required)
+    # machine/instance type of the test VM - not all machines are available in all regions (optional)
     instance_type: t3.micro
 
-    # ssh related configuration for logging in to the VM (required)
+    # ssh related configuration for logging in to the VM (optional)
     ssh:
-        # path to the ssh key file (required)
+        # path to the ssh key file (optional)
         ssh_key_filepath: ~/.ssh/id_rsa_gardenlinux_test
         # passphrase for a secured SSH key (optional)
         passphrase:
-        # name of the public ssh key object as it gets imported into EC2 (required)
+        # name of the public ssh key object as it gets imported into EC2 (optional)
         key_name: gardenlinux-test-2
-        # username used to connect to the EC2 instance (required, must be admin on AWS)
+        # username used to connect to the EC2 instance (optional, must be admin on AWS)
         user: admin
 
-    # if specified this already existing AMI will be used and no image uploaded (optional/required)
+    # if specified this already existing AMI will be used and no image uploaded (optional/alternatively required)
     #ami_id: ami-xxx
-    # local/S3 image file to be uploaded for the test (optional/required)
+    # local/S3 image file to be uploaded for the test (optional/alternatively required)
     image: file:/build/aws/20210714/amd64/bullseye/rootfs.raw
     #image: s3://gardenlinux/objects/078f440a76024ccd1679481708ebfc32f5431569
-    # bucket where the image will be uploded to (required if local file is used)
+    # bucket where the image will be uploded to (optional)
     bucket: import-to-ec2-gardenlinux-validation
 
     # keep instance running after tests finishes (optional)
@@ -60,22 +60,22 @@ aws:
 <details>
 
 - **region** _(required)_: the AWS region in which all test relevant resources will be created 
-- **instanc-type** _(required)_: the instance type that will be used for the EC2 instance used for testing
+- **instanc-type** _(optional)_: the instance type that will be used for the EC2 instance used for testing, defaults to `t3.micro` if not specified
 
-- **ssh_key_filepath** _(required)_: The SSH key that will be deployed to the EC2 instance and that will be used by the test framework to log on to it. Must be the file containing the private part of an SSH keypair which needs to be generated with `openssh-keygen` beforehand.
+- **ssh_key_filepath** _(optional)_: The SSH key that will be deployed to the EC2 instance and that will be used by the test framework to log on to it. Must be the file containing the private part of an SSH keypair which needs to be generated with `openssh-keygen` beforehand. If not provided, a new SSH key with 2048 bits will be generated just for the test.
 - **passphrase** _(optional)_: If the given SSH key is protected with a passphrase, it needs to be provided here.
-- **key_name** _(required)_: The SSH key gets uploaded to EC2, this is the name of the key object resource.
-- **user** _(required)_: The user that will be provisioned to the EC2 instance, which the SSH key gets assigned to and that is used by the test framework to log on the EC2 instance. On AWS, this must be `admin`.
+- **key_name** _(optional)_: The SSH key gets uploaded to EC2, this is the name of the key object resource.
+- **user** _(optional)_: The user that will be provisioned to the EC2 instance, which the SSH key gets assigned to and that is used by the test framework to log on the EC2 instance. Defaults to `admin`.
 
-- **ami_id** _(optional/required)_: If the tests should get executed against an already existing AMI, this is its ID. It must exist in the region given above. Either **ami_id** or **image** must be supplied but not both.
-- **image** _(optional/required)_: If the tests should be executed against a Garden Linux filesystem snapshot that resulted from (local) build, this option is the URI that points to it. The file must be of type `.raw`. Either **ami_id** or **image** must be supplied but not both.
+- **ami_id** _(optional/alternatively required)_: If the tests should get executed against an already existing AMI, this is its ID. It must exist in the region given above. Either **ami_id** or **image** must be supplied but not both.
+- **image** _(optional/alternatively required)_: If the tests should be executed against a Garden Linux filesystem snapshot that resulted from (local) build, this option is the URI that points to it. The file must be of type `.raw`. Either **ami_id** or **image** must be supplied but not both.
 The URI can be:
     - `file:/path/to/my/rootfs.raw`: for local files, in that case, the option **bucket** must be provided as well
     - `s3://mybucketname/objects/objectkey`: for files in S3
 
-- **bucket** _(optional)_: To create an AMI/EC2 instance from a local filesystem snapshot, it needs to be uploaded to an S3 bucket first. The bucket needs to exist in the given region and its name must be provided here.
+- **bucket** _(optional)_: To create an AMI/EC2 instance from a local filesystem snapshot, it needs to be uploaded to an S3 bucket first. The bucket needs to exist in the given region and its name must be provided here. If not provided, a bucket will be created in the given region.
 
-- **keep_running** _(optional)_: if set to `true`, all tests resources, especially the VM will not get removed after the test (independent of the test result) to allow for debugging
+- **keep_running** _(optional)_: if set to `true`, all tests resources, especially the VM will not get removed after the test (independent of the test result) to allow for debugging. Defaults to `False`.
 
 </details>
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Running an integration/platform test on AWS required several parameters in the config file that a user/developer should not be concerned with if a simple test should be run. Such parameters will now be generated. E.g. if no SSH key gets provided for a test, it will be generated just for this test.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- test(aws): parameter and key generation
```
