### PR TITLE
Ci: also add digest to rootfs-resources

### DIFF
--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -326,6 +326,11 @@ def _image_rootfs_resource(
         type=resource_type,
         labels=labels,
         access=resource_access,
+        digest=cm.DigestSpec(
+            hashAlgorithm='NO-DIGEST',
+            normalisationAlgorithm='EXCLUDE-FROM-SIGNATURE',
+            value='NO-DIGEST',
+        ),
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, rootfs-resources will also get digest-information added to the component-descriptor.