### PR TITLE
908: Set distribution to gardenlinux in os-release

### DIFF
--- a/features/base/file.include/usr/lib/os-release
+++ b/features/base/file.include/usr/lib/os-release
@@ -1,0 +1,7 @@
+PRETTY_NAME="Garden Linux"
+NAME="GardenLinux"
+ID=gardenlinux
+ID_LIKE=debian
+HOME_URL="https://gardenlinux.io/"
+SUPPORT_URL="https://github.com/gardenlinux/gardenlinux#readme"
+BUG_REPORT_URL="https://github.com/gardenlinux/gardenlinux/issues/new/choose"


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Make GardenLinux a Debian Derivative

**Which issue(s) this PR fixes**:
Fixes #908 

**Special notes for your reviewer**:

**Release note**:
NONE
