### PR TITLE
feature(pytest): Add generic function to test for a systemd unit

### DIFF
--- a/features/gardener/test/test_systemd_units.py
+++ b/features/gardener/test/test_systemd_units.py
@@ -1,0 +1,17 @@
+import pytest
+from helper.utils import execute_remote_command
+from helper.utils import validate_systemd_unit
+
+
+@pytest.mark.parametrize(
+    "systemd_unit",
+    [
+        "containerd",
+        "docker",
+    ]
+)
+
+
+def test_systemd_unit(client, systemd_unit, non_chroot):
+    execute_remote_command(client, f"systemctl start {systemd_unit}")
+    validate_systemd_unit(client, f"{systemd_unit}")

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -106,6 +106,19 @@ def get_kernel_version(client):
     return output
 
 
+def validate_systemd_unit(client, systemd_unit):
+    """ Validate a given systemd unit """
+    cmd = f"systemctl status {systemd_unit}.service"
+    (exit_code, output, error) = client.execute_command(
+        cmd, quiet=True)
+    assert exit_code == 0, f"systemd-unit: {systemd_unit} exited with 1."
+
+    # Validate output lines of systemd-unit
+    for line in output.splitlines():
+        if "Active:" in line:
+            assert not "dead" in line, f"systemd-unit: {systemd_unit} did not start."
+
+
 def execute_local_command(cmd):
     """ Run local commands in Docker container """
     p = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
feature(pytest): Add generic function to test for a systemd unit
 * Test `docker` by `gardener` feature
 * Test `containerd` by `gardener` feature
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Add Pytest based unit tests to validate systemd units.


**Which issue(s) this PR fixes**:
Fixes #1066 
Fixes #1067

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Tests**:

Failed:
```
FAILED gardener/test/test_systemd_units.py::test_systemd_unit[containerd] - AssertionError: no error='Failed to start containerd.service: Unit containerd.service not found.\n' ex...
FAILED gardener/test/test_systemd_units.py::test_systemd_unit[docker] - AssertionError: no error='Failed to start docker.service: Unit docker.service not found.\n' expected
```

Pass:
```
PASSED gardener/test/test_systemd_units.py::test_systemd_unit[containerd]
PASSED gardener/test/test_systemd_units.py::test_systemd_unit[docker]
```