### PR TITLE
Disable selinux for gardener

### DIFF
--- a/bin/makepart
+++ b/bin/makepart
@@ -20,9 +20,11 @@ mkdir -p "$rootfs_work/overlay"/{etc,var}/{upper,work}
 
 find "$rootfs_work/var/log/" -type f -delete
 
-chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
-chroot "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
-rm "$rootfs_work/.autorelabel"
+if [ -f "$rootfs_work/.autorelabel" ]; then
+	chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
+	chroot "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
+	rm "$rootfs_work/.autorelabel"
+fi
 
 # sign unified image
 datefudge -s "@$timestamp" sbsign --cert /kernel.crt --key /kernel.key --output "$rootfs_work/boot/efi/EFI/BOOT/BOOTX64.EFI" "$rootfs_work/boot/efi/EFI/BOOT/BOOTX64.EFI"

--- a/features/base/test/packages-musthave.chroot
+++ b/features/base/test/packages-musthave.chroot
@@ -6,7 +6,9 @@ thisDir=$(readlink -e $(dirname "${BASH_SOURCE[0]}"))
 
 echo "checking for musthave packages"
 
-cat "${thisDir}/packages-musthave.d/"*.list  | awk -F _ '!/^ *#/ && NF {print $1}' | xargs -rn 1 basename > "${thisDir}/packages-musthave.d/final.list"
+cat "${thisDir}/packages-musthave.d/"*include.list  | awk -F _ '!/^ *#/ && NF {print $1}' | xargs -rn 1 basename > "${thisDir}/packages-musthave.d/include.list"
+cat "${thisDir}/packages-musthave.d/"*exclude.list  | awk -F _ '!/^ *#/ && NF {print $1}' | xargs -rn 1 basename > "${thisDir}/packages-musthave.d/exclude.list"
+cat "${thisDir}/packages-musthave.d/include.list" | grep -v -f "${thisDir}/packages-musthave.d/exclude.list" > "${thisDir}/packages-musthave.d/final.list"
 if ! packages=$(grep -vf <(dpkg -l | awk '$1~/ii|hi/ { split($2,s,":"); print s[1]; next}') "${thisDir}/packages-musthave.d/final.list"); then
 	echo "OK - all packages that must be installed are installed"
 	exit 0

--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -20,3 +20,5 @@ chmod u-s /sbin/mount.nfs /sbin/mount.cifs
 #
 systemctl disable docker
 systemctl disable containerd
+
+rm /.autorelabel

--- a/features/gardener/file.include/etc/kernel/cmdline.d/90-lsm.cfg
+++ b/features/gardener/file.include/etc/kernel/cmdline.d/90-lsm.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX apparmor=1 selinux=0"

--- a/features/gardener/pkg.exclude
+++ b/features/gardener/pkg.exclude
@@ -1,0 +1,2 @@
+selinux-basics
+selinux-policy-default

--- a/features/gardener/test/packages-musthave.d/pkg.exclude
+++ b/features/gardener/test/packages-musthave.d/pkg.exclude
@@ -1,0 +1,1 @@
+../../pkg.exclude

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -7,7 +7,7 @@ systemctl enable ssh-keygen
 systemctl enable tmp.mount
 #systemctl enable ssh-moduli
 
-#selinix-activate
+#selinux-activate
 touch /.autorelabel
 
 for i in $(ls /boot | grep vmlinuz | sed "s/vmlinuz-//"); do

--- a/features/server/file.include/etc/kernel/cmdline.d/90-lsm.cfg
+++ b/features/server/file.include/etc/kernel/cmdline.d/90-lsm.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX selinux=1 apparmor=0"

--- a/features/server/file.include/etc/kernel/cmdline.d/90-selinux.cfg
+++ b/features/server/file.include/etc/kernel/cmdline.d/90-selinux.cfg
@@ -1,1 +1,0 @@
-CMDLINE_LINUX="$CMDLINE_LINUX security=selinux"


### PR DESCRIPTION
**How to categorize this PR?**

/kind fix
/area os
/os garden-linux

**What this PR does / why we need it**:
We need to disable selinux for gardener. 
Fixing the packages-musthave test in order to properly handle excluded packages.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

