### PR TITLE
fix: use user and group names instead of ids in sgid_suid_files test

### DIFF
--- a/features/base/test/test_sgid_suid_files.py
+++ b/features/base/test/test_sgid_suid_files.py
@@ -7,35 +7,25 @@ import pytest
      "test_type,whitelist_files",
     [
         ("sgid", [
-                 "/usr/bin/expiry,0,42",
-                 "/usr/bin/write,0,5",
-                 "/usr/bin/wall,0,5",
-                 "/usr/bin/chage,0,42",
-                 "/usr/bin/ssh-agent,0,115",
-                 "/usr/bin/ssh-agent,0,114",
-                 "/usr/bin/ssh-agent,0,113",
-                 "/usr/bin/ssh-agent,0,112",
-                 "/usr/sbin/unix_chkpwd,0,42",
-                 "/usr/lib/systemd-cron/crontab_setgid,0,104",
-                 "/usr/lib/systemd-cron/crontab_setgid,0,106",
-                 "/usr/lib/systemd-cron/crontab_setgid,0,114",
-                 "/usr/lib/systemd-cron/crontab_setgid,0,115",
-                 "/usr/lib/systemd-cron/crontab_setgid,0,116"
+                 "/usr/bin/expiry,root,shadow",
+                 "/usr/bin/write,root,tty",
+                 "/usr/bin/wall,root,tty",
+                 "/usr/bin/chage,root,shadow",
+                 "/usr/bin/ssh-agent,root,_ssh",
+                 "/usr/sbin/unix_chkpwd,root,shadow",
+                 "/usr/lib/systemd-cron/crontab_setgid,root,crontab",
                  ]
         ),
         ("suid", [
-                 "/usr/bin/chsh,0,0",
-                 "/usr/lib/openssh/ssh-keysign,0,0",
-                 "/usr/bin/newgrp,0,0",
-                 "/usr/bin/su,0,0",
-                 "/usr/lib/dbus-1.0/dbus-daemon-launch-helper,0,113",
-                 "/usr/lib/dbus-1.0/dbus-daemon-launch-helper,0,112",
-                 "/usr/lib/dbus-1.0/dbus-daemon-launch-helper,0,111",
-                 "/usr/lib/dbus-1.0/dbus-daemon-launch-helper,0,110",
-                 "/usr/bin/chfn,0,0",
-                 "/usr/bin/gpasswd,0,0",
-                 "/usr/bin/sudo,0,0",
-                 "/usr/bin/passwd,0,0"
+                 "/usr/bin/chsh,root,root",
+                 "/usr/lib/openssh/ssh-keysign,root,root",
+                 "/usr/bin/newgrp,root,root",
+                 "/usr/bin/su,root,root",
+                 "/usr/lib/dbus-1.0/dbus-daemon-launch-helper,root,messagebus",
+                 "/usr/bin/chfn,root,root",
+                 "/usr/bin/gpasswd,root,root",
+                 "/usr/bin/sudo,root,root",
+                 "/usr/bin/passwd,root,root"
                  ]
         )
     ]

--- a/features/server/test/sgid
+++ b/features/server/test/sgid
@@ -1,1 +1,0 @@
-../../base/test/sgid

--- a/features/server/test/sgid.d/sgid.list
+++ b/features/server/test/sgid.d/sgid.list
@@ -1,3 +1,0 @@
-/usr/bin/ssh-agent,0,113
-/usr/lib/systemd-cron/crontab_setgid,0,116
-/usr/sbin/unix_chkpwd,0,42

--- a/tests/helper/tests/sgid_suid_files.py
+++ b/tests/helper/tests/sgid_suid_files.py
@@ -12,7 +12,7 @@ def _get_remote_files(client, perm):
     """ Get remote files of given attribute """
     files = []
     cmd_find = f"find / -type f -perm {perm} -exec "
-    cmd_stat = "stat -c '%n,%u,%g' {} \\; 2> /dev/null"
+    cmd_stat = "stat -c '%n,%U,%G' {} \\; 2> /dev/null"
     cmd = cmd_find + cmd_stat
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

currently sgid_suid_files test uses hardcoded ids, this occasionally breaks as gids for system groups differ between flavours, probably depending on set of installed packages

this switches the test to use group and user names instead of ids to make the test behave more reproducibly regardless of how ids get assigned to groups