### PR TITLE
fix: github_release build-config

### DIFF
--- a/ci/github_release.py
+++ b/ci/github_release.py
@@ -41,10 +41,15 @@ def _get_download_url(
         print(f'Could not find path for platform {platform=}, skipping release.')
         return None
 
+    if image_metadata_tag:
+        image_metadata = getattr(manifest.published_image_metadata, image_metadata_tag)
+    else:
+        image_metadata = None
+
     return (
         path.name,
         f'https://gardenlinux.s3.eu-central-1.amazonaws.com/{path.s3_key}',
-        getattr(manifest.published_image_metadata, image_metadata_tag),
+        image_metadata,
     )
 
 
@@ -158,6 +163,16 @@ def make_release(
     )
     print(f'Openstack: name: {name_openstack}, url: {download_link_openstack}')
 
+    platform = 'vmware'
+    suffix = glci.util.virtual_image_artifact_for_platform(platform)
+    name_vmware, download_link_vmware, ids_vmware = _get_download_url(
+        platform=platform,
+        suffix=suffix,
+        manifest_set=manifest_set,
+        image_metadata_tag=None
+    )
+    print(f'VMware: name: {name_vmware}, url: {download_link_vmware}')
+
     # Generate markdown:
     template_path = os.path.abspath(
         os.path.join(repo_dir, "ci/templates/github_release.md")
@@ -183,6 +198,8 @@ def make_release(
         'gcp_id': id_gcp,
         'openstack_name': name_openstack,
         'openstack_url': download_link_openstack,
+        'vsphere_name': name_vmware,
+        'vsphere_url': download_link_vmware,
     }
     release_descr = release_template.safe_substitute(values)
 

--- a/ci/templates/github_release.md
+++ b/ci/templates/github_release.md
@@ -52,6 +52,9 @@ urn: $azure_id
 ### Openstack CCEE (AMD64, VMware as Hypervisor)
 * [$openstack_name]($openstack_url)
 
+### VMware vSphere (AMD64)
+* [$vsphere_name]($vsphere_url)
+
 <details>
 
 ## How to import images to public Cloud Providers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:

Fixes `github_release.py` which stopped working with the changes introduced in PR #600. Includes links to documentation on how to import Garden Linux images into public cloud providers (which were removed in PR #657) into the GitHub Release template. Finally, it adds the download link to vSphere images into the GitHub release page generator.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
fix: github_release build-config
doc: include links to import guide in release template
feat: include vSphere images in release page
```
