### PR TITLE
Do not remove full /var/log

### DIFF
--- a/bin/makepart
+++ b/bin/makepart
@@ -18,7 +18,7 @@ rootfs_work=$(mktemp -d)
 
 cp -a "$rootfs/." "$rootfs_work"
 
-rm -rf "$rootfs_work/var/log"
+find "$rootfs_work/var/log/" -type f -delete
 
 chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
 chroot "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
For reproducible builds we should remove just the log files from /var/log and keep the directory structure intact.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
