### PR TITLE
feat(gardener): Allow non-root `dmesg` permissions

### DIFF
--- a/features/gardener/file.exclude
+++ b/features/gardener/file.exclude
@@ -1,1 +1,2 @@
 /etc/containerd/config.toml
+/etc/sysctl.d/restric-dmesg.conf

--- a/features/gardener/file.include/etc/sysctl.d/allow-nonroot-dmesg.conf
+++ b/features/gardener/file.include/etc/sysctl.d/allow-nonroot-dmesg.conf
@@ -1,0 +1,1 @@
+kernel.dmesg_restrict = 0 

--- a/features/gardener/test/test_dmesg.py
+++ b/features/gardener/test/test_dmesg.py
@@ -1,0 +1,18 @@
+import pytest
+from helper.tests.file_content import file_content
+from helper.utils import execute_remote_command
+
+
+@pytest.mark.parametrize(
+    "file,args",
+    [
+        ("/etc/sysctl.d/allow-nonroot-dmesg.conf", {"kernel.dmesg_restrict": "0"}),
+        ("/tmp/sysctl.txt", {"kernel.dmesg_restrict": "0"})
+    ]
+)
+
+
+def test_dmesg(client, file, args, non_chroot):
+    cmd = "sysctl -a > /tmp/sysctl.txt"
+    execute_remote_command(client, cmd)
+    file_content(client, file, args)

--- a/features/server/test/test_dmesg.py
+++ b/features/server/test/test_dmesg.py
@@ -6,14 +6,13 @@ from helper.tests.file_content import file_content
 @pytest.mark.parametrize(
     "file,args",
     [
-        ("/boot/config-", {"CONFIG_SECURITY_DMESG_RESTRICT": "y"}),
-        ("/etc/sysctl.d/restric-dmesg.conf", {"kernel.dmesg_restrict": "1"})
+        ("/etc/sysctl.d/restric-dmesg.conf", {"kernel.dmesg_restrict": "1"}),
+        ("/tmp/sysctl.txt", {"kernel.dmesg_restrict": "1"})
     ]
 )
 
 
-def test_dmesg(client, file, args, non_chroot):
-    kernel_ver = get_kernel_version(client)
-    if '/boot/config-' in file:
-        file = f"{file}{kernel_ver}"
+def test_dmesg(client, file, args, non_chroot, non_feature_gardener):
+    cmd = "sysctl -a > /tmp/sysctl.txt"
+    execute_remote_command(client, cmd)
     file_content(client, file, args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -461,6 +461,12 @@ def non_metal(testconfig):
         pytest.skip('test not supported on metal')
 
 @pytest.fixture
+def non_feature_gardener(testconfig):
+    features = testconfig.get("features", [])
+    if "gardener" in features:
+        pytest.skip('test is not supported on gardener')
+
+@pytest.fixture
 def non_dev(testconfig):
     features = testconfig.get("features", [])
     if "_dev" in features:

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -112,3 +112,12 @@ def execute_local_command(cmd):
     rc = p.returncode
     out = p.stdout.decode()
     return rc, out
+
+
+def execute_remote_command(client, cmd):
+    """ Run remote command on test platform """
+    (exit_code, output, error) = client.execute_command(
+        cmd, quiet=True)
+    assert exit_code == 0, f"no {error=} expected"
+    output = output.strip()
+    return output


### PR DESCRIPTION
feat(gardener): Allow non-root `dmesg` permissions
 * Allow non-root `dmesg` permissions
 * If feature `server` and `gardener` are active
   `test_dmesg.py` will be executed from `gardener` feature

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #982

**Special notes for your reviewer**:
`gardener` feature requires us to allow `non-root` users to access `dmesg`. The configuration will apply to `gardener` feature and deprecated the used config in `server`. Next to this, a new ficture `deprecated_by_gardener`
 is created, to avoid running the tests in `server`  and `gardener` that would lead to different outputs.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
bugfix
```
