### PR TITLE
Adjust podman documentation in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, Garden Linux uses [Podman](https://podman.io/) as container runtime 
 
 **Debian/Ubuntu:**
 ```
-apt install bash podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64
+sudo apt install bash podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64 coreutils
 ```
 
 **CentOS/RedHat (>=8):**
@@ -70,7 +70,7 @@ CFSSL requires `GLIBC 2.28`. Therefore, we recommand to build on systems running
 
 ```
 # Install needed packages
-yum install bash podman crun make gnupg git qemu-kvm qemu-img
+sudo yum install bash podman crun make gnupg git qemu-kvm qemu-img coreutils
 ```
 
 **Adjust Repository:**

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ yum install bash podman crun make gnupg git qemu-kvm qemu-img
 
 Add `docker.io` to `unqualified-search-registries` in your [registries.conf](https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md). On freshly installed `Podman` systems this can be done by executing:
 ```
-echo 'unqualified-search-registries = ["docker.io"]' >> /etc/containers/registries.conf
+echo 'unqualified-search-registries = ["docker.io"]' | sudo tee -a /etc/containers/registries.conf
 ```
 If `Podman` was already present please add the repository yourself to `unqualified-search-registries` in `/etc/containers/registries.conf`.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Adjust the podman documentation in the `README.md`. The example of adding `docker.io` to the `registries.conf` did not work for on system on which the `registries.conf` is only writable for root.

The adjustment takes this into consideration now.