### PR TITLE
Preserve symbolic links in file.include

### DIFF
--- a/bin/garden-config
+++ b/bin/garden-config
@@ -44,7 +44,7 @@ printf "## copying from file.include\n"
 for i in $(tr ',' '\n' <<< $features); do
 	if [ -d "$featureDir/$i/file.include" ]; then
 		printf "### $i:\n"
-		tar --owner=0 --group=0 -cC $featureDir/$i/file.include . | tar -xvC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  - | indent
+		tar --owner=0 --group=0 -cC $featureDir/$i/file.include . | tar -xvhC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  - | indent
 	fi
 done
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Adjust `bin/garden-config` so that directories within `file.include` may not break the rootfs during the build because they overwrite important sym links (e.g. `lib -> /usr/lib`).

The adjustment will preserve sym links of the target directory (rootfs) in which the tarball of `file.include` will be extracted.

**Which issue(s) this PR fixes**:
Fixes #606 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
