### PR TITLE
fix(cis): Add additional rules for `audit.rules` file

### DIFF
--- a/features/cis_audit/exec.config
+++ b/features/cis_audit/exec.config
@@ -70,6 +70,9 @@ echo "-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=100
 echo "-a always,exit -F path=/usr/lib/systemd-cron/crontab_setgid -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/audit.rules
 echo "-a always,exit -F path=/usr/lib/dbus-1.0/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/audit.rules
 echo "-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/audit.rules
+echo "-a always,exit -F path=/usr/bin/dotlockfile -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/audit.rules
+echo "-a always,exit -F path=/usr/bin/mailq -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/audit.rules
+echo "-a always,exit -F path=/usr/sbin/nullmailer-queue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/audit.rules
 
 # 4.1.12: Record sucessful mounts
 echo "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts" >> /etc/audit/rules.d/audit.rules


### PR DESCRIPTION
fix(cis): Add additional rules for `audit.rules` file
 * Add: dotlockfile
 * Add: mailq
 * Add: nullmailer-queue

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
fix(cis): Add additional rules for `audit.rules` file
 * Add: dotlockfile
 * Add: mailq
 * Add: nullmailer-queue

**Which issue(s) this PR fixes**:
Fixes #943

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Validation**:
```
4.1.11_record_privileged_ [INFO] Working on 4.1.11_record_privileged_commands
4.1.11_record_privileged_ [INFO] [DESCRIPTION] Collect use of privileged commands.
4.1.11_record_privileged_ [INFO] Checking Configuration
4.1.11_record_privileged_ [INFO] Performing audit
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/dotlockfile -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/expiry -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/mailq -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/lib/systemd-cron/crontab_setgid -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/lib/dbus-1.0/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audd
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/sbin/nullmailer-queue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged is present in /etc/audit/audit.rules
4.1.11_record_privileged_ [ OK ] Check Passed
```