### PR TITLE
Fix type in general heading

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -1,6 +1,7 @@
 # Features
 
 <website-features>
+
 ## General
 Each folder represents a usable Garden Linux `feature` that can be added to a final Garden Linux artifact. This allows you to build Garden Linux for different cloud platforms with a different set of features like `CIS`, `read only` etc. Currently, the following feature types are available:
 


### PR DESCRIPTION
**How to categorize this PR?**
/kind TODO
/area os
/os garden-linux

**What this PR does / why we need it**:
The heading is currently not rendered correctly because of a missing blank line.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE
