### PR TITLE
Feature/1119 gardenlinux version number is always today

### DIFF
--- a/bin/garden-build
+++ b/bin/garden-build
@@ -145,7 +145,8 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	sed -i "s/^SUPPORT_URL=.*$/SUPPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\"/g" rootfs/etc/os-release
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
 	echo "GARDENLINUX_FEATURES=$fullfeatures" >> rootfs/etc/os-release
-	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
+	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version)" >> rootfs/etc/os-release
+	echo "GARDENLINUX_VERSION_AT_BUILD=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID_LONG=$commitid_long" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$version" >> rootfs/etc/os-release

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -145,7 +145,7 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	sed -i "s/^SUPPORT_URL=.*$/SUPPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\"/g" rootfs/etc/os-release
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
 	echo "GARDENLINUX_FEATURES=$fullfeatures" >> rootfs/etc/os-release
-	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version)" >> rootfs/etc/os-release
+	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID_LONG=$commitid_long" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$version" >> rootfs/etc/os-release

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -145,16 +145,8 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	sed -i "s/^SUPPORT_URL=.*$/SUPPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\"/g" rootfs/etc/os-release
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
 	echo "GARDENLINUX_FEATURES=$fullfeatures" >> rootfs/etc/os-release
-<<<<<<< HEAD
-<<<<<<< HEAD
 	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID_LONG=$commitid_long" >> rootfs/etc/os-release
-=======
-	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major)" >> rootfs/etc/os-release
->>>>>>> 766c883d (only use the major version in os-release file)
-=======
-	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
->>>>>>> 3253c3ff (assemble <major>.<minor> for os-release file instead of today)
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$version" >> rootfs/etc/os-release
 	if [ -f rootfs/etc/update-motd.d/05-logo ]; then

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -145,8 +145,12 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	sed -i "s/^SUPPORT_URL=.*$/SUPPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\"/g" rootfs/etc/os-release
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
 	echo "GARDENLINUX_FEATURES=$fullfeatures" >> rootfs/etc/os-release
+<<<<<<< HEAD
 	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID_LONG=$commitid_long" >> rootfs/etc/os-release
+=======
+	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major)" >> rootfs/etc/os-release
+>>>>>>> 766c883d (only use the major version in os-release file)
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$version" >> rootfs/etc/os-release
 	if [ -f rootfs/etc/update-motd.d/05-logo ]; then

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -146,11 +146,15 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	sed -i "s/^BUG_REPORT_URL=.*$/BUG_REPORT_URL=\"https:\/\/github.com\/gardenlinux\/gardenlinux\/issues\"/g" rootfs/etc/os-release
 	echo "GARDENLINUX_FEATURES=$fullfeatures" >> rootfs/etc/os-release
 <<<<<<< HEAD
+<<<<<<< HEAD
 	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
 	echo "GARDENLINUX_COMMIT_ID_LONG=$commitid_long" >> rootfs/etc/os-release
 =======
 	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major)" >> rootfs/etc/os-release
 >>>>>>> 766c883d (only use the major version in os-release file)
+=======
+	echo "GARDENLINUX_VERSION=$($scriptsDir/garden-version --major | tr -d '\n'; echo -n "."; $scriptsDir/garden-version --minor)" >> rootfs/etc/os-release
+>>>>>>> 3253c3ff (assemble <major>.<minor> for os-release file instead of today)
 	echo "GARDENLINUX_COMMIT_ID=$commitid" >> rootfs/etc/os-release
 	echo "VERSION_CODENAME=$version" >> rootfs/etc/os-release
 	if [ -f rootfs/etc/update-motd.d/05-logo ]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
write the actual version number in the os-release file instead of 'today'
**Which issue(s) this PR fixes**:
Fixes #1119 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
