### PR TITLE
feat(test): Add option to source VARs from config file

### DIFF
--- a/features/cis/test/config.yaml
+++ b/features/cis/test/config.yaml
@@ -1,0 +1,7 @@
+cis:
+  git_debian_cis: "https://github.com/ovh/debian-cis.git"
+  git_gardenlinux: "https://github.com/gardenlinux/gardenlinux.git"
+  config_src: "/tmp/gardenlinux/features/cis/test/conf.d/*.cfg"
+  config_dst: "/tmp/debian-cis/etc/conf.d/"
+  script_src: "/tmp/gardenlinux/features/cis/test/check_scripts/*.sh"
+  script_dst: "/tmp/debian-cis/bin/hardening/"


### PR DESCRIPTION
feat(test): Add option to source VARs from config file
 * Add option to source VARs for running tests in PyTest
   from a feature related `config.yaml` file in `test` folder

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**Which issue(s) this PR fixes**:
Fixes #788

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
