### PR TITLE
fix(startvm): Allow virtualized ARM64 systems to run QEMU

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -198,8 +198,14 @@ if [ "$arch" = "$(uname -m)" ]; then
 		[ -z "${cpuinfo##*vmx*}" -o -z "${cpuinfo##*svm*}" ] &&
 			virtOpts+=("-enable-kvm" "-cpu host" "-machine q35,smm=on")
 		elif [ "$arch" = aarch64 ]; then
-			virtOpts+=("-cpu host" "-machine virt")
-			[ -e "/dev/kvm" ] && virtOpts+=("-accel kvm")
+                        # Check if aarch64 is running in a virtualized
+                        # environment where we may not use any accleration
+                        if [ "QEMU" = "$(dmesg  | grep "DMI: QEMU" | awk {'print $4'})" ] && [ "not" = "$(dmesg | grep -i kvm | awk {'print $7'})" ]; then
+			    virtOpts+=("-cpu max" "-machine virt")
+			else
+                            virtOpts+=("-cpu host" "-machine virt")
+			    [ -e "/dev/kvm" ] && virtOpts+=("-accel kvm")
+                        fi
 		fi
 else
 	if [ "$arch" = x86_64 ]; then


### PR DESCRIPTION
fix(startvm): Allow virtualized ARM64 systems to run QEMU even when no further accleration is supported

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR allows  Apple Silicon (M1/M2) users to run VMs with `bin/startvm` script which may fail based on the underlying virtualization technology like `UTM`.

**Which issue(s) this PR fixes**:
Fixes #957


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
