### PR TITLE
fix: use dynamic version for the base image of integration-test

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -40,7 +40,7 @@ build-base-test: needslim
 build-integration-test: build-base-test
 	mkdir -p integration-test/_pipfiles
 	cp ../tests/Pipfile* integration-test/_pipfiles
-	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/integration-test:$(VERSION) integration-test
+	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/integration-test:$(VERSION) integration-test
 
 .PHONY: build-kernelmodule
 build-kernelmodule: build

--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -1,4 +1,5 @@
-FROM gardenlinux/base-test:dev
+ARG VERSION
+FROM gardenlinux/base-test:${VERSION}
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
      && unzip awscliv2.zip \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that the build pipeline uses a dynamic version for referencing the base image of the the `integration-test` container in its Dockerfile. This way, we can ensure that the image version between the `integration-test` and `base-test` (base image of `integration-test`) are kept in sync during the build.

In the past, the base image version has been hard coded and did not work anymore due to a change from `dev` to `today`.

**Which issue(s) this PR fixes**:
Fixes #1074 
