### PR TITLE
GitHub actions: automatically select newest qemu-user-static version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,5 +10,8 @@ jobs:
         modifier: [ "", "-dev" ]
     steps:
       - uses: actions/checkout@v2
-      - run: wget https://deb.debian.org/debian/pool/main/q/qemu/qemu-user-static_6.2+dfsg-1_amd64.deb && sudo dpkg -i qemu-user-static_6.2+dfsg-1_amd64.deb
+      - run: |
+          version=$(curl -s -f https://deb.debian.org/debian/pool/main/q/qemu/ | grep -oP '(?<=href="qemu-user-static_).*?(?=_amd64.deb")' | sort | tail -n 1)
+          wget https://deb.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}_amd64.deb
+          sudo dpkg -i qemu-user-static_${version}_amd64.deb
       - run: make ARCH=${{ matrix.architecture }} ${{ matrix.target }}${{ matrix.modifier }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

automatically get newest version of qemu instead hard coded version
