### PR TITLE
Ci: Add component-responsible-labels to Component Descriptor

### DIFF
--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -229,6 +229,15 @@ def oci_image_resources(
                             'modifiers': release_manifest.modifiers,
                         }
                     ),
+                    cm.Label(
+                        name='cloud.gardener.cnudie/responsibles',
+                        value=[
+                            {
+                                'type': 'emailAddress',
+                                'email': 'thomas.buchner@sap.com',
+                            },
+                        ],
+                    ),
                 ]
             )
 
@@ -301,6 +310,15 @@ def _image_rootfs_resource(
               'buildTimestamp': release_manifest.build_timestamp,
               'debianPackages': [p for p in _virtual_image_packages(release_manifest, cicd_cfg)],
           }
+        ),
+        cm.Label(
+            name='cloud.gardener.cnudie/responsibles',
+            value=[
+                {
+                    'type': 'emailAddress',
+                    'email': 'thomas.buchner@sap.com',
+                },
+            ],
         ),
     ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a label to the oci-image and rootfs-resources of this component, indicating who is responsible for them in respect to our compliance scans.

**Special notes for your reviewer**:
@MrBatschner seems to be a good fit for the responsible here. Feel free to add/modify the suggested responsibles, e.g.:
```python3
cm.Label(
    name='cloud.gardener.cnudie/responsibles',
    value=[
        {
            'type': 'emailAddress',
            'email': 'thomas.buchner@sap.com',
        }, {
            'type': 'emailAddress',
            'email': 'andreas.burger@sap.com',
        }
    ],
),
```
Alternatively, responsibles can also be added by github-user, e.g.:
```python3
cm.Label(
    name='cloud.gardener.cnudie/responsibles',
    value=[
        {
            'type': 'githubUser',
            'email': 'MrBatschner',
        },
    ],
),
```

Once this is merged, this should also be cherry-picked to the current release-branch for 576.
