### PR TITLE
test: check for timestamps in the future

### DIFF
--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -49,6 +49,30 @@ def test_ntp(client, non_azure, non_chroot):
     assert ntp_ok, "NTP not activated"
     assert ntp_synchronised_ok, "NTP not synchronized"
 
+def test_files_not_in_future(client):
+    testscript_name="/tmp/filemodtime-test.py"
+    testscript='''import os
+import sys
+from datetime import datetime
+
+now = datetime.now()
+dirs = ["/bin", "/etc/ssh"]
+for dir in dirs:
+    for (dirpath, dirnames, filenames) in os.walk(dir):
+        for f in filenames:
+            file = os.path.join(dir, f)
+            modification = datetime.fromtimestamp(os.path.getmtime(file))
+            if modification > now:
+                print(f"FAIL - {file}s timestamp is {modification}")
+                sys.exit(1)
+__EOF
+'''
+    (exit_code, output, error) = client.execute_command(f"cat << '__EOF'\n{testscript}\n > {testscript_name}")
+    assert exit_code == 0, f"no {error=} expected"
+    (exit_code, output, error) = client.execute_command(f"python3 {testscript_name}")
+    assert exit_code == 0, f"no {error=} expected"
+    assert "FAIL" not in output
+
 def test_ls(client):
     (exit_code, output, error) = client.execute_command("ls /")
     assert exit_code == 0, f"no {error=} expected"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Provides a platform test that check that file timestamps are not in the future (which could provide a smell for clock skew).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- test: check for timestamps in the future
```
