### PR TITLE
dracut gardenlinux-live module: fix problem from generator being run twice

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-overlay-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-overlay-setup.sh
@@ -61,6 +61,7 @@ if echo "$ovlconf" | grep -q '^/:\|,/:'; then
 	echo "[Unit]
 	Before=initrd-root-fs.target
 	After=run-rootfs.mount
+	Requires=run-rootfs.mount
 	After=ignition-disks.service
 	After=create-mountpoints.service
 	Requires=create-mountpoints.service

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
@@ -8,31 +8,34 @@ GENERATOR_DIR="$1"
 
 mkdir -p /run/rootfs
 
-if [ -f /root.squashfs ]; then
-	mv /root.squashfs /run/root.squashfs
-else
-	cat >"${GENERATOR_DIR}/live-get-squashfs.service" <<-EOF
-	[Unit]
-	Description=Download squashfs image
+if [ ! -e /run/root.squashfs ]; then
+	if [ -e /root.squashfs ]; then
+		mv /root.squashfs /run/root.squashfs
+	else
+		cat >"${GENERATOR_DIR}/live-get-squashfs.service" <<-EOF
+		[Unit]
+		Description=Download squashfs image
 
-	After=network-online.target systemd-resolved.service
-	Wants=network-online.target systemd-resolved.service
+		After=network-online.target systemd-resolved.service
+		Wants=network-online.target systemd-resolved.service
 
-	OnFailure=emergency.target
-	OnFailureJobMode=isolate
-	DefaultDependencies=no
+		OnFailure=emergency.target
+		OnFailureJobMode=isolate
+		DefaultDependencies=no
 
-	[Service]
-	Type=oneshot
-	TimeoutStartSec=600
-	RemainAfterExit=yes
-	ExecStart=/sbin/live-get-squashfs
-	EOF
+		[Service]
+		Type=oneshot
+		TimeoutStartSec=600
+		RemainAfterExit=yes
+		ExecStart=/sbin/live-get-squashfs
+		EOF
+	fi
 fi
 
 cat >"${GENERATOR_DIR}/run-rootfs.mount" <<EOF
 [Unit]
 After=live-get-squashfs.service
+Wants=live-get-squashfs.service
 After=dracut-pre-mount.service
 Before=initrd-root-fs.target
 DefaultDependencies=no
@@ -43,7 +46,3 @@ Where=/run/rootfs
 Type=squashfs
 Options=loop
 EOF
-
-mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
-ln -s ../run-rootfs.mount "$GENERATOR_DIR"/initrd-root-fs.target.requires/run-rootfs.mount
-[ -f /root.squashfs ] || ln -s ../live-get-squashfs.service "$GENERATOR_DIR"/initrd-root-fs.target.requires/live-get-squashfs.service


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

fixes problem with EFI PXE boot

**Origin of the problem**

dracut runs the squash-mount-generator twice and on the second run /root.squashfs is already moved, so it'll generate live-get-squashfs.service which causes a race condition in systemd unit ordering and sometimes breaks boot