### PR TITLE
Set digest attribute for resources in Component Descriptor

### DIFF
--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -246,12 +246,12 @@ def virtual_machine_image_resource(
 
     labels = [
         cm.Label(
-          name='gardener.cloud/gardenlinux/ci/build-metadata',
-          value={
-              'modifiers': release_manifest.modifiers,
-              'buildTimestamp': release_manifest.build_timestamp,
-              'debianPackages': [p for p in _virtual_image_packages(release_manifest, cicd_cfg)],
-          }
+            name='gardener.cloud/gardenlinux/ci/build-metadata',
+            value={
+                'modifiers': release_manifest.modifiers,
+                'buildTimestamp': release_manifest.build_timestamp,
+                'debianPackages': [p for p in _virtual_image_packages(release_manifest, cicd_cfg)],
+            }
         ),
     ]
 
@@ -267,6 +267,11 @@ def virtual_machine_image_resource(
         type=cm.AccessType.S3,
         bucketName=bucket_name,
         objectKey=image_file_path.s3_key,
+        digest=cm.DigestSpec(
+            hashAlgorithm='NO-DIGEST',
+            normalisationAlgorithm='EXCLUDE-FROM-SIGNATURE',
+            value='NO-DIGEST',
+        )
     )
 
     return cm.Resource(


### PR DESCRIPTION
We plan to sign Component Descriptors in the near future. This PR sets the necessary values in the CDs published for Gardenlinux that tell the signing code to skip including the resources in our s3 bucket for the time being.

Also fixes some under-indented lines.