### PR TITLE
907: dpkg origin gardenlinux

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# set Garden Linux as default for dpkg
+ln -sf /etc/dpkg/origins/gardenlinux /etc/dpkg/origins/default
+
 chmod u-s /bin/umount /bin/mount

--- a/features/base/file.include/etc/dpkg/origins/gardenlinux
+++ b/features/base/file.include/etc/dpkg/origins/gardenlinux
@@ -1,0 +1,4 @@
+Vendor: GardenLinux
+Vendor-URL: https://gardenlinux.io/
+Bugs: https://github.com/gardenlinux/gardenlinux/issues/new
+Parent: Debian


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR changes the default vendor from Debian to GardenLinux. GardenLinux is not Debian, but a Debian Derivative.

**Which issue(s) this PR fixes**:
Fixes #907 

**Release note**:
NONE