### PR TITLE
mark usr-is-merged as manual installed to pass orphaned test

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -5,3 +5,8 @@ set -Eeuo pipefail
 ln -sf /etc/dpkg/origins/gardenlinux /etc/dpkg/origins/default
 
 chmod u-s /bin/umount /bin/mount
+
+# Issue #1137
+# Mark package as manual installed to pass the orphaned test
+# The package is installed and required by debootstrap 1.0.127
+apt-mark manual usr-is-merged


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
mark usr-is-merged package as manual installed to pass orphaned test. The package is installed by debootstrap, it is a requirement since the debootstrap version 1.0.127
debootstrap 1.0.127 was released on 27.07.2022.

**Which issue(s) this PR fixes**:
Fixes #1137 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
