### PR TITLE
Missing selinux context for boot efi

### DIFF
--- a/bin/makepart
+++ b/bin/makepart
@@ -118,6 +118,8 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 			used_inodes=$(for (( inode=1; inode <= "$num_inodes"; inode++ )); do echo "testi <$inode>"; done | debugfs "$file" 2> /dev/null | grep -oP '(?<=Inode )[0-9]+(?= is marked in use)')
 			for inode in $used_inodes; do for field in {a,m,c}time; do echo "set_inode_field <$inode> $field $timestamp"; done; done | debugfs -w "$file" &> /dev/null
 
+			chcon -R system_u:object_r:dosfs_t:s0 "$rootfs_work/boot/efi"
+
 			rm -rf "$rootfs_work$target"
 			mkdir "$rootfs_work$target"
 			;;

--- a/bin/makepart
+++ b/bin/makepart
@@ -118,10 +118,16 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 			used_inodes=$(for (( inode=1; inode <= "$num_inodes"; inode++ )); do echo "testi <$inode>"; done | debugfs "$file" 2> /dev/null | grep -oP '(?<=Inode )[0-9]+(?= is marked in use)')
 			for inode in $used_inodes; do for field in {a,m,c}time; do echo "set_inode_field <$inode> $field $timestamp"; done; done | debugfs -w "$file" &> /dev/null
 
-			chcon -R system_u:object_r:dosfs_t:s0 "$rootfs_work/boot/efi"
+			if [[ -d "$rootfs_work/boot/efi" ]]; then
+				chcon system_u:object_r:dosfs_t:s0 "$rootfs_work/boot/efi"
+			fi
 
 			rm -rf "$rootfs_work$target"
 			mkdir "$rootfs_work$target"
+
+			if [[ "$target" = "/overlay" ]]; then
+				chcon system_u:object_r:default_t:s0 "$rootfs_work/overlay"
+			fi
 			;;
 		"vfat")
 			uuid=${uuid:-$(echo "gardenlinux:$version:fs_uuid:$fs:$target" | sha256sum | cut -c -8)}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Set proper selinux context for /boot/efi and /overlay

**Which issue(s) this PR fixes**:
Fixes #541

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
