### PR TITLE
fix: garden-version script when given version number as input

### DIFF
--- a/bin/garden-version
+++ b/bin/garden-version
@@ -51,6 +51,7 @@ then	[ $(cut -d. -sf3 <<< ${input}) ] && eusage "invalid version format ${input}
 	if [ $(cut -d. -sf2 <<< ${input}) ]; then 
 		minor="$(cut -d. -f2 <<< ${input})"
 	fi
+	version="${major}.${minor}"
 else	if	[[ ${input} = dev ]];
 	then	indate=$(date --date "today" +%s 2>/dev/null)
 		major="$(( (${indate} - $(date --date "${startdate}" +%s)) / (60*60*24) ))"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Currently `bin/garden-version` only works with *"dev"* or a date as input, but breaks when given a version number as input. This PR fixes that.
