### PR TITLE
Fetch ignition pkg from snapshot

### DIFF
--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -3,4 +3,4 @@ dosfstools
 btrfs-progs
 xfsprogs
 dracut-network
-http://ftp.de.debian.org/debian/pool/main/i/ignition/ignition_2.13.0+ds1-1_${arch}.deb
+https://snapshot.debian.org/archive/debian/20220127T211926Z/pool/main/i/ignition/ignition_2.13.0+ds1-1_${arch}.deb


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Fetch ignition package from snapshot.debian.org.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: