### PR TITLE
Use ignition from own repo

### DIFF
--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -3,4 +3,4 @@ dosfstools
 btrfs-progs
 xfsprogs
 dracut-network
-https://snapshot.debian.org/archive/debian/20220127T211926Z/pool/main/i/ignition/ignition_2.13.0+ds1-1_${arch}.deb
+ignition


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ignotion` package is finally in Debian Bookworm, so it can be fetched from our mirrored repo.
