### PR TITLE
fix(doc): Add `sudo` package for installation (may not be present on …

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ By default, Garden Linux uses [Podman](https://podman.io/) as container runtime 
 
 **Debian/Ubuntu:**
 ```
-sudo apt install bash podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64
+apt install bash sudo podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64
 ```
 
 **CentOS/RedHat (>=8):**
@@ -75,7 +75,7 @@ CFSSL requires `GLIBC 2.28`. Therefore, we recommand to build on systems running
 
 ```
 # Install needed packages
-sudo yum install bash podman crun make gnupg git qemu-kvm qemu-img coreutils
+yum install bash sudo podman crun make gnupg git qemu-kvm qemu-img coreutils
 ```
 
 **Adjust Repository:**


### PR DESCRIPTION
fix(doc): Add `sudo` package for installation (may not be present on minimal)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Add `sudo` package to avoid failing the build proc like:
```
#> make kvm-dev
make --directory=container build-base-test
make[1]: Entering directory '/root/gardenlinux/container'
./needslim: line 7: sudo: command not found
WARNING: There is no gardenlinux/slim on this box. Since this is the builder script, it will pull no binary docker images from public repos.
```
**Which issue(s) this PR fixes**:
Fixes #959


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
