### PR TITLE
minor fixes

### DIFF
--- a/features/base/file.include/etc/apt/apt.conf.d/no-recommends
+++ b/features/base/file.include/etc/apt/apt.conf.d/no-recommends
@@ -1,3 +1,2 @@
-APT::Install-Recommends false;
-APT::Install-Suggests false;
-Apt::AutoRemove::SuggestsImportant "false";
+APT::Install-Recommends "false";
+Apt::AutoRemove::RecommendsImportant "false";

--- a/features/base/file.include/etc/apt/apt.conf.d/no-suggests
+++ b/features/base/file.include/etc/apt/apt.conf.d/no-suggests
@@ -1,0 +1,2 @@
+APT::Install-Suggests "false";
+Apt::AutoRemove::SuggestsImportant "false";

--- a/features/base/file.include/etc/ucf.conf
+++ b/features/base/file.include/etc/ucf.conf
@@ -1,0 +1,1 @@
+conf_force_conffold=YES

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -18,6 +18,8 @@ update-ca-certificates
 addgroup --system wheel
 
 sed -i "s/#RuntimeWatchdogSec=0/RuntimeWatchdogSec=20s/g" /etc/systemd/system.conf
+sed -i "s/#ManageForeignRoutingPolicyRules=yes/ManageForeignRoutingPolicyRules=no/g" /etc/systemd/networkd.conf
+sed -i "s/#ManageForeignRoutes=yes/ManageForeignRoutes=no/g" /etc/systemd/networkd.conf
 
 #chmod u-s /bin/umount /bin/mount
 chmod 0440 /etc/sudoers.d/wheel /etc/sudoers.d/keepssh


### PR DESCRIPTION
Fix about recommends and suggests:
  - deselecting recommends and suggests is now in separate files
  - recommends have been deselected but not cleaned up if installed
 
UCF handling
  - dpkg is already on leaf old config
  - ucf is now as well (became visible on the latest ssh update)

Systemd fixes:
  - systemd cleans ip rules and ip routes of foreign configs since 249
  - this causes sever damage if you have a lot of foreign routes -> e.g. bgp
  - and causes problems if ip rules are manipulated e.g. cilium