### PR TITLE
fix(pkg): Fix pkg install in debootstrap not using `noninteractive` mode

### DIFF
--- a/bin/garden-init
+++ b/bin/garden-init
@@ -189,13 +189,13 @@ fi
 [ "${include_aptfile}" != "" ] &&
 "$thisDir/garden-chroot" "$targetDir" bash -c '
 	cd '${tmp#$targetDir}'
-	INITRD="No" apt-get install -y --allow-downgrades --no-install-recommends -f $1
+	INITRD="No" DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --no-install-recommends -f $1
 ' -- "$include_aptfile"
 rm -rf $tmp
 
 [ "${include_aptversion}" != "" ] &&
 "$thisDir/garden-chroot" "$targetDir" bash -c '
-	INITRD="No" apt-get install -y --allow-downgrades --no-install-recommends -f $1
+	INITRD="No" DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades --no-install-recommends -f $1
 ' -- "$include_aptversion"
 
 # fix ownership/permissions on / (otherwise "debootstrap" leaves them as-is which causes reproducibility issues)


### PR DESCRIPTION
fix(pkg): Fix pkg install in debootstrap not using `noninteractive` mode

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind TODO
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR fixes that the debootstrap process doesn't use a `noninteractive` mode for installing packages from repository that may regularly need a further dialog.

**Which issue(s) this PR fixes**:
Fixes #917

**Special notes for your reviewer**:
Can be tested with the package `git`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
bugfix
```
