### PR TITLE
update: kernel 5.10.103

### DIFF
--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -6,5 +6,5 @@ syslinux-common
 cloud-guest-utils
 libpam-cracklib
 rng-tools5
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.100-garden-cloud-${arch}_5.10.100-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.100-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.103-garden-cloud-${arch}_5.10.103-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.103-0gardenlinux1_${arch}.deb

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -19,5 +19,5 @@ bird2
 syslinux
 syslinux-common
 
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.100-garden-${arch}_5.10.100-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.100-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.103-garden-${arch}_5.10.103-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.103-0gardenlinux1_${arch}.deb


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
* Upgrades the kernel to 5.10.103.
* Disabled `CONFIG_LOCK_DOWN_KERNEL_FORCE_INTEGRITY` again (as in 576.2 and before), to allow usage of externally build drivers. 

**Which issue(s) this PR fixes**:
Fixes #688
Fixes an issue where users have reported that custom build drivers could not be loaded (due to `CONFIG_LOCK_DOWN_KERNEL_FORCE_INTEGRITY`) 

**Special notes for your reviewer**:
This PR must be merged into `rel-576`, not into main.


**Release note**:

```feature user
feat: kernel update to 5.10.103
```
