### PR TITLE
fix: remove cni demo binaries from garden feature

### DIFF
--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -1,6 +1,5 @@
 apparmor
 containerd
-containernetworking-plugins
 docker.io
 ethtool
 ipvsadm

--- a/features/khost/pkg.include
+++ b/features/khost/pkg.include
@@ -1,5 +1,4 @@
 apparmor
-containernetworking-plugins
 conntrack
 ethtool
 ipvsadm


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:

The package `containernetworking-plugins` just contains "Some reference and example networking plugins" according to their [GitHub project page](https://github.com/containernetworking/plugins). Gardener does not need these, as we are deploying Calico or Cilium as CNI.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix: remove cni demo binaries from garden feature
```
