### PR TITLE
fix(secureboot): Re-enable enroll-gardenlinux-secureboot-keys in clou…

### DIFF
--- a/features/cloud/file.include/usr/sbin/enroll-gardenlinux-secureboot-keys
+++ b/features/cloud/file.include/usr/sbin/enroll-gardenlinux-secureboot-keys
@@ -1,1 +1,6 @@
-../../../../metal/file.include/usr/sbin/enroll-gardenlinux-secureboot-keys
+#!/bin/bash
+set -Eeufo pipefail
+
+efi-updatevar -f /etc/gardenlinux/gardenlinux-secureboot.pk.auth PK
+efi-updatevar -f /etc/gardenlinux/gardenlinux-secureboot.kek.auth KEK
+efi-updatevar -f /etc/gardenlinux/gardenlinux-secureboot.db.auth db


### PR DESCRIPTION
…d feature

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
PR #1106 introduced an bug which included a symlink of `enroll-gardenlinux-secure-keys` to the final Garden Linux image although it should contain the actual script.

This PR fixes the issue by providing a proper script instead of a symlink for `/usr/sbin/enroll-gardenlinux-secureboot-keys`

**Which issue(s) this PR fixes**:
Fixes #1105 