### PR TITLE
tests: support ARM64 for tests on AWS

### DIFF
--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -114,6 +114,7 @@ def register_image(
     ec2_client: 'botocore.client.EC2',
     snapshot_id: str,
     image_name: str,
+    architecture: str='x86_64',
 ) -> str:
     '''
     @return: ami-id of registered image
@@ -122,7 +123,7 @@ def register_image(
 
     result = ec2_client.register_image(
         # ImageLocation=XX, s3-url?
-        Architecture='x86_64', # | i386, arm64
+        Architecture=architecture # x86_64, i386, arm64
         BlockDeviceMappings=[
             {
                 'DeviceName': root_device_name,

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,6 +78,8 @@ aws:
     region: eu-central-1
     # machine/instance type of the test VM - not all machines are available in all regions (optional)
     instance_type: t3.micro
+    # architecture of the image and VM to be used (optional)
+    architecture: x86_64
 
     # ssh related configuration for logging in to the VM (optional)
     ssh:
@@ -108,6 +110,7 @@ aws:
 
 - **region** _(required)_: the AWS region in which all test relevant resources will be created 
 - **instanc-type** _(optional)_: the instance type that will be used for the EC2 instance used for testing, defaults to `t3.micro` if not specified
+- **architecture** _(optional)_: the architecture under which the AMI of the image to test should be registered (`x86_64` or `arm64`), must match the instance type, defaults to `x86_64` if not specified
 
 - **ssh_key_filepath** _(optional)_: The SSH key that will be deployed to the EC2 instance and that will be used by the test framework to log on to it. Must be the file containing the private part of an SSH keypair which needs to be generated with `openssh-keygen` beforehand. If not provided, a new SSH key with 2048 bits will be generated just for the test.
 - **passphrase** _(optional)_: If the given SSH key is protected with a passphrase, it needs to be provided here.

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -52,6 +52,8 @@ class AWS:
             pytest.exit("Neither 'image' nor 'ami_id' specified, cannot continue.", 2)
         if not 'instance_type' in cfg:
             cfg['instance_type'] = "t3.micro"
+        if not 'architecture' in cfg:
+            cfg['architecture'] = "x86_64"
         if not 'bucket' in cfg:
             cfg['bucket'] = f"img-{test_name}-upload"
         if not 'securitygroup_name' in cfg:
@@ -502,7 +504,8 @@ class AWS:
         self._ami_id = glci.aws.register_image(
             ec2_client = self.ec2_client,
             snapshot_id = self._snapshot_id,
-            image_name = image_name
+            image_name = image_name,
+            architecture = self.config["architecture"]
         )
         self.ec2_client.create_tags(
             Resources = [self._ami_id],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Extends the Integration/Platform tests for AWS to support ARM64 images.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- extends the Integration/Platform tests for AWS to support ARM64 images.
```
