### PR TITLE
fix: install latest cloud-init for alicloud

### DIFF
--- a/features/ali/pkg.include
+++ b/features/ali/pkg.include
@@ -1,5 +1,4 @@
 python3-cffi-backend
 python3-boto
 dmidecode
-# Workaround for https://bugs.launchpad.net/cloud-init/+bug/1917875 in 20.4.1
-http://snapshot.debian.org/archive/debian/20200520T032945Z/pool/main/c/cloud-init/cloud-init_20.2-2_all.deb
+cloud-init

--- a/features/server/file.include/etc/systemd/system/systemd-resolved.service.d/wait-for-networkd.conf
+++ b/features/server/file.include/etc/systemd/system/systemd-resolved.service.d/wait-for-networkd.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=systemd-networkd.service

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -38,7 +38,7 @@ def test_ntp(client, non_azure, non_chroot):
     (exit_code, output, error) = client.execute_command("timedatectl show")
     assert exit_code == 0, f"no {error=} expected"
     lines = output.splitlines()
-    npt_ok=False
+    ntp_ok=False
     ntp_synchronised_ok=False
     for l in lines:
         nv = l.split("=")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
Changes the cloud-init version that gets installed into the ali-cloud image from the previously pinned 20.2 version to the latest upstream version. Also fixes some typos in the platform tests and changes their order to allow for enough time for the NTP client in Garden Linux to successfully synchronize before checking its status.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- fix: install latest cloud-init for alicloud
```
