### PR TITLE
Add lynis CIS Pytest for Integration Tests - Discussion

### DIFF
--- a/tests/integration/test_cis.py
+++ b/tests/integration/test_cis.py
@@ -1,0 +1,23 @@
+import logging
+import os
+import pytest
+import yaml
+
+from .sshclient import RemoteClient
+
+LYNIS_VER = "3.0.7"
+
+logger = logging.getLogger(__name__)
+
+def test_download_lynis(client):
+    (exit_code, output, error) = client.execute_command("wget -O /tmp/lynis.tar.gz https://downloads.cisofy.com/lynis/lynis-{LYNIS_VER}.tar.gz".format(LYNIS_VER=LYNIS_VER))
+    assert exit_code == 0, f"no {error=} expected"
+
+def test_unarchive_lynis(client):
+    (exit_code, output, error) = client.execute_command("tar xfvz /tmp/lynis.tar.gz")
+    assert exit_code == 0, f"no {error=} expected"
+
+def test_lynis_cis(client):
+    # Unfortunately we need to change to the
+    # lynis dir before we may execute lynis
+    (exit_code, output, error) = client.execute_command("cd /root/lynis/ && /root/lynis/lynis audit system")

--- a/tests/integration/test_cis.py
+++ b/tests/integration/test_cis.py
@@ -6,7 +6,7 @@ import yaml
 from .sshclient import RemoteClient
 
 LYNIS_VER = "3.0.7"
-
+LYNIS_REPORT = "/var/log/lynis-report.dat"
 logger = logging.getLogger(__name__)
 
 def test_download_lynis(client):
@@ -14,10 +14,32 @@ def test_download_lynis(client):
     assert exit_code == 0, f"no {error=} expected"
 
 def test_unarchive_lynis(client):
-    (exit_code, output, error) = client.execute_command("tar xfvz /tmp/lynis.tar.gz")
+    (exit_code, output, error) = client.execute_command("tar xfvz /tmp/lynis.tar.gz -C /tmp/")
     assert exit_code == 0, f"no {error=} expected"
 
 def test_lynis_cis(client):
     # Unfortunately we need to change to the
     # lynis dir before we may execute lynis
-    (exit_code, output, error) = client.execute_command("cd /root/lynis/ && /root/lynis/lynis audit system")
+    (exit_code, output, error) = client.execute_command("cd /tmp/lynis/ && /usr/bin/sh /tmp/lynis/lynis --no-log audit system > /tmp/lynis.output")
+    assert exit_code == 0, f"no {error=} expected"
+
+def test_lynis_output(client):
+    (exit_code, output, error) = client.execute_command("cat /tmp/lynis.output")
+    validation = False
+    if "Great, no warnings" in output:
+        validation = True
+    assert validation
+
+def test_lynis_log_warn(client):
+    (exit_code, output, error) = client.execute_command(f"cat {LYNIS_REPORT}")
+    validation = False
+    if not "warning[]" in output:
+        validation = True
+    assert validation
+
+def test_lynis_log_crit(client):
+    (exit_code, output, error) = client.execute_command(f"cat {LYNIS_REPORT}")
+    validation = False
+    if not "critical[]" in output:
+        validation = True
+    assert validation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds a basic integration of Cisofy's lynis check within Pytest.
To make sure this one can be executed on all platforms it will be downloaded and executed via the `client` object from `RemoteClient` in `sshclient`. Therefore, we are limited in Python commands on the target environment without installing further apps/libs which would result in a changed artifact. As a result, this minimal test is used.

However, this is like the current ones but I'm not quite sure if this is the way we want to go. Please, let's discuss...
 
**Which issue(s) this PR relates**:
Relates #647

**Special notes for your reviewer**:
DO NOT MERGE YET

**Release note**:
NONE
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
