### PR TITLE
test: check for enabled AppArmor

### DIFF
--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -371,9 +371,10 @@ def test_aws_ena_driver(client, aws):
 
 def test_apparmor(client, non_chroot):
     (exit_code, output, error) = client.execute_command("grep apparmor /sys/kernel/security/lsm")
-    assert exit_code == 1, f"expected apparmor to be disabled"
+    assert exit_code == 0, f"no {error=} expected"
+    assert "apparmor" in output.rstrip(), "expected AppArmor to be in ist of lsms"
 
 def test_selinux(client, non_chroot):
     (exit_code, output, error) = client.execute_command("grep selinux /sys/kernel/security/lsm")
-    assert exit_code == 0, f"no {error=} expected"
-    assert "selinux" in output.rstrip(), "Expected SELinux to be enabled."
+    assert exit_code == 1, f"expected selinux not in list of lsms"
+    assert "selinux" not in output.rstrip(), "Expected SELinux not to be enabled."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

In PR #766 we introduced the check for an enabled SELinux LSM. Since we currently build Garden Linux with AppArmor as LSM, this PR reverts the check to AppArmor.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
test: check for enabled AppArmor
```
