### PR TITLE
fix: add xen-blkfront driver to initrd for aws images

### DIFF
--- a/features/aws/file.include/etc/dracut.conf.d/90-xen-blkfront-driver.conf
+++ b/features/aws/file.include/etc/dracut.conf.d/90-xen-blkfront-driver.conf
@@ -1,0 +1,1 @@
+add_drivers+=" xen-blkfront "


### PR DESCRIPTION
/kind bug
/area os
/os garden-linux

**Which issue(s) this PR fixes**:

some aws ec2 instance types use xen vbd for disks, so without the xen-blkfront driver in the initrd the block device for the root partition could not be detected
