### PR TITLE
feature(startvm): Check if `/dev/kvm` can be used by user

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -70,10 +70,36 @@ This script allows to inject a SSH pubkey to a final Garden Linux image to ensur
 ### start-vm
 This script starts a given `.raw` or `.qcow2` image in a local QEMU/KVM VM and supports `amd64` and `arm64 builds`. Keep in mind, that running different architectures may be very slow. However, it may still be useful for validating and running unit tests. A spawned VM runs in `textmode` which a `hostfwd` (portforward) for SSH on `tcp/2222`. By the given options this allows the user to user copy/paste in the terminal, as well as connecting to the sshd. *(Hint: Custom SSH pubkeys can be injected with `inject-sshkey`.)*
 
+**Acceleration Support:**
+
+Currently, `start-vm` supports `KVM` and `HVF` acceleration. While `HVF` is only supported on macOS, `KVM` will mostly be used. When using `KVM` acceleration you need to ensure that `/dev/kvm` can be used by your user account. However, if `/dev/kvm` is not usable it will fallback to a non accelerated support that may still work but may be slower. Setting permissions on `/dev/kvm` can be don is several ways; for example:
+
+```
+# Adding specific user to related groups
+sudo usermod -G -a kvm "$username"
+sudo usermod -G -a libvirtd "$username"
+```
+
+```
+# Setting permissions for all users
+sudo chmod +666 /dev/kvm
+```
+
+**Options:**
+| Option (short) | Descriptions |
+|--|--|
+| --arch | Architecture to use [x86_64, aarch64] |
+| --cpu | CPU type to emulate if an specific should be used |
+| --mem | Memory size to use for VM |
+| --uuefi | Run in `UEFI` mode instead of legacy `Bios`|
+| --ueficode | Path to custom UEFI Code file |
+| --uefivars | Path to custom UEFI Vars file |
+
 **Usage:**
 
-`startvm /path/to/$image_name`
+Running same arch: `start-vm /path/to/$image_name`
 
+Running specific arch (e.g. `aarch64`): `start-vm --arch aarch64 /path/to/$image_name`
 
 ### make-ali-ami
 This script orchestrates the upload/integration of a Garden Linux image for the `ALI` platform.

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -291,8 +291,10 @@ if [ "$arch" = x86_64 ]; then
             # Validate for KVM support on x86_64
             # If no KVM support is present QEMU handles
             # the -cpu option itself
-            if [ -e "/dev/kvm" ]; then
+            if [ -w "/dev/kvm" ]; then
                 virtOpts+=("-enable-kvm" "-cpu host" "-machine q35,smm=on")
+            else
+                echo -e "WARNING: Can not use KVM acceleration. Please see:\n https://github.com/gardenlinux/gardenlinux/tree/main/bin#start-vm \n\n"
             fi
 
         fi
@@ -332,8 +334,11 @@ if [ "$arch" = aarch64 ]; then
         else
 
             # Validate for KVM support on AARCH64
-            if [ -e "/dev/kvm" ]; then
+            if [ -w "/dev/kvm" ]; then
                 virtOpts+=("-cpu host" "-machine virt" "-accel kvm")
+            else
+                echo -e "WARNING: Can not use KVM acceleration. Please see:\nhttps://github.com/gardenlinux/gardenlinux/tree/main/bin#start-vm \n\n"
+                virtOpts+=("-cpu max" "-machine virt")
             fi
 
         fi


### PR DESCRIPTION
feature(startvm): Check if `/dev/kvm` can be used by user
 * Check if device is accessible and fallback to non accelerated usage
 * Add documentation how to solve a non accessible device

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**Which issue(s) this PR fixes**:
Fixes #1051

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
