### PR TITLE
Adjusted documentation/README fixes #593

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,27 @@ Garden Linux is a [Debian](https://debian.org) derivate that aims to provide a s
 
 ## Build Requirements
 
-The entire build runs in a docker container (well a privileged one with extended capabilities - since we need loop back support)
-We can run on any system supporting Docker and having loopback support and has
+The entire build runs in a docker container (well a privileged one with extended capabilities - since we need loop back support).
+We can run on any system supporting Docker and having loopback support and has:
 
-- 2+ GiB (use RAM-disk; use fs with sparse-file support)
+- 2+ GiB (use '--lessram' to lower memory usage)
 - 10+ GiB free disk space
-- Internet connection to access snapshot.debian.org and repo.gardenlinux.io
+- Internet connection (snapshot.debian.org, deb.debian.org, repo.gardenlinux.io, docker.io, golang.org, gopkg.in, github.com)
+
+## Build Options
+
+| Option | Description  |
+|---|---|
+| --features  | Comma separated list of features activated (see features/) (default:base) |
+| --disable-features | Comma separated list of features to deactivate (see features/) |
+| --lessram | Build will be no longer in memory (default: off) |
+| --debug | Activates basically \`set -x\` everywhere (default: off) |
+| --manual | Built will stop in build environment and activate manual mode (debugging) (default:off) |
+| --arch | Builds for a specific architecture (default: architecture the build runs on) |
+| --suite | Specifies the debian suite to build for e.g. bullseye, potatoe (default: testing) |
+| --skip-tests | Deactivating tests (default: off) |
+| --skip-build | Do not create the build container BUILD_IMAGE variable would specify an alternative name |
+
 
 ### Required packages for a convenient build (on Debian/Ubuntu):
 
@@ -72,7 +87,7 @@ ext4, loop, squashfs, vfat, vsock (for VM image builds and extended virtualized 
 
 ### Required packages to configure the CI pipeline
 
-`apt install bash git python`
+`apt install bash git python python-pip`
 
 `pip install tekton`
 
@@ -94,6 +109,8 @@ Building specific platform images:
     make metal
 
 See in `.build/` folder for the outcome, there are subdirectories for the platform and the build date.
+Related dev images can be created by appending the '-dev' suffix (e.g. "make aws-dev").
+
 
 ## Customize builds
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">&bull;
     <a href="#Features">Features</a> &bull;
     <a href="#build-requirements">Build Requirements</a> &bull;
+    <a href="#build-options">Build Options</a> &bull;
     <a href="#quick-start">Quick Start</a> &bull;
     <a href="#customize-builds">Customize</a> &bull;
     <a href="#garden-linux-releases">Releases</a> &bull;
@@ -52,21 +53,6 @@ We can run on any system supporting Docker and having loopback support and has:
 - 10+ GiB free disk space
 - Internet connection (snapshot.debian.org, deb.debian.org, repo.gardenlinux.io, docker.io, golang.org, gopkg.in, github.com)
 
-## Build Options
-
-| Option | Description  |
-|---|---|
-| --features  | Comma separated list of features activated (see features/) (default:base) |
-| --disable-features | Comma separated list of features to deactivate (see features/) |
-| --lessram | Build will be no longer in memory (default: off) |
-| --debug | Activates basically \`set -x\` everywhere (default: off) |
-| --manual | Built will stop in build environment and activate manual mode (debugging) (default:off) |
-| --arch | Builds for a specific architecture (default: architecture the build runs on) |
-| --suite | Specifies the debian suite to build for e.g. bullseye, potatoe (default: testing) |
-| --skip-tests | Deactivating tests (default: off) |
-| --skip-build | Do not create the build container BUILD_IMAGE variable would specify an alternative name |
-
-
 ### Required packages for a convenient build (on Debian/Ubuntu):
 
 `apt install bash docker.io docker-compose make coreutils gnupg git qemu-system-x86`
@@ -90,6 +76,20 @@ ext4, loop, squashfs, vfat, vsock (for VM image builds and extended virtualized 
 `apt install bash git python python-pip`
 
 `pip install tekton`
+
+## Build Options
+
+| Option | Description  |
+|---|---|
+| --features  | Comma separated list of features activated (see features/) (default:base) |
+| --disable-features | Comma separated list of features to deactivate (see features/) |
+| --lessram | Build will be no longer in memory (default: off) |
+| --debug | Activates basically \`set -x\` everywhere (default: off) |
+| --manual | Built will stop in build environment and activate manual mode (debugging) (default:off) |
+| --arch | Builds for a specific architecture (default: architecture the build runs on) |
+| --suite | Specifies the debian suite to build for e.g. bullseye, potatoe (default: testing) |
+| --skip-tests | Deactivating tests (default: off) |
+| --skip-build | Do not create the build container BUILD_IMAGE variable would specify an alternative name |
 
 ## Quick start
 


### PR DESCRIPTION
**Overview**
  - Adjusted sources that are accessed to obtain needed bins/pkgs/imgs etc.
  - Adjusted dep-pkgs for installing 'tekton'
  - Added build options table overview
  - Some smaller adjustments

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Adjusting the primary documentation / README.md. This gives new users an easier way to test and build *Garden Linux*.

**Which issue(s) this PR fixes**:
Fixes #593 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
