### PR TITLE
feat: use self hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: gardenlinux-${{ matrix.architecture }}
     strategy:
       matrix:
         architecture: [ amd64, arm64 ]
@@ -10,8 +10,4 @@ jobs:
         modifier: [ "", "-dev" ]
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          version=$(curl -s -f https://deb.debian.org/debian/pool/main/q/qemu/ | grep -oP '(?<=href="qemu-user-static_).*?(?=_amd64.deb")' | sort | tail -n 1)
-          wget https://deb.debian.org/debian/pool/main/q/qemu/qemu-user-static_${version}_amd64.deb
-          sudo dpkg -i qemu-user-static_${version}_amd64.deb
-      - run: make BUILD_OPTS=--lessram ARCH=${{ matrix.architecture }} ${{ matrix.target }}${{ matrix.modifier }}
+      - run: make ARCH=${{ matrix.architecture }} ${{ matrix.target }}${{ matrix.modifier }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

- use selfhosted github action runners instead of github hosted runners
  - allows for native arm builds which are significantly faster than current cross architecture builds
  - our self hosted runners are configured with more ram than github's runners, so `--lessram` option is no longer needed
