### PR TITLE
fix(apparmor): disable selinux completey for 576 for server feature

### DIFF
--- a/features/server/file.include/etc/kernel/cmdline.d/90-lsm.cfg
+++ b/features/server/file.include/etc/kernel/cmdline.d/90-lsm.cfg
@@ -1,1 +1,1 @@
-CMDLINE_LINUX="$CMDLINE_LINUX selinux=1 apparmor=0"
+CMDLINE_LINUX="$CMDLINE_LINUX selinux=0 apparmor=1"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind regression
/area os
/os garden-linux

**What this PR does / why we need it**:

GardenLinux 576.0 and 576.1 had SElinux enabled, breaking compatibility with previous Garden Linux releases and workloads that require AppArmor. 576.2 attempted to reenable AppArmor with commit be5c1c0 for the `gardener` feature but left SELinux in for the `server` feature. This PR will disable SELinux altogether for GL576.

**Special notes for your reviewer**:

Must be merged into __rel-576__ branch, NOT into __main__.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix(apparmor): disable selinux completey for 576, even in server feature
```
