### PR TITLE
fix: metal/cloud exec.confing

### DIFF
--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
 # set default umask to a more conservative value
 sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 #cat <<EOF >>/etc/pam.d/common-session

--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
 systemctl enable haveged
 systemctl enable ipmievd
 


### PR DESCRIPTION
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
exec.config from the metal/cloud features are missing the shebang, plus the build process should be aborted if there are any issues.

