### PR TITLE
fix: upgrade kernel to 5.10.133

### DIFF
--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -1,10 +1,8 @@
 fdisk
-#[${arch}=amd64] grub-cloud-amd64
-#[${arch}=arm64] grub-cloud-arm64
 syslinux
 syslinux-common
 cloud-guest-utils
 libpam-cracklib
 rng-tools5
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.123-garden-cloud-${arch}_5.10.123-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.123-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.133-garden-cloud-${arch}_5.10.133-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.133-0gardenlinux1_${arch}.deb

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -1,14 +1,11 @@
 ethtool
-#busybox
 fdisk
 lvm2
 dosfstools
 efibootmgr
 haveged
 ipmitool
-#grub-cloud-amd64
 cloud-guest-utils
-#irqbalance
 pciutils
 usbutils
 numactl
@@ -18,5 +15,5 @@ smartmontools
 bird2
 syslinux
 syslinux-common
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.123-garden-${arch}_5.10.123-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.123-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.133-garden-${arch}_5.10.133-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.133-0gardenlinux1_${arch}.deb


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Upgrades Linux kernel of Garden Linux 576 to 5.10.133 to fix a number of CVEs.

**Special notes for your reviewer**:
Must be merged into `rel-576`, **NOT** into `main`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Upgrades Linux kernel of Garden Linux 576 to 5.10.133
```
