### PR TITLE
look for rw partition and make sure it is last for makedisk input

### DIFF
--- a/bin/garden-build
+++ b/bin/garden-build
@@ -203,7 +203,11 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 			elif [ -s $featureDir/$i/image ]; then
 				"$featureDir/$i/image" "$rootfs" "$targetBase"
 			elif [ -f "$featureDir/$i/fstab" ]; then
-				makepart "$rootfs" "$arch" < "$featureDir/$i/fstab" | makedisk "$rootfs" "$targetBase.raw"
+				# find the writable partition and make sure it is the last one in the next step
+				rwpart=$(sed -n '/rw/ s/LABEL=\([[:upper:]]*\).*/\1/p' < "$featureDir/$i/fstab")
+				makepart "$rootfs" "$arch" < "$featureDir/$i/fstab" \
+				| sed '$a\\n' | sed "/$rwpart/{h;d}; \$g; /^$/d" \
+				| makedisk "$rootfs" "$targetBase.raw"
 			else
 				true
 			fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Find the rw partition in fstab and move it to be last partition for makedisk input. 
**Which issue(s) this PR fixes**:
Fixes #631 

**Special notes for your reviewer**:
A little hackish, but it solves the problem without re-writing the makepart script.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
