### PR TITLE
Move IAAS related fixtures to conftest

### DIFF
--- a/features/cis/test/test_debian_cis.py
+++ b/features/cis/test/test_debian_cis.py
@@ -2,7 +2,7 @@ from helper.exception import NotPartOfFeatureError, DisabledBy
 from helper.tests.debian_cis import DebianCIS
 import pytest
 
-def test_feature_debian_cis(client, features):
+def test_feature_debian_cis(client, features, non_chroot):
     """The test function executed by pytest"""
     try:
         DebianCIS(client, features)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,3 +345,68 @@ def features(client):
             features = line.split('=')[1]
     current = (os.getenv('PYTEST_CURRENT_TEST')).split('/')
     yield features.split(','), current[0]
+
+
+@pytest.fixture
+def non_ali(iaas):
+    if iaas == 'ali':
+        pytest.skip('test not supported on ali')
+
+@pytest.fixture
+def ali(iaas):
+    if iaas != 'ali':
+        pytest.skip('test only supported on ali')
+
+@pytest.fixture
+def non_azure(iaas):
+    if iaas == 'azure':
+        pytest.skip('test not supported on azure')
+
+@pytest.fixture
+def azure(iaas):
+    if iaas != 'azure':
+        pytest.skip('test only supported on azure')
+
+@pytest.fixture
+def aws(iaas):
+    if iaas != 'aws':
+        pytest.skip('test only supported on aws')
+
+@pytest.fixture
+def gcp(iaas):
+    if iaas != 'gcp':
+        pytest.skip('test only supported on gcp')
+
+@pytest.fixture
+def non_kvm(iaas):
+    if iaas == 'kvm':
+        pytest.skip('test not supported on kvm')
+
+@pytest.fixture
+def kvm(iaas):
+    if iaas != 'kvm':
+        pytest.skip('test only supported on kvm')
+
+@pytest.fixture
+def non_chroot(iaas):
+    if iaas == 'chroot':
+        pytest.skip('test not supported on chroot')
+
+@pytest.fixture
+def chroot(iaas):
+    if iaas != 'chroot':
+        pytest.skip('test only supported on chroot')
+
+@pytest.fixture
+def non_openstack(iaas):
+    if iaas == 'openstack-ccee':
+        pytest.skip('test not supported on openstack')
+
+@pytest.fixture
+def openstack(iaas):
+    if iaas != 'openstack-ccee':
+        pytest.skip('test only supported on openstack')
+
+@pytest.fixture
+def openstack_flavor():
+    return OpenStackCCEE.instance().flavor

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -22,68 +22,6 @@ from integration.sshclient import RemoteClient
 
 logger = logging.getLogger(__name__)
 
-@pytest.fixture(scope='module')
-def non_ali(iaas):
-    if iaas == 'ali':
-        pytest.skip('test not supported on ali')
-
-@pytest.fixture(scope='module')
-def ali(iaas):
-    if iaas != 'ali':
-        pytest.skip('test only supported on ali')
-
-@pytest.fixture(scope='module')
-def non_azure(iaas):
-    if iaas == 'azure':
-        pytest.skip('test not supported on azure')
-
-@pytest.fixture(scope='module')
-def azure(iaas):
-    if iaas != 'azure':
-        pytest.skip('test only supported on azure')
-
-@pytest.fixture(scope='module')
-def aws(iaas):
-    if iaas != 'aws':
-        pytest.skip('test only supported on aws')
-
-@pytest.fixture(scope='module')
-def gcp(iaas):
-    if iaas != 'gcp':
-        pytest.skip('test only supported on gcp')
-
-def non_kvm(iaas):
-    if iaas == 'kvm':
-        pytest.skip('test not supported on kvm')
-
-@pytest.fixture(scope='module')
-def kvm(iaas):
-    if iaas != 'kvm':
-        pytest.skip('test only supported on kvm')
-
-def non_chroot(iaas):
-    if iaas == 'chroot':
-        pytest.skip('test not supported on chroot')
-
-@pytest.fixture(scope='module')
-def chroot(iaas):
-    if iaas != 'chroot':
-        pytest.skip('test only supported on chroot')
-
-@pytest.fixture(scope='module')
-def non_openstack(iaas):
-    if iaas == 'openstack-ccee':
-        pytest.skip('test not supported on openstack')
-
-@pytest.fixture(scope='module')
-def openstack(iaas):
-    if iaas != 'openstack-ccee':
-        pytest.skip('test only supported on openstack')
-
-@pytest.fixture(scope='module')
-def openstack_flavor():
-    return OpenStackCCEE.instance().flavor
-
 
 def test_clock(client):
     (exit_code, output, error) = client.execute_command("date '+%s'")


