### PR TITLE
feat(test): add chroot as integration test platform (#709)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -544,7 +544,68 @@ Run the tests (be sure you properly mounted the Garden Linux repository to the c
     pytest --iaas=kvm --configfile=/config/mykvmconfig.yaml integration/
 
 
-### 2.7. Manual testing
+### 2.7 CHROOT
+
+CHROOT tests are designed to run directly on your platform within a `chroot` environment and boosts up the time for the integration tests that do not need any target platform.
+
+Notes:
+ * CHROOT will run inside your `integration-test` Docker container
+ * Docker container needs `SYS_ADMIN` capability
+ * Temporary SSH keys are auto generated and injected
+
+Use the following configuration file to proceed; only the path to the TAR image needs to be adjusted:
+
+```yaml
+chroot:
+    # Path to a final artifact. Represents the .tar.xz archive image file (required)
+    image: /gardenlinux/.build/kvm_dev-amd64-dev-local.tar.xz
+
+    # IP or hostname of target machine (required)
+    # Default: 127.0.0.1
+    ip: 127.0.0.1
+
+    # port for remote connection (required)
+    # Default: 2223
+    port: 2222
+
+    # SSH configuration (required)
+    ssh:
+        # Defines path where to look for a given key
+        # or to save the new generated one. Take care
+        # that you do NOT overwrite your key. (required)
+        ssh_key_filepath: /tmp/ssh_priv_key
+
+        # Defines the user for SSH login (required)
+        # Default: root
+        user: root
+```
+
+#### 2.7.1 Configuration options
+
+<details>
+
+- **ssh_key_filepath** _(required)_: The SSH key that will be injected to the *chroot* and that will be used by the test framework to log on to it. In default, you do **not** need to provide or mount your real SSH key; a new one will be generated and injected by every new run. However, if you really want, a present one can be defined - take care that this will not be overwritten and set `ssh_key_generate` to false.
+- **user** _(required)_: The user that will be used for the connection.
+</details>
+
+#### 2.7.2 Running the tests
+
+Start docker container with dependencies:
+
+- mount Garden Linux repository to `/gardenlinux`
+- mount build result directory to `/build` (if not part of the Garden Linux file tree)
+- mount directory with configfile to `/config`
+
+```
+docker run --cap-add SYS_ADMIN --security-opt apparmor=unconfined -it --rm -v `pwd`:/gardenlinux gardenlinux/integration-test:dev /bin/bash
+```
+
+Run the tests (be sure you properly mounted the Garden Linux repository to the container and you are in `/gardenlinux/tests`):
+
+    pytest --iaas=chroot --configfile=/config/mychrootmconfig.yaml integration/
+
+
+### 2.8. Manual testing
 
 So for some reason, you do not want to test Garden Linux by using a tool that automatically sets up the testbed in a cloud environment for you.
 
@@ -567,7 +628,7 @@ manual:
         user: admin
 ```
 
-#### 2.7.1 Running the tests
+#### 2.8.1 Running the tests
 
 Start docker container with dependencies:
 

--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -150,13 +150,9 @@ class CHROOT:
         """ Generate new SSH key for integration test """
         logger.info("Generating new SSH key for integration tests.")
         ssh_key_path = self.config["ssh"]["ssh_key_filepath"]
-        # Private key
-        key = paramiko.RSAKey.generate(2048)
-        key.write_private_key_file(ssh_key_path)
-        # Public key (as authorized_keys)
-        public_key = key.get_base64()
-        with open("/tmp/authorized_keys", "w") as f:
-            f.write("ssh-rsa " + public_key)
+        keyfp = RemoteClient.generate_key_pair(
+            filename = ssh_key_path,
+        )
         logger.info("SSH key for integration tests generated.")
 
 
@@ -219,12 +215,13 @@ class CHROOT:
             logger.error("Could not copy sshd_config_integration_tests to {dir}".format(
               dir=chroot_sshd_cfg_dir))
         # Copy ssh / authorized_keys file for root user
+        local_ssh_key_path = self.config["ssh"]["ssh_key_filepath"] + ".pub"
         chroot_root_dir = tmp_dir + "/root/"
         chroot_ssh_authorized_keys = chroot_root_dir + ".ssh/authorized_keys"
         ssh_authorized_keys = "/tmp/authorized_keys"
         self._create_dir(chroot_root_dir+".ssh", 0o600)
         try:
-            shutil.copyfile("/tmp/authorized_keys", chroot_ssh_authorized_keys)
+            shutil.copyfile(local_ssh_key_path, chroot_ssh_authorized_keys)
             logger.info("Copied authorized_keys to: {dir}".format(
               dir=chroot_ssh_authorized_keys))
         except OSError:

--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -197,7 +197,7 @@ class CHROOT:
         # Generate chroot sshd directory for run/pid
         chroot_sshd_run_dir = rootfs + "/run/sshd"
         try:
-            os.mkdir(rootfs + "/run/sshd")
+            os.mkdir(chroot_sshd_run_dir)
             logger.info("Created directory: {dir}".format(
               dir=chroot_sshd_run_dir))
         except OSError:
@@ -207,7 +207,7 @@ class CHROOT:
         sshd_config_src_file = "integration/misc/sshd_config_integration_tests"
         chroot_sshd_cfg_dir = rootfs + "/etc/ssh/"
         try:
-            shutil.copyfile(sshd_config_src_file, chroot_sshd_cfg_dir+"sshd_config_integration_tests")
+            shutil.copy(sshd_config_src_file, chroot_sshd_cfg_dir)
             logger.info("Copied sshd_config_integration_tests to: {dir}".format(
               dir=chroot_sshd_cfg_dir))
         except OSError:
@@ -232,13 +232,12 @@ class CHROOT:
         """ Start sshd inside the chroot """
         # Define vars to have it more readable
         gl_chroot_bin = "/gardenlinux/bin/garden-chroot"
-        chroot = rootfs
         chroot_cmd = "/usr/sbin/sshd -D -f /etc/ssh/sshd_config_integration_tests"
         # Execute in Popen as background task
         # while we may perform our integration tests
         proc_exec = "{chroot_bin} {chroot_env} {chroot_cmd}".format(
           chroot_bin=gl_chroot_bin,
-          chroot_env=chroot,
+          chroot_env=rootfs,
           chroot_cmd=chroot_cmd)
         p = subprocess.Popen([proc_exec], shell=True)
         logger.info("Started SSHD in chroot environment.")
@@ -249,12 +248,12 @@ class CHROOT:
         port = self.config["port"]
         logger.info("Waiting for SSHD in chroot to be ready on tcp/{port}...".format(
           port=port))
-        cmd_chroot = "ssh-keyscan -p {port} localhost".format(
+        cmd = "ssh-keyscan -p {port} localhost".format(
           port=port)
 
         rc = 1
         while rc != 0:
-            p = subprocess.run([cmd_chroot], shell=True, stdout=subprocess.PIPE, \
+            p = subprocess.run([cmd], shell=True, stdout=subprocess.PIPE, \
               stderr=subprocess.STDOUT)
             rc = p.returncode
             logger.info(str(p.returncode) + " Waiting...")

--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -1,0 +1,298 @@
+import logging
+import json
+import time
+import os
+import subprocess
+import threading
+import tempfile
+import time
+import paramiko
+import pytest
+import sys
+import tempfile
+import lzma
+import tarfile
+import shutil
+import socket
+from contextlib import closing
+from novaclient import client
+from .sshclient import RemoteClient
+from . import util
+
+# Define global logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+BIN_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "bin")
+
+class CHROOT:
+    """Handle CHROOT flavour"""
+
+    @classmethod
+    def fixture(cls, config):
+
+        logger.info("Starting CHROOT integration tests.")
+
+        # We need to validate basic information
+        # for 'RemoteClient' object first. Afterwards
+        # we can run regular validation
+        logger.info("Validation starting...")
+        ip = config.get("ip", "127.0.0.1")
+        logger.info(f"Using IP {ip} to connect to chroot.")
+        port = config.get("port", "2222")
+        logger.info(f"Using port tcp/{port} to connect to chroot.")
+
+        chroot = CHROOT(config)
+        cls.chroot = chroot
+
+        try:
+            ssh = RemoteClient(
+                host=ip,
+                port=port,
+                sshconfig=config["ssh"],
+            )
+            yield ssh
+        finally:
+            if ssh is not None:
+                ssh.disconnect()
+            if chroot is not None:
+                chroot.__del__()
+
+    @classmethod
+    def instance(cls):
+        return cls.chroot
+
+
+    def __init__(self, config):
+        """ Creating self config """
+        # Define self.config
+        self.config = config
+        # Perform basic validation
+        self._validate()
+        # Unarchive defined tar ball
+        tmp_dir = self._unarchive_image()
+        # Generate temporary keys for integration testing
+        self._generate_ssh_key()
+        # Adjust chroot to be able to connect
+        self._adjust_chroot(tmp_dir)
+        # Start sshd inside the chroot
+        self._start_sshd_chroot(tmp_dir)
+        # Make sure ssh is up and running to avoid
+        # Paramiko error messages
+        self._wait_sshd()
+
+
+    def __del__(self):
+        """ Cleanup resources held by this object """
+        if "keep_running" in self.config and self.config["keep_running"] == True:
+            logger.info("Keeping all resources")
+
+
+    def _validate(self):
+        """ Validate basic settings befor running the tests """
+        # Check if tar archive as image path is defined
+        if not "image" in self.config:
+            logger.error("No path to image archive defined.")
+        else:
+            logger.info("Path to image archive defined: {path}".format(
+              path=self.config["image"]))
+
+        # Check if tar archive as image path  is present
+        image_archive = os.path.exists(self.config["image"])
+        if image_archive:
+            logger.info("Image archive is present: {path}".format(
+              path=self.config["image"]))
+        else:
+            logger.error("Image archive is not present: {path}".format(
+              path=self.config["image"]))
+
+        # Check if port is defined
+        if not "port" in self.config:
+            logger.error("No port for ssh connection defined.")
+        else:
+            logger.info("Port for ssh connection defined: {port}".format(
+              port=self.config["port"]))
+
+        # Check if sshd port can be used
+        self._port_val(self.config["ip"], self.config["port"])
+
+
+    def _unarchive_image(self):
+        """ Unarchive image tar ball """
+        image = self.config["image"]
+        logger.info("Creating tmp_dir")
+        tmp_dir = tempfile.mkdtemp(prefix="gl-int-chroot-")
+        logger.info("Created tmp_dir in {tmp_dir}".format(
+          tmp_dir=tmp_dir))
+        logger.info("Unarchiving image {image} to {tmp_dir}".format(
+          image=image, tmp_dir=tmp_dir))
+        try:
+            with lzma.open(self.config["image"]) as f:
+                with tarfile.open(fileobj=f) as tar:
+                    content = tar.extractall(tmp_dir)
+        except IOError:
+            logger.error("Could not unarchive image file due to IO Error.")
+        except lzma.LZMAError:
+            logger.error("LZMA decompression error.")
+        except tarfile.ReadError:
+            logger.error(("Archive is present but can not be handled by tar."+
+                          "Validate that your tar archive is not corrupt."))
+        except tarfile.CompressionError:
+            logger.error("Used compression is not supported.")
+        except tarfile.HeaderError:
+            logger.error("Malformed tar header information.")
+        logger.info("Unarchived image {image} to {tmp_dir}".format(
+          image=image, tmp_dir=tmp_dir))
+        return tmp_dir
+
+
+    def _generate_ssh_key(self):
+        """ Generate new SSH key for integration test """
+        logger.info("Generating new SSH key for integration tests.")
+        ssh_key_path = self.config["ssh"]["ssh_key_filepath"]
+        # Private key
+        key = paramiko.RSAKey.generate(2048)
+        key.write_private_key_file(ssh_key_path)
+        # Public key (as authorized_keys)
+        public_key = key.get_base64()
+        with open("/tmp/authorized_keys", "w") as f:
+            f.write("ssh-rsa " + public_key)
+        logger.info("SSH key for integration tests generated.")
+
+
+    def _adjust_chroot(self, tmp_dir):
+        """ Adjust chroot to make it usable """
+        logger.info("Adjusting chroot environment")
+        # Adjust garden-epoch to dev
+        chroot_epoch = tmp_dir + "/" + "garden-epoch"
+        chroot_epoch_bool = os.path.exists(chroot_epoch)
+        if chroot_epoch_bool:
+            logger.warning("'garden-epoch' already present. This will be set to 'dev', now.")
+        try:
+            with open(chroot_epoch, 'w') as f:
+                f.write("dev")
+            logger.info("Wrote garden-epoch to chroot in {tmp_dir}".format(
+              tmp_dir=tmp_dir))
+        except IOError:
+            logger.error("Could not write garden-epoch to chroot in {tmp_dir}".format(
+              tmp_dir=tmp_dir))
+        # Generate SSH hostkeys for chroot
+        # (this way we do not need to execute this inside the 'chroot'
+        #  environment and still support amd64 and arm64 architectures)
+        chroot_ssh_dir = tmp_dir + "/etc/ssh/"
+        cmd_ssh_keys = []
+        cmd_ssh_keys.append('ssh-keygen -q -N "" -t dsa -f {ssh_dir}/ssh_host_dsa_key'.format(
+          ssh_dir=chroot_ssh_dir))
+        logger.info(cmd_ssh_keys)
+        cmd_ssh_keys.append('ssh-keygen -q -N "" -t rsa -b 4096 -f {ssh_dir}/ssh_host_rsa_key'.format(
+          ssh_dir=chroot_ssh_dir))
+        cmd_ssh_keys.append('ssh-keygen -q -N "" -t ecdsa -f {ssh_dir}/ssh_host_ecdsa_key'.format(
+          ssh_dir=chroot_ssh_dir))
+        cmd_ssh_keys.append('ssh-keygen -q -N "" -t ed25519 -f {ssh_dir}/ssh_host_ed25519_key'.format(
+          ssh_dir=chroot_ssh_dir))
+        for i in cmd_ssh_keys:
+            logger.info("Running command: {cmd}".format(
+              cmd=i))
+            p = subprocess.run([i], shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            rc = p.returncode
+            if rc != 0:
+                logger.error("Command failed.")
+            else:
+                logger.info("Command sucessfully executed.")
+        # Generate chroot sshd directory for run/pid
+        chroot_sshd_run_dir = tmp_dir + "/run/sshd"
+        try:
+            os.mkdir(tmp_dir + "/run/sshd")
+            logger.info("Created directory: {dir}".format(
+              dir=chroot_sshd_run_dir))
+        except OSError:
+            logger.error("Could not create directory: {dir}".format(
+              dir=chroot_sshd_run_dir))
+        # Copy dedicated sshd config to chroot
+        sshd_config_src_file = "integration/misc/sshd_config_integration_tests"
+        chroot_sshd_cfg_dir = tmp_dir + "/etc/ssh/"
+        try:
+            shutil.copyfile(sshd_config_src_file, chroot_sshd_cfg_dir+"sshd_config_integration_tests")
+            logger.info("Copied sshd_config_integration_tests to: {dir}".format(
+              dir=chroot_sshd_cfg_dir))
+        except OSError:
+            logger.error("Could not copy sshd_config_integration_tests to {dir}".format(
+              dir=chroot_sshd_cfg_dir))
+        # Copy ssh / authorized_keys file for root user
+        chroot_root_dir = tmp_dir + "/root/"
+        chroot_ssh_authorized_keys = chroot_root_dir + ".ssh/authorized_keys"
+        ssh_authorized_keys = "/tmp/authorized_keys"
+        self._create_dir(chroot_root_dir+".ssh", 0o600)
+        try:
+            shutil.copyfile("/tmp/authorized_keys", chroot_ssh_authorized_keys)
+            logger.info("Copied authorized_keys to: {dir}".format(
+              dir=chroot_ssh_authorized_keys))
+        except OSError:
+            logger.error("Could not copy authorized_keys to {dir}".format(
+              dir=chroot_ssh_authorized_keys))
+
+
+    def _start_sshd_chroot(self, tmp_dir):
+        """ Start sshd inside the chroot """
+        # Define vars to have it more readable
+        gl_chroot_bin = "/gardenlinux/bin/garden-chroot"
+        chroot = tmp_dir
+        chroot_cmd = "/usr/sbin/sshd -D -f /etc/ssh/sshd_config_integration_tests"
+        # Execute in Popen as background task
+        # while we may perform our integration tests
+        proc_exec = "{chroot_bin} {chroot_env} {chroot_cmd}".format(
+          chroot_bin=gl_chroot_bin,
+          chroot_env=chroot,
+          chroot_cmd=chroot_cmd)
+        p = subprocess.Popen([proc_exec], shell=True)
+        logger.info("Started SSHD in chroot environment.")
+
+
+    def _wait_sshd(self):
+        """ Wait for defined SSH port to become ready in chroot environment """
+        port = self.config["port"]
+        logger.info("Waiting for SSHD in chroot to be ready on tcp/{port}...".format(
+          port=port))
+        cmd_kvm = "ssh-keyscan -p {port} localhost".format(
+          port=port)
+
+        rc = 1
+        while rc != 0:
+            p = subprocess.Popen([cmd_kvm], shell=True, stdout=subprocess.PIPE, \
+              stderr=subprocess.STDOUT)
+            output = p.stdout.read()
+            output, error = p.communicate()
+            rc = p.returncode
+            logger.info(str(p.returncode) + " Waiting...")
+            time.sleep(5)
+        logger.info("SSH ready in chroot.")
+
+
+    def _create_dir(self, dir, mode):
+        """ Helper func: Create directory by given path and mode """
+        try:
+            orig_mask = os.umask(000)
+            os.makedirs(dir, mode)
+            os.umask(orig_mask)
+            logger.info("Created {dir} with mode {mode}.".format(
+                dir=dir, mode=mode))
+        except OSError:
+            logger.error("Directory {dir} already present.".format(
+                dir=dir))
+
+
+    def _port_val(self, host, port):
+        """ Helper func: Check if a port is already in use """
+        logger.info("Validating if {port} on {host} is already in use.".format(
+          host=host, port=port))
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(3)
+        try:
+            s.connect((host, port))
+            logger.error("Port {port} on {host} is alread in use.".format(
+              host=host, port=port))
+            return True
+        except:
+            logger.info("Port {port} on {host} can be used.".format(
+              host=host, port=port))
+            return False

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -14,6 +14,7 @@ from .aws import AWS
 from .gcp import GCP
 from .azure import AZURE
 from .openstackccee import OpenStackCCEE
+from .chroot import CHROOT
 from .kvm import KVM
 from .manual import Manual
 from .ali import ALI
@@ -49,6 +50,8 @@ def client(request, config: dict, iaas) -> Iterator[RemoteClient]:
         yield from AZURE.fixture(config["azure"])
     elif iaas == "openstack-ccee":
         yield from OpenStackCCEE.fixture(config["openstack_ccee"])
+    elif iaas == "chroot":
+        yield from CHROOT.fixture(config["chroot"])
     elif iaas == "kvm":
         yield from KVM.fixture(config["kvm"])
     elif iaas == "ali":
@@ -97,6 +100,15 @@ def non_kvm(iaas):
 def kvm(iaas):
     if iaas != 'kvm':
         pytest.skip('test only supported on kvm')
+
+def non_chroot(iaas):
+    if iaas == 'chroot':
+        pytest.skip('test not supported on chroot')
+
+@pytest.fixture(scope='module')
+def chroot(iaas):
+    if iaas != 'chroot':
+        pytest.skip('test only supported on chroot')
 
 @pytest.fixture(scope='module')
 def non_openstack(iaas):

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,0 +1,17 @@
+chroot:
+    # Path to a final artifact. Represents the .tar.xz archive image file (required)
+    image: /gardenlinux/.build/kvm_dev-amd64-dev-local.tar.xz
+
+    ip: 127.0.0.1
+    port: 2222
+
+    # SSH configuration (required)
+    ssh:
+        # Defines path where to look for a given key
+        # or to save the new generated one. Take care
+        # that you do NOT overwrite your key. (required)
+        ssh_key_filepath: /tmp/ssh_priv_key
+
+        # Defines the user for SSH login (required)
+        # Default: root
+        user: root


### PR DESCRIPTION
Add 'chroot' as a new integration platform to perform tests.
  * New 'chroot' integration platform
  * Adjusted 'RemoteClient' to support 'chroot'
  * Adjusted 'test_gardenlinux.py' to support in/exclude for 'chroot' tests

**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds a new platform provider for integration tests. This allows us to perform tests inside a `chroot`. Next to the new `KVM` this allows users to run integration (and future unit) tests without any cloud platform like GCP, AWS,....  The new `chroot` platform is also the base for the migration (#676) from unit tests to a common Pytest base.


**Which issue(s) this PR fixes**:
Fixes #709

**Special notes for your reviewer**:
The provided `test_config.yaml` can be used for testing this feature without any needed changes. Make sure to have a matching tar ball - this can be created by running:
```
make kvm-dev
```

`test_config.yaml` can be removed before merging.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
NONE
```feature user

```
