### PR TITLE
arm64 image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ AWS_DISTRIBUTE=
 BUILDDIR=.build
 MAINTAINER_EMAIL="contact@gardenlinux.io"
 
+ARCH ?= $(shell ./get_arch.sh)
+override BUILD_OPTS += --arch=$(ARCH)
+
 ifneq ($(wildcard local_packages),)
 LOCAL_PKGS=local_packages
 endif

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -96,6 +96,7 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	export version="$version"
 
 	initArgs=( --arch="$dpkgArch" )
+	configArgs=( --arch="$dpkgArch" )
 	initArgs+=( --debian )
 	if [ -n "${ports-}" ]; then
 		initArgs+=(

--- a/bin/garden-config
+++ b/bin/garden-config
@@ -6,18 +6,20 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
-	--flags 'features:' \
+	--flags 'features:,arch:' \
 	-- \
 	'<target-dir>' \
 	'rootfs'
 
 eval "$dgetopt"
 features=
+arch=
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
 		--features) features="${features:+$features,}$1"; shift ;;
+		--arch) arch="$1"; shift ;;
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -51,7 +53,7 @@ printf "## executing exec.config\n"
 for i in $(tr ',' '\n' <<< $features); do
 	if [ -f $featureDir/$i/exec.config ]; then
 		printf "### $i:\n"
-		$thisDir/garden-chroot $targetDir /tmp/$(basename $featureDir)/$i/exec.config | indent
+		"$thisDir/garden-chroot" "$targetDir" env arch="$arch" "/tmp/$(basename $featureDir)/$i/exec.config" 2>&1 | indent
 	fi
 done
 

--- a/bin/makepart
+++ b/bin/makepart
@@ -69,7 +69,7 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 	label=$(grep -oP '(?<=^LABEL=)[a-zA-Z0-9\_\-]*$' <<< "$source" || true)
 
 	# compute sufficiently padded size for partition (aligned to nearest MB (2048 sectors))
-	size=${size:-$(du -sb "$rootfs_work$target" | awk '{ size = $1 * 1.5; padded_size = size + (MB - (size % MB) % MB); print (padded_size / MB) "MiB" }' 'MB=1048576')}
+	size=${size:-$(du -sb "$rootfs_work$target" | awk '{ min_size = 64 * MB; size = $1 * 1.5; padded_size = size + (MB - (size % MB) % MB); if (padded_size < min_size) padded_size = min_size; print (padded_size / MB) "MiB" }' 'MB=1048576')}
 
 	file=$([[ "$type" = "uefi" ]] && echo "$uefi_partition" || mktemp)
 	truncate -s "$size" "$file"
@@ -186,12 +186,10 @@ fi
 initrd="$(mktemp)"
 unified_image="$(mktemp)"
 unified_image_signed="$(mktemp)"
+
 [[ ! -e "$rootfs$initrd" ]]
 touch "$rootfs$initrd"
 mount --bind "$initrd" "$rootfs$initrd"
-[[ ! -e "$rootfs$unified_image" ]]
-touch "$rootfs$unified_image"
-mount --bind "$unified_image" "$rootfs$unified_image"
 [[ ! -e "$rootfs/etc/veritytab" ]]
 touch "$rootfs/etc/veritytab"
 mount --bind "$veritytab" "$rootfs/etc/veritytab"
@@ -209,30 +207,39 @@ chroot "$rootfs" dracut \
 	--reproducible \
 	"$initrd"
 
