### PR TITLE
test(manual): reenable manual test for existing host

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from integration.ali import ALI
 from integration.openstackccee import OpenStackCCEE
 from integration.chroot import CHROOT
 from integration.kvm import KVM
+from integration.manual import Manual
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -183,6 +184,8 @@ def testconfig(pipeline, iaas, pytestconfig):
         elif iaas == 'chroot':
             pass
         elif iaas == 'kvm':
+            pass
+        elif iaas == 'manual':
             pass
         return config
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

(Re-)Enables running the platform/integration tests on an already existing and provisioned host of which an SSH key and the IP/hostname is known. This functionality was introduced in PR #461 and got broken in the refactoring of the test framework.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- test(manual): reenable manual test for existing host
```
