### PR TITLE
Tests/shellcheck

### DIFF
--- a/docker/integration-test/Dockerfile
+++ b/docker/integration-test/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc
           libguestfs-tools \
           qemu-system-x86 \
           qemu-system-arm \
+          shellcheck \
      && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
      && unzip awscliv2.zip \
      && ./aws/install \

--- a/tests/shellcheck/README.md
+++ b/tests/shellcheck/README.md
@@ -1,0 +1,64 @@
+# Shellcheck Tests
+
+Shellcheck tests must be executed explicitly via `pytest shellcheck` (see [Running the Tests](#running-the-tests)),
+and will **not** be executed as part of other pytests (e.g. the integration tests).
+
+## Prerequisites
+
+The tests **do not** require a running Garden Linux instance. Neither do the test require the repository to be in a buildable state.  
+[Shellcheck](https://github.com/koalaman/shellcheck) is a requirement. 
+It must be installed on the test system on which the shellcheck tests should run.  
+
+
+**tl;dr** snippet to install the requirements for the shellcheck tests:
+```
+python3 -m venv env
+source env/bin/activate
+pip install pytest
+
+# A shellcheck package can be installed via debian apt repos (e.g. bookworm)
+sudo apt-get install shellcheck
+``` 
+
+## Running the Tests
+Shellcheck tests are executed from the `gardenlinux-repo/tests` folder.
+
+```
+pytest shellcheck
+```
+
+## Running Shellcheck manually
+
+`shellcheck <path-to-file>` to run shellcheck manually and get output for a single file.
+You can also integrate shellcheck in your editor. 
+Checkout the github readme from the [koalaman/shellcheck](https://github.com/koalaman/shellcheck#in-your-editor) repo for more information.
+
+## Configuration
+
+### Ignoring Shellcheck errors/warnings
+The text file `tests/shellcheck/error.ignore` is a line separated list of errors that must be ignored by the shellcheck pytests.
+
+```
+# Comments start with '#' and will be ignored
+
+SC1090
+
+```
+
+### Ignoring files
+
+The text file `tests/shellcheck/file.ignore` is a line-separated list of paths starting from the Garden Linux repo root, that must be ignored in the shellcheck pytests.
+
+```
+# Comments start with '#' and will be ignored
+
+# All files must be specified relative to the root dir of this repository
+bin/
+ci/
+
+# Explicitly ignore single file
+docker/build/install-cfssl.sh
+```
+
+
+

--- a/tests/shellcheck/README.md
+++ b/tests/shellcheck/README.md
@@ -35,6 +35,14 @@ Checkout the github readme from the [koalaman/shellcheck](https://github.com/koa
 
 ## Configuration
 
+### Severity Level
+Severity level determines for what kind of findings the shellcheck tests should fail.  
+Starting from the most sensitive, to least sensitive, the available levels are: `error`, `warning`, `info`, `style`
+
+```
+pytest shellcheck --severity=error
+```
+
 ### Ignoring Shellcheck errors/warnings
 The text file `tests/shellcheck/error.ignore` is a line separated list of errors that must be ignored by the shellcheck pytests.
 

--- a/tests/shellcheck/README.md
+++ b/tests/shellcheck/README.md
@@ -2,59 +2,39 @@
 
 Shellcheck tests must be executed explicitly via `pytest shellcheck` (see [Running the Tests](#running-the-tests)),
 and will **not** be executed as part of other pytests (e.g. the integration tests).
+The tests **do not** require a running Garden Linux instance. 
+Neither do the test require the repository to be in a buildable state. 
 
 ## Prerequisites
 
-The tests **do not** require a running Garden Linux instance. Neither do the test require the repository to be in a buildable state.  
-[Shellcheck](https://github.com/koalaman/shellcheck) is a requirement. 
-It must be installed on the test system on which the shellcheck tests should run.  
-
-
-**tl;dr** snippet to install the requirements for the shellcheck tests:
+The `gardenlinux/integration-test` container has all dependencies installed that are required to run the shellcheck tests.
+Build the container image from the base directory of this repository by running: 
 ```
-python3 -m venv env
-source env/bin/activate
-pip install pytest
-
-# A shellcheck package can be installed via debian apt repos (e.g. bookworm)
-sudo apt-get install shellcheck
-``` 
-
-## Running the Tests
-Shellcheck tests are executed from the `gardenlinux-repo/tests` folder.
-
-```
-pytest shellcheck
+make --directory=docker build-integration-test
 ```
 
-## Running Shellcheck manually
+## Configuration Options
 
-`shellcheck <path-to-file>` to run shellcheck manually and get output for a single file.
-You can also integrate shellcheck in your editor. 
-Checkout the github readme from the [koalaman/shellcheck](https://github.com/koalaman/shellcheck#in-your-editor) repo for more information.
+<details>
 
-## Configuration
-
-### Severity Level
-Severity level determines for what kind of findings the shellcheck tests should fail.  
+**Severity Level**  
+determines for what kind of findings the shellcheck tests should fail.  
 Starting from the most sensitive, to least sensitive, the available levels are: `error`, `warning`, `info`, `style`
 
 ```
 pytest shellcheck --severity=error
 ```
 
-### Ignoring Shellcheck errors/warnings
+**Ignoring Shellcheck errors/warnings**  
 The text file `tests/shellcheck/error.ignore` is a line separated list of errors that must be ignored by the shellcheck pytests.
 
 ```
 # Comments start with '#' and will be ignored
 
 SC1090
-
 ```
 
-### Ignoring files
-
+**Ignoring files**  
 The text file `tests/shellcheck/file.ignore` is a line-separated list of paths starting from the Garden Linux repo root, that must be ignored in the shellcheck pytests.
 
 ```
@@ -67,6 +47,24 @@ ci/
 # Explicitly ignore single file
 docker/build/install-cfssl.sh
 ```
+</details>
 
+## Running the Tests
 
+Start the container
+- mount Garden Linux repository to /gardenlinux
+```
+docker run -it --rm -v `pwd`:/gardenlinux gardenlinux/integration-test:`bin/garden-version` /bin/bash
+```
+
+Run the rests
+```
+pytest shellcheck
+```
+
+## Running Shellcheck manually
+
+`shellcheck <path-to-file>` to run shellcheck manually and get output for a single file.
+You can also integrate shellcheck in your editor. 
+Checkout the github readme from the [koalaman/shellcheck](https://github.com/koalaman/shellcheck#in-your-editor) repo for more information.
 

--- a/tests/shellcheck/conftest.py
+++ b/tests/shellcheck/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from _pytest.config.argparsing import Parser
+
+
+def pytest_addoption(parser: Parser):
+    parser.addoption(
+        "--severity",
+        action="store",
+        default="warning",
+        help="Severity level of shellcheck (error, warning, info, style)",
+    )
+
+
+@pytest.fixture
+def severity_level(request):
+    return request.config.getoption("--severity")

--- a/tests/shellcheck/error.ignore
+++ b/tests/shellcheck/error.ignore
@@ -1,0 +1,4 @@
+# For the sake of simplicity we do not care about non-constant source links,
+# we just scan every bash file in the repository, unless specified explicitly in the file.ignore file.
+# See https://github.com/koalaman/shellcheck/wiki/SC1090
+SC1090

--- a/tests/shellcheck/file.ignore
+++ b/tests/shellcheck/file.ignore
@@ -4,3 +4,4 @@
 ci/
 env/
 tests/env
+.git/

--- a/tests/shellcheck/file.ignore
+++ b/tests/shellcheck/file.ignore
@@ -3,6 +3,8 @@
 # All files must be specified relative to the root dir of this repository
 bin/
 ci/
+env/
+tests/env
 
 # Explicitly ignore single file
 docker/build/install-cfssl.sh

--- a/tests/shellcheck/file.ignore
+++ b/tests/shellcheck/file.ignore
@@ -1,10 +1,6 @@
 # Comments start with '#' and will be ignored
 
 # All files must be specified relative to the root dir of this repository
-bin/
 ci/
 env/
 tests/env
-
-# Explicitly ignore single file
-docker/build/install-cfssl.sh

--- a/tests/shellcheck/pytest.ini
+++ b/tests/shellcheck/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 log_auto_indent = true
-log_cli = false
+log_cli = true
 log_file = test.log
 log_file_level = INFO
 log_level = INFO

--- a/tests/shellcheck/pytest.ini
+++ b/tests/shellcheck/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 log_auto_indent = true
-log_cli = true
-log_cli_level = INFO
+log_cli = false
 log_file = test.log
 log_file_level = INFO
 log_level = INFO

--- a/tests/shellcheck/pytest.ini
+++ b/tests/shellcheck/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+log_auto_indent = true
+log_cli = true
+log_cli_level = INFO
+log_file = test.log
+log_file_level = INFO
+log_level = INFO

--- a/tests/shellcheck/shellcheck.ignore
+++ b/tests/shellcheck/shellcheck.ignore
@@ -1,0 +1,8 @@
+# Comments start with '#' and will be ignored
+
+# All files must be specified relative to the root dir of this repository
+bin/
+ci/
+
+# Explicitly ignore single file
+docker/build/install-cfssl.sh

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -14,6 +14,7 @@ from itertools import filterfalse
 logger = logging.getLogger(__name__)
 
 SKIP_COMMENT = "skip-shellcheck"
+SHEBANG_REGEX = r"^#! */[^ ]*/(env *)?[abk]*sh"
 
 
 def is_bash_script(filepath):
@@ -25,7 +26,7 @@ def is_bash_script(filepath):
     except IOError:
         logger.warn('File {filepath} not found')
         return False
-    if 'bash' in head:
+    if re.search(SHEBANG_REGEX, str(head), re.IGNORECASE):
         return True
     return False
 

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -1,0 +1,37 @@
+import logging
+import glob
+import os
+import pytest
+from pathlib import Path
+from subprocess import PIPE, run
+
+logger = logging.getLogger(__name__)
+
+
+def is_bash_script(filepath):
+    try:
+        with open(filepath) as file:
+          head = file.readline()
+    except UnicodeDecodeError:
+        return False # Ignore binary data
+    if 'bash' in head:
+        return True
+    return False
+
+def get_files_to_check(directory):
+    all_files = Path(directory).glob('**/*')
+    ret = list()
+    for filename in all_files:
+        if os.path.isfile(filename) and is_bash_script(filename):
+            ret.append(filename)
+    return ret
+
+
+FILES_TO_CHECK = get_files_to_check('../')
+
+@pytest.mark.parametrize('filepath', FILES_TO_CHECK)
+def test_shellcheck_on_file(filepath):
+    command = ['shellcheck','--severity=warning' , filepath]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert result.returncode==0, f"Shellcheck failed for file {filepath} \n {result.stderr} {result.stdout} "
+

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -7,6 +7,7 @@ from subprocess import PIPE, run
 
 logger = logging.getLogger(__name__)
 
+SKIP_COMMENT = "skip-shellcheck"
 
 def is_bash_script(filepath):
     try:
@@ -18,20 +19,36 @@ def is_bash_script(filepath):
         return True
     return False
 
+def has_skip_comment(filepath):
+    fp = open(filepath)
+    ret = False
+    for i, line in enumerate(fp):
+        if i == 1:
+            logger.info(line)
+            if SKIP_COMMENT in line:
+                ret = True
+                break
+        if i > 1:
+            break;
+
+    fp.close()
+    return ret
+
 def get_files_to_check(directory):
     all_files = Path(directory).glob('**/*')
     ret = list()
     for filename in all_files:
         if os.path.isfile(filename) and is_bash_script(filename):
-            ret.append(filename)
+            if not has_skip_comment(filename):
+                ret.append(filename)
     return ret
 
-
-FILES_TO_CHECK = get_files_to_check('../')
+FILES_TO_CHECK = get_files_to_check('../features/metal')
 
 @pytest.mark.parametrize('filepath', FILES_TO_CHECK)
 def test_shellcheck_on_file(filepath):
     command = ['shellcheck','--severity=warning' , filepath]
     result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    assert result.returncode==0, f"Shellcheck failed for file {filepath} \n {result.stderr} {result.stdout} "
+    assert result.returncode==0, f"Shellcheck failed for: {filepath} \n {result.stderr} {result.stdout} "
+    #assert result.returncode==0, f"Shellcheck failed for: {filepath}"
 

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -13,8 +13,8 @@ from itertools import filterfalse
 
 logger = logging.getLogger(__name__)
 
-SKIP_COMMENT = "skip-shellcheck"
-SHEBANG_REGEX = r"^#! */[^ ]*/(env *)?[abk]*sh"
+SKIP_COMMENT = 'skip-shellcheck'
+SHEBANG_REGEX = r'^#! */[^ ]*/(env *)?[abk]*sh'
 
 
 def is_bash_script(filepath):
@@ -24,7 +24,7 @@ def is_bash_script(filepath):
     except UnicodeDecodeError:
         return False  # Ignore binary data
     except IOError:
-        logger.warn('File {filepath} not found')
+        logger.warn(f'File {filepath} not found')
         return False
     if re.search(SHEBANG_REGEX, str(head), re.IGNORECASE):
         return True
@@ -43,7 +43,7 @@ def has_skip_comment(filepath):
             if i > 1:
                 break
     except IOError:
-        logger.warn('File {filepath} not found')
+        logger.warn(f'File {filepath} not found')
     fp.close()
     return ret
 
@@ -51,7 +51,7 @@ def has_skip_comment(filepath):
 def get_ignore_list(ignore_path):
     ret = list()
     if not os.path.isfile(ignore_path):
-        logger.warn(f"File {ignore_path} does not exist")
+        logger.warn(f'File {ignore_path} does not exist')
         return ret
     with open(ignore_path) as file:
         for line in file.readlines():
@@ -73,7 +73,7 @@ def is_file_ignored(filename, ignore_list):
             continue
         if ignore_expression.startswith('#'):
             continue
-        regex = rf"\.\.\/" + re.escape(ignore_expression) + ".*"
+        regex = rf'\.\.\/' + re.escape(ignore_expression) + '.*'
         if re.search(regex, str(filename), re.IGNORECASE):
             return True
     return False
@@ -112,9 +112,9 @@ def test_shellcheck_on_file(severity_level, filepath):
     for err in ERRORS_TO_IGNORE:
         command.append('--exclude')
         command.append(err)
-    command.append(f"--severity={severity_level}")
+    command.append(f'--severity={severity_level}')
     command.append(filepath)
 
     result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     assert result.returncode == 0, \
-        f"Shellcheck failed on: {filepath} \n {result.stderr} {result.stdout} "
+        f'Shellcheck failed on: {filepath} \n {result.stderr} {result.stdout}'

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -22,22 +22,27 @@ def is_bash_script(filepath):
             head = file.readline()
     except UnicodeDecodeError:
         return False  # Ignore binary data
+    except IOError:
+        logger.warn('File {filepath} not found')
+        return False
     if 'bash' in head:
         return True
     return False
 
 
 def has_skip_comment(filepath):
-    fp = open(filepath)
-    ret = False
-    for i, line in enumerate(fp):
-        if i == 1:
-            if SKIP_COMMENT in line:
-                ret = True
+    try:
+        fp = open(filepath)
+        ret = False
+        for i, line in enumerate(fp):
+            if i == 1:
+                if SKIP_COMMENT in line:
+                    ret = True
+                    break
+            if i > 1:
                 break
-        if i > 1:
-            break
-
+    except IOError:
+        logger.warn('File {filepath} not found')
     fp.close()
     return ret
 
@@ -74,10 +79,8 @@ def is_file_ignored(filename, ignore_list):
 
 
 def apply_ignore_filter(ignore_list, all_list):
-
     filtered_list = \
         [file for file in all_list if not is_file_ignored(file, ignore_list)]
-
     return filtered_list
 
 

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -43,11 +43,11 @@ def get_files_to_check(directory):
                 ret.append(filename)
     return ret
 
-FILES_TO_CHECK = get_files_to_check('../features/metal')
+FILES_TO_CHECK = get_files_to_check('..')
 
 @pytest.mark.parametrize('filepath', FILES_TO_CHECK)
 def test_shellcheck_on_file(filepath):
-    command = ['shellcheck','--severity=warning' , filepath]
+    command = ['shellcheck','--exclude', 'SC1090', '--severity=warning' , filepath]
     result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     assert result.returncode==0, f"Shellcheck failed for: {filepath} \n {result.stderr} {result.stdout} "
     #assert result.returncode==0, f"Shellcheck failed for: {filepath}"

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from subprocess import PIPE, run
 from itertools import filterfalse
 
-
 logger = logging.getLogger(__name__)
 
 SKIP_COMMENT = "skip-shellcheck"
@@ -50,6 +49,12 @@ def get_ignore_list(ignore_path):
         return ret
     with open(ignore_path) as file:
         for line in file.readlines():
+            if not line:
+                continue
+            if line.isspace():
+                continue
+            if line.startswith('#'):
+                continue
             ret.append(line.rstrip())
     return ret
 
@@ -97,14 +102,13 @@ ERRORS_TO_IGNORE = \
 
 
 @pytest.mark.parametrize('filepath', FILES_TO_CHECK)
-def test_shellcheck_on_file(filepath):
+def test_shellcheck_on_file(severity_level, filepath):
     command = ['shellcheck']
 
     for err in ERRORS_TO_IGNORE:
         command.append('--exclude')
         command.append(err)
-
-    command.append('--severity=warning')
+    command.append(f"--severity={severity_level}")
     command.append(filepath)
 
     result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -50,18 +50,18 @@ def has_skip_comment(filepath):
 
 def get_ignore_list(ignore_path):
     ret = list()
-    if not os.path.isfile(ignore_path):
-        logger.warn(f'File {ignore_path} does not exist')
-        return ret
-    with open(ignore_path) as file:
-        for line in file.readlines():
-            if not line:
-                continue
-            if line.isspace():
-                continue
-            if line.startswith('#'):
-                continue
-            ret.append(line.rstrip())
+    try:
+        with open(ignore_path) as file:
+            for line in file.readlines():
+                if not line:
+                    continue
+                if line.isspace():
+                    continue
+                if line.startswith('#'):
+                    continue
+                ret.append(line.rstrip())
+    except IOError:
+        logger.error(f"Could not open {ignore_path}")
     return ret
 
 

--- a/tests/shellcheck/test_shellcheck_gl_source.py
+++ b/tests/shellcheck/test_shellcheck_gl_source.py
@@ -1,3 +1,6 @@
+from codecs import ignore_errors
+from curses import ERR
+from distutils.log import ERROR
 import logging
 import glob
 import os
@@ -13,15 +16,17 @@ logger = logging.getLogger(__name__)
 
 SKIP_COMMENT = "skip-shellcheck"
 
+
 def is_bash_script(filepath):
     try:
         with open(filepath) as file:
-          head = file.readline()
+            head = file.readline()
     except UnicodeDecodeError:
-        return False # Ignore binary data
+        return False  # Ignore binary data
     if 'bash' in head:
         return True
     return False
+
 
 def has_skip_comment(filepath):
     fp = open(filepath)
@@ -32,17 +37,22 @@ def has_skip_comment(filepath):
                 ret = True
                 break
         if i > 1:
-            break;
+            break
 
     fp.close()
     return ret
 
-def get_ignore_list():
+
+def get_ignore_list(ignore_path):
     ret = list()
-    with open(Path(os.getcwd() +  '/shellcheck/shellcheck.ignore')) as file:
+    if not os.path.isfile(ignore_path):
+        logger.warn(f"File {ignore_path} does not exist")
+        return ret
+    with open(ignore_path) as file:
         for line in file.readlines():
             ret.append(line.rstrip())
     return ret
+
 
 def is_file_ignored(filename, ignore_list):
     for ignore_expression in ignore_list:
@@ -57,10 +67,14 @@ def is_file_ignored(filename, ignore_list):
             return True
     return False
 
+
 def apply_ignore_filter(ignore_list, all_list):
 
-    filtered_list = [file for file in all_list if not is_file_ignored(file, ignore_list)]
+    filtered_list = \
+        [file for file in all_list if not is_file_ignored(file, ignore_list)]
+
     return filtered_list
+
 
 def get_files_to_check(directory):
     all_files = Path(directory).glob('**/*')
@@ -71,12 +85,28 @@ def get_files_to_check(directory):
                 ret.append(filename)
     return ret
 
-FILES_TO_CHECK = apply_ignore_filter(get_ignore_list(), get_files_to_check('..'))
+
+FILES_TO_CHECK = \
+    apply_ignore_filter(
+            get_ignore_list(Path(os.getcwd() + '/shellcheck/file.ignore')),
+            get_files_to_check('..')
+        )
+
+ERRORS_TO_IGNORE = \
+    get_ignore_list(Path(os.getcwd() + '/shellcheck/error.ignore'))
+
 
 @pytest.mark.parametrize('filepath', FILES_TO_CHECK)
 def test_shellcheck_on_file(filepath):
-    command = ['shellcheck','--exclude', 'SC1090', '--severity=warning' , filepath]
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    assert result.returncode==0, f"Shellcheck failed for: {filepath} \n {result.stderr} {result.stdout} "
-    #assert result.returncode==0, f"Shellcheck failed for: {filepath}"
+    command = ['shellcheck']
 
+    for err in ERRORS_TO_IGNORE:
+        command.append('--exclude')
+        command.append(err)
+
+    command.append('--severity=warning')
+    command.append(filepath)
+
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert result.returncode == 0, \
+        f"Shellcheck failed on: {filepath} \n {result.stderr} {result.stdout} "


### PR DESCRIPTION
**What this PR does / why we need it**:
- Runs `shellcheck` on all bash scripts in this repository, except the files defined in `tests/shellcheck/file.ignore`
- shellcheck errors listed in `tests/shellcheck/error.ignore` will be ignored
- If a bash script contains a `#skip-shellcheck` comment in line 2, after the `#!/...` line, it will also be ignored by our shellcheck pytest
- The `severity` flag can be specified for pytest, and is passed on to shellcheck tests
    - `pytest shellcheck --severity=error` 
- [Documentation](https://github.com/gardenlinux/gardenlinux/tree/tests/shellcheck/tests/shellcheck/README.md)

**Which issue(s) this PR fixes**:
Fixes #725 

