### PR TITLE
simplify existing pytest password hashes

### DIFF
--- a/features/base/test/test_password_hashes.py
+++ b/features/base/test/test_password_hashes.py
@@ -1,10 +1,1 @@
-from helper.exception import NotPartOfFeatureError, DisabledBy
-from helper.tests.password_hashes import PasswordHashes
-import pytest
-
-def test_password_hashes(client, features):
-    """The test function executed by pytest"""
-    try:
-        PasswordHashes(client, features)
-    except (NotPartOfFeatureError, DisabledBy) as e:
-        pytest.skip(str(e))
+from helper.tests.password_hashes import password_hashes as test_password_hashes

--- a/tests/helper/tests/password_hashes.py
+++ b/tests/helper/tests/password_hashes.py
@@ -1,80 +1,26 @@
-import logging
+def password_hashes(client):
+    """Check configured password hashes"""
+    # Call binary on remote and get content of file
+    (exit_code, output, error) = client.execute_command(
+        "cat /etc/pam.d/common-password", quiet=True)
+    assert exit_code == 0, f"no {error=} expected"
 
-from helper import utils
-from helper.exception import NotPartOfFeatureError, TestFailed, DisabledBy
+    # Validate that the main part is present
+    match_list = []
+    for line in output.split('\n'):
+        # First fetch the corresponding line(s)
+        if "[success=1 default=ignore]" in line:
+            # Do not fetch comments
+            if not line.startswith("#"):
+                match_list.append(line)
+                test_line = line
 
-logger = logging.getLogger(__name__)
+    # Validate that this is only defined a single time
+    # to ensure no feature has appended different options
+    # multiple times
+    assert len(match_list) == 1, \
+        "Redundant options defined in /etc/pam.d/common-password"
 
-
-class PasswordHashes():
-    """Class containing the test for checking if debsums are available"""
-    failed_before = False
-    def __new__(cls, client, features):
-        """The actual test.
-        Placing the code for the test in the __new__ method allows to test if
-        there is already an instance of this class and avoid executing the
-        test more than once.
-        The class variable failed_before is used to make sure the test is
-        shown as failed when the first call of the test had failed.
-        If the test had passed the first time and is called again the same
-        instance is returned and the test is shown as passed, but the test is
-        NOT executed again. Therefore the test collects the test configuration
-        from all enabled features, so it is not necessary to executed the test
-        more than once.
-        """
-
-        # throws exception if the test had failed before to make sure it is
-        # not show as passed when called again by another feature.
-        if cls.failed_before:
-            raise Exception("This test failed before in another feature")
-
-        (enabled_features, my_feature) = features
-
-        # check if test is disabled in a feature
-        test_is_disabled = utils.disabled_by(enabled_features, 'password_hashes')
-        if not len(test_is_disabled) == 0:
-            raise DisabledBy("Test is explicitly disabled by features " +
-                f"{', '.join(test_is_disabled)}")
-
-        # check if the test is part of the features used to build the
-        # gardenlinux image
-        if my_feature not in enabled_features:
-            raise NotPartOfFeatureError(
-                f"Feature {my_feature} this test belongs to is not enabled")
-
-        # first check if there is already an instance of this class, if it is
-        # the first time this instance is initiated add the class variable
-        # instance containing the instance itself and then do the actual
-        # testing.
-        if not hasattr(cls, 'instance'):
-            cls.instance = super(PasswordHashes, cls).__new__(cls)
-
-            # Call binary on remote and get content of file
-            (exit_code, output, error) = client.execute_command(
-                "cat /etc/pam.d/common-password", quiet=True)
-
-            # Validate that the main part is present
-            match_list = []
-            for line in output.split('\n'):
-                # First fetch the corresponding line(s)
-                if "[success=1 default=ignore]" in line:
-                    # Do not fetch comments
-                    if not line.startswith("#"):
-                        match_list.append(line)
-                        test_line = line
-
-            # Validate that this is only defined a single time
-            # to ensure no feature has appended different options
-            # multiple times
-            if len(match_list) > 1:
-                msg_err = "Redundant options defined in /etc/pam.d/common-password"
-                logger.error(msg_err)
-                raise TestFailed(msg_err)
-
-            # Validate the entry for 'sha512' or 'yescrypt'
-            if not 'yescrypt' or 'sha512' in test_line:
-                msg_err = "No yescrypt or sha512 found in /etc/pam.d/common-password"
-                logger.error(msg_err)
-                raise TestFailed(msg_err) 
-
-        return cls.instance
+    # Validate the entry for 'sha512' or 'yescrypt'
+    assert 'yescrypt' in test_line or 'sha512' in test_line, \
+        f"No yescrypt or sha512 found in /etc/pam.d/common-password"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
simplify existing pytest password hashes
**Which issue(s) this PR fixes**:
Fixes #874 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
