### PR TITLE
Cleanup chroot tests

### DIFF
--- a/tests/Pipfile.lock
+++ b/tests/Pipfile.lock
@@ -842,11 +842,11 @@
         },
         "paramiko": {
             "hashes": [
-                "sha256:443f4da23ec24e9a9c0ea54017829c282abdda1d57110bf229360775ccd27a31",
-                "sha256:f6cbd3e1204abfdbcd40b3ecbc9d32f04027cd3080fe666245e21e7540ccfc1b"
+                "sha256:3c9ed6084f4b671ab66dc3c729092d32d96c3258f1426071301cb33654b09027",
+                "sha256:3d2e650b6812ce6d160abff701d6ef4434ec97934b13e95cf1ad3da70ffb5c58"
             ],
             "index": "pypi",
-            "version": "==2.10.1"
+            "version": "==2.10.4"
         },
         "pbr": {
             "hashes": [

--- a/tests/helper/tests/password_shadow.py
+++ b/tests/helper/tests/password_shadow.py
@@ -50,12 +50,12 @@ class PasswordShadow():
             cls.instance = super(PasswordShadow, cls).__new__(cls)
 
             (exit_code, output, error) = client.execute_command(
-                "awk -F: '$2~/\*/ { next; } $2~/!/ { next; } {print $0; exit 1}' /etc/shadow", quiet=True)
+                "awk -F: '$2~/\\*/ { next; } $2~/!/ { next; } {print $0; exit 1}' /etc/shadow", quiet=True)
             if exit_code != 0:
                 raise TestFailed(f"No passwords should be set in /etc/shadow")
 
             (exit_code, output, error) = client.execute_command(
-                "awk -F: '$2~/\*/ { next; } $2~/x/ { next; } {print $0; exit 1}' /etc/passwd", quiet=True)
+                "awk -F: '$2~/\\*/ { next; } $2~/x/ { next; } {print $0; exit 1}' /etc/passwd", quiet=True)
             if exit_code != 0:
                 raise TestFailed(f"Malformed entries in /etc/passwd \n {output} {error}")
 

--- a/tests/helper/tests/sgid_suid_files.py
+++ b/tests/helper/tests/sgid_suid_files.py
@@ -12,7 +12,7 @@ def _get_remote_files(client, perm):
     """ Get remote files of given attribute """
     files = []
     cmd_find = f"find / -type f -perm {perm} -exec "
-    cmd_stat = "stat -c '%n,%u,%g' {} \; 2> /dev/null"
+    cmd_stat = "stat -c '%n,%u,%g' {} \\; 2> /dev/null"
     cmd = cmd_find + cmd_stat
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -118,7 +118,7 @@ def test_timesync(client, azure):
     (exit_code, output, error) = client.execute_command("test -L /dev/ptp_hyperv")
     assert exit_code == 0, f"Expected /dev/ptp_hyperv to be a symbolic link"
 
-def test_loadavg(client, non_kvm):
+def test_loadavg(client, non_kvm, non_chroot):
     """This test does not produce any load. Make sure no 
        other process does."""
     (exit_code, output, error) = client.execute_command("cat /proc/loadavg")
@@ -337,7 +337,7 @@ def test_apparmor(client, non_chroot):
     (exit_code, output, error) = client.execute_command("grep apparmor /sys/kernel/security/lsm")
     assert exit_code == 1, f"expected apparmor to be disabled"
 
-def test_selinux(client):
+def test_selinux(client, non_chroot):
     (exit_code, output, error) = client.execute_command("grep selinux /sys/kernel/security/lsm")
     assert exit_code == 0, f"no {error=} expected"
     assert "selinux" in output.rstrip(), "Expected SELinux to be enabled."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR fixes the mentioned issues of #859 
* Fix escaping
* Update paramiko, so that it works with the newer Python version and does not produce warnings
* Disables 'test_loadavg' on 'kvm' and 'chroot' platform since the load heavily depends on the load of the build system in theses cases.
* Disabled `test_selinux` on 'chroot' platform similar to 'test_apparmor'

**Which issue(s) this PR fixes**:
Fixes #859 