### PR TITLE
fix: Disable rngd.service on ARM machines

### DIFF
--- a/features/cloud/file.include/etc/systemd/system/rngd.service.d/architecture.conf
+++ b/features/cloud/file.include/etc/systemd/system/rngd.service.d/architecture.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionArchitecture=x86-64

--- a/features/firecracker/file.include/etc/systemd/system/rngd.service.d/architecture.conf
+++ b/features/firecracker/file.include/etc/systemd/system/rngd.service.d/architecture.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionArchitecture=x86-64


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR disables `rngd.service` on ARM machines

**Which issue(s) this PR fixes**:
Fixes #1124 

**Special notes for your reviewer**:
The following tests shows, that `rngd.service` is disabled on ARM machines:
```
root@localhost:~# systemctl status rngd 
○ rngd.service - Start entropy gathering daemon (rngd)
     Loaded: loaded (/lib/systemd/system/rngd.service; enabled; vendor preset: >
    Drop-In: /etc/systemd/system/rngd.service.d
             └─architecture.conf
     Active: inactive (dead)
  Condition: start condition failed at Thu 2022-07-21 12:31:13 UTC; 18min ago
             └─ ConditionArchitecture=x86-64 was not met
       Docs: man:rngd(8)

Jul 21 12:31:13 localhost systemd[1]: Start entropy gathering daemon (rngd) was>
root@localhost:~# uname -a
Linux localhost 5.15.54-gardenlinux-cloud-arm64 #1 SMP Debian 5.15.54-0gardenlinux1 (2022-07-13) aarch64 GNU/Linux
```

On the other hand, it is still active an AMD ones:
```
root@localhost:~# systemctl status rngd 
● rngd.service - Start entropy gathering daemon (rngd)
     Loaded: loaded (/lib/systemd/system/rngd.service; enabled; vendor preset: >
    Drop-In: /etc/systemd/system/rngd.service.d
             └─architecture.conf
     Active: active (running) since Thu 2022-07-21 12:46:38 UTC; 3min 27s ago
       Docs: man:rngd(8)
   Main PID: 342 (rngd)
      Tasks: 1 (limit: 2351)
     Memory: 256.0K
        CPU: 69ms
     CGroup: /system.slice/rngd.service
             └─342 /usr/sbin/rngd -f

Jul 21 12:46:38 localhost systemd[1]: Started Start entropy gathering daemon (r>
root@localhost:~# uname -a
Linux localhost 5.15.54-gardenlinux-cloud-amd64 #1 SMP Debian 5.15.54-0gardenlinux1 (2022-07-13) x86_64 GNU/Linux
```
