### PR TITLE
fix(test): fix integration tests for Ali, chroot, OpenStack, KVM

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,9 @@ from .aws import AWS
 from .azure import AZURE
 from .gcp import GCP
 from .ali import ALI
+from .openstackccee import OpenStackCCEE
+from .chroot import CHROOT
+from .kvm import KVM
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -172,6 +175,10 @@ def testconfig(pipeline, iaas, pytestconfig):
             pass
         elif iaas == 'openstack-ccee':
             pass
+        elif iaas == 'chroot':
+            pass
+        elif iaas == 'kvm':
+            pass
         return config
 
 
@@ -311,14 +318,14 @@ def client(testconfig, iaas, imageurl, request) -> Iterator[RemoteClient]:
         credentials = request.getfixturevalue('azure_credentials')
         yield from AZURE.fixture(credentials, testconfig, imageurl)
     elif iaas == "openstack-ccee":
-        yield from OpenStackCCEE.fixture(config["openstack_ccee"])
+        yield from OpenStackCCEE.fixture(testconfig)
     elif iaas == "chroot":
-        yield from CHROOT.fixture(config["chroot"])
+        yield from CHROOT.fixture(testconfig)
     elif iaas == "kvm":
-        yield from KVM.fixture(config["kvm"])
+        yield from KVM.fixture(testconfig)
     elif iaas == "ali":
-        yield from ALI.fixture(config["ali"])
+        yield from ALI.fixture(testconfig)
     elif iaas == "manual":
-        yield from Manual.fixture(config["manual"])
+        yield from Manual.fixture(testconfig)
     else:
         raise ValueError(f"invalid {iaas=}")


### PR DESCRIPTION
**How to categorize this PR?**
This fixes the broken integration tests for `ALI`, `chroot`, `OpenStack` and `KVM` that resulted from #724.
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Integration tests for  `ALI`, `chroot`, `OpenStack` and `KVM` are currently not usable.

**Special notes for your reviewer**:
@MrBatschner, please take a short look. Thanks.

**Release note**:
NONE
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