-chroot "$rootfs" dracut \
-	--force \
-	--kver "$kernel_version" \
-	--uefi \
-	--modules "bash dash systemd systemd-initrd systemd-veritysetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown" \
-	--install "/etc/veritytab" \
-	--kernel-cmdline "$cmdline" \
-	--reproducible \
-	"$unified_image"
+umount "$rootfs/proc"
+umount "$rootfs$initrd"
+rm "$rootfs$initrd"
+umount "$rootfs/etc/veritytab"
+rm "$rootfs/etc/veritytab"
+
+case "$arch" in
+	amd64)
+		uefi_arch=X64
+		gnu_arch=x86_64
+		initrd_vma=0x3000000
+		;;
+	arm64)
+		uefi_arch=AA64
+		gnu_arch=aarch64
+		initrd_vma=0x4000000
+		;;
+esac
+
+# create unified image
+cmdline_file=$(mktemp)
+echo "$cmdline" > "$cmdline_file"
+"${gnu_arch}-linux-gnu-objcopy" \
+	--add-section .cmdline="$cmdline_file" --change-section-vma .cmdline=0x1000000 \
+	--add-section .linux="$kernel_file" --change-section-vma .linux=0x2000000 \
+	--add-section .initrd="$initrd" --change-section-vma .initrd="$initrd_vma" \
+	"$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" "$unified_image"
+rm "$cmdline_file"
 
 # sign unified image
 datefudge -s "@$timestamp" sbsign --cert /kernel.crt --key /kernel.key --output "$unified_image_signed" "$unified_image"
 
-umount "$rootfs/proc"
-umount "$rootfs$initrd"
-rm "$rootfs$initrd"
-umount "$rootfs$unified_image"
-rm "$rootfs$unified_image"
-umount "$rootfs/etc/veritytab"
-rm "$rootfs/etc/veritytab"
-case "$arch" in
-	amd64) uefi_arch=X64;;
-	arm64) uefi_arch=AA64;;
-esac
+# copy unified image to uefi partition
 datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$unified_image_signed" "::/EFI/BOOT/BOOT$uefi_arch.EFI"
 
 if [[ -f "$rootfs/usr/bin/syslinux" ]]; then

--- a/bin/makepart
+++ b/bin/makepart
@@ -21,11 +21,8 @@ mkdir -p "$rootfs_work/overlay"/{etc,var}/{upper,work}
 find "$rootfs_work/var/log/" -type f -delete
 
 chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
-chroot "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
+chroot "$rootfs_work" /usr/bin/env -i /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
 rm "$rootfs_work/.autorelabel"
-
-# sign unified image
-datefudge -s "@$timestamp" sbsign --cert /kernel.crt --key /kernel.key --output "$rootfs_work/boot/efi/EFI/BOOT/BOOTX64.EFI" "$rootfs_work/boot/efi/EFI/BOOT/BOOTX64.EFI"
 
 uefi_partition=$(mktemp)
 fstab=$(mktemp)
@@ -188,6 +185,7 @@ fi
 
 initrd="$(mktemp)"
 unified_image="$(mktemp)"
+unified_image_signed="$(mktemp)"
 [[ ! -e "$rootfs$initrd" ]]
 touch "$rootfs$initrd"
 mount --bind "$initrd" "$rootfs$initrd"
@@ -221,6 +219,9 @@ chroot "$rootfs" dracut \
 	--reproducible \
 	"$unified_image"
 
+# sign unified image
+datefudge -s "@$timestamp" sbsign --cert /kernel.crt --key /kernel.key --output "$unified_image_signed" "$unified_image"
+
 umount "$rootfs/proc"
 umount "$rootfs$initrd"
 rm "$rootfs$initrd"
@@ -228,13 +229,20 @@ umount "$rootfs$unified_image"
 rm "$rootfs$unified_image"
 umount "$rootfs/etc/veritytab"
 rm "$rootfs/etc/veritytab"
-datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$initrd" "::/legacy/$kernel_version/initrd.img-$kernel_version"
-datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$unified_image" "::/EFI/BOOT/BOOTX64.EFI"
+case "$arch" in
+	amd64) uefi_arch=X64;;
+	arm64) uefi_arch=AA64;;
+esac
+datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$unified_image_signed" "::/EFI/BOOT/BOOT$uefi_arch.EFI"
 
