### PR TITLE
fix: debugfs timestamps

### DIFF
--- a/bin/make_reproducible_ext4
+++ b/bin/make_reproducible_ext4
@@ -75,4 +75,4 @@ fi
 # fixup timestamp on all used inodes to create reproducible ext4 image
 num_inodes=$(dumpe2fs -h "$target" 2> /dev/null | grep '^Inode count:' | cut -d ':' -f 2 | tr -d ' ')
 used_inodes=$(for (( inode=1; inode <= "$num_inodes"; inode++ )); do echo "testi <$inode>"; done | debugfs "$target" 2> /dev/null | grep -oP '(?<=Inode )[0-9]+(?= is marked in use)')
-for inode in $used_inodes; do for field in {a,m,c}time; do echo "set_inode_field <$inode> $field $timestamp"; done; done | debugfs -w "$target" &> /dev/null
+for inode in $used_inodes; do for field in {a,m,c}time; do echo "set_inode_field <$inode> $field @$timestamp"; done; done | debugfs -w "$target" &> /dev/null


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

ensure debugfs parses the timestamp as a plain timestamps and not some date format
