### PR TITLE
Integrate arch for KVM tests properly

### DIFF
--- a/bin/garden-integration-test-config
+++ b/bin/garden-integration-test-config
@@ -12,7 +12,6 @@ set -Eeuo pipefail
 # features:     list of enabled features (default: base)
 # outputDir:    directory where the outcome of the build is stored (default: .build)
 # arch:         architecture of the build target, defaults the arch of the image/archive to test
-# thisDir:      root of the gardenlinux repository which is also the default
 
 if [[ ! "$1" == "chroot" ]] && [[ ! "$1" == "kvm" ]]; then
     echo "The first argument must be 'chroot' or 'kvm'."
@@ -21,12 +20,10 @@ fi
 
 # define more or less sane defaults
 workDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-thisDir="${workDir%/bin}"
 features="base"
 outputDir=".build"
 prefix="kvm_dev-amd64-dev-local"
-# extract the default arch from the image/archive name
-arch=$(sed "s/.*-\(.*\)-.*-.*/\1/g" <<< ${prefix})
+arch="amd64"
 
 # use positional arguments if given else use the defaults
 test=$1
@@ -34,7 +31,6 @@ prefix=${2:-$prefix}
 features=($(echo ${3:-features} | tr "," "\n"))
 outputDir=${4:-$outputDir}
 arch=${5:-$arch}
-thisDir=${6:-$thisDir}
 
 # create directory for the test configs
 configDir=$(mktemp -d)

--- a/build.sh
+++ b/build.sh
@@ -168,7 +168,7 @@ else
 		containerName=$uuid_gen
 		prefix="$(cat $outputDir/prefix.info)"
 		fullfeatures="$(cat $outputDir/fullfeature.info)"
-		configDir=$(${thisDir}/bin/garden-integration-test-config chroot ${prefix} ${fullfeatures} ${outputDir})
+		configDir=$(${thisDir}/bin/garden-integration-test-config chroot ${prefix} ${fullfeatures} ${outputDir} ${arch})
 		echo "Running pytests in chroot"
 		${gardenlinux_build_cre} run --cap-add sys_admin --cap-add mknod --cap-add audit_write --cap-add net_raw --security-opt apparmor=unconfined \
 			--name $containerName --rm -v `pwd`:/gardenlinux -v ${configDir}:/config \
@@ -182,7 +182,7 @@ else
 		containerName=$uuid_gen
 		prefix="$(cat $outputDir/prefix.info)"
 		fullfeatures="$(cat $outputDir/fullfeature.info)"
-		configDir=$(${thisDir}/bin/garden-integration-test-config kvm ${prefix} ${fullfeatures} ${outputDir})
+		configDir=$(${thisDir}/bin/garden-integration-test-config kvm ${prefix} ${fullfeatures} ${outputDir} ${arch})
 		echo "Running pytests in KVM"
 		${gardenlinux_build_cre} run --name $containerName --rm -v /boot/:/boot \
 			-v /lib/modules:/lib/modules -v `pwd`:/gardenlinux -v ${configDir}:/config \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that the correct architecture is passed to the KVM tests during a build. Previously, the `garden-integration-test-config` returned a wrong configuration which provided a pytest configuration for `amd64` tests although the image has been built as an `arm64` image. 