### PR TITLE
fix(test): fix broken KVM test (wrong func. order)

### DIFF
--- a/tests/integration/kvm.py
+++ b/tests/integration/kvm.py
@@ -45,8 +45,9 @@ class KVM:
                 sshconfig=config["ssh"],
                 port=port,
             )
-            yield ssh
             ssh.wait_ssh()
+            yield ssh
+
         finally:
             if ssh is not None:
                 ssh.disconnect()


### PR DESCRIPTION
**How to categorize this PR?**
Fix broken `KVM` integration test (wrong func order)
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Fixes the `KVM` integration test

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
