### PR TITLE
ci: treat 'dev' version string like 'today' version string

### DIFF
--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -679,6 +679,7 @@ epoch_date = datetime.datetime.fromisoformat('2020-04-01')
 
 # special version value - use "today" as gardenlinux epoch (depend on build-time)
 version_today = 'today'
+version_dev = 'dev'
 
 
 def gardenlinux_epoch(date: typing.Union[str, datetime.datetime] = None):
@@ -757,7 +758,7 @@ def next_release_version_from_workingtree(
 ):
     version_str = _parse_version_from_workingtree(version_file_path=version_file_path)
 
-    if version_str == version_today:
+    if version_str == version_today or version_str == version_dev:
         # the first release-candidate is always <gardenlinux-epoch>.0
         return f'{gardenlinux_epoch_from_workingtree(epoch = epoch)}.0'
 
@@ -796,7 +797,7 @@ def gardenlinux_epoch_from_workingtree(
     except ValueError:
         pass
 
-    if version_str == version_today:
+    if version_str == version_today or version_str == version_dev:
         return epoch
 
     raise ValueError(f'{version_str=} was not understood - either semver or "today" are supported')


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind regression
/area os
/os garden-linux

**What this PR does / why we need it**:

Restores pipeline functionality that got broken with PR #583.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
ci: treat 'dev' version string like 'today' version string
```
