### PR TITLE
temp fix for missing bird2 package

### DIFF
--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -14,7 +14,7 @@ numactl
 mdadm
 hdparm
 smartmontools
-bird2
+#bird2
 [${arch}=amd64] syslinux
 [${arch}=amd64] syslinux-common
 linux-image-5.15-${arch}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
do not install bird2 package as it is missing in debian testing right now, new bird2 version will be commit to testing in 3 days
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
