### PR TITLE
Sync sshd_config with SSH documentation

### DIFF
--- a/docs/configuration/ssh-hardening.md
+++ b/docs/configuration/ssh-hardening.md
@@ -50,32 +50,31 @@ If the default configuration of OpenSSH would provide a non secure Cipher Suite,
 
 #### Cipher Suites
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L276-278) of the corresponding Debian package uses the following default ciphers:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.9p1-3/sshd_config.0#L276-278) of the corresponding Debian package uses the following default ciphers:
 ```
 chacha20-poly1305@openssh.com,
 aes128-ctr,aes192-ctr,aes256-ctr,
 aes128-gcm@openssh.com,aes256-gcm@openssh.com
 ```
 
-As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default ciphers used by OpenSSH are considered to be strong.
-
 #### Kex Algorithms
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L582-586) of the corresponding Debian package uses default Key Exchange (Kex) Algorithms like:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.9p1-3/sshd_config.0#L580-585) of the corresponding Debian package uses default Key Exchange (Kex) Algorithms like:
 ```
 curve25519-sha256,curve25519-sha256@libssh.org,
 ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,
+sntrup761x25519-sha512@openssh.com,
 diffie-hellman-group-exchange-sha256,
 diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,
 diffie-hellman-group14-sha256
 
 ```
 
-As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default Kex Algorithms used by OpenSSH are considered to be strong, too.
+As [RFC 9142](https://datatracker.ietf.org/doc/rfc9142/) stats, the default Kex Algorithms used by OpenSSH are considered to be strong.
 
 #### Message Authentication Codes (MACs)
 
-The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.8p1-1/sshd_config.0#L669-673) of the corresponding Debian package uses default MACs like:
+The [OpenSSH configuration](https://salsa.debian.org/ssh-team/openssh/-/blob/debian/1%258.9p1-3/sshd_config.0#L668-672) of the corresponding Debian package uses default MACs like:
 ```
 umac-64-etm@openssh.com,umac-128-etm@openssh.com,
 hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,

--- a/features/server/file.include/etc/ssh/sshd_config
+++ b/features/server/file.include/etc/ssh/sshd_config
@@ -22,11 +22,7 @@ LogLevel VERBOSE
 # Ensure usage of PAM
 UsePAM yes
 
-# Use secure Ciphers
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
-KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
-
+# Disable message of the day
 PrintMotd no
 
 # Allow client to pass locale environment variables

--- a/features/server/test/sshd.d/ssh_expected
+++ b/features/server/test/sshd.d/ssh_expected
@@ -3,11 +3,11 @@ HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
 # HostKey /etc/ssh/ssh_host_ecdsa_key
  
-KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,sntrup761x25519-sha512@openssh.com,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
  
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
  
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
  
 # Password based logins are disabled - only public key based logins are allowed.
 AuthenticationMethods publickey


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that the [SSH documentation](https://github.com/gardenlinux/gardenlinux/blob/701_sync_sshd_config/docs/configuration/ssh-hardening.md) and the [sshd_config](https://github.com/gardenlinux/gardenlinux/blob/701_sync_sshd_config/features/server/file.include/etc/ssh/sshd_config) are in sync by ensuring that `Ciphers`, `KexAlgorithms` and `MACs` are set properly. 

In addition, the SSH documentation has been updated to reference the current OpenSSH version and its default configuration.

**Which issue(s) this PR fixes**:
Fixes #701 