### PR TITLE
feature(pytest): Add PyTest for validating the `machine-id`

### DIFF
--- a/features/server/test/test_machine_id.py
+++ b/features/server/test/test_machine_id.py
@@ -1,1 +1,8 @@
-from helper.tests.machine_id import machine_id as test_machine_id
+from helper.tests.machine_id import machine_id
+from helper.tests.machine_id import machine_id_powered_on
+
+def test_machine_id(client, chroot):
+     machine_id(client)
+
+def test_machine_id_powered_on(client, non_chroot):
+     machine_id_powered_on(client)

--- a/tests/helper/tests/machine_id.py
+++ b/tests/helper/tests/machine_id.py
@@ -1,9 +1,7 @@
-import logging
 import string
 
-logger = logging.getLogger(__name__)
 
-def machine_id(client, chroot):
+def machine_id(client):
     """Test if /etc/machine_id exists and is not initialized"""
     (exit_code, output, error) = client.execute_command(
         "[[ ! -s /etc/machine-id ]] || cat /etc/machine-id", quiet=True)
@@ -12,3 +10,25 @@ def machine_id(client, chroot):
 
     assert exit_code == 0 and ( machine_id == "uninitialized" or
             machine_id == ""), "machine-id doesn't exist or is not empty!"
+
+
+def machine_id_powered_on(client):
+    """Test if /etc/machine_id exists and is initialized"""
+    # Validate that systemd unit is started
+    systemd_unit = "systemd-machine-id-commit"
+    cmd = f"systemctl status {systemd_unit}.service"
+    (rc, out, err) = client.execute_command(
+        cmd, quiet=True)
+
+    # Validate output lines of systemd-unit
+    for line in out.splitlines():
+        if "Active:" in line:
+            assert not "dead" in line, f"systemd-unit: {systemd_unit} did not start."
+
+    # Validate content of generated output
+    # from systemd-machine-id-commit unit
+    machine_id_file = "/etc/machine-id"
+    cmd = f"cat {machine_id_file}"
+    (rc, out, err) = client.execute_command(
+        cmd, quiet=True)
+    assert not (out == "" or out == "uninitialized"), f"machine-id is uninitialized in {machine_id_file}"


### PR DESCRIPTION
feature(pytest): Add PyTest for validating the `machine-id`
This PyTest validates the systemd unit for creating a machine-id
as well as the content of the created machine-id

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds another PyTest for validating the `machine-id`.

**Which issue(s) this PR fixes**:
Fixes #1051

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```