### PR TITLE
fix(pytest): Add `usr/share/runit/meta/ssh/installed` to be excluded

### DIFF
--- a/features/base/test/test_debsums.py
+++ b/features/base/test/test_debsums.py
@@ -6,6 +6,7 @@ import pytest
     [
         [
             "/lib/systemd/system/dbus.socket",
+            "/usr/share/runit/meta/ssh/installed",
             "/usr/share/pam-configs/cracklib"
         ]
     ]


### PR DESCRIPTION
fix(pytest): Add `usr/share/runit/meta/ssh/installed` to be excluded

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Fixes the `test_debsums` PyTest and avoids failing the test pipeline.

**Which issue(s) this PR fixes**:
Fixes #961

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
