### PR TITLE
Add explanation to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,12 +5,29 @@ labels: kind/bug
 
 ---
 
-**What happened**:
+**What happened:**
+- *Brief description of Bug*
 
-**What you expected to happen**:
+**Debug Logs:**
+- *Build System debug logs if applicable*
+  - *To generate debug logs, you may want to add `set -x` at the beginning of invoked bash scripts*
+  - *Logs are located in the `<repo>/.build/` folder*
+- *Runtime Debug logs if applicable* 
 
-**How to reproduce it (as minimally and precisely as possible)**:
+**How to reproduce it**:
+- *Step by step with the given environment specified in the next section*
+ 
+**Environment:**
+
+|                     |       |
+| ------------------- | ----- |
+| Garden Linux Branch | e.g.: *main* |
+| Container runtime (version)  | e.g.: *podman (3.4.7)* | 
+| Host OS of build machine  | e.g: *macOS* | 
+
+- *Please feel free to add additional details*
 
 **Anything else we need to know**:
-
-**Environment**:
+- *e.g. last time it worked without the bug?* 
+- *e.g. link to your garden linux fork*
+- *e.g. tested on other build environments*

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ labels: kind/bug
  
 **Environment:**
 
-|                     |       |
+| Name | Value |
 | ------------------- | ----- |
 | Garden Linux Branch | e.g.: *main* |
 | Container runtime (version)  | e.g.: *podman (3.4.7)* | 


### PR DESCRIPTION
**What this PR does / why we need it**:
This template helps the bug reporter to provide additional helpful information:
- debug logs
- details about the environment

Furthermore, this template should give the bug reporter an idea about what to include in the `Anything else we need to know` section.

