### PR TITLE
Disable rp_filter due to incompatibility with Cilium

### DIFF
--- a/features/cloud/file.include/etc/sysctl.d/20-cloud.conf
+++ b/features/cloud/file.include/etc/sysctl.d/20-cloud.conf
@@ -13,12 +13,6 @@ net.ipv4.conf.all.secure_redirects = 1
 # Ignore ICMP redirects from non-GW hosts
 net.ipv4.conf.default.secure_redirects = 1
 
-# Reverse path filtering&mdash;IP spoofing protection
-net.ipv4.conf.all.rp_filter = 1
-
-# Reverse path filtering&mdash;IP spoofing protection
-net.ipv4.conf.default.rp_filter = 1
-
 # Ignore ICMP broadcasts to avoid participating in Smurf attacks
 net.ipv4.icmp_echo_ignore_broadcasts = 1
 

--- a/features/gcp/file.include/etc/sysctl.d/60-gce-network-security.conf
+++ b/features/gcp/file.include/etc/sysctl.d/60-gce-network-security.conf
@@ -36,11 +36,6 @@ net.ipv4.ip_forward=0
 net.ipv4.conf.all.send_redirects=0
 net.ipv4.conf.default.send_redirects=0
 
-# Turn on Source Address Verification in all interfaces to
-# prevent some spoofing attacks.
-net.ipv4.conf.all.rp_filter=1
-net.ipv4.conf.default.rp_filter=1
-
 # Ignore ICMP broadcasts to avoid participating in Smurf attacks
 net.ipv4.icmp_echo_ignore_broadcasts=1
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

This PR disables the kernel reverse path filtering (rp_filter) which clashes with Cilium.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature bugfix
Disable reverse path filtering (rp_filter) which clashes with Cilium.
```
