### PR TITLE
Fix missing os import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import logging
 import json
 import yaml
 import os
+import sys
 
 import glci.util
 
@@ -336,7 +337,8 @@ def client(testconfig, iaas, imageurl, request) -> Iterator[RemoteClient]:
 def features(client):
     (exit_code, output, error) = client.execute_command("cat /etc/os-release")
     if exit_code != 0:
-        sys.exit(error)
+        logger.error(error)
+        sys.exit(exit_code)
     for line in output.split('\n'):
         if line.startswith('GARDENLINUX_FEATURES'):
             features = line.split('=')[1]


### PR DESCRIPTION
 * Fix missing sys import
 * Add log line on error
 * Use exit_code for sys.exit() func

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR fixes to usage of sys.exit() without sys import. Furthermore this line should use the logger function.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
