### PR TITLE
remove out commented cloud-guest-utils from metal and cloud feature

### DIFF
--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -2,7 +2,6 @@ fdisk
 [${arch}=amd64] syslinux
 [${arch}=amd64] syslinux-common
 #[${arch}=arm64] grub-cloud-arm64
-#cloud-guest-utils
 libpam-cracklib
 rng-tools5
 linux-image-5.15-cloud-${arch}

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -7,7 +7,6 @@ efibootmgr
 haveged
 ipmitool
 #grub-cloud-amd64
-#cloud-guest-utils
 #irqbalance
 pciutils
 usbutils


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
remove out commented cloud-guest-utils from metal and cloud feature
**Which issue(s) this PR fixes**:
Fixes #102

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
