### PR TITLE
fix(secureboot): Symlink enroll-gardenlinux-secureboot-keys to only have a single file

### DIFF
--- a/features/cloud/file.include/usr/sbin/enroll-gardenlinux-secureboot-keys
+++ b/features/cloud/file.include/usr/sbin/enroll-gardenlinux-secureboot-keys
@@ -1,14 +1,1 @@
-#!/bin/bash
-set -Eeufo pipefail
-
-function write_efi_secureboot_var {
-	efi_var_file="/sys/firmware/efi/efivars/$1"
-	echo -n > "$efi_var_file"
-	chattr -i "$efi_var_file"
-	lsattr "$efi_var_file"
-	{ printf '\x27\x00\x00\x00'; cat; } | dd bs=1M of="$efi_var_file"
-}
-
-write_efi_secureboot_var PK-8be4df61-93ca-11d2-aa0d-00e098032b8c < /etc/gardenlinux/gardenlinux-secureboot.pk.auth
-write_efi_secureboot_var KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c < /etc/gardenlinux/gardenlinux-secureboot.kek.auth
-write_efi_secureboot_var db-d719b2cb-3d3a-4596-a3bc-dad00e67656f < /etc/gardenlinux/gardenlinux-secureboot.db.auth
+../../../../metal/file.include/usr/sbin/enroll-gardenlinux-secureboot-keys


### PR DESCRIPTION
fix(secureboot): Symlink enroll-gardenlinux-secureboot-keys to only have a single file
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
These two files were drifting...

**Which issue(s) this PR fixes**:
Fixes #1105

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
