### PR TITLE
Repart fixes

### DIFF
--- a/bin/makepart
+++ b/bin/makepart
@@ -42,6 +42,9 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 | while read -r depth source target fs options args; do
 	# parse extra fstab arguments to determine partition attributes
 	type=$([[ "$fs" = "swap" ]] && echo "swap" || echo "linux")
+	# consider switching this to args
+	[[ "$target" = "/" && "$arch" = "amd64" ]] && type="4f68bce3-e8cd-4db1-96e7-fbcaf984b709"
+	[[ "$target" = "/" && "$arch" = "arm64" ]] && type="b921b045-1df0-41c3-af44-4c6f280d3fae"
 	size=
 	resize=1
 	verity=0

--- a/bin/makepart
+++ b/bin/makepart
@@ -205,7 +205,7 @@ kernel_version="${kernel_file#*-}"
 chroot "$rootfs" dracut \
 	--force \
 	--kver "$kernel_version" \
-	--modules "bash dash systemd systemd-initrd systemd-veritysetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown" \
+	--modules "bash dash systemd systemd-initrd systemd-repart systemd-veritysetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown" \
 	--install "/etc/veritytab" \
 	--reproducible \
 	"$initrd"

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -18,7 +18,7 @@ for kernel in /boot/vmlinuz-*; do
    dracut\
    --force\
    --kver "${kernel#*-}"\
-   --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
+   --modules "bash dash systemd systemd-initrd systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
    --reproducible\
    "/boot/initrd.img-${kernel#*-}"
 done

--- a/features/cloud/file.include/etc/repart.d/root.conf
+++ b/features/cloud/file.include/etc/repart.d/root.conf
@@ -1,2 +1,2 @@
 [Partition]
-Label=ROOT
+Type=root

--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -10,7 +10,7 @@ for kernel in /boot/vmlinuz-*; do
    dracut\
    --force\
    --kver "${kernel#*-}"\
-   --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
+   --modules "bash dash systemd systemd-initrd systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd gardenlinux base fs-lib shutdown"\
    --reproducible\
    "/boot/initrd.img-${kernel#*-}"
 done

--- a/features/metal/file.include/etc/repart.d/root.conf
+++ b/features/metal/file.include/etc/repart.d/root.conf
@@ -1,3 +1,3 @@
 # disable for metal builds
 #[Partition]
-#Label=ROOT
+#Type=root

--- a/features/metal/file.include/etc/repart.d/root.conf
+++ b/features/metal/file.include/etc/repart.d/root.conf
@@ -1,3 +1,0 @@
-# disable for metal builds
-#[Partition]
-#Type=root


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
systemd-repart is not properly working as the detection mechanism is not working as expected, hence we're adding special partition type UUIDs from the discoverable partitions specification. Also, we need to enable the systemd-repart dracut module.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
