### PR TITLE
fix: use $version instead of hardcoded dev for test container

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -162,7 +162,7 @@ else
 		echo "Running pytests in chroot"
 		${gardenlinux_build_cre} run --cap-add sys_admin --cap-add mknod --cap-add audit_write --cap-add net_raw --security-opt apparmor=unconfined \
 			--name $containerName --rm -v `pwd`:/gardenlinux -v ${configDir}:/config \
-			gardenlinux/base-test:dev \
+			"gardenlinux/base-test:$version" \
 			pytest --iaas=chroot --configfile=/config/config.yaml &
 		wait %1
 		rm -r ${configDir}
@@ -176,7 +176,7 @@ else
 		echo "Running pytests in KVM"
 		${gardenlinux_build_cre} run --name $containerName --rm -v /boot/:/boot \
 			-v /lib/modules:/lib/modules -v `pwd`:/gardenlinux -v ${configDir}:/config \
-			gardenlinux/base-test:dev \
+			"gardenlinux/base-test:$version" \
 			pytest --iaas=kvm --configfile=/config/config.yaml &
 		wait %1
 		rm -r ${configDir}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

`build.sh` was using hardcoded `dev` version of the `base-test` container.
This breaks when building a specific version in a clean build environment where no prior dev builds ran.
