### PR TITLE
Fix containerd CVE-2021-43816

### DIFF
--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -1,5 +1,5 @@
 apparmor
-containerd
+http://snapshot.debian.org/archive/debian/20220120T210710Z/pool/main/c/containerd/containerd_1.5.9~ds1-1_amd64.deb
 containernetworking-plugins
 docker.io
 ethtool


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Fix for containerd CVE-2021-43816

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Already fixed in main with a new Debian snapshot.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fix for containerd CVE-2021-43816
```
