### PR TITLE
fix: use .endswith to check for allowed image extensions

### DIFF
--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -105,20 +105,16 @@ class CHROOT:
               path=self.config["image"]))
 
         # Validate if image extension is defined corretly
-        allowed_image_ext = [
-                            "tar.xz",
-                            "txz",
-                            "tgz",
-                            "tar",
-                            "tar.gz"
-                            ]
+        allowed_image_ext = (
+                            ".tar.xz",
+                            ".txz",
+                            ".tgz",
+                            ".tar",
+                            ".tar.gz"
+                            )
         file_name = os.path.basename(self.config["image"])
-        # Get extensions by dot counting in reverse order
-        file_ext = file_name.split(".")[1:]
-        # Join file extension if we have multiple ones (e.g. .tar.gz)
-        file_ext = ".".join(file_ext)
         # Fail on unsupported image types
-        if not file_ext in allowed_image_ext:
+        if not file_name.endswith(allowed_image_ext):
             msg_err = f"{file_ext} is not supported for this platform test type."
             logger.error(msg_err)
             pytest.exit(msg_err, 1)

--- a/tests/integration/kvm.py
+++ b/tests/integration/kvm.py
@@ -92,17 +92,13 @@ class KVM:
             logger.info("'image' defined. Using: {image}".format(image=self.config["image"]))
 
         # Validate if image extension is defined corretly
-        allowed_image_ext = [
-                            "raw",
-                            "qcow2"
-                            ]
+        allowed_image_ext = (
+                            ".raw",
+                            ".qcow2"
+                            )
         file_name = os.path.basename(self.config["image"])
-        # Get extensions by dot counting in reverse order
-        file_ext = file_name.split(".")[1:]
-        # Join file extension if we have multiple ones (e.g. .tar.gz)
-        file_ext = ".".join(file_ext)
         # Fail on unsupported image types
-        if not file_ext in allowed_image_ext:
+        if not file_name.endswith(allowed_image_ext):
             msg_err = f"{file_ext} is not supported for this platform test type."
             logger.error(msg_err)
             pytest.exit(msg_err, 1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Currently tests fail with
```
ERROR    integration.chroot:chroot.py:123 0-local.tar.xz is not supported for this platform test type.
```
when using any version other then `dev` since in that case everything after the dot in the version number gets treated as part of the image extension.

This fixes it by using the string `endswith` method instead of manually parsing out the extension from the filename.