### PR TITLE
replace waagent with cloud-init in azure and disable cloud-init netwo…

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf
+#sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf
 
 # On Azure we use chrony and ptp to set the time
 #apt-get remove systemd-timesyncd
 #apt-get install -y chrony
 
-systemctl disable waagent-apt.service
+#systemctl disable waagent-apt.service
+
+# disable cloud-init network configuration
+echo -e "network:\n  config: disabled\n" >> /etc/cloud/cloud.cfg.d/00_azure.cfg

--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-#sed -i 's/Provisioning.RegenerateSshHostKeyPair=y/Provisioning.RegenerateSshHostKeyPair=n/g;s/Provisioning.DecodeCustomData=n/Provisioning.DecodeCustomData=y/g;s/OS.EnableFirewall=n/OS.EnableFirewall=y/g;s/Provisioning.ExecuteCustomData=n/Provisioning.ExecuteCustomData=y/g;s/Provisioning.MonitorHostName=y/Provisioning.MonitorHostName=n/g;s/Logs.Verbose=n/Logs.Verbose=y/g' /etc/waagent.conf
-
-# On Azure we use chrony and ptp to set the time
-#apt-get remove systemd-timesyncd
-#apt-get install -y chrony
-
-#systemctl disable waagent-apt.service
-
 # disable cloud-init network configuration
 echo -e "network:\n  config: disabled\n" >> /etc/cloud/cloud.cfg.d/00_azure.cfg

--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -2,3 +2,4 @@
 #waagent
 chrony
 cloud-init
+python3-cffi-backend

--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,5 +1,3 @@
-# Azure images require waagent
-#waagent
 chrony
 cloud-init
 python3-cffi-backend

--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,3 +1,4 @@
 # Azure images require waagent
-waagent
+#waagent
 chrony
+cloud-init


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
replace waagent with cloud-init in azure and disable cloud-init network config
**Which issue(s) this PR fixes**:
Fixes #925 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
