### PR TITLE
fix(test): Make packages_musthave work with pkg.exclude properly

### DIFF
--- a/tests/helper/tests/packages_musthave.py
+++ b/tests/helper/tests/packages_musthave.py
@@ -6,7 +6,7 @@ import pytest
 
 def packages_musthave(client, testconfig):
     """"Test if the packages defined in pkg.include are installed"""
-    installed_pkgslist = get_package_list(client)
+    installed_package_list = get_package_list(client)
 
     current = (os.getenv('PYTEST_CURRENT_TEST')).split('/')[0]
     path = f"/gardenlinux/features/{current}/pkg.include"
@@ -59,8 +59,8 @@ def packages_musthave(client, testconfig):
         if package in exclude:
             continue
 
-        if not (package in installed_pkgslist or
-                f"{package}:{arch}" in installed_pkgslist):
+        if not (package in installed_package_list or
+                f"{package}:{arch}" in installed_package_list):
             missing.append(package)
 
     assert len(missing) == 0, \

--- a/tests/helper/tests/packages_musthave.py
+++ b/tests/helper/tests/packages_musthave.py
@@ -54,8 +54,9 @@ def packages_musthave(client, testconfig):
         # * the architecture as a variable in the package name
         elif package.endswith(r"-${arch}"):
             package = package.replace(r"${arch}", arch)
+
         # explicitly excluded packages are allowed to miss 
-        elif package in exclude:
+        if package in exclude:
             continue
 
         if not (package in installed_pkgslist or


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR resolves an issue with the `packages_musthave` test which did not work properly with `pkg.exclude` files within affected features.

**Which issue(s) this PR fixes**:
Fixes #1112 