-syslinux_conf="$(mktemp)"
-mcopy -i "$uefi_partition" "::/syslinux/syslinux.cfg" "$syslinux_conf"
-sed -i 's|APPEND.*|APPEND '"$cmdline"'|' "$syslinux_conf"
-datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$syslinux_conf" "::/syslinux/syslinux.cfg"
+if [[ -f "$rootfs/usr/bin/syslinux" ]]; then
+	syslinux_conf="$(mktemp)"
+	mcopy -i "$uefi_partition" "::/syslinux/syslinux.cfg" "$syslinux_conf"
+	sed -i 's|APPEND.*|APPEND '"$cmdline"'|' "$syslinux_conf"
+	datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$syslinux_conf" "::/syslinux/syslinux.cfg"
+	datefudge -s "@$timestamp" mcopy -i "$uefi_partition" -o -p "$initrd" "::/legacy/$kernel_version/initrd.img-$kernel_version"
+	rm "$syslinux_conf"
+fi
 
 # cleanup
-rm -rf "$rootfs_work" "$fstab" "$veritytab" "$root_hash" "$initrd" "$unified_image" "$syslinux_conf"
+rm -rf "$rootfs_work" "$fstab" "$veritytab" "$root_hash" "$initrd" "$unified_image" "$unified_image_signed"

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -16,7 +16,7 @@ set -Eeuo pipefail
 thisDir=$(dirname "$(readlink -f "$BASH_SOURCE")")
 targetDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cpu=2
-arch=x86_64
+arch="$(uname -m)"
 memory=2Gi
 monitor=1
 bridge=
@@ -26,8 +26,8 @@ pxefile=$thisDir/../examples/ipxe/start-vm.ipxe
 portbase=2223
 port=$portbase; while ss -tul | grep :$port &> /dev/null; do (( ++port )); done
 uefi=
-uefiCode=/usr/share/OVMF/OVMF_CODE.fd
-uefiVars=/usr/share/OVMF/OVMF_VARS.fd
+uefiCode=
+uefiVars=
 tpm=1
 vnc=
 vncbase=5900
@@ -44,9 +44,9 @@ source "${thisDir}/.constants.sh" \
 	--sample '.build/rootfs.raw' \
         --sample ',1G ubuntu-16.04.7-server-amd64.iso' \
 	--help  "Starts a virtual machine with the most basic environment, needed. Perfect use for test cases and running samples of GardenLinux. This script can run unprivileged but it should have the possibility to use kvm (group kvm) otherwise it will be super slow. If not being root, the network will be slow and no ICMP (ping) capabilities are with the VM.
-	
+
 --cpu <int>	number of vCPUs to start the VM with (default: $cpu)
---arch <platform> set the emulated platform. 
+--arch <platform> set the emulated platform.
 		i386, x86_64, x86_64-microvm, arm, aarch64 are supported. (default: $arch)
 --mem <int>	memory provided to the virtual machine (default: $memory) in MB if unit is omitted
 
@@ -56,7 +56,7 @@ source "${thisDir}/.constants.sh" \
 		set (default: $uefiVars)
 
 --bridge <if>	disables host networking and bridges the machine to the specified interface
---port <int>	specifies the local ssh port. this port is mounted to the running machine, 
+--port <int>	specifies the local ssh port. this port is mounted to the running machine,
 		not if --bridge is specified (default: $portbase)
 --mac <macaddr> the mac address is usually randomized. It is used to identify the monitoring
 		port, the mac address of the machine and the UUID. Can be set to this value.
@@ -68,13 +68,13 @@ source "${thisDir}/.constants.sh" \
 --vnc		sitches from serial console to vnc graphics console / enables vnc in --daemonize
 		the vnc baseport is $vncbase. if this is not empty we try the next
 
-<image file>	a file containing the image to boot. Format is determined by the extension. 
-                raw, vdi, vpc, vhd, vhdx, vmdk, qcow2, iso are recognized. 
+<image file>	a file containing the image to boot. Format is determined by the extension.
+                raw, vdi, vpc, vhd, vhdx, vmdk, qcow2, iso are recognized.
 		,<size> is optional. If the file is smaller then <size> it will be resized
