### PR TITLE
Add SSH Hardening documentation

### DIFF
--- a/docs/configuration/ssh-hardening.md
+++ b/docs/configuration/ssh-hardening.md
@@ -1,0 +1,90 @@
+---
+title: SSH Hardening
+weight: 10
+disableToc: false
+---
+
+This document highlights which SSH configuration parameters are set in Garden Linux in order to harden it. Thereby, it also explains why specific values have been set and what were the reasons for them.
+
+## Configuration parameters
+The SSH configuration of Garden Linux is mainly done in the [server feature](https://github.com/gardenlinux/gardenlinux/tree/main/features/server).
+
+It provides the `openssh-server` package and the corresponding configuration ([sshd_config]((https://github.com/gardenlinux/gardenlinux/blob/main/features/server/file.include/etc/ssh/sshd_config))) to properly install and configure a SSH server.
+
+By that, the following aspects has been taken into consideration to improve the overall security.
+
+### Direct Root Login
+Direct root login **MUST** be disabled. Therefore, the `PermitRootLogin` parameter is set to `no`.
+
+### TCP Forwarding
+Disabling the TCP Forwarding does not bring a significant security improvement since users which have SSH access to hosts are still able to use other forwarders like `nc` or `socat` to work around this limitation.
+
+Moreover, there are cases in which this feature is explicitly required. This is the case for the Gardener bastion host for example.
+
+As a result, TCP Forwarding is not disabled in Garden Linux.
+
+### X11 Forwarding
+X11 Forwarding on the other hand is already disabled by default in the OpenSSH configuration.
+
+However, the corresponding `sshd_config` of Garden Linux explicitly sets the `X11Forwarding` parameter to `no`
+
+### Public Key Authentication
+Public Key Authentication is the preferred authentication method in Garden Linux. There may also be some cloud providers which are enabling password authentication by default, but Garden Linux only enables Public Key Authentication
+
+This is achieved by setting the `AuthenticationMethods` parameter to `publickey` only.
+
+### Verbose Log Level
+In order to provide a good audit track, a verbose Log Level of SSH is recommended.
+
+For this reason, Garden Linux sets the `LogLevel` parameter to `VERBOSE` to achieve this.
+
+### Host authentication
+In general, host authentication should not be enabled by default. Only automated processes **MAY** use this authentication method.
+
+By default, Garden Linux sets the `HostbasedAuthentication` parameter to `no` to disable host authentication.
+
+### Cipher Suites, Kex Algorithms and Message Authentication Codes
+Overall, the default Cipher Suites of OpenSSH - as they are used in Garden Linux via the `debian/testing` package - already fulfill a specific level of security.
+
+The designated SSH Team of Debian always tries to use a State of the Art level of security for the Cipher Suites, Kex Algorithms and MACs.
+
+#### Cipher Suites
+
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) uses the following ciphers:
+```
+chacha20-poly1305@openssh.com,
+aes128-ctr,aes192-ctr,aes256-ctr,
+aes128-gcm@openssh.com,aes256-gcm@openssh.com
+```
+
+As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default ciphers used by OpenSSH are considered to be strong.
+
+#### Kex Algorithms
+
+The [OpenSSH configuration](42https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) uses Key Exchange (Kex) Algorithms like:
+```
+curve25519-sha256,curve25519-sha256@libssh.org,
+ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,
+diffie-hellman-group-exchange-sha256,
+diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,
+diffie-hellman-group14-sha256
+
+```
+
+As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default Kex Algorithms used by OpenSSH are considered to be strong, too.
+
+#### Message Authentication Codes (MACs)
+
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) uses MACs like:
+```
+umac-64-etm@openssh.com,umac-128-etm@openssh.com,
+hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,
+hmac-sha1-etm@openssh.com,
+umac-64@openssh.com,umac-128@openssh.com,
+hmac-sha2-256,hmac-sha2-512,hmac-sha1
+```
+
+The OpenSSH default configuration still supports HMAC-SHA-1. Althrough SHA-1 is not recommended to be used as a plain hash algorithm, it can still be used as a hash algorithm for MACs as [RFC 6194](https://datatracker.ietf.org/doc/rfc6194/) stats:
+```
+As of today, there is no indication that attacks on SHA-1 can be extended to HMAC-SHA-1.
+```

--- a/docs/configuration/ssh-hardening.md
+++ b/docs/configuration/ssh-hardening.md
@@ -4,53 +4,53 @@ weight: 10
 disableToc: false
 ---
 
-This document highlights which SSH configuration parameters are set in Garden Linux in order to harden it. Thereby, it also explains why specific values have been set and what were the reasons for them.
+This document highlights which SSH configuration parameters are set in Garden Linux in order to harden it. Thereby, it also explains which specific values are set and what their reasons are.
 
 ## Configuration parameters
 The SSH configuration of Garden Linux is mainly done in the [server feature](https://github.com/gardenlinux/gardenlinux/tree/main/features/server).
 
-It provides the `openssh-server` package and the corresponding configuration ([sshd_config]((https://github.com/gardenlinux/gardenlinux/blob/main/features/server/file.include/etc/ssh/sshd_config))) to properly install and configure a SSH server.
+It provides the `openssh-server` package and the corresponding configuration ([sshd_config](https://github.com/gardenlinux/gardenlinux/blob/main/features/server/file.include/etc/ssh/sshd_config)) to properly install and configure a SSH server.
 
 By that, the following aspects has been taken into consideration to improve the overall security.
 
 ### Direct Root Login
-Direct root login **MUST** be disabled. Therefore, the `PermitRootLogin` parameter is set to `no`.
+Direct root login **MUST** be disabled. As a result, the `PermitRootLogin` parameter is set to `no`.
 
 ### TCP Forwarding
-Disabling the TCP Forwarding does not bring a significant security improvement since users which have SSH access to hosts are still able to use other forwarders like `nc` or `socat` to work around this limitation.
+Disabling the TCP Forwarding does not bring a significant security improvement since users that have SSH access are still able to use other forwarders like `nc` or `socat` to work around this limitation.
 
 Moreover, there are cases in which this feature is explicitly required. This is the case for the Gardener bastion host for example.
 
-As a result, TCP Forwarding is not disabled in Garden Linux.
+Therefore, TCP Forwarding is not disabled in Garden Linux.
 
 ### X11 Forwarding
-X11 Forwarding on the other hand is already disabled by default in the OpenSSH configuration.
+Besides the TCP Forwarding, X11 Forwarding on the other hand is already disabled in the OpenSSH configuration by default.
 
-However, the corresponding `sshd_config` of Garden Linux explicitly sets the `X11Forwarding` parameter to `no`
+In addition, the corresponding `sshd_config` of Garden Linux explicitly sets the `X11Forwarding` parameter to `no`
 
 ### Public Key Authentication
-Public Key Authentication is the preferred authentication method in Garden Linux. There may also be some cloud providers which are enabling password authentication by default, but Garden Linux only enables Public Key Authentication
+Public Key Authentication is the preferred authentication method in Garden Linux. There might be some cloud providers which are enabling password authentication for their customers after the initialization, but Garden Linux only enables Public Key Authentication by default.
 
 This is achieved by setting the `AuthenticationMethods` parameter to `publickey` only.
 
 ### Verbose Log Level
-In order to provide a good audit track, a verbose Log Level of SSH is recommended.
+In order to provide a good audit track, a verbose Log Level of the SSH Server is recommended.
 
-For this reason, Garden Linux sets the `LogLevel` parameter to `VERBOSE` to achieve this.
+For this reason, Garden Linux sets the `LogLevel` parameter to `VERBOSE`.
 
 ### Host authentication
 In general, host authentication should not be enabled by default. Only automated processes **MAY** use this authentication method.
 
-By default, Garden Linux sets the `HostbasedAuthentication` parameter to `no` to disable host authentication.
+As a result, Garden Linux sets the `HostbasedAuthentication` parameter to `no` to disable host authentication.
 
 ### Cipher Suites, Kex Algorithms and Message Authentication Codes
-Overall, the default Cipher Suites of OpenSSH - as they are used in Garden Linux via the `debian/testing` package - already fulfill a specific level of security.
+Overall, the default Cipher Suites of OpenSSH already provides a set of algorithms that are considered to be safe. Thereby, Garden Linux uses the OpenSSH version that `debian/testing` provides, so there is an additional layer of trust.
 
-The designated SSH Team of Debian always tries to use a State of the Art level of security for the Cipher Suites, Kex Algorithms and MACs.
+If the default configuration of OpenSSH would provide a non secure Cipher Suite, Kex Algorithm or Message Authentication Code, this team would probably remove the corresponding algorithm from the default list.
 
 #### Cipher Suites
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) uses the following ciphers:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) of the corresponding Debian package uses the following default ciphers:
 ```
 chacha20-poly1305@openssh.com,
 aes128-ctr,aes192-ctr,aes256-ctr,
@@ -61,7 +61,7 @@ As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default ciph
 
 #### Kex Algorithms
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L582-586) uses Key Exchange (Kex) Algorithms like:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L582-586) of the corresponding Debian package uses default Key Exchange (Kex) Algorithms like:
 ```
 curve25519-sha256,curve25519-sha256@libssh.org,
 ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,
@@ -75,7 +75,7 @@ As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default Kex 
 
 #### Message Authentication Codes (MACs)
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L669-673) uses MACs like:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L669-673) of the corresponding Debian package uses default MACs like:
 ```
 umac-64-etm@openssh.com,umac-128-etm@openssh.com,
 hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,

--- a/docs/configuration/ssh-hardening.md
+++ b/docs/configuration/ssh-hardening.md
@@ -61,7 +61,7 @@ As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default ciph
 
 #### Kex Algorithms
 
-The [OpenSSH configuration](42https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) uses Key Exchange (Kex) Algorithms like:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L582-586) uses Key Exchange (Kex) Algorithms like:
 ```
 curve25519-sha256,curve25519-sha256@libssh.org,
 ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,
@@ -75,7 +75,7 @@ As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default Kex 
 
 #### Message Authentication Codes (MACs)
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) uses MACs like:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L669-673) uses MACs like:
 ```
 umac-64-etm@openssh.com,umac-128-etm@openssh.com,
 hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR contains a documentation about the SSH Hardening actions done in Garden Linux. It also explains what SSH configuration parameters have been set (and where) and what the reason were.

**Which issue(s) this PR fixes**:
Fixes #516

**Special notes for your reviewer**:
As of now, the current [sshd_config](https://github.com/gardenlinux/gardenlinux/blob/516_add_ssh_hardening_docs/features/server/file.include/etc/ssh/sshd_config#L26-L28) still sets Cipher Suites, Kex Algorithms and MACs explicitly. However, the documentation recommends to use the default algorithms that the OpenSSH implementation provides.

There may be a change in future which affects either these configuration parameters or the corresponding section in the documentation.
