### PR TITLE
Expect ping to have capabilities in pxe as well

### DIFF
--- a/features/_pxe/test/capabilities.d/capabilities.list
+++ b/features/_pxe/test/capabilities.d/capabilities.list
@@ -1,1 +1,2 @@
+/bin/ping cap_net_raw=ep
 /usr/bin/arping cap_net_raw=ep


### PR DESCRIPTION
**How to categorize this PR?**
/kind bugfix
/area os
/os garden-linux

**What this PR does / why we need it**:
We have `/bin/ping` in the PXE feature as well and need to expect capabilities on it.
