### PR TITLE
Fix file.exclude for directories

### DIFF
--- a/bin/garden-config
+++ b/bin/garden-config
@@ -65,7 +65,7 @@ for i in $(tr ',' '\n' <<< $features); do
 		printf "### $i:\n"
 		cat $featureDir/$i/file.exclude | paste -sd' '  - | indent
 		for j in $(cat $featureDir/$i/file.exclude); do
-			rm -f $targetDir$j || true
+			rm -fr $targetDir$j || true
 		done
 	fi
 done


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that directories can also be removed via the `file.exclude` mechanism like it can be used for files. As of now, directories could be referenced but the build pipeline wasn't able to delete them properly and was just printing a warning to the console without aborting the build.

By providing this change, one can also reference directories in the `file.exclude` file then.

**Which issue(s) this PR fixes**:
Fixes #463 