### PR TITLE
test: check for presence of SELinux

### DIFF
--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -380,5 +380,10 @@ def test_aws_ena_driver(client, aws):
 
 def test_apparmor(client):
     (exit_code, output, error) = client.execute_command("/usr/bin/aa-enabled")
+    assert exit_code == 1, f"expected aa-enabled to return with rc=1"
+    assert "No" in output.rstrip(), "Expected AppArmor not to be enabled by default."
+
+def test_selinux(client):
+    (exit_code, output, error) = client.execute_command("grep selinux /sys/kernel/security/lsm")
     assert exit_code == 0, f"no {error=} expected"
-    assert output.rstrip() == "Yes", "Expected AppArmor to be enabled."
+    assert "selinux" in output.rstrip(), "Expected SELinux to be enabled."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
As Garden Linux changed the default security module from AppArmor to SELinux, adapting the tests to check for SELinux' presence.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
test: check for presence of SELinux
```
