### PR TITLE
fix: remove duplicate ExecStart from systemd-networkd service

### DIFF
--- a/features/server/file.include/etc/systemd/system/systemd-networkd-wait-online.service.d/any.conf
+++ b/features/server/file.include/etc/systemd/system/systemd-networkd-wait-online.service.d/any.conf
@@ -1,3 +1,2 @@
 [Service]
-ExecStart=
 ExecStart=/lib/systemd/systemd-networkd-wait-online --any


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Having two `ExecStart=` lines in a unit file might cause problems as the [documentation](https://www.freedesktop.org/software/systemd/man/systemd.service.html) clearly states _"Unless Type= is oneshot, exactly one command must be given."_

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
fix: remove duplicate ExecStart from systemd-networkd service
```
