### PR TITLE
fix: skip dev builds in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         architecture: [ amd64, arm64 ]
         target: [ kvm, metal, gcp, aws, azure, ali, openstack, vmware, pxe, firecracker, github_action_runner ]
-        modifier: [ "", "-dev" ]
+        modifier: [ "" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
we probably don't need to build `_dev` flavours all the time.
this should slightly reduce build times and significantly reduce aws costs for autoscaling runners.