### PR TITLE
feature(test): Add AWS MFA information to the documentation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -115,7 +115,23 @@ These tests test Garden Linux on public cloud providers like Amazons AWS, Google
 
 Notes for AWS credentials:
 - credentials must be supplied by having them ready in `~/.aws/config` and `~/.aws/credentials`
+  - The `aws configure` command can be used to create these files.
 - `~/.aws` gets mounted into the container that executes the integration tests
+- While using MFA, a dedicated MFA session must be created.
+  - This can be achieved by executing the following command (requires login)
+    ```
+    aws sts get-session-token --serial-number <MFA Device ID> --token-code <Token>
+    ```
+  - The returned `AccessKeyID`, `SecretAccessKey` and `SessionToken` must be stored in the `~/.aws/credentials` file.
+  - It is useful to use a dedicated profile for the MFA session, which could look like this:
+    ```
+    [mfa]
+    aws_access_key_id = <Access Key ID>
+    aws_secret_access_key = <Secret Access Key>
+    aws_session_token = <Session Token>
+    region = <Region>
+    ```
+  - In order to let pytest use the correct profile, it must be assigned via the `AWS_PROFILE` environment variable during execution.
 
 Use the following configuration file:
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR extends the test documentation by adding information about the login procedure while using MFA. This should help new developers to perform tests more easily.

**Special notes for your reviewer**:
This PR is related to #1035 
