### PR TITLE
CI: use more appropriate service-principal and storage-account

### DIFF
--- a/ci/cicd.yaml
+++ b/ci/cicd.yaml
@@ -6,8 +6,8 @@ cicd_cfgs:
       s3_bucket_name: 'gardenlinux'
       gcp_bucket_name: 'gardenlinux-images'
       gcp_cfg_name: 'gardenlinux'
-      storage_account_config_name: 'gardenlinux-dev'
-      service_principal_name: 'shoot-operator-dev'
+      storage_account_config_name: 'gardenlinux'
+      service_principal_name: 'gardenlinux'
       plan_config_name: 'gardenlinux-greatest'
       oss_bucket_name: 'gardenlinux' #alicloud
       alicloud_region: 'eu-central-1'
@@ -20,8 +20,8 @@ cicd_cfgs:
         offer_id: 'gardenlinux'
         publisher_id: 'sap'
         plan_id: 'greatest'
-        service_principal_cfg_name: 'shoot-operator-dev'
-        storage_account_cfg_name: 'gardenlinux-dev'
+        service_principal_cfg_name: 'gardenlinux'
+        storage_account_cfg_name: 'gardenlinux'
         shared_gallery_cfg_name: 'gardenlinux-shared-gallery'
         notification_emails: [andreas.burger@sap.com, dominic.kistner@sap.com]
       openstack:


### PR DESCRIPTION
Instead of re-using some existing secrets, use ones created for gardenlinux. This also moves the final build artifacts to the proper gardenlinux Azure subscription.
After this PR is merged, I will also port it to all release-branches.