### PR TITLE
fix: retry go build of garden-feat

### DIFF
--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -1,13 +1,17 @@
 ARG build_base_image=gardenlinux/slim
 FROM	golang:latest as golang
 COPY	garden-feat.go /go/src
-RUN	go install golang.org/x/lint/golint@latest \
-     && cd /go/src \
-     && golint garden-feat.go \
-     && go mod init garden-feat.go \
-     && go mod tidy -go=1.16 \
-     && go mod tidy -go=1.17 \
-     && go build garden-feat.go
+RUN	set -x; retry_cntr=10; while [ "$retry_cntr" -gt 0 ]; do \
+		go install golang.org/x/lint/golint@latest \
+		&& cd /go/src \
+		&& golint garden-feat.go \
+		&& go mod init garden-feat.go \
+		&& go mod tidy -go=1.16 \
+		&& go mod tidy -go=1.17 \
+		&& go build garden-feat.go \
+		&& break \
+		|| retry_cntr="$((retry_cntr-1))"; \
+	done
 
 FROM 	$build_base_image
 ARG	DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

retry building garden-feat.go in build-image container
this is needed as a workaround to prevent builds occasionally failing with errors like
```
stream error: stream ID 1371; INTERNAL_ERROR; received from peer
```
