### PR TITLE
fix(start-vm): Pass $imagefile also when running as `root`

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -75,7 +75,11 @@ fi
 keypress=1
 mac="$(printf '02:%02x:%02x:%02x:%02x:%02x' $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)) $((RANDOM%256)))"
 virtOpts=( )
+
+[ $(id -u) == 0 ] && virtOpts=(	"-runas nobody" )
+
 gardenlinux_build_cre=${GARDENLINUX_BUILD_CRE:-"sudo podman"}
+
 source "${thisDir}/.constants.sh" \
 	--flags 'daemonize,uefi,skipkp,vnc' \
 	--flags 'cpu:,mem:,bridge:,port:,mac:,arch:' \
@@ -223,8 +227,6 @@ while (( "$#" )); do
 	shift
 done
 [ $diskcount -gt 0 -o "$pxe" -o "$pxe_binary" ] || eusage 'missing bootdisk. boot via --pxe, provide tmpdisk via --disk or provide bootdisk image file'
-
-[ $(id -u) == 0 ] && virtOpts=(	"-runas nobody" )
 
 [[ "${memory: -1}" =~ [0-9] ]] && memory="${memory}Mi"
 memory=$(numfmt --from=auto --suffix="B" --format "%f" ${memory} | $gnu_head -c-2)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Currently, we can not execute `start-vm` as `root` users (which may be especially a problem in containers). This is caused by:
```
[ $(id -u) == 0 ] && virtOpts=(        "-runas nobody" )
```
We can just move it up to avoid overwriting our `virtOpts` like the previously added image file. No further adjustments here at this time (that'll be done in #1062).

**Which issue(s) this PR fixes**:
Fixes #1084

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
