### PR TITLE
fix(start-vm): Use $TMPDIR for {monitor,socket} files

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -15,6 +15,7 @@ set -Eeuo pipefail
 
 thisDir=$(dirname "$(readlink -f "$BASH_SOURCE")")
 targetDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+tmpDir=${TMPDIR:-/tmp}
 cpu=2
 arch="$(uname -m)"
 memory=2Gi
@@ -187,7 +188,7 @@ uuid="12345678-0000-0000-0000-${mac}"
 virtOpts+=(     "-uuid $uuid" )
 
 # support for qemu guest agent. There is no way for this script if inside VM is connected or not
-virtOpts+=(	"-chardev socket,path=$targetDir/$mac.guest,server=on,wait=off,id=qga0"
+virtOpts+=(	"-chardev socket,path=$tmpDir/$mac.guest,server=on,wait=off,id=qga0"
 		"-device virtio-serial"
 		"-device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0" )
 
@@ -217,8 +218,8 @@ fi
 
 # adding a monitoring port for extended commands
 if [ $monitor ]; then
-	[ -e $targetDir/$mac.monitor ] && eusage "monitor to this macaddress already exists $targetDir/$mac.monitor"
-	virtOpts+=(	"-monitor unix:$targetDir/$mac.monitor,server,nowait" )
+	[ -e $tmpDir/$mac.monitor ] && eusage "monitor to this macaddress already exists $targetDir/$mac.monitor"
+	virtOpts+=(	"-monitor unix:$tmpDir/$mac.monitor,server,nowait" )
 fi
 
 [ $daemonize ] && virtOpts+=(	"-daemonize" )
@@ -371,6 +372,3 @@ if [ $vnc ]; then
 fi
 
 qemu-system-$arch ${virtOpts[@]}
-
-### cleanup
-[ $daemonize ] || rm -f $targetDir/$mac.monitor


### PR DESCRIPTION
fix(start-vm): Use $TMPDIR for {monitor,socket} files
 * Add new VAR "tmpDir" that tests if $TMPDIR is set
   with fallback to '/tmp'
 * Remove cleanup (QEMU handles this itself)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Use $TMPDIR for {monitor,socket} files

**Which issue(s) this PR fixes**:
Fixes #1008

**Special notes for your reviewer**:
Tested by @chrinorse (reported this issue) and @gyptazy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
