### PR TITLE
Rkhunter test fixes

### DIFF
--- a/features/base/test/rkhunter.chroot
+++ b/features/base/test/rkhunter.chroot
@@ -12,6 +12,12 @@ fi
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y -qq rkhunter apt-utils &> /dev/null
 
+for dir in sys dev proc; do
+	if [ -e "/$dir" ]; then
+		mountpoint -q "/$dir" && umount -l "/$dir"
+	fi
+done
+
 # run propupd just to avoid extra warnings in the log
 rkhunter --configfile "${thisDir}/rkhunter.d/rkhunter.conf" --propupd -q
 rkhunter --configfile "${thisDir}/rkhunter.d/rkhunter.conf" --enable system_configs_ssh,group_accounts,filesystem,group_changes,passwd_changes,startup_malware,system_configs_ssh,properties -q --rwo --noappend-log 2>/dev/null


### PR DESCRIPTION
**How to categorize this PR?**

/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
The rkhunter test is running chrooted; garden-chroot is bind mounting /dev, /sys and /proc from the build system and that's not really needed and could also create false positives.

**Which issue(s) this PR fixes**:
Fixes #565 and #592

**Special notes for your reviewer**:

**Release note**:
