### PR TITLE
doc: use new container for kernel module build

### DIFF
--- a/docs/build/driver.md
+++ b/docs/build/driver.md
@@ -7,21 +7,21 @@ disableToc: false
 Drivers/LKMs not included in upstream linux of kernel.org can be build out of tree.
 
 ## build-kernelmodule container 
+We provide build container that come with gardenlinux linux-headers installed. 
+These build containers have a `uname -r` wrapper installed. 
+This wrapper outputs the latest installed kernel header in that container.
 
-The ```gardenlinux/build-kernelmodule:$(KERNEL_VERSION)``` container comes with pre-installed kernel headers for the respective kernel version.
+Container is created here: https://gitlab.com/gardenlinux/driver/gardenlinux-driver-build-container
 
-Before building this container, the following packages are required to be available under ```.packages/main/l/linux/```
 
-- ```linux-kbuild*$(KERNEL_VERSION)*.deb ```
-- ```linux-compiler-gcc*$(KERNEL_VERSION)*.deb ```
-- ```linux-headers*$(KERNEL_VERSION)*.deb ```
+```
+docker pull registry.gitlab.com/gardenlinux/driver/gardenlinux-driver-build-container/gl-driver-build:dev
+```
 
-The ```KERNEL_VERSION``` variable is set in docker/Makefile. 
+## manual kernel module build
 
-## manual LKM/Driver build
-
-1. Load your LKM sources into the container
-1. Make sure the LKM Makefile uses the kbuild system preinstalled in the container 
+1. Load your kernel module sources into the container
+1. If the Makefile does not use `uname -r`, make sure to reference the correct kernel headers
     * e.g: ```$(MAKE) -C /lib/modules/$(BUILD_KERNEL)/build M=$(CURDIR) modules```
 1. continue with the LKM build instructions
 


### PR DESCRIPTION
**What**
Added documentation on where to find the kernel module build container. 

Previous documentation is outdated.

**Note**
We will probably change the location where to find the container. Until then, let us keep the docs up to date. 


