### PR TITLE
feat(cis): Fix log permissions to succeed CIS check 4.2.3

### DIFF
--- a/features/cis_os/file.include/etc/sysstat/sysstat
+++ b/features/cis_os/file.include/etc/sysstat/sysstat
@@ -1,0 +1,44 @@
+# sysstat configuration file. See sysstat(5) manual page.
+
+# How long to keep log files (in days).
+# Used by sa2(8) script
+# If value is greater than 28, then use sadc's option -D to prevent older
+# data files from being overwritten. See sadc(8) and sysstat(5) manual pages.
+HISTORY=7
+
+# Compress (using xz, gzip or bzip2) sa and sar files older than (in days):
+COMPRESSAFTER=10
+
+# Parameters for the system activity data collector (see sadc(8) manual page)
+# which are used for the generation of log files.
+# By default contains the `-S DISK' option responsible for generating disk
+# statisitcs. Use `-S XALL' to collect all available statistics.
+SADC_OPTIONS="-S DISK"
+
+# Directory where sa and sar files are saved. The directory must exist.
+SA_DIR=/var/log/sysstat
+
+# Compression program to use.
+ZIP="xz"
+
+# By default sa2 script generates yesterday's summary, since the cron job
+# usually runs right after midnight. If you want sa2 to generate the summary
+# of the same day (for example when cron job runs at 23:53) set this variable.
+#YESTERDAY=no
+
+# By default sa2 script generates reports files (the so called sarDD files).
+# Set this variable to false to disable reports generation.
+#REPORTS=false
+
+# Tell sa2 to wait for a random delay in the range 0 .. ${DELAY_RANGE} before
+# executing. This delay is expressed in seconds, and is aimed at preventing
+# a massive I/O burst at the same time on VM sharing the same storage area.
+# Set this variable to 0 to make sa2 generate reports files immediately.
+DELAY_RANGE=0
+
+# The sa1 and sa2 scripts generate system activity data and report files in
+# the /var/log/sysstat directory. By default the files are created with umask 0022
+# and are therefore readable for all users. Change this variable to restrict
+# the permissions on the files (e.g. use 0027 to adhere to more strict
+# security standards).
+UMASK=0027

--- a/features/cis_os/file.include/usr/lib/tmpfiles.d/var.conf
+++ b/features/cis_os/file.include/usr/lib/tmpfiles.d/var.conf
@@ -1,0 +1,24 @@
+#  This file is part of systemd and modified for the
+#  CIS feature of Garden Linux.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+# See tmpfiles.d(5) for details
+
+q /var 0755 - - -
+
+L /var/run - - - - ../run
+
+d /var/log 0755 - - -
+f /var/log/wtmp 0640 root utmp -
+f /var/log/btmp 0640 root utmp -
+f /var/log/lastlog 0640 root utmp -
+
+d /var/cache 0755 - - -
+
+d /var/lib 0755 - - -
+
+d /var/spool 0755 - - -

--- a/features/cis_packages/pkg.include
+++ b/features/cis_packages/pkg.include
@@ -1,5 +1,5 @@
-syslog-ng
+git
 libpam-pwquality
 libpam-modules-bin
+syslog-ng
 tcpd
-git


### PR DESCRIPTION
feat(cis): Fix log permissions to succeed CIS check 4.2.3

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Fix initial log file permissions for log files that are created during the system start up.

**Which issue(s) this PR fixes**:
Fixes #785


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Test**:
```
4.2.3_logs_permissions    [INFO] Working on 4.2.3_logs_permissions
4.2.3_logs_permissions    [INFO] [DESCRIPTION] Check permissions on logs (other has no permissions on any files and group does not have write or execute permissions on any file)
4.2.3_logs_permissions    [INFO] Checking Configuration
4.2.3_logs_permissions    [INFO] Performing audit
4.2.3_logs_permissions    [ OK ] /var/log/btmp permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/sysstat/sa25 permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/kern.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/sudo.log permissions were set to 600
4.2.3_logs_permissions    [ OK ] /var/log/wtmp permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/auth.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/error permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/journal/1234567800000000000002e870ec0df3/system@cf437f7292e549978297cf7e51befd9c-0000000000000765-0005dfd2639c8c1f.journal permissions wer 
4.2.3_logs_permissions    [ OK ] /var/log/journal/1234567800000000000002e870ec0df3/system@cf437f7292e549978297cf7e51befd9c-0000000000000001-0005dfd25a7ab5da.journal permissions were
4.2.3_logs_permissions    [ OK ] /var/log/journal/1234567800000000000002e870ec0df3/system.journal permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/journal/1234567800000000000002e870ec0df3/system@cf437f7292e549978297cf7e51befd9c-0000000000000570-0005dfd25d3ceab6.journal permissions were
4.2.3_logs_permissions    [ OK ] /var/log/journal/1234567800000000000002e870ec0df3/system@cf437f7292e549978297cf7e51befd9c-00000000000002f0-0005dfd25c0190b8.journal permissions were
4.2.3_logs_permissions    [ OK ] /var/log/audit/audit.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/lastlog permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/daemon.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/user.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/cron.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/debug permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/mail.log permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/messages permissions were set to 640
4.2.3_logs_permissions    [ OK ] /var/log/syslog permissions were set to 640
4.2.3_logs_permissions    [ OK ] Logs in /var/log have correct permissions
4.2.3_logs_permissions    [ OK ] Check Passed
```