### PR TITLE
feat: include long git commit hash in os-release

### DIFF
--- a/bin/garden-build
+++ b/bin/garden-build
@@ -27,6 +27,7 @@ while true; do
 		--suffix) suffix="$1"; shift ;; # target name prefix
 		--prefix) prefix="$1"; shift ;; # target name suffix
 		--commitid) commitid="$1"; shift ;; # build commit hash
+		--commitid-long) commitid_long="$1"; shift ;; # build commit hash, untruncated - used for /etc/os-release only
 		--skip-tests) tests=0 shift ;; # skip tests
 		--userid) userID="$1" shift ;;
 		--usergid) userGID="$1" shift ;;
@@ -39,6 +40,7 @@ if [ ${debug:-} ]; then
 	set -x
 fi
 
+commitid_long="${commitid_long:-$commitid}"
 userID="${userID:-$(id -u)}";
 userGID="${userGID:-$(id -g)}";
 disablefeatures="${disablefeatures:-}"
@@ -144,6 +146,7 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
 	echo "GARDENLINUX_FEATURES=$fullfeatures" >> rootfs/etc/os-release
 	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version)" >> rootfs/etc/os-release
+	echo "GARDENLINUX_COMMIT_ID_LONG=$commitid_long" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$version" >> rootfs/etc/os-release
 	if [ -f rootfs/etc/update-motd.d/05-logo ]; then

--- a/build.sh
+++ b/build.sh
@@ -132,9 +132,10 @@ if [ -n "$cert" ]; then
 fi
 
 if [ -z "$(git status --porcelain)" ]; then
+	commitid_long="$(git rev-parse HEAD)"
 	commitid="$(git rev-parse --short HEAD)"
 	echo "clean working tree, using $commitid as commit id"
-	dockerArgs+=" -e commitid=$commitid"
+	dockerArgs+=" -e commitid=$commitid -e commitid_long=$commitid_long"
 else
 	echo 'modified working tree, using "local" instead of commit id'
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Inlcudes the long/untruncated git commit hash into `/etc/os-release`.

**Which issue(s) this PR fixes**:
Required for proper artifact handling in build pipeline and also for consistency - the final artifact should have to full Git commit hash in it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: include long git commit hash in os-release
```
