### PR TITLE
Test aws ena

### DIFF
--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -391,7 +391,9 @@ class AWS:
 
         self.logger = logging.getLogger('aws-testbed')
         self.logger.setLevel(logging.DEBUG)
-        self.logger.info(f"This test's name is {self.test_name} and its uuid is: {self.test_uuid}")
+        self.logger.info(f"This test's tags are:")
+        for tag in self._tags:
+            self.logger.info(f"\t{tag['Key']}: {tag['Value']}")
 
         self._storage_bucket_name = None
 
@@ -412,7 +414,7 @@ class AWS:
 
     def cleanup_test_resources(self):
         if "keep_running" in self.config and self.config['keep_running'] == True:
-            self.logger.info(f"Keeping resource group {self._resourcegroup.name} and all resources in it alive.")
+            self.logger.info(f"Keeping all resources alive as requested.")
             return
         if self._instance:
             self.terminate_vm(self._instance)
@@ -438,7 +440,6 @@ class AWS:
 
 
     def upload_image(self, image_url):
-        # image_name = "gl-integration-test-" + str(int(time.time()))
         image_name = f"img-{self.test_name}"
 
         if 'ami_id' in self.config:

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -389,3 +389,7 @@ def test_startup_script(client, gcp):
     (exit_code, output, error) = client.execute_command("test -f /tmp/startup-script-ok")
     assert exit_code == 0, f"no {error=} expected. Startup script did not run"
 
+def test_aws_ena_driver(client, aws):
+    (exit_code, output, error) = client.execute_command("ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
+    assert exit_code == 0, f"no {error=} expected"
+    assert output.rstrip() == "ena", "Expected network interface to run with ena driver"

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -390,6 +390,6 @@ def test_startup_script(client, gcp):
     assert exit_code == 0, f"no {error=} expected. Startup script did not run"
 
 def test_aws_ena_driver(client, aws):
-    (exit_code, output, error) = client.execute_command("ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
+    (exit_code, output, error) = client.execute_command("sudo /sbin/ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
     assert exit_code == 0, f"no {error=} expected"
     assert output.rstrip() == "ena", "Expected network interface to run with ena driver"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
The platform tests now check if the ena driver was successfully loaded for the default network interface on AWS.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- test(aws): check for presence of ena driver
- test(aws): print out tags and fix teardown 
```
