### PR TITLE
910: remove old code path, that will not be called any more

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -1,15 +1,4 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-#cat /garden-epoch | md5sum | cut -f1 -d' ' > /etc/machine-id
-#chmod 0644 /etc/machine-id
-	
-aptVersion="$(dpkg-query --show --showformat "\${Version}\n" apt)"
-isDebianJessie="$([ -f "/etc/os-release" ] && source "/etc/os-release" && [ "${ID:-}" = 'debian' ] && [ "${VERSION_ID:-}" = '8' ] && echo '1')" || :
-if [ -n "$isDebianJessie" ] || [[ "$aptVersion" == 0.* ]] || dpkg --compare-versions "$aptVersion" '<<' '1.0.9.2~'; then
-	cat >> "$targetDir/etc/apt/apt.conf.d/docker-gzip-indexes" <<-'EOF'
-		Acquire::CompressionTypes::Order:: "gz";
-	EOF
-fi
-
 chmod u-s /bin/umount /bin/mount


### PR DESCRIPTION
**How to categorize this PR?**
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR removes old unused code

**Which issue(s) this PR fixes**:
Fixes #910 

**Special notes for your reviewer**:
NONE

**Release note**:
NONE