### PR TITLE
feature(test): Make feature test work with AWS images (arm64/amd64)

### DIFF
--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -58,10 +58,12 @@ class RemoteClient:
         self,
         host,
         sshconfig,
-        port="22"
+        port="22",
+        sudo=False
     ) -> None:
         self.host = host
         self.port = port
+        self.sudo = sudo
         self.client = None
         self.scp = None
         self.conn = None
@@ -249,6 +251,8 @@ class RemoteClient:
             self.client = self.__connect()
         if not quiet:
             logger.info(f"$ {command.rstrip()}")
+        if self.sudo:
+            command = 'sudo ' + command
 
         _, stdout, stderr = self.client.exec_command(command=command, timeout=timeout)
         exit_status = stdout.channel.recv_exit_status()

--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -238,7 +238,13 @@ class RemoteClient:
             self.conn = self.__connect()
         self.scp.get(file)
 
-    def execute_command(self, command: str, timeout: int = 30, quiet: bool = False) -> tuple[int, str, str]:
+    def execute_command(
+        self,
+        command: str,
+        timeout: int = 30,
+        quiet: bool = False,
+        disable_sudo: bool = False
+    ) -> tuple[int, str, str]:
         """
         Execute commands on remote host
 
@@ -251,7 +257,7 @@ class RemoteClient:
             self.client = self.__connect()
         if not quiet:
             logger.info(f"$ {command.rstrip()}")
-        if self.sudo:
+        if self.sudo and not disable_sudo:
             command = 'sudo ' + command
 
         _, stdout, stderr = self.client.exec_command(command=command, timeout=timeout)

--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -258,7 +258,7 @@ class RemoteClient:
         if not quiet:
             logger.info(f"$ {command.rstrip()}")
         if self.sudo and not disable_sudo:
-            command = 'sudo ' + command
+            command = f"sudo {command}"
 
         _, stdout, stderr = self.client.exec_command(command=command, timeout=timeout)
         exit_status = stdout.channel.recv_exit_status()

--- a/tests/helper/tests/ssh_authorized.py
+++ b/tests/helper/tests/ssh_authorized.py
@@ -1,6 +1,6 @@
 import hashlib
 
-def ssh_authorized(client, testconfig):
+def ssh_authorized(client, testconfig, chroot):
     """Test to that not user has an authorized_keys file and also check
     that the test_authorized_keys file injected for testing wasn't modified"""
     # get passwd

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -36,6 +36,7 @@ class AWS:
             ssh = RemoteClient(
                 host=instance.public_dns_name,
                 sshconfig=config["ssh"],
+                sudo=True
             )
             yield ssh
         finally:

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -101,7 +101,7 @@ def test_ls(client):
 
 
 def test_no_man(client):
-    (exit_code, _, error) = client.execute_command("man ls")
+    (exit_code, _, error) = client.execute_command("man ls", disable_sudo=True)
     assert exit_code == 127, '"man" should not be installed'
     assert "man: command not found" in error
 
@@ -294,7 +294,7 @@ def test_nvme_kernel_parameter(client, aws):
     assert output.rstrip() == "1", "Expected 'nvme_core.io_timeout=4294967295' kernel parameter"
 
 def test_random(client, non_metal):
-    (exit_code, output, error) = client.execute_command("time dd if=/dev/random of=/dev/null bs=8k count=1000 iflag=fullblock")
+    (exit_code, output, error) = client.execute_command("time dd if=/dev/random of=/dev/null bs=8k count=1000 iflag=fullblock", disable_sudo=True)
     """ Output should be like this:
 # time dd if=/dev/random of=/dev/null bs=8k count=1000 iflag=fullblock
 1000+0 records in
@@ -316,7 +316,7 @@ sys     0m0.042s
     duration = (int(m.group(1)) * 60) + int(m.group(2))
     assert duration == 0, "runtime of test expected to be below one second %s" % m.group(1)
 
-    (exit_code, output, error) = client.execute_command("time rngtest --blockcount=9000  < /dev/random")
+    (exit_code, output, error) = client.execute_command("time rngtest --blockcount=9000  < /dev/random", disable_sudo=True)
     """ Output should be like this:
 # time rngtest --blockcount=9000  < /dev/random
 rngtest 5
