### PR TITLE
fix(tests): do not attempt to read empty ssh keys

### DIFF
--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -15,11 +15,13 @@ from azure.core.exceptions import (
 from urllib.request import urlopen
 from urllib.parse import urlparse
 
-from azure.mgmt.subscription import SubscriptionClient
-from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.storage import StorageManagementClient
 from azure.mgmt.network import NetworkManagementClient
+from azure.mgmt.resource import (
+    ResourceManagementClient,
+    SubscriptionClient
+)
 
 from azure.mgmt.storage.models import StorageAccountCheckNameAvailabilityParameters
 from azure.storage.blob import BlobClient

--- a/tests/integration/sshclient.py
+++ b/tests/integration/sshclient.py
@@ -34,7 +34,7 @@ class RemoteClient:
         :param passphrase: passphrase of the RSA key
         :param comment: comment for RSA key
         """
-        if path.exists(filename):
+        if filename and path.exists(filename) and path.getsize(filename) > 0:
             pub = RSAKey(filename=filename, password=passphrase)
             logger.info("SSH key already exists, skipping generating SSH key")
         else:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
1. With the changes introduced in PR #730, the ssh-key generator for the test framework will run into an error if the ssh-key file exists but is of size zero (which is the case for the platform tests). Therefore, extending the check if a keyfile is already present by additionally checking on its file size too.

1. The `SubscriptionClient` for Azure which we use to translate a subscription name to its id moved packages which required a small change to the test code.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
fix(tests): do not attempt to read empty ssh keys
fix(test): honor move of Azure SubscriptionClient
```
