### PR TITLE
fix gcp to work with new google-guest-agent package in repo

### DIFF
--- a/features/gcp/exec.config
+++ b/features/gcp/exec.config
@@ -4,9 +4,6 @@ set -Eeuo pipefail
 # set default timezone
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
-# cannot execute startup script in /tmp, usr /var/tmp instead
-sed -i 's/^run_dir =\s*/run_dir = \/var\/tmp/g' /etc/default/instance_configs.cfg
-
 cat >>/etc/ssh/sshd_conf <<EOF
 
 # Needed for google oslogin

--- a/features/gcp/file.include/etc/default/instance_configs.cfg
+++ b/features/gcp/file.include/etc/default/instance_configs.cfg
@@ -1,0 +1,38 @@
+[Accounts]
+deprovision_remove = false
+gpasswd_add_cmd = gpasswd -a {user} {group}
+gpasswd_remove_cmd = gpasswd -d {user} {group}
+groupadd_cmd = groupadd {group}
+groups = adm,dip,docker,lxd,plugdev,video
+useradd_cmd = useradd -m -s /bin/bash -p * {user}
+userdel_cmd = userdel -r {user}
+
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+network_daemon = true
+
+[InstanceSetup]
+host_key_types = ecdsa,ed25519,rsa
+network_enabled = true
+optimize_local_ssd = true
+set_boto_config = true
+set_host_keys = true
+set_multiqueue = true
+
+[IpForwarding]
+ethernet_proto_id = 66
+ip_aliases = true
+target_instance_ips = true
+
+[MetadataScripts]
+default_shell = /bin/bash
+run_dir = /var/tmp
+shutdown = true
+startup = true
+
+[NetworkInterfaces]
+dhclient_script = /sbin/google-dhclient-script
+dhcp_command =
+ip_forwarding = true
+setup = true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

https://gitlab.com/gardenlinux/gardenlinux-package-build/-/commit/f2b28665 updated repo to mirror debian version of google-guest-agent. This broke `gcp/exec.config` because it no longer ships with `/etc/default/instance_configs.cfg`. This PR fixes it by providing a default config in `gcp/file.include`
