### PR TITLE
test: seperate capability list

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -160,7 +160,7 @@ else
 		fullfeatures="$(${thisDir}/bin/garden-feat --featureDir $featureDir --features "$features" --ignore "$disablefeatures" features)"
 		configDir=$(${thisDir}/bin/garden-integration-test-config chroot ${prefix} ${fullfeatures} ${outputDir})
 		echo "Running pytests in chroot"
-		${gardenlinux_build_cre} run --cap-add SYS_ADMIN,MKNOD,AUDIT_WRITE,NET_RAW --security-opt apparmor=unconfined \
+		${gardenlinux_build_cre} run --cap-add sys_admin --cap-add mknod --cap-add audit_write --cap-add net_raw --security-opt apparmor=unconfined \
 			--name $containerName --rm -v `pwd`:/gardenlinux -v ${configDir}:/config \
 			gardenlinux/base-test:dev \
 			pytest --iaas=chroot --configfile=/config/config.yaml &


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Even though Garden Linux builds with PodMan nowadays, it still supports building with Docker by setting the env variable `GARDENLINUX_BUILD_CRE=docker`. For the tests, a container with an elaborate set of capabilities is started but apparently, Docker does not like these capabilities to be supplied as a comma-separated list (PodMan does though) and the tests fail to run. Thus, this PR now supplies each capability with its own `--cap-add` switch.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- test: capabilities supplied individually to container runtime
```
