### PR TITLE
feat(test): Add validation for supported file extensions

### DIFF
--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -104,6 +104,25 @@ class CHROOT:
             logger.error("Image archive is not present: {path}".format(
               path=self.config["image"]))
 
+        # Validate if image extension is defined corretly
+        allowed_image_ext = [
+                            "tar.xz",
+                            "txz",
+                            "tgz",
+                            "tar",
+                            "tar.gz"
+                            ]
+        file_name = os.path.basename(self.config["image"])
+        # Get extensions by dot counting in reverse order
+        file_ext = file_name.split(".")[1:]
+        # Join file extension if we have multiple ones (e.g. .tar.gz)
+        file_ext = ".".join(file_ext)
+        # Fail on unsupported image types
+        if not file_ext in allowed_image_ext:
+            msg_err = f"{file_ext} is not supported for this platform test type."
+            logger.error(msg_err)
+            pytest.exit(msg_err, 1)
+
         # Check if port is defined
         if not "port" in self.config:
             logger.error("No port for ssh connection defined.")

--- a/tests/integration/kvm.py
+++ b/tests/integration/kvm.py
@@ -91,6 +91,22 @@ class KVM:
         else:
             logger.info("'image' defined. Using: {image}".format(image=self.config["image"]))
 
+        # Validate if image extension is defined corretly
+        allowed_image_ext = [
+                            "raw",
+                            "qcow2"
+                            ]
+        file_name = os.path.basename(self.config["image"])
+        # Get extensions by dot counting in reverse order
+        file_ext = file_name.split(".")[1:]
+        # Join file extension if we have multiple ones (e.g. .tar.gz)
+        file_ext = ".".join(file_ext)
+        # Fail on unsupported image types
+        if not file_ext in allowed_image_ext:
+            msg_err = f"{file_ext} is not supported for this platform test type."
+            logger.error(msg_err)
+            pytest.exit(msg_err, 1)
+
         # Validate if image is already running
         pid = os.path.exists("/tmp/qemu.pid")
         if pid:


### PR DESCRIPTION
feat(test): Add validation for supported file extensions
 * Validate file extension for KVM test platform
 * Validate file extension for CHROOT test platform

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR catches user errors and will fail when unsupported image types are used on `KVM` or `CHROOT` test platforms.
 
**Which issue(s) this PR fixes**:
Fixes #861

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Test**:
Failed:
```
ERROR    integration.chroot:chroot.py:123 tar.foo is not supported for this platform test type.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!! _pytest.outcomes.Exit: tar.foo is not supported for this platform test type. !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```