### PR TITLE
Remove unused gdisk

### DIFF
--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -1,4 +1,3 @@
-gdisk
 curl
 dosfstools
 btrfs-progs


### PR DESCRIPTION
**How to categorize this PR?**
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
We have several partition tools installed (`fdisk` and `gdisk`). As `fdisk` can do all the work now, even for GPT, we can remove `gdisk`.
