### PR TITLE
fix: hand build arch over to makepart

### DIFF
--- a/bin/garden-build
+++ b/bin/garden-build
@@ -48,6 +48,7 @@ disableimages="${disableimages:-}"
 epoch="$(garden-version --epoch "$version")"
 serial="$(garden-version --date "$version")"
 dpkgArch="${arch:-$(dpkg --print-architecture | awk -F- "{ print \$NF }")}"
+export arch="$arch"
 
 fullfeatures="$(garden-feat --featureDir $featureDir --features "$features" --ignore "$disablefeatures" features)"
 
@@ -202,7 +203,7 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 			elif [ -s $featureDir/$i/image ]; then
 				"$featureDir/$i/image" "$rootfs" "$targetBase"
 			elif [ -f "$featureDir/$i/fstab" ]; then
-				makepart "$rootfs" < "$featureDir/$i/fstab" | makedisk "$rootfs" "$targetBase.raw"
+				makepart "$rootfs" "$arch" < "$featureDir/$i/fstab" | makedisk "$rootfs" "$targetBase.raw"
 			else
 				true
 			fi

--- a/bin/makepart
+++ b/bin/makepart
@@ -12,6 +12,7 @@ function uuid_hash {
 }
 
 rootfs="$1"
+arch="${2:-$arch}"
 timestamp=$(garden-version --epoch "$version")
 
 rootfs_work=$(mktemp -d)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

If the build architecture is not set in the environment (which is the case for the build pipeline), then `makepart` will fail with the changes introduced in PR #605  . The architecture is now handed over from `garden-build` to `makepart`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix: hand build arch over to makepart
```
