### PR TITLE
Let Github Actions run with --lessram

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,4 @@ jobs:
           version=$(curl -s -f https://deb.debian.org/debian/pool/main/q/qemu/ | grep -oP '(?<=href="qemu-user-static_).*?(?=_amd64.deb")' | sort | tail -n 1)
           wget https://deb.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}_amd64.deb
           sudo dpkg -i qemu-user-static_${version}_amd64.deb
-      - run: make ARCH=${{ matrix.architecture }} ${{ matrix.target }}${{ matrix.modifier }}
+      - run: make BUILD_OPTS=--lessram ARCH=${{ matrix.architecture }} ${{ matrix.target }}${{ matrix.modifier }}


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that the Github Action builds are executed with the `--lessram` parameter. It reduces the memory consumption of the Github Action builds which should mitigate failed builds due to memory issues.

**Which issue(s) this PR fixes**:
Fixes #689 
