### PR TITLE
feat: switchable build container runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ $(info using local packages from $(LOCAL_PKGS))
 override BUILD_OPTS += --local-pkgs=$(LOCAL_PKGS)
 endif
 
+GARDENLINUX_BUILD_CRE ?= sudo podman 
+
 .PHONY:all
 all: all_dev all_prod
 
@@ -165,9 +167,9 @@ clean:
 	@echo "emptying $(BUILDDIR)"
 	@rm -rf $(BUILDDIR)/*
 	@echo "deleting all containers running gardenlinux/build-image"
-	@-sudo podman container rm $$(sudo podman container ls -a | awk '{ print $$1,$$2 }' | grep gardenlinux/build-image: | awk '{ print $$1 }') 2> /dev/null || true
+	@-$(GARDENLINUX_BUILD_CRE) container rm $$($(GARDENLINUX_BUILD_CRE) container ls -a | awk '{ print $$1,$$2 }' | grep gardenlinux/build-image: | awk '{ print $$1 }') 2> /dev/null || true
 	@echo "deleting all containers running gardenlinux/integration-test"
-	@-sudo podman container rm $$(sudo podman container ls -a | awk '{ print $$1,$$2 }' | grep gardenlinux/integration-test: | awk '{ print $$1 }') 2> /dev/null || true
+	@-$(GARDENLINUX_BUILD_CRE) container rm $$($(GARDENLINUX_BUILD_CRE) container ls -a | awk '{ print $$1,$$2 }' | grep gardenlinux/integration-test: | awk '{ print $$1 }') 2> /dev/null || true
 
 distclean: clean
 	make --directory=container clean

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
 ## Quick Start
 The entire build runs in a <i>privileged</i> Podman/Docker container that orchestrates all further actions. If not explicitly skipped, unit tests will be performed. Extended capabilities are at least needed for loop back support. Currently AMD64 and ARM64 architectures are supported.
 
+By default, Garden Linux uses [Podman](https://podman.io/) as container runtime for building Garden Linux images (Garden Linux artifacts however will have Docker in them to maintain compatibility with older Kubernetes versions). If - for whatever reason - you want or need to use Docker instead, you can set the environment variable `GARDENLINUX_BUILD_CRE=docker` before invoking the build.
+
 ### Build Requirements
 
 **System:**
@@ -104,7 +106,7 @@ To build all supported images you may just run the following command:
     make all
 ```
 
-However, to safe time you may also build just a platform specific image by running one of the following commands. Related dev images can be created by appending the '-dev' suffix (e.g. "make aws-dev").
+However, to save time you may also build just a platform specific image by running one of the following commands. Related dev images can be created by appending the '-dev' suffix (e.g. "make aws-dev").
 ```
     make aws
     make gcp

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -11,11 +11,13 @@ go build garden-feat.go
 endef
 export BASH_BUILD
 
+GARDENLINUX_BUILD_CRE ?= sudo podman
+
 .PHONY: all
 all: garden-feat
 
 garden-feat: *.go
-	sudo podman run -v $(SCRIPTDIR):/go/src docker.io/library/golang:latest bash -c "$$BASH_BUILD"
+	$(GARDENLINUX_BUILD_CRE) run -v $(SCRIPTDIR):/go/src docker.io/library/golang:latest bash -c "$$BASH_BUILD"
 	rm -f go.mod go.sum
 
 .PHONY: clean

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -37,6 +37,7 @@ vncport=0; while ss -tul | grep :$(( vncport + $vncbase )) &> /dev/null; do (( +
 keypress=1
 mac="$(printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))"
 virtOpts=( )
+gardenlinux_build_cre=${GARDENLINUX_BUILD_CRE:-"sudo podman"}
 source "${thisDir}/.constants.sh" \
 	--flags 'daemonize,uefi,skipkp,vnc' \
 	--flags 'cpu:,mem:,bridge:,port:,mac:,arch:' \
@@ -318,7 +319,7 @@ if [ $pxe ]; then
 		echo "removing symlinks"
 		rm  "$pxe/root."{vmlinuz,initrd,squashfs}
 		echo "stopping helper for pxe"
-		sudo podman stop -t 0 $1
+		${gardenlinux_build_cre} stop -t 0 $1
 		[[ ! -s "$pxe/ignition.json" ]] && rm -f "$pxe/ignition.json"
 		echo "everything stopped..."
 	}
@@ -329,9 +330,9 @@ if [ $pxe ]; then
 	trap 'stop $containerName' EXIT
 	echo "starting helper container"
 	if [ "$ignfile" ]; then
-		sudo podman run -it --rm -d -p 127.0.0.1:8888:80 --name ${containerName} -v ${pxe}:/usr/share/nginx/html -v ${ignfile}:/usr/share/nginx/html/ignition.json nginx
+		${gardenlinux_build_cre} run -it --rm -d -p 127.0.0.1:8888:80 --name ${containerName} -v ${pxe}:/usr/share/nginx/html -v ${ignfile}:/usr/share/nginx/html/ignition.json nginx
 	else
-		sudo podman run -it --rm -d -p 127.0.0.1:8888:80 --name ${containerName} -v ${pxe}:/usr/share/nginx/html:ro nginx
+		${gardenlinux_build_cre} run -it --rm -d -p 127.0.0.1:8888:80 --name ${containerName} -v ${pxe}:/usr/share/nginx/html:ro nginx
 	fi
 fi
 

--- a/cert/Makefile
+++ b/cert/Makefile
@@ -6,6 +6,8 @@ KEYTYPE=RSA
 KEYLENGTH=4096
 HOSTNAME=
 
+GARDENLINUX_BUILD_CRE ?= sudo podman
+
 #internal
 INTERNAL_HOSTNAME=$(shell [ -n "$(HOSTNAME)" ] && printf "%s=%s" "-hostname" "$(HOSTNAME)" )
 
@@ -79,7 +81,7 @@ test:
 cfssl/cfssl cfssl/cfssljson:
 	@echo "Building cfssl / cfssljson"
 	@mkdir -p cfssl
-	@sudo podman run --volume "$$(realpath cfssl):/build" --rm golang:latest bash -c "$$BASH_BUILD"
+	@$(GARDENLINUX_BUILD_CRE) run --volume "$$(realpath cfssl):/build" --rm golang:latest bash -c "$$BASH_BUILD"
 
 #### CA
 .PHONY: %.ca

--- a/container/Makefile
+++ b/container/Makefile
@@ -5,6 +5,8 @@ ALTNAME_INTERNAL=$(shell [ -n "$(ALTNAME)" ] && printf "%s %s" "-t" "$(ALTNAME)"
 PATH_KERNEL_PACKAGES="../.packages/main/l/linux"
 KERNEL_VERSION=5.10
 
+GARDENLINUX_BUILD_CRE ?= sudo podman
+
 all: build-image build-integration-test
 
 .PHONY: needslim
@@ -14,27 +16,27 @@ needslim:
 .PHONY: build-image
 build-image: needslim
 	cp ../bin/garden-feat.go build-image/
-	@sudo podman build --build-arg VERSION=$(VERSION) -t gardenlinux/build-image:$(VERSION) $(ALTNAME_INTERNAL) build-image
+	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/build-image:$(VERSION) $(ALTNAME_INTERNAL) build-image
 
 .PHONY: build
 build: needslim
-	@sudo podman build --build-arg BUILDARCH="$$([ "$$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64")" -t gardenlinux/build $(ALTNAME_INTERNAL) build
+	@$(GARDENLINUX_BUILD_CRE) build --build-arg BUILDARCH="$$([ "$$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64")" -t gardenlinux/build $(ALTNAME_INTERNAL) build
 
 .PHONY: build-deb
 build-deb: build
-	@sudo podman build -t gardenlinux/build-deb $(ALTNAME_INTERNAL) build-deb
+	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/build-deb $(ALTNAME_INTERNAL) build-deb
 
 .PHONY: build-base-test
 build-base-test: needslim
 	mkdir -p base-test/_pipfiles
 	cp ../tests/Pipfile* base-test/_pipfiles
-	@sudo podman build -t gardenlinux/base-test:$(VERSION) base-test
+	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/base-test:$(VERSION) base-test
 
 .PHONY: build-integration-test
 build-integration-test: build-base-test
 	mkdir -p integration-test/_pipfiles
 	cp ../tests/Pipfile* integration-test/_pipfiles
-	@sudo podman build -t gardenlinux/integration-test:$(VERSION) integration-test
+	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/integration-test:$(VERSION) integration-test
 
 .PHONY: build-kernelmodule
 build-kernelmodule: build
@@ -43,13 +45,13 @@ build-kernelmodule: build
 	cp ../.packages/main/l/linux/linux-kbuild*$(KERNEL_VERSION)*.deb build-kernelmodule/packages/ || (echo "Error: Build Kernel packages first." && exit 1)
 	cp ../.packages/main/l/linux/linux-compiler-gcc*$(KERNEL_VERSION)*.deb build-kernelmodule/packages/ || (echo "Error: Build Kernel packages first." && exit 1)
 	cp ../.packages/main/l/linux/linux-headers*$(KERNEL_VERSION)*.deb build-kernelmodule/packages/ || (echo "Error: Build Kernel packages first." && exit 1)
-	@sudo podman build -t gardenlinux/build-kernelmodule:$(KERNEL_VERSION) build-kernelmodule
+	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/build-kernelmodule:$(KERNEL_VERSION) build-kernelmodule
 
 .PHONY: clean
 clean:
 	rm -rf integration-test/_pipfiles
-	-@[ -n "$$(sudo podman image ls gardenlinux/integration-test --format "{{.ID}}")" ] && sudo podman image rm --force $$(sudo podman image ls gardenlinux/integration-test --format "{{.Repository}}:{{.Tag}}"); true
-	-@[ -n "$$(sudo podman image ls gardenlinux/build-image --format "{{.ID}}")" ] && sudo podman image rm --force $$(sudo podman image ls gardenlinux/build-image --format "{{.Repository}}:{{.Tag}}"); true
-	-@[ -n "$$(sudo podman image ls gardenlinux/build-deb --format "{{.ID}}")" ] && sudo podman image rm --force $$(sudo podman image ls gardenlinux/build-deb --format "{{.Repository}}:{{.Tag}}"); true
-	-@[ -n "$$(sudo podman image ls gardenlinux/build --format "{{.ID}}")" ] && sudo podman image rm --force $$(sudo podman image ls gardenlinux/build --format "{{.Repository}}:{{.Tag}}"); true
-	-@[ -n "$$(sudo podman image ls gardenlinux/slim --format "{{.ID}}")" ] && sudo podman image rm --force $$(sudo podman image ls gardenlinux/slim --format "{{.Repository}}:{{.Tag}}"); true
+	-@[ -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/integration-test --format "{{.ID}}")" ] && $(GARDENLINUX_BUILD_CRE) image rm --force $$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/integration-test --format "{{.Repository}}:{{.Tag}}"); true
+	-@[ -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-image --format "{{.ID}}")" ] && $(GARDENLINUX_BUILD_CRE) image rm --force $$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-image --format "{{.Repository}}:{{.Tag}}"); true
+	-@[ -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-deb --format "{{.ID}}")" ] && $(GARDENLINUX_BUILD_CRE) image rm --force $$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-deb --format "{{.Repository}}:{{.Tag}}"); true
+	-@[ -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build --format "{{.ID}}")" ] && $(GARDENLINUX_BUILD_CRE) image rm --force $$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build --format "{{.Repository}}:{{.Tag}}"); true
+	-@[ -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/slim --format "{{.ID}}")" ] && $(GARDENLINUX_BUILD_CRE) image rm --force $$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/slim --format "{{.Repository}}:{{.Tag}}"); true

--- a/container/needslim
+++ b/container/needslim
@@ -2,26 +2,27 @@
 set -Eeuo pipefail
 
 VERSION="$(../bin/garden-version)"
+gardenlinux_build_cre=${GARDENLINUX_BUILD_CRE:-"sudo podman"}
 
-if [ "$(sudo podman image ls gardenlinux/slim --format \"{{.Repository}}:{{.Tag}}\")" == "" ]; then
+if [ "$(${gardenlinux_build_cre} image ls gardenlinux/slim --format \"{{.Repository}}:{{.Tag}}\")" == "" ]; then
 	echo "WARNING: There is no gardenlinux/slim on this box. Since this is the builder script, it will pull no binary docker images from public repos."
 	echo
 	echo "Since gardenlinux/slim is needed for almost all images we pull debian/testing-slim and rename it to gardenlinux/slim so we avoid the Chicken-and-Egg problem temporarily"
 	echo
 	echo "Please run 'make slim' afterwards"
 	echo
-	sudo podman pull debian:testing-slim
-	sudo podman tag  debian:testing-slim gardenlinux/slim
-	sudo podman tag  debian:testing-slim gardenlinux/slim:$VERSION
-	sudo podman tag  debian:testing-slim gardenlinux/slim:latest
+	${gardenlinux_build_cre} pull debian:testing-slim
+	${gardenlinux_build_cre} tag  debian:testing-slim gardenlinux/slim
+	${gardenlinux_build_cre} tag  debian:testing-slim gardenlinux/slim:$VERSION
+	${gardenlinux_build_cre} tag  debian:testing-slim gardenlinux/slim:latest
 else
-	if [ "$(sudo podman image ls gardenlinux/slim:latest --format \"{{.ID}}\")" == \
-	     "$(sudo podman image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
+	if [ "$(${gardenlinux_build_cre} image ls gardenlinux/slim:latest --format \"{{.ID}}\")" == \
+	     "$(${gardenlinux_build_cre} image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
 		echo "WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:latest!"
 		echo
 		echo "Please run 'make slim' to fix"
-	elif [ "$(sudo podman image ls gardenlinux/slim:$VERSION --format \"{{.ID}}\")" == \
-	       "$(sudo podman image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
+	elif [ "$(${gardenlinux_build_cre} image ls gardenlinux/slim:$VERSION --format \"{{.ID}}\")" == \
+	       "$(${gardenlinux_build_cre} image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
 		echo "WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:$VERSION!"
 		echo
 		echo "Please run 'make slim' to fix"

--- a/features/fedramp/test/test.sh
+++ b/features/fedramp/test/test.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+gardenlinux_build_cre=${GARDENLINUX_BUILD_CRE:-"sudo podman"}
+
 ######## BANNER ################
 BANNER=$(cat /etc/issue.net | grep "You are accessing a U.S. Government")
 if [ -z "$BANNER" ]
@@ -91,7 +94,7 @@ else
 fi
 # Cloud watch agent is irrelevant on Gardener AMIs as we push logs via fluentd.
 ######## CLOUDWATCH ############
-# CLOUDWATCH_DS=$(sudo podman ps | grep -i "cloudwatch")
+# CLOUDWATCH_DS=$(${gardenlinux_build_cre} ps | grep -i "cloudwatch")
 # if [ -z "$CLOUDWATCH_DS" ]
 # then
 #   CLOUDWATCH_CONFIG=$(sudo cat /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json | grep -i "/var/log/syslog")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

With PR #702 we changed the container runtime environment for all build and test containers to Podman to exclusively use free and open-source licenses. However, some users might not be able to use Podman (e.g. because they are not sudoer but members of a `docker` group) but a different container runtime which is compatible to Docker/Podman.

With this PR, by setting the environment variable `GARDENLINUX_BUILD_CRE` to e.g. `docker`, the container runtime used for building Garden Linux can be configured.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- feat: build container runtime can be switched
```
