### PR TITLE
Fix: use dracut pkgs from repo for metal-iso

### DIFF
--- a/features/_iso/pkg.include
+++ b/features/_iso/pkg.include
@@ -1,2 +1,3 @@
-main/d/dracut/dracut-core_055-1gardenlinux2_${arch}.deb
-main/d/dracut/dracut_055-1gardenlinux2_all.deb
+dracut-core
+dracut
+binutils


### PR DESCRIPTION
**What this PR does / why we need it**:

`features/_iso/pkg.include` referenced old deb pool from outdated package build.
This leads to a failing `make metal-iso`: 
```
++ mktemp -d -p rootfs
+ tmp=rootfs/tmp.uJezFXWA1P
+ '[' '' '!=' '' ']'
+ '[' './dracut-core_055-1gardenlinux2_amd64.deb ./dracut_055-1gardenlinux2_all.deb ' '!=' '' ']'
+ /opt/gardenlinux/bin/garden-chroot rootfs bash -c '
        cd /tmp.uJezFXWA1P
        INITRD="No" apt-get install -y --allow-downgrades --no-install-recommends -f $1
' -- './dracut-core_055-1gardenlinux2_amd64.deb ./dracut_055-1gardenlinux2_all.deb '
Reading package lists...
E: Unsupported file ./dracut-core_055-1gardenlinux2_amd64.deb given on commandline
E: Unsupported file ./dracut_055-1gardenlinux2_all.deb given on commandline
```

**Special notes for your reviewer**:

Also added binutils to the image so that dracut can use it to create an executable UEFI. Otherwise: 
```
dracut: Executing: /usr/bin/dracut -f /tmp/unified 5.10.100-garden-amd64 --uefi --kernel-cmdline "console=tty0 console=ttyS0,115200 gl.ovl=/:tmpfs ip=dhcp gl.ram=1" -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown gardenlinux-live" -o gardenlinux --reproducible
dracut: Need 'objcopy' to create a UEFI executable
make: *** [Makefile:138: metal-iso] Error 1
```
