### PR TITLE
Disable verity feature for KVM images

### DIFF
--- a/features/kvm/fstab
+++ b/features/kvm/fstab
@@ -1,0 +1,4 @@
+# <file system>    <dir>        <type>    <options>                                <makeimg args>
+LABEL=EFI          /boot/efi    vfat      umask=0077                               type=uefi
+LABEL=ROOT         /            ext4      rw,errors=remount-ro,prjquota,discard
+LABEL=USR          /usr         ext4      ro,discard

--- a/features/kvm/info.yaml
+++ b/features/kvm/info.yaml
@@ -3,7 +3,6 @@ type: platform
 features:
   include: 
     - cloud
-    - _fstab_verity
 disk:
   boot: 
     - efi


### PR DESCRIPTION
Temporary disable the 'verity' feature for 'kvm' images. The
current 'verity' implementation seems to be buggy. Therefore, we
need to disable this feature temporary to proceed with other tasks.

Fixes: #677

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR deactivates temporary the verity feature for KVM images to make sure we can proceed with other tasks.
Verity must be reimplemented in a more stable way. However, this gives us more possibilities to identify the needed parts while log files (and journal) will be written, now.

**Which issue(s) this PR fixes**:
Fixes #677 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
