### PR TITLE
Add libssl1.1 to blacklisted packages

### DIFF
--- a/features/base/test/blacklisted-packages.d/blacklisted-packages.list
+++ b/features/base/test/blacklisted-packages.d/blacklisted-packages.list
@@ -5,3 +5,5 @@ telnet
 # XXX: Test does not manage arch specifiers for multi-arch packages
 libdb5.3:amd64
 libdb5.3:arm64
+libssl1.1:amd64
+libssl1.1:arm64

--- a/features/base/test/blacklisted-packages.d/final.list
+++ b/features/base/test/blacklisted-packages.d/final.list
@@ -5,3 +5,5 @@ telnet
 # XXX: Test does not manage arch specifiers for multi-arch packages
 libdb5.3:amd64
 libdb5.3:arm64
+libssl1.1:amd64
+libssl1.1:arm64


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds `libssl1.1` to the blacklisted packages. Thereby, this change should verify if there are still packages that depend on `libssl1.1`. All Garden Linux packages should depend on `libssl3` instead.

**Which issue(s) this PR fixes**:
Fixes #796 
