### PR TITLE
Drop explicit removal of libdb5.3

### DIFF
--- a/features/base/test/blacklisted-packages.d/blacklisted-packages.list
+++ b/features/base/test/blacklisted-packages.d/blacklisted-packages.list
@@ -2,4 +2,6 @@ rlogin
 rsh
 rcp
 telnet
-libdb
+# XXX: Test does not manage arch specifiers for multi-arch packages
+libdb5.3:amd64
+libdb5.3:arm64

--- a/features/base/test/blacklisted-packages.d/final.list
+++ b/features/base/test/blacklisted-packages.d/final.list
@@ -2,4 +2,6 @@ rlogin
 rsh
 rcp
 telnet
-libdb
+# XXX: Test does not manage arch specifiers for multi-arch packages
+libdb5.3:amd64
+libdb5.3:arm64

--- a/features/server/exec.post
+++ b/features/server/exec.post
@@ -5,6 +5,3 @@ set -Eeuo pipefail
 $thisDir/garden-chroot $targetDir find /usr/lib -type d -name __pycache__ -exec rm -rf {} +
 
 rm $targetDir/etc/nvme/hostid $targetDir/etc/nvme/hostnqn
-
-echo "# Deleting libdb forcefully"
-$thisDir/garden-chroot $targetDir apt-get autoremove --purge -y libdb5.3


### PR DESCRIPTION
**What this PR does / why we need it**:
The explicit removal is not longer needed since we install from a repo not containing it in the first place. Also fix up the test for it.

/kind cleanup
/area os
/os garden-linux