### PR TITLE
feat(test): Remove unneeded `apt-utils` package from legacy tests

### DIFF
--- a/features/base/test/debsums.chroot
+++ b/features/base/test/debsums.chroot
@@ -7,8 +7,7 @@ exec 2> /dev/null
 
 thisDir=$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")
 
-#DEBIAN_FRONTEND=noninteractive apt-get update &> /dev/null
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends debsums apt-utils &> /dev/null
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends debsums &> /dev/null
 
 if out=$(debsums -l); then
 	echo "OK - verifying if all installed packages provide md5sums"

--- a/features/base/test/orphaned.chroot
+++ b/features/base/test/orphaned.chroot
@@ -2,7 +2,7 @@
 
 rc=0
 #DEBIAN_FRONTEND=noninteractive apt-get update > /dev/null
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends deborphan apt-utils > /dev/null
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends deborphan > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-mark showmanual > /var/lib/deborphan/keep
 unneeded=$(deborphan -an)
 

--- a/features/base/test/rkhunter.chroot
+++ b/features/base/test/rkhunter.chroot
@@ -10,7 +10,7 @@ if [[ ! -f "${thisDir}/rkhunter.d/rkhunter.conf" ]]; then
 	exit 1
 fi
 
-DEBIAN_FRONTEND=noninteractive apt-get install -y -qq rkhunter apt-utils &> /dev/null
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq rkhunter &> /dev/null
 
 for dir in sys dev proc; do
 	if [ -e "/$dir" ]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR removes the unneeded package `apt-utils` from legacy test scripts.

**Special notes for your reviewer**:
Locally tested:
```
test debsums is disabled by the following features: cloud 
test dev is enabled by the following features: base 
testing /dev contents
OK - all /dev devices match
passed

test dmesg is enabled by the following features: server 
testing dmesg access for non-root users (SAP Security 2.90.03)
OK - dmesg restricted | kernel config parameter
passed

test groups is enabled by the following features: _dev base 
testing administrative accounts
OK - all user accounts/groups are as expected
passed

test history is enabled by the following features: server 
OK - history is disabled and variable is read-only
passed

test home-perm is enabled by the following features: server 
checking home permissions
OK - correct home permissions
passed

test orphaned is enabled by the following features: base 
debconf: delaying package configuration, since apt-utils is not installed
OK - verifying if any extra unneeded packages are installed
passed

test pam_cracklib is enabled by the following features: cloud 
testing pam cracklib settings
OK - pam cracklib settings are correct
passed

test pam_faillock is enabled by the following features: cloud 
testing pam faillock settings
OK - pam faillock settings are correct
passed

test proc is enabled by the following features: base 
checking for an empty /proc
OK - /proc is empty
passed

test rkhunter is enabled by the following features: base 
OK - rkhunter didn't detect any issues
passed

test wireguard is enabled by the following features: cloud 
checking for wireguard capabilities
OK - capable for wireguarding
passed

Tests done. 0/12 failed. 0/12 skipped.
Done
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
