### PR TITLE
disable rp_filter and enable BTF for 576

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 .idea
 __pycache__
 /dev
+/test.log
+/test_results.json
+/tests/*.log
+/tests/*.xml

--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -6,6 +6,5 @@ syslinux-common
 cloud-guest-utils
 libpam-cracklib
 rng-tools5
-http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.0-garden-cloud-${arch}_5.10.93-0gardenlinux1_${arch}.deb
-http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.93-0gardenlinux1_${arch}.deb
-
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.100-garden-cloud-${arch}_5.10.100-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.100-0gardenlinux1_${arch}.deb

--- a/features/cloud/test/kernel_config_options
+++ b/features/cloud/test/kernel_config_options
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "testing kernel configuration"
+
+rootfsDir=$1
+thisDir=$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")
+rootfsDir=$(readlink -e "$rootfsDir")
+
+
+function check_config_line() {
+    file=$1
+    option=$2
+    value=$3
+
+    config_line=$(cat $1 | grep -ve "^#" | grep -w $2)
+    IFS="=" read key val <<< $config_line
+    ucval=$(tr \[a-z\] \[A-Z\] <<< $val)
+
+    case $value in
+      unset)
+        if [ -n "$config_line" -a "$ucval" != "N" ]; then
+            echo "FAIL - $config_line must not be enabled in $file"
+            exit 1
+        fi
+      ;;
+      set)
+        if [ -z "$config_line" -o "$ucval" == "N" ]; then
+            echo "FAIL - $config_line must be enabled in $file"
+            exit 1
+        fi
+      ;;
+      *)
+        if [ -z "$config_line" -o "$val" == "$value" ]; then
+            echo "FAIL: $config_line must be have value $value in $file"
+            exit 1
+        fi
+      ;;
+    esac
+
+    echo "OK - $config_line has value $value in $file"
+}
+
+
+kernel_configfiles=$(ls -1 ${rootfsDir}/boot/config-*)
+
+for config in $kernel_configfiles; do
+    check_config_line $config "CONFIG_DEBUG_INFO_BTF" "set"
+done

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -19,5 +19,5 @@ bird2
 syslinux
 syslinux-common
 
-main/l/linux-signed-amd64/linux-image-${arch}_5.10.83-1gardenlinux1_${arch}.deb
-main/l/linux-signed-amd64/linux-image-5.10.0-9-${arch}_5.10.83-1gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.100-garden-${arch}_5.10.100-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.100-0gardenlinux1_${arch}.deb


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Upgrades the kernel to 5.10.100 and (re-) enables `CONFIG_DEBUG_INFO_BTF`. Disables rp_filter to improve compatibility with Cilium.

**Special notes for your reviewer**:

This PR must be merged into `rel-576`, not into `main`.

**Fixes**:

Issue #649 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: Disable rp_filter for better compatibility to Cilium
feat: kernel 5.10.100 with BTF for GL576.4
chore: git-ignore logs files from tests
test: check for required kernel configuration
```
