### PR TITLE
fix expected value for kernel.randomize_va_space

### DIFF
--- a/features/server/test/test_kernel_parameter.py
+++ b/features/server/test/test_kernel_parameter.py
@@ -6,7 +6,7 @@ import pytest
     [
         ("fs.protected_symlinks", 1),
         ("fs.protected_hardlinks", 1),
-        ("kernel.randomize_va_space", 1)
+        ("kernel.randomize_va_space", 2)
     ]
 )
 def test_kernel_parameter(client, parameter, value):


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
fix the expected value for kernel.randomize_va_space that was accidentally changed during testing
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
