### PR TITLE
fix: Gitter chat badge links to gitter channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![build](https://github.com/gardenlinux/gardenlinux/actions/workflows/build.yml/badge.svg)](https://github.com/gardenlinux/gardenlinux/actions/workflows/build.yml)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3925/badge)](https://bestpractices.coreinfrastructure.org/projects/3925)
  [![MIT License](https://img.shields.io/github/license/gardenlinux/gardenlinux)](https://img.shields.io/github/license/gardenlinux/gardenlinux)
-[![Gitter Chat](https://img.shields.io/gitter/room/gardenlinux/community)](https://img.shields.io/gitter/room/gardenlinux/community)
+[![Gitter](https://badges.gitter.im/gardenlinux/community.svg)](https://gitter.im/gardenlinux/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![GitHub Open Issues](https://img.shields.io/github/issues-raw/gardenlinux/gardenlinux)](https://img.shields.io/github/issues-raw/gardenlinux/gardenlinux)
 [![GitHub Closed PRs](https://img.shields.io/github/issues-pr-closed-raw/gardenlinux/gardenlinux)](https://img.shields.io/github/issues-pr-closed-raw/gardenlinux/gardenlinux)
 


### PR DESCRIPTION
Clicking on the badge redirects to the Garden Linux Gitter channel

**Which issue(s) this PR fixes**:
Fixes #158
