### PR TITLE
doc: make it clear that integration_tests is only used by tekton

### DIFF
--- a/integration_tests/readme.md
+++ b/integration_tests/readme.md
@@ -1,6 +1,10 @@
+> 🗒 Tests in this directory are only used by tekton pipelines.  
+> Please find the recommended default test setup in the `tests/` folder.  
+> Read the [tests/README.md](https://github.com/gardenlinux/gardenlinux/blob/main/tests/README.md) for further details.
+
 ### Integration Tests
 
-This directory contains the files that make up the integration test suites for the various providers.
+This directory contains the files that make up the integration test suites for the various providers. 
 
 ### Usage
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it clear that the integration_tests/ folder is only used by tekton pipelines.
A new developer looking for tests may find the integration_tests/ folder.

**Which issue(s) this PR fixes**:
Fixes #713 