-		withthe sparse feature of the filesystem to  the requested size. 
-		If <image file> is omitted and only ,<size> is specified, a temporary file 
+		withthe sparse feature of the filesystem to  the requested size.
+		If <image file> is omitted and only ,<size> is specified, a temporary file
 		of this size will be created. The file will not be deleted."
-	
+
 eval "$dgetopt"
 while true; do
 	flag="$1"; shift
@@ -98,6 +98,15 @@ while true; do
 	esac
 done
 
+if [ "$arch" = x86_64 ]; then
+	uefiCode="${uefiCode:-/usr/share/OVMF/OVMF_CODE.fd}"
+	uefiVars="${uefiVars:-/usr/share/OVMF/OVMF_VARS.fd}"
+elif [ "$arch" = aarch64 ]; then
+	uefi=1
+	uefiCode="${uefiCode:-/usr/share/AAVMF/AAVMF_CODE.fd}"
+	uefiVars="${uefiVars:-/usr/share/AAVMF/AAVMF_VARS.fd}"
+fi
+
 # adding the disks (using parameters without - or --)
 inflatelist=( )
 diskcount=0
@@ -108,8 +117,8 @@ while (( "$#" )); do
 	imagedirect=""
 	if [[ $imagefile == *","* ]]; then	imagesize=${imagefile##*,}	# check if a ,3G or such is present
 						imagefile=${imagefile%%,$imagesize}; fi
-	[ "$imagefile" == "" ] && 		imagefile=$(mktemp --suff=.raw)  # if no filename is left point to tmp  
-	[[ $imagefile == *"."* ]] &&		imageext=${imagefile##*.}; 
+	[ "$imagefile" == "" ] && 		imagefile=$(mktemp --suff=.raw)  # if no filename is left point to tmp
+	[[ $imagefile == *"."* ]] &&		imageext=${imagefile##*.};
 	[ -e $imagefile ] || eusage "file \"$imagefile\" does not exist"
 
 	imagesizeBytes=$(numfmt --from=auto --suffix="B" --format "%f" ${imagesize} | head -c-2)  # calculate in bytes
@@ -141,7 +150,7 @@ memory=$(numfmt --from=auto --suffix="B" --format "%f" ${memory} | head -c-2)
 virtOpts+=(	"-smp $cpu"
 	   	"-m $(( $memory / 1048576 ))" )
 
-# add a watchdog to maintain automatic reboots 
+# add a watchdog to maintain automatic reboots
 virtOpts+=(	"-watchdog i6300esb" )
 
 # remove default things like floppies, serial port, parallel port
@@ -154,9 +163,11 @@ virtOpts+=(	"-device virtio-balloon" )
 virtOpts+=(	"-device virtio-rng-pci,rng=rng0"
 	   	"-object rng-random,id=rng0,filename=/dev/random" )
 
-# adding a bmc simulator
-virtOpts+=(	"-device ipmi-bmc-sim,id=bmc0"
-		"-device isa-ipmi-kcs,bmc=bmc0,ioport=0xca2"  )
+if [ "$arch" = x86_64 ]; then
+	# adding a bmc simulator
+	virtOpts+=(	"-device ipmi-bmc-sim,id=bmc0"
+			"-device isa-ipmi-kcs,bmc=bmc0,ioport=0xca2"  )
+fi
 
 # adding a uuid since this is expected by systemd and gardenlinux
 mac="$(printf "%012s" | tr -d ":" <<< ${mac,,})"
@@ -165,15 +176,27 @@ uuid="12345678-0000-0000-0000-${mac}"
 virtOpts+=(     "-uuid $uuid" )
 
 # support for qemu guest agent. There is no way for this script if inside VM is connected or not
-virtOpts+=(	"-chardev socket,path=$targetDir/$mac.guest,server,nowait,id=qga0"
+virtOpts+=(	"-chardev socket,path=$targetDir/$mac.guest,server=on,wait=off,id=qga0"
 		"-device virtio-serial"
 		"-device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0" )
 
-# virtualization with max performance if the cpu has vmx
-cpuinfo="$(grep "^flags" /proc/cpuinfo | uniq)"
-[ -z "${cpuinfo##*vmx*}" -o -z "${cpuinfo##*svm*}" ] &&
-	virtOpts+=(	"-enable-kvm"
-			"-cpu host"  )
+if [ "$arch" = "$(uname -m)" ]; then
+	if [ "$arch" = x86_64 ]; then
+		# virtualization with max performance if the cpu has vmx
+		cpuinfo="$(grep "^flags" /proc/cpuinfo | uniq)"
+		[ -z "${cpuinfo##*vmx*}" -o -z "${cpuinfo##*svm*}" ] &&
+			virtOpts+=("-enable-kvm" "-cpu host" "-machine q35,smm=on")
+		elif [ "$arch" = aarch64 ]; then
+			virtOpts+=("-cpu host" "-machine virt")
+			[ -e "/dev/kvm" ] && virtOpts+=("-accel kvm")
+		fi
+else
+	if [ "$arch" = x86_64 ]; then
+		virtOpts+=("-cpu Broadwell")
+	elif [ "$arch" = aarch64 ]; then
+		virtOpts+=("-cpu cortex-a72" "-machine virt")
+	fi
+fi
 
 # adding a monitoring port for extended commands
 if [ $monitor ]; then
@@ -182,7 +205,7 @@ if [ $monitor ]; then
 fi
 
 [ $daemonize ] && virtOpts+=(	"-daemonize" )
-[ $daemonize ] || virtOpts+=(	"-nographic" 
+[ $daemonize ] || virtOpts+=(	"-nographic"
 				"-serial mon:stdio" )
 [ $vnc ] && 	  virtOpts+=(	"-vnc :${vncport},password" )
 [ $daemonize ] && [ ! $vnc ] && virtOpts+=(	"-display none" )
@@ -193,10 +216,12 @@ if [ $uefi ]; then
 
 	[ -e $targetDir/$mac.vars ] || cp $uefiVars $targetDir/$mac.vars
 
-	virtOpts+=(	"-machine q35,smm=on"
-			"-global driver=cfi.pflash01,property=secure,value=on"
-			"-drive if=pflash,format=raw,unit=0,file=${uefiCode},readonly=on"
-			"-drive if=pflash,format=raw,unit=1,file=$targetDir/$mac.vars" )
+	if [ "$arch" = x86_64 ]; then
+		virtOpts+=("-global driver=cfi.pflash01,property=secure,value=on")
+	fi
+
+	virtOpts+=("-drive if=pflash,format=raw,unit=0,file=${uefiCode},readonly=on"
+	           "-drive if=pflash,format=raw,unit=1,file=$targetDir/$mac.vars")
 fi
 
 # pxe
@@ -205,7 +230,7 @@ if [ $pxe ]; then
 
 	# modify the boot.ipxe to load the proper kernel and initramfs
 	sed -i "s/PATHGOESHERE//g;s/IPADDRESSGOESHERE/10.0.2.2/g" $targetDir/$mac.ipxe
-	
+
 	virtOpts+=( -boot order=nc )
 fi
 
@@ -251,7 +276,7 @@ fi
 # modifying /etc/qemu/bridge.conf - would be good to be root!!!
 if [ $bridge ]; then
 	[ $(id -u) == 0 ] || eusage "for bridging you must be root"
-	if [ ! -d /etc/qemu ]; then 
+	if [ ! -d /etc/qemu ]; then
 		mkdir -p /etc/qemu
 		chown root:kvm /etc/qemu
 	fi
@@ -279,4 +304,3 @@ qemu-system-$arch ${virtOpts[@]}
 
 ### cleanup
 [ $daemonize ] || rm -f $targetDir/$mac.monitor
-

--- a/docker/build-image/Dockerfile
+++ b/docker/build-image/Dockerfile
@@ -12,6 +12,8 @@ RUN	go install golang.org/x/lint/golint@latest \
 FROM 	$build_base_image
 ARG	DEBIAN_FRONTEND=noninteractive
 
+RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
+
 RUN	apt-get update \
      &&	apt-get install -y --no-install-recommends \
 		debian-ports-archive-keyring \
@@ -26,7 +28,7 @@ RUN	apt-get update \
 		qemu-user-static \
 		qemu-utils \
 		cpio \
-                syslinux syslinux-common isolinux xorriso \
+		syslinux:amd64 syslinux-common:amd64 isolinux:amd64 xorriso:amd64 \
 		dpkg-dev \
      &&	rm -rf /var/lib/apt/lists/*
 

--- a/docker/build-image/Dockerfile
+++ b/docker/build-image/Dockerfile
@@ -14,8 +14,8 @@ ARG	DEBIAN_FRONTEND=noninteractive
 
 RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
 
-RUN	apt-get update \
-     &&	apt-get install -y --no-install-recommends \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		debian-ports-archive-keyring \
 		debootstrap \
 		wget ca-certificates gettext-base \
@@ -29,8 +29,14 @@ RUN	apt-get update \
 		qemu-utils \
 		cpio \
 		syslinux:amd64 syslinux-common:amd64 isolinux:amd64 xorriso:amd64 \
-		dpkg-dev \
-     &&	rm -rf /var/lib/apt/lists/*
+		dpkg-dev
+
+RUN echo "deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+	&& echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default-testing \
+	&& apt-get update \
+	&& apt-get install -t unstable -y --no-install-recommends binutils-x86-64-linux-gnu binutils-aarch64-linux-gnu
+
+RUN rm -rf /var/lib/apt/lists/*
 
 ENV	PATH=${PATH}:/opt/gardenlinux/bin
 #COPY	--from=gcr.io/kaniko-project/executor:latest /kaniko/executor /usr/local/bin/executor

--- a/features/base/test/root-perm
+++ b/features/base/test/root-perm
@@ -3,13 +3,13 @@
 rootfsDir=$1
 rc=0
 
-# the rood directory should be with permissions 0700
+# the root directory should be with permissions 0700
 echo "checking root permissions"
 findCommand="usr/bin/find"
 rootDir="root"
 correctPermissions="0700"
 
-output=$("${rootfsDir}/${findCommand}" "${rootfsDir}" -name "${rootDir}" -perm "${correctPermissions}")
+output=$(find "${rootfsDir}" -name "${rootDir}" -perm "${correctPermissions}")
 
 if [ -z "${output}" ]
 then

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -13,12 +13,6 @@ update-kernel-cmdline
 
 mkdir -p /boot/efi/EFI/BOOT
 
-case $(dpkg --print-architecture) in
-   amd64) uefi_arch=X64;;
-   arm64) uefi_arch=AA64;;
-   *) echo "Unknown arch"; exit 1;;
-esac
-
 for kernel in /boot/vmlinuz-*; do
    #legacy
    dracut\
@@ -27,16 +21,6 @@ for kernel in /boot/vmlinuz-*; do
    --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
    --reproducible\
    "/boot/initrd.img-${kernel#*-}"
-
-   #uefi
-   dracut\
-   --force\
-   --kver "${kernel#*-}"\
-   --uefi\
-   --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
-   --kernel-cmdline "$(cat /etc/kernel/cmdline)"\
-   --reproducible\
-   "/boot/efi/EFI/BOOT/BOOT${uefi_arch}.EFI"
 done
 
 rm -f /etc/dracut.conf.d/30-secureboot.conf

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -15,6 +15,7 @@ mkdir -p /boot/efi/EFI/BOOT
 
 case $(dpkg --print-architecture) in
    amd64) uefi_arch=X64;;
+   arm64) uefi_arch=AA64;;
    *) echo "Unknown arch"; exit 1;;
 esac
 
@@ -40,9 +41,11 @@ done
 
 rm -f /etc/dracut.conf.d/30-secureboot.conf
 
-# bootloader
-mkdir -p /boot/efi/syslinux
-cp /usr/lib/syslinux/modules/bios/menu.c32 /boot/efi/syslinux/
-cp /usr/lib/syslinux/modules/bios/libutil.c32 /boot/efi/syslinux/
+if [ -f "/usr/bin/syslinux" ]; then
+    # bootloader
+    mkdir -p /boot/efi/syslinux
+    cp /usr/lib/syslinux/modules/bios/menu.c32 /boot/efi/syslinux/
+    cp /usr/lib/syslinux/modules/bios/libutil.c32 /boot/efi/syslinux/
 
-update-syslinux
+    update-syslinux
+fi

--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -1,8 +1,6 @@
 fdisk
-#[${arch}=amd64] grub-cloud-amd64
-#[${arch}=arm64] grub-cloud-arm64
-syslinux
-syslinux-common
+[${arch}=amd64] syslinux
+[${arch}=amd64] syslinux-common
 cloud-guest-utils
 libpam-cracklib
 rng-tools5

--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -5,12 +5,6 @@ update-kernel-cmdline
 
 mkdir -p /boot/efi/EFI/BOOT
 
-case $(dpkg --print-architecture) in
-   amd64) uefi_arch=X64;;
-   arm64) uefi_arch=AA64;;
-   *) echo "Unknown arch"; exit 1;;
-esac
-
 for kernel in /boot/vmlinuz-*; do
    #legacy
    dracut\
@@ -19,16 +13,6 @@ for kernel in /boot/vmlinuz-*; do
    --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
    --reproducible\
    "/boot/initrd.img-${kernel#*-}"
-
-   #uefi
-   dracut\
-   --force\
-   --kver "${kernel#*-}"\
-   --uefi\
-   --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
-   --kernel-cmdline "$(cat /etc/kernel/cmdline)"\
-   --reproducible\
-   "/boot/efi/EFI/BOOT/BOOT${uefi_arch}.EFI"
 done
 
 rm -f /etc/dracut.conf.d/30-secureboot.conf

--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -7,6 +7,7 @@ mkdir -p /boot/efi/EFI/BOOT
 
 case $(dpkg --print-architecture) in
    amd64) uefi_arch=X64;;
+   arm64) uefi_arch=AA64;;
    *) echo "Unknown arch"; exit 1;;
 esac
 
@@ -32,9 +33,11 @@ done
 
 rm -f /etc/dracut.conf.d/30-secureboot.conf
 
-# bootloader
-mkdir -p /boot/efi/syslinux
-cp /usr/lib/syslinux/modules/bios/menu.c32 /boot/efi/syslinux/
-cp /usr/lib/syslinux/modules/bios/libutil.c32 /boot/efi/syslinux/
+if [ -f "/usr/bin/syslinux" ]; then
+   # bootloader
+   mkdir -p /boot/efi/syslinux
+   cp /usr/lib/syslinux/modules/bios/menu.c32 /boot/efi/syslinux/
+   cp /usr/lib/syslinux/modules/bios/libutil.c32 /boot/efi/syslinux/
 
-update-syslinux
+   update-syslinux
+fi

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -16,6 +16,6 @@ mdadm
 hdparm
 smartmontools
 bird2
-syslinux
-syslinux-common
+[${arch}=amd64] syslinux
+[${arch}=amd64] syslinux-common
 linux-image-5.10-${arch}

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -32,5 +32,3 @@ nvme-cli
 selinux-basics
 selinux-policy-default
 sosreport
-binutils
-sbsigntool

--- a/get_arch.sh
+++ b/get_arch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeufo pipefail
+
+case "$(uname -m)" in
+	"x86_64"|"amd64")
+		echo "amd64"
+		;;
+	"aarch64"|"arm64")
+		echo "arm64"
+		;;
+	*)
+		echo "unsupported architecture" >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement 
/area os
/os garden-linux


**What this PR does / why we need it**:

- adds support for building arm64 images
- cross architecture builds (from x86 to arm and vice versa) are possible by passing the `ARCH=amd64|arm64` variable to `make`
  - cross architecture builds require binfmt_misc support on the build host machine, with the appropriate qemu-user-static handlers set for the target architecture
  - on debian this can be achieved by installing the packages `qemu-user-static` and `binfmt-support`

(requires #574)
(supersedes #530)