### PR TITLE
feat(test): Adjust Garden Linux Repository File and Add Test for CIS

### DIFF
--- a/bin/garden-debian-sources-list
+++ b/bin/garden-debian-sources-list
@@ -39,7 +39,9 @@ version="${1:-}"; shift || eusage 'missing version'
 
 epoch="$(< "$targetDir/garden-epoch")"
 
+# Garden Linux Repository configuration
 gardenlinuxMirror='https://repo.gardenlinux.io/gardenlinux'
+gardenlinuxMirrorKey='/etc/apt/trusted.gpg.d/gardenlinux.asc'
 
 if [ -z "$ports" ]; then
 	standardMirror='https://deb.debian.org/debian'
@@ -60,7 +62,7 @@ deb() {
 	case "$target" in
 		standard) mirror="$standardMirror" ;;
 		security) mirror="$securityMirror" ;;
-		gardenlinux) mirror="$gardenlinuxMirror" ;;
+		gardenlinux) mirror="[arch=$arch signed-by=$gardenlinuxMirrorKey] $gardenlinuxMirror" ;;
 		*) echo >&2 "error: unknown 'deb' line target: '$target'"; exit 1 ;;
 	esac
 

--- a/features/cis/test/check_scripts/1.2.2_ensure_apt_gpg_keys.sh
+++ b/features/cis/test/check_scripts/1.2.2_ensure_apt_gpg_keys.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# run-shellcheck
+#
+# CIS Debian Hardening
+#
+
+#
+# 1.2.2 Ensure APT GPG Keys (not scored)
+#
+
+set -e # One error, it's over
+set -u # One variable unset, it's over
+
+# shellcheck disable=2034
+HARDENING_LEVEL=0
+# shellcheck disable=2034
+DESCRIPTION="Check for GPG key in repo list."
+
+FILES="/etc/apt/sources.list"
+DIRECTORY="/etc/apt"
+PATTERN='signed-by=/etc/apt/trusted.gpg.d/gardenlinux.asc'
+
+# This function will be called if the script status is on enabled / audit mode
+audit() {
+    FILES="$FILES $($SUDO_CMD find $DIRECTORY -type f)"
+    FOUND=0
+    for FILE in $FILES; do
+        does_pattern_exist_in_file "$FILE" "$PATTERN"
+        if [ "$FNRET" = 0 ]; then
+            FOUND=1
+        fi
+    done
+    if [ $FOUND = 1 ]; then
+        ok "$PATTERN is present in $FILES"
+    else
+        crit "$PATTERN is not present in $FILES"
+    fi
+}
+
+# This function will check config parameters required
+check_config() {
+    :
+}
+
+# Source Root Dir Parameter
+if [ -r /etc/default/cis-hardening ]; then
+    # shellcheck source=../../debian/default
+    . /etc/default/cis-hardening
+fi
+if [ -z "$CIS_ROOT_DIR" ]; then
+    echo "There is no /etc/default/cis-hardening file nor cis-hardening directory in current environment."
+    echo "Cannot source CIS_ROOT_DIR variable, aborting."
+    exit 128
+fi
+
+# Main function, will call the proper functions given the configuration (audit, enabled, disabled)
+if [ -r "$CIS_ROOT_DIR"/lib/main.sh ]; then
+    # shellcheck source=../../lib/main.sh
+    . "$CIS_ROOT_DIR"/lib/main.sh
+else
+    echo "Cannot find main.sh, have you correctly defined your root directory? Current value is $CIS_ROOT_DIR in /etc/default/cis-hardening"
+    exit 128
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR modifies the Garden Linux Repo entry in `/etc/apt/sources.list` 
from:
```
deb https://repo.gardenlinux.io/gardenlinux dev main
```
to:
```
deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/gardenlinux.asc] https://repo.gardenlinux.io/gardenlinux dev main
```

While Debian and Garden Linux are package signed this is not really important. However, we can just add this to be more `CIS` complaint.

**Which issue(s) this PR fixes**:
Fixes #842

**Special notes for your reviewer**:
Please check that this change:
 * won't break anything else
 * implementation style

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
