### PR TITLE
fix: remove arptables and ebtables packages

### DIFF
--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -6,8 +6,6 @@ ipvsadm
 socat
 curl
 logrotate
-arptables
-ebtables
 xfsprogs
 btrfs-progs
 jq


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

- Setup of arptables and ebtables is broken (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1007829)
- Remove both from `gardener/pkg.include` since most features should be covered by iptables anyways