### PR TITLE
Remove duplicate coreutils on apt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, Garden Linux uses [Podman](https://podman.io/) as container runtime 
 
 **Debian/Ubuntu:**
 ```
-sudo apt install bash podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64 coreutils
+sudo apt install bash podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64
 ```
 
 **CentOS/RedHat (>=8):**


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
removes duplicate package `coreutils` from `apt install` line
