### PR TITLE
test: enable Azure boot diagnostics

### DIFF
--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -322,6 +322,11 @@ class AZURE:
                         }
                     ]
                 },
+                'diagnostics_profile': {
+                    'boot_diagnostics': {
+                        'enabled': True,
+                    }
+                },
                 'tags': self._tags
             }
         ).result()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Enables the boot diagnostics for platform tests on Azure so that it is possible to see what went wrong if a machine fails to properly boot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- enable Azure boot diagnostics
```