@@ -365,7 +365,7 @@ def test_startup_script(client, gcp):
     assert exit_code == 0, f"no {error=} expected. Startup script did not run"
 
 def test_aws_ena_driver(client, aws):
-    (exit_code, output, error) = client.execute_command("sudo /sbin/ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
+    (exit_code, output, error) = client.execute_command("/sbin/ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
     assert exit_code == 0, f"no {error=} expected"
     assert output.rstrip() == "ena", "Expected network interface to run with ena driver"
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that feature tests can be executed on the AWS platform, too. As of now, some feature test failed because they couldn't be executed properly. In order to fix this, the current implementation of the SSHClient needed to be adjusted, so that we can control what test commands are executed with `sudo` and which one are not. Some of the feature tests require root privileges but the AWS platform usually uses a dedicated test user called `admin` which does not have these privileges.

By merging this change, each test command that is executed against a AWS VM (EC2 instances) is executed with `sudo` except for some commands which must be executed with the normal user.

This way, we are able to execute all feature tests successfully on AWS by using either amd64 or arm64 images.

**Which issue(s) this PR fixes**:
Fixes #1036 

**Special notes for your reviewer**:

```
PASSED _dev/test/test_packages_musthave.py::test_packages_musthave
PASSED aws/test/test_packages_musthave.py::test_packages_musthave
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[rlogin]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[rsh]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[rcp]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[telnet]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[libdb5.3:amd64]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[libdb5.3:arm64]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[libssl1.1:amd64]
PASSED base/test/test_blacklisted_packages.py::test_blacklisted_packages[libssl1.1:arm64]
PASSED base/test/test_duplicate_uids.py::test_duplicate_uids
PASSED base/test/test_kernel_config.py::test_kernel_config[args0]
PASSED base/test/test_password_hashes.py::test_password_hashes
PASSED base/test/test_password_shadow.py::test_password_shadow
PASSED base/test/test_sgid_suid_files.py::test_sgid_suid_files[sgid-whitelist_files0]
PASSED base/test/test_sgid_suid_files.py::test_sgid_suid_files[suid-whitelist_files1]
PASSED cloud/test/test_autologout.py::test_autologout[/etc/profile.d/50-autologout.sh-dict0]
PASSED cloud/test/test_packages_musthave.py::test_packages_musthave
PASSED cloud/test/test_pam_cracklib.py::test_pam_faillock[/etc/pam.d/common-password-password required pam_cracklib.so dcredit=-1 ucredit=-1 lcredit=-1 minlen=8 retry=5 reject_username]
PASSED cloud/test/test_pam_cracklib.py::test_pam_faillock[/etc/pam.d/common-password-password required pam_pwhistory.so use_authtok remember=5 retry=5]
PASSED cloud/test/test_pam_faillock.py::test_pam_faillock[/etc/pam.d/common-auth-auth required pam_faillock.so preauth silent audit deny=5 unlock_time=900]
PASSED cloud/test/test_pam_faillock.py::test_pam_faillock[/etc/pam.d/common-auth-auth [default=die] pam_faillock.so authfail silent audit deny=5 unlock_time=900]
PASSED cloud/test/test_pam_faillock.py::test_pam_faillock[/etc/pam.d/common-account-account required pam_faillock.so]
PASSED cloud/test/test_umask.py::test_umask[/etc/login.defs-dict0]
PASSED cloud/test/test_wireguard.py::test_kernel_modules[net/wireguard/wireguard.ko]
PASSED gardener/test/test_dmesg.py::test_dmesg[/etc/sysctl.d/allow-nonroot-dmesg.conf-args0]
PASSED gardener/test/test_dmesg.py::test_dmesg[/tmp/sysctl.txt-args1]
PASSED gardener/test/test_packages_musthave.py::test_packages_musthave
PASSED gardener/test/test_systemd_units.py::test_systemd_unit[containerd]
PASSED gardener/test/test_systemd_units.py::test_systemd_unit[docker]
PASSED server/test/test_capabilities.py::test_capabilities
PASSED server/test/test_history.py::test_history[/etc/profile.d/50-nohistory.sh-args0]
PASSED server/test/test_kernel_parameter.py::test_kernel_parameter[fs.protected_symlinks-1]
PASSED server/test/test_kernel_parameter.py::test_kernel_parameter[fs.protected_hardlinks-1]
PASSED server/test/test_kernel_parameter.py::test_kernel_parameter[kernel.randomize_va_space-2]
PASSED server/test/test_machine_id.py::test_machine_id_powered_on
PASSED server/test/test_packages_musthave.py::test_packages_musthave
PASSED server/test/test_reset_env_vars.py::test_reset_env_vars[/etc/sudoers-args0]
PASSED server/test/test_sshd.py::test_sshd[HostKey /etc/ssh/ssh_host_ed25519_key]
PASSED server/test/test_sshd.py::test_sshd[HostKey /etc/ssh/ssh_host_rsa_key]
PASSED server/test/test_sshd.py::test_sshd[KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256]
PASSED server/test/test_sshd.py::test_sshd[Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com]
PASSED server/test/test_sshd.py::test_sshd[MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1]
PASSED server/test/test_sshd.py::test_sshd[AuthenticationMethods publickey]
PASSED server/test/test_sshd.py::test_sshd[LogLevel VERBOSE]
PASSED server/test/test_sshd.py::test_sshd[Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO]
PASSED server/test/test_sshd.py::test_sshd[PermitRootLogin No]
PASSED server/test/test_sshd.py::test_sshd[X11Forwarding no]
PASSED server/test/test_sshd.py::test_sshd[UsePAM yes]
PASSED server/test/test_systemctl.py::test_systemctl[enabled-services0]
PASSED server/test/test_systemctl.py::test_systemctl[disabled-services1]
PASSED integration/test_gardenlinux.py::test_clock
PASSED integration/test_gardenlinux.py::test_ntp
PASSED integration/test_gardenlinux.py::test_files_not_in_future
PASSED integration/test_gardenlinux.py::test_ls
PASSED integration/test_gardenlinux.py::test_no_man
PASSED integration/test_gardenlinux.py::test_metadata_connection
PASSED integration/test_gardenlinux.py::test_loadavg
PASSED integration/test_gardenlinux.py::test_ping4[8.8.8.8]
PASSED integration/test_gardenlinux.py::test_ping4[dns.google]
PASSED integration/test_gardenlinux.py::test_ping4[heise.de]
PASSED integration/test_gardenlinux.py::test_startup_time
PASSED integration/test_gardenlinux.py::test_docker
PASSED integration/test_gardenlinux.py::test_clocksource
PASSED integration/test_gardenlinux.py::test_nvme_kernel_parameter
PASSED integration/test_gardenlinux.py::test_random
PASSED integration/test_gardenlinux.py::test_aws_ena_driver
PASSED integration/test_gardenlinux.py::test_apparmor
PASSED integration/test_gardenlinux.py::test_selinux
SKIPPED [2] helper/tests/capabilities.py: test is not part of the enabled features
SKIPPED [11] helper/tests/packages_musthave.py: test is not part of the enabled features
SKIPPED [1] ../features/base/test/test_debsums.py:4: test is disabled by feature cloud
SKIPPED [4] conftest.py:482: test not supported on dev
SKIPPED [6] conftest.py:428: test only supported on chroot
SKIPPED [1] helper/tests/packages_musthave.py:17: feature base does not have a pkg.include file
SKIPPED [1] conftest.py:445: test only supported on containers
SKIPPED [1] ../features/cis/test/test_debian_cis.py:5: test is not part of the enabled features
SKIPPED [1] ../features/fedramp/test/test_fedramp.py:6: test is not part of the enabled features
SKIPPED [1] ../features/gcp/test/test_blacklisted_packages.py:4: test is not part of the enabled features
SKIPPED [2] ../features/server/test/test_autologin.py:9: test is disabled by feature _dev
SKIPPED [2] conftest.py:470: test is not supported on gardener
SKIPPED [4] conftest.py:398: test only supported on azure
SKIPPED [1] conftest.py:388: test only supported on ali
SKIPPED [3] integration/test_gardenlinux.py:172: ipv6 not available in all vpcs
SKIPPED [1] conftest.py:418: test only supported on kvm
SKIPPED [1] conftest.py:438: test only supported on openstack
SKIPPED [2] conftest.py:408: test only supported on gcp
```