### PR TITLE
Add custom whitelist checks for CIS tests

### DIFF
--- a/features/cis/test/conf.d/6.1.13_find_suid_files.cfg
+++ b/features/cis/test/conf.d/6.1.13_find_suid_files.cfg
@@ -1,0 +1,4 @@
+# 6.1.13: Find SUID files
+# Enabled: Provide custom whitelist for excluded SUID files
+status=audit
+EXCEPTIONS="/usr/lib/dbus-1.0/dbus-daemon-launch-helper /bin/mount /usr/bin/mount /bin/ping /usr/bin/ping /bin/ping6 /usr/bin/ping6 /bin/su /usr/bin/su /bin/umount /usr/bin/umount /usr/bin/chfn /usr/bin/chsh /usr/bin/fping /usr/bin/fping6 /usr/bin/gpasswd /usr/bin/mtr /usr/bin/newgrp /usr/bin/passwd /usr/bin/sudo /usr/bin/sudoedit /usr/lib/openssh/ssh-keysign /usr/lib/pt_chown /usr/bin/at"

--- a/features/cis/test/conf.d/6.1.14_find_sgid_files.cfg
+++ b/features/cis/test/conf.d/6.1.14_find_sgid_files.cfg
@@ -1,0 +1,4 @@
+# 6.1.14: Find SGID files
+# Enabled: Provide custom whitelist for excluded SGID files
+status=audit
+EXCEPTIONS="/usr/bin/write /usr/lib/systemd-cron/crontab_setgid /sbin/unix_chkpwd /usr/sbin/unix_chkpwd /usr/bin/bsd-write /usr/bin/chage /usr/bin/crontab /usr/bin/expiry /usr/bin/mutt_dotlock /usr/bin/screen /usr/bin/ssh-agent /usr/bin/wall /usr/sbin/postdrop /usr/sbin/postqueue /usr/bin/at /usr/bin/dotlockfile /usr/bin/mail-lock /usr/bin/mail-touchlock /usr/bin/mail-unlock"


### PR DESCRIPTION
* Add custom whiteliste for CIS check: 6.1.13: Find SUID
  -> Add: /usr/lib/dbus-1.0/dbus-daemon-launch-helper
* Add custom whiteliste for CIS check: 6.1.14: Find SGID
  -> Add: /usr/bin/write
  -> Add: /usr/lib/systemd-cron/crontab_setgid

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Add and extend whitelist configs for the `CIS` tests. This adds:
```
* Add custom whiteliste for CIS check: 6.1.13: Find SUID
  -> Add: /usr/lib/dbus-1.0/dbus-daemon-launch-helper
* Add custom whiteliste for CIS check: 6.1.14: Find SGID
  -> Add: /usr/bin/write
  -> Add: /usr/lib/systemd-cron/crontab_setgid
 ```

**Which issue(s) this PR fixes**:
Fixes ##786

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
