### PR TITLE
cleanup: remove policykit

### DIFF
--- a/features/base/test/suid.d/suid.list
+++ b/features/base/test/suid.d/suid.list
@@ -7,6 +7,4 @@
 /usr/bin/su,0,0
 /usr/bin/sudo,0,0
 /usr/lib/openssh/ssh-keysign,0,0
-/usr/lib/policykit-1/polkit-agent-helper-1,0,0
 /usr/lib/dbus-1.0/dbus-daemon-launch-helper,0,105
-/usr/libexec/polkit-agent-helper-1,0,0

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -14,7 +14,6 @@ lsb-release
 net-tools
 netbase
 openssh-server
-policykit-1
 procps
 sudo
 sysstat


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:

Do we need policykit for anything? If not we should probably just get rid of it, the less setuid binaries the better.
