### PR TITLE
Mark which.debianutils as a script

### DIFF
--- a/features/base/test/rkhunter.d/rkhunter.conf
+++ b/features/base/test/rkhunter.d/rkhunter.conf
@@ -14,6 +14,7 @@ DISABLE_TESTS=immutable suspscan hidden_ports hidden_procs deleted_files packet_
 SCRIPTWHITELIST=/usr/bin/egrep
 SCRIPTWHITELIST=/usr/bin/fgrep
 SCRIPTWHITELIST=/usr/bin/which
+SCRIPTWHITELIST=/usr/bin/which.debianutils
 SCRIPTWHITELIST=/usr/bin/ldd
 SCRIPTWHITELIST=/usr/sbin/adduser
 WEB_CMD="/bin/false"


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This merge request marks the `which.debianutils` file as a script, so that `rkhunter` isn't throwing a false positive during the unit tests.

**Which issue(s) this PR fixes**:
Fixes #680
