### PR TITLE
remove deprecated net.ipv4.ip_forward, use net.ipv4.conf.all.forwardi…

### DIFF
--- a/features/cis_sysctl/file.include/etc/sysctl.d/99-cis.conf
+++ b/features/cis_sysctl/file.include/etc/sysctl.d/99-cis.conf
@@ -1,4 +1,4 @@
-net.ipv4.ip_forward=0
+net.ipv4.conf.all.forwarding = 0
 net.ipv4.conf.all.accept_redirects = 0
 net.ipv4.conf.default.accept_redirects=0
 net.ipv6.conf.all.accept_redirects=0

--- a/features/cloud/file.include/etc/sysctl.d/20-cloud.conf
+++ b/features/cloud/file.include/etc/sysctl.d/20-cloud.conf
@@ -55,6 +55,3 @@ net.ipv4.conf.all.send_redirects = 1
 
 # Promote a secondary IP address in case a primary IP address is removed
 net.ipv4.conf.all.promote_secondaries = 1
-
-# Forward Packets between interfaces.
-net.ipv4.ip_forward = 1


### PR DESCRIPTION
…ng instead

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
remove deprecated net.ipv4.ip_forward, use net.ipv4.conf.all.forwarding instead


**Which issue(s) this PR fixes**:
Fixes #784 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
