### PR TITLE
Fix package priority of the Garden Linux repo

### DIFF
--- a/features/base/file.include/etc/apt/preferences.d/gardenlinux
+++ b/features/base/file.include/etc/apt/preferences.d/gardenlinux
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=GardenLinux
+Pin-Priority: 900


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
It fixes issues with package dependencies like it is currently the case with the `rkhunter` test  during the build by ensuring that packages from the Garden Linux have a higher priority than other package repos (e.g. `debian/bookworm`)

**Which issue(s) this PR fixes**:
Fixes #668 
