### PR TITLE
Change Garden Linux defaults to nftables and cgroupv2

### DIFF
--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# set the default to iptalbes and deactivate nf_tables kernel modules
-#
-update-alternatives --set iptables /usr/sbin/iptables-legacy
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-update-alternatives --set arptables /usr/sbin/arptables-legacy
-update-alternatives --set ebtables /usr/sbin/ebtables-legacy
-
-# just to make sure there are no traces left
-#
-systemctl mask nftables.service
-
 # fix file system permissions for higher security
 chmod u-s /sbin/mount.nfs /sbin/mount.cifs
 

--- a/features/gardener/file.include/etc/kernel/cmdline.d/80-cgroup.cfg
+++ b/features/gardener/file.include/etc/kernel/cmdline.d/80-cgroup.cfg
@@ -1,3 +1,0 @@
-# Disable cgroup v2 support
-
-CMDLINE_LINUX="$CMDLINE_LINUX systemd.unified_cgroup_hierarchy=0"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

This PR removes the code that sets legacy iptables as default in Garden Linux. It also removes systemd configuration that triggers docker to run with cgroupv1.

This change might have an impact on current Gardener and Kubernetes releases. Kubernetes releases prior to 1.19 will definitely not work with this change. I have already opened https://github.com/gardener/gardener-extension-os-gardenlinux/issues/50 to provide a mitigation if necessary.

**Which issue(s) this PR fixes**:
Fixes #193

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