### PR DESCRIPTION
Move IAAS related fixtures to global 'conftest.py'. This
allows all tests regarding their location to use the functions.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Currently, it isn't possible to exclude target platforms (`fixtures`) in PyTests within `features` directories. This may tests fail that can't be triggered on specific target platforms. This PR will add the possibility to add `fixtures` as target platform args for related functions to exclude them again.

**Which issue(s) this PR fixes**:
Fixes #781

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: developer
```

Test run:
Command: `pytest --iaas=chroot --configfile=chroot.yaml`
Output:
```
========================================================= test session starts ==========================================================
platform linux -- Python 3.9.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /gardenlinux/tests, configfile: pytest.ini, testpaths: ../features, integration
collected 54 items                                                                                                                     

_dev/test/test_packages_musthave.py::test_packages_musthave 
------------------------------------------------------------ live log setup ------------------------------------------------------------
INFO     conftest:conftest.py:312 Testconfig for iaas='chroot' is {'image': '/gardenlinux/.build/kvm-cis_dev-amd64-dev-local.tar.xz', 'ip': '127.0.0.1', 'port': 2222, 'ssh': {'ssh_key_filepath': '/tmp/ssh_priv_key', 'user': 'root'}}
INFO     integration.chroot:chroot.py:34 Starting CHROOT integration tests.
INFO     integration.chroot:chroot.py:39 Validation starting...
INFO     integration.chroot:chroot.py:41 Using IP 127.0.0.1 to connect to chroot.
INFO     integration.chroot:chroot.py:43 Using port tcp/2222 to connect to chroot.
INFO     integration.chroot:chroot.py:95 Path to image archive defined: /gardenlinux/.build/kvm-cis_dev-amd64-dev-local.tar.xz
INFO     integration.chroot:chroot.py:101 Image archive is present: /gardenlinux/.build/kvm-cis_dev-amd64-dev-local.tar.xz
INFO     integration.chroot:chroot.py:111 Port for ssh connection defined: 2222
INFO     integration.chroot:chroot.py:257 Validating if 2222 on 127.0.0.1 is already in use.
INFO     integration.chroot:chroot.py:267 Port 2222 on 127.0.0.1 can be used.
INFO     integration.chroot:chroot.py:121 Creating rootfs as tmpdir
INFO     integration.chroot:chroot.py:123 Created rootfs in /tmp/gl-int-chroot-kz9aowrh
INFO     integration.chroot:chroot.py:125 Unarchiving image /gardenlinux/.build/kvm-cis_dev-amd64-dev-local.tar.xz to /tmp/gl-int-chroot-kz9aowrh
INFO     integration.chroot:chroot.py:133 Unarchived image /gardenlinux/.build/kvm-cis_dev-amd64-dev-local.tar.xz to /tmp/gl-int-chroot-kz9aowrh
INFO     integration.chroot:chroot.py:148 Generating new SSH key for integration tests.
INFO     integration.sshclient:sshclient.py:47 generated RSA key pair: /tmp/ssh_priv_key
INFO     integration.sshclient:sshclient.py:54 fingerprint: 2048 04:b5:8d:ab:59:42:66:bb:77:d4:36:c9:df:0d:e7:54 /tmp/ssh_priv_key.pub (RSA)
INFO     integration.chroot:chroot.py:153 SSH key for integration tests generated.
INFO     integration.chroot:chroot.py:158 Adjusting chroot environment
INFO     integration.chroot:chroot.py:166 Wrote garden-epoch to chroot in /tmp/gl-int-chroot-kz9aowrh
INFO     integration.chroot:chroot.py:185 Running command: ssh-keygen -q -N "" -t dsa -f /tmp/gl-int-chroot-kz9aowrh/etc/ssh//ssh_host_dsa_key
INFO     integration.chroot:chroot.py:192 Command sucessfully executed.
INFO     integration.chroot:chroot.py:185 Running command: ssh-keygen -q -N "" -t rsa -b 4096 -f /tmp/gl-int-chroot-kz9aowrh/etc/ssh//ssh_host_rsa_key
INFO     integration.chroot:chroot.py:192 Command sucessfully executed.
INFO     integration.chroot:chroot.py:185 Running command: ssh-keygen -q -N "" -t ecdsa -f /tmp/gl-int-chroot-kz9aowrh/etc/ssh//ssh_host_ecdsa_key
INFO     integration.chroot:chroot.py:192 Command sucessfully executed.
INFO     integration.chroot:chroot.py:185 Running command: ssh-keygen -q -N "" -t ed25519 -f /tmp/gl-int-chroot-kz9aowrh/etc/ssh//ssh_host_ed25519_key
INFO     integration.chroot:chroot.py:192 Command sucessfully executed.
INFO     integration.chroot:chroot.py:197 Created directory: /tmp/gl-int-chroot-kz9aowrh/run/sshd
INFO     integration.chroot:chroot.py:207 Copied sshd_config_integration_tests to: /tmp/gl-int-chroot-kz9aowrh/etc/ssh/
INFO     integration.chroot:chroot.py:248 Created /tmp/gl-int-chroot-kz9aowrh/root/.ssh with mode 384.
INFO     integration.chroot:chroot.py:220 Copied authorized_keys to: /tmp/gl-int-chroot-kz9aowrh/root/.ssh/authorized_keys
INFO     integration.chroot:chroot.py:239 Started SSHD in chroot environment.
INFO     integration.sshclient:sshclient.py:185 Waiting for SSHD in test env to become ready on tcp/2222 and 127.0.0.1
INFO     integration.sshclient:sshclient.py:205 1 Waiting... Run: 1/20 
INFO     integration.sshclient:sshclient.py:205 0 Waiting... Run: 2/20 
INFO     integration.sshclient:sshclient.py:208 SSH ready in test env.
INFO     paramiko.transport:transport.py:1873 Connected (version 2.0, client OpenSSH_9.0p1)
INFO     paramiko.transport:transport.py:1873 Authentication (publickey) successful!
PASSED                                                                                                                           [  1%]
_iso/test/test_capabilities.py::test_capabilities SKIPPED (Feature _iso this test belongs to is not enabled)                     [  3%]
_iso/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature _iso this test belongs to is not enabled)           [  5%]
_pxe/test/test_capabilities.py::test_capabilities SKIPPED (Feature _pxe this test belongs to is not enabled)                     [  7%]
_pxe/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature _pxe this test belongs to is not enabled)           [  9%]
ali/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature ali this test belongs to is not enabled)             [ 11%]
aws/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature aws this test belongs to is not enabled)             [ 12%]
azure/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature azure this test belongs to is not enabled)         [ 14%]
base/test/test_blacklisted_packages.py::test_blacklisted_packages PASSED                                                         [ 16%]
base/test/test_capabilities.py::test_capabilities PASSED                                                                         [ 18%]
base/test/test_debsums.py::test_debsums SKIPPED (Test is explicitly disabled by features cloud)                                  [ 20%]
base/test/test_packages_musthave.py::test_packages_musthave PASSED                                                               [ 22%]
chost/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature chost this test belongs to is not enabled)         [ 24%]
cis/test/test_debian_cis.py::test_feature_debian_cis SKIPPED (test not supported on chroot)                                      [ 25%]
cloud/test/test_packages_musthave.py::test_packages_musthave PASSED                                                              [ 27%]
gardener/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature gardener this test belongs to is not enabled)   [ 29%]
gcp/test/test_blacklisted_packages.py::test_blacklisted_packages SKIPPED (Feature gcp this test belongs to is not enabled)       [ 31%]
gcp/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature gcp this test belongs to is not enabled)             [ 33%]
khost/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature khost this test belongs to is not enabled)         [ 35%]
kvm/test/test_packages_musthave.py::test_packages_musthave PASSED                                                                [ 37%]
metal/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature metal this test belongs to is not enabled)         [ 38%]
openstack/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature openstack this test belongs to is not enabled) [ 40%]
server/test/test_capabilities.py::test_capabilities PASSED                                                                       [ 42%]
server/test/test_packages_musthave.py::test_packages_musthave PASSED                                                             [ 44%]
vmware/test/test_packages_musthave.py::test_packages_musthave SKIPPED (Feature vmware this test belongs to is not enabled)       [ 46%]
integration/test_gardenlinux.py::test_clock
[...] 
```

Related line:
```
cis/test/test_debian_cis.py::test_feature_debian_cis SKIPPED (test not supported on chroot)
```