### PR TITLE
adjust snapshot size for kvm integration tests

### DIFF
--- a/features/cis_os/exec.config
+++ b/features/cis_os/exec.config
@@ -59,7 +59,8 @@ echo "auth	required	pam_wheel.so" >> /etc/pam.d/su
 
 # 99.1.1.23: Disable USB Dev
 echo 'ACTION=="add", SUBSYSTEMS=="usb", TEST=="authorized_default", ATTR{authorized_default}="0"' >> /etc/udev/rules.d/10-CIS_99.2_usb_devices.sh
-echo 'ACTION=="add", ATTR{bDeviceClass}=="09", TEST=="authorized", ATTR{authorized}="1"' >> /etc/udev/rules.d/10-CIS_99.2_usb_devices.shecho 'ACTION=="add", ATTR{product}=="*[Kk]eyboard*", TEST=="authorized", ATTR{authorized}="1"' >> /etc/udev/rules.d/10-CIS_99.2_usb_devices.sh
+echo 'ACTION=="add", ATTR{bDeviceClass}=="09", TEST=="authorized", ATTR{authorized}="1"' >> /etc/udev/rules.d/10-CIS_99.2_usb_devices.sh
+echo 'ACTION=="add", ATTR{product}=="*[Kk]eyboard*", TEST=="authorized", ATTR{authorized}="1"' >> /etc/udev/rules.d/10-CIS_99.2_usb_devices.sh
 echo 'ACTION=="add", ATTR{product}=="*Thinnet TM*", TEST=="authorized", ATTR{authorized}="1"' >> /etc/udev/rules.d/10-CIS_99.2_usb_devices.sh
 
 # Set SHA512 encrypted root password

--- a/tests/integration/kvm.py
+++ b/tests/integration/kvm.py
@@ -193,7 +193,7 @@ class KVM:
         # so that we can modify it for our tests
         snapshot_cmd = (
             f"qemu-img create -f qcow2 -F raw -b {image} "
-            f"/tmp/{image_name}.snapshot.qcow2 2G"
+            f"/tmp/{image_name}.snapshot.qcow2 4G"
         )
         cmds.append(snapshot_cmd)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
adjust snapshot size for kvm integration tests to make it work for the CIS image
**Which issue(s) this PR fixes**:
Fixes #1098 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
