### PR TITLE
feat(driver): amzn ena_linux_2.6.0 driver

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,11 +1,13 @@
 POOLDIR=$$(mkdir -p ../.packages; realpath ../.packages)
 MANUALDIR=$(realpath manual)
-KERNELDIR=$(realpath kernel)
+KERNELMODDIR=$(realpath lkm)
+BUILDLOGDIR=$$(mkdir -p ../.buildlogs; realpath ../.buildlogs)
 CERTDIR=$(realpath ../cert)
 DEBFULLNAME="Garden Linux Maintainers"
 DEBEMAIL="contact@gardenlinux.io"
 BUILDIMAGE="gardenlinux/build-deb"
-BUILDKERNEL="gardenlinux/build-kernel"
+BUILDKERNEL="gardenlinux/build-kernelmodule"
+KERNELVERSION=5.10
 BUILDVERSION=$$(../bin/garden-version)
 BUILDEPOCH=$$(../bin/garden-version --epoch)
 .PHONY: all
@@ -19,8 +21,8 @@ sign:
 docker:
 	make --directory=../docker $$(basename $(BUILDIMAGE))
 
-.PHONY: docker-kernel
-docker-kernel:
+.PHONY: docker-kernelmodule
+docker-kernelmodule:
 	make --directory=../docker $$(basename $(BUILDKERNEL))
 
 #--volume $(MANUALDIR)/../quiltrc:/home/dev/.quiltrc
@@ -44,6 +46,28 @@ manual: docker sign
 		--env DEBEMAIL=$(DEBEMAIL) \
 		--env WORKDIR="/home/dev" \
 		$(BUILDIMAGE) bash -c "manual/.docker; bash"
+
+.PHONY: manual-kernelmodule
+manual-kernelmodule: docker-kernelmodule sign
+	docker run --rm -ti \
+		--volume $(POOLDIR):/pool \
+		--volume $(KERNELMODDIR):/home/dev/lkm \
+		--volume $(KERNELMODDIR)/../Makefile.kernelmodule:/home/dev/Makefile \
+		--volume "$$(gpgconf --list-dir agent-socket)":/home/dev/.gnupg/S.gpg-agent \
+		--volume $(CERTDIR)/sign.pub:/sign.pub \
+		--volume $(CERTDIR)/Kernel.sign.full:/kernel.full \
+		--volume $(CERTDIR)/Kernel.sign.crt:/kernel.crt \
+		--volume $(CERTDIR)/Kernel.sign.key:/kernel.key \
+		 --tmpfs /tmp:exec,noatime \
+	       	--env BUILDTARGET="/pool" \
+		--env BUILDIMAGE=$(BUILDKERNEL) \
+		--env BUILDVERSION=$(BUILDVERSION) \
+		--env BUILDEPOCH=$(BUILDEPOCH) \
+		--env DEBFULLNAME=$(DEBFULLNAME) \
+		--env DEBEMAIL=$(DEBEMAIL) \
+		--env WORKDIR="/home/dev" \
+		$(BUILDKERNEL):$(KERNELVERSION) bash -c "lkm/.docker; bash"
+
 .PHONY: pipeline
 pipeline: docker sign
 	docker run --rm \
@@ -63,17 +87,4 @@ pipeline: docker sign
 		--env DEBEMAIL=$(DEBEMAIL) \
 		--env WORKDIR="/home/dev" \
 		$(BUILDIMAGE) bash -c "gpg --import /sign.pub; make"
-manual-kernel: docker-kernel
-	docker run --rm --volume "$(POOLDIR)":/pool --volume "$(KERNELDIR)":/home/dev/manual \
-	       	--env BUILDTARGET="$(POOLDIR)" \
-		--env BUILDIMAGE="$(BUILDKERNEL)" \
-		--env BUILDVERSION=$(BUILDVERSION) \
-		--env BUILDEPOCH=$(BUILDEPOCH) \
-		--env DEBFULLNAME="$(DEBFULLNAME)" \
-		--env DEBEMAIL="$(DEBEMAIL)" \
-		--env WORKDIR="/home/dev" \
-		$(BUILDKERNEL) bash -c " \
-		set -euo pipefail \
-		sudo apt-get install --no-install-recommends -y wget quilt vim less \
-		\
-		bash"
+

--- a/packages/Makefile.kernelmodule
+++ b/packages/Makefile.kernelmodule
@@ -1,0 +1,9 @@
+.PHONY: all
+all: amzn-ena
+
+%:
+	lkm/$@
+
+.PHONY: clean
+clean:
+	sudo rm -r amzn-ena*

--- a/packages/lkm/.docker
+++ b/packages/lkm/.docker
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail 
+
+sudo apt-get install --no-install-recommends -y wget quilt vim less

--- a/packages/lkm/amzn-ena
+++ b/packages/lkm/amzn-ena
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+baseName="amzn-ena"
+enaVersion=2.6.0
+packageName="${baseName}-${enaVersion}"
+
+callerDir="$(readlink -f "$(pwd)")"
+scriptDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+baseDir="${scriptDir}/${baseName}.d"
+srcDir="${packageName}-src"
+packageDir="${packageName}"
+
+mkdir "${srcDir}"
+pushd "${srcDir}"
+
+    git clone --depth 1 --branch ena_linux_${enaVersion}  https://github.com/amzn/amzn-drivers/
+
+    echo "### make ena drivers"
+    pushd amzn-drivers/kernel/linux/ena
+        make 
+    popd ||exit 1
+
+popd || exit 1
+
+# Create a fresh folder for packaging and copy only required files from build output above
+mkdir "${packageDir}"
+pushd "${packageDir}"
+    cp -r "${baseDir}/DEBIAN" .
+
+    maintainerString="${DEBFULLNAME} <${DEBEMAIL}>"
+    echo "### setting maintainer to ${maintainerString}"
+    sed -i "s/Maintainer:/Maintainer: ${maintainerString}/g" DEBIAN/control
+    
+    echo "### prepare folder structure for dpkg packaging"
+    mkdir -p opt/drivers
+    cp "${callerDir}/${srcDir}/amzn-drivers/kernel/linux/ena/ena.ko" opt/drivers/ena.ko
+
+popd || exit 1
+
+echo "### create deb file"
+dpkg -b ${packageName}
+
+targetpath="main/e/ena"
+echo "### move deb file to ${BUILDTARGET}/${targetpath}/"
+sudo mkdir -p "${BUILDTARGET}/${targetpath}/"
+sudo mv "${packageName}.deb" "${BUILDTARGET}/${targetpath}/"

--- a/packages/lkm/amzn-ena.d/DEBIAN/control
+++ b/packages/lkm/amzn-ena.d/DEBIAN/control
@@ -1,0 +1,8 @@
+Package: amzn-ena
+Version: 2.6.0
+Architecture: amd64
+Maintainer: 
+Depends: 
+Installed-Size: 4300
+Homepage: https://github.com/amzn/amzn-drivers/
+Description: Garden Linux Package of amazon's ena driver  


### PR DESCRIPTION
**What this PR does / why we need it**:

* builds specified ena driver and creates a deb package

**Which issue(s) this PR fixes**:
Required for #397 

**Special notes for your reviewer**:

``` build-kernelmodule``` container image build is triggered as dependency. This image requires linux kernel packages to be placed in ```../.packages/main/l/linux/```. 


```bash
cd packages
# build-kernelmodule container will be created
make manual-kernelmodule
# in container
make amzn-ena
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
