### PR TITLE
fix(cis): Add whitelist for `CIS` check `1.5.1_bootloader_ownership`

### DIFF
--- a/features/cis/test/conf.d/1.5.1_bootloader_ownership.cfg
+++ b/features/cis/test/conf.d/1.5.1_bootloader_ownership.cfg
@@ -1,0 +1,3 @@
+# 1.5.1_bootloader_ownership.
+# Disabled: This is validated in `1.5.1_bootloader_ownership_syslinux.sh`
+status=disabled


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Add whitelist for `CIS` check `1.5.1_bootloader_ownership`. Another check is already given by https://github.com/gardenlinux/gardenlinux/blob/main/features/cis/test/check_scripts/1.5.1_bootloader_ownership_syslinux.sh 

**Which issue(s) this PR fixes**:
Fixes #939

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
