### PR TITLE
576: Kernel-update and fix of build-image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /cert/*.csr
 /cert/*.full
 /cert/*.chain
+/cert/secureboot.*
+/cert/GUID.txt
 !/cert/gardenlinux.kernel.sign.crt
 !/cert/gardenlinux.sign.pub
 /features/metal/file.include/lib/firmware/
@@ -25,3 +27,4 @@ __pycache__
 /test_results.json
 /tests/*.log
 /tests/*.xml
+/bin/garden-feat

--- a/ci/steps/build_base_image.py
+++ b/ci/steps/build_base_image.py
@@ -16,11 +16,11 @@ def build_base_image(
     for docker_dir in docker_dirs:
         dockerfile_relpath = os.path.join(repo_dir, "docker", docker_dir, "Dockerfile")
         print(f'---Building now {dockerfile_relpath}')
-        build_base_image = 'debian:testing-slim'
+        build_base_image = 'debian:stable-slim'
         if docker_dir == 'build-deb':
             build_base_image = f'{oci_path}/gardenlinux-build:{version_label}'
         else:
-            build_base_image = 'debian:testing-slim'
+            build_base_image = 'debian:stable-slim'
         context_dir = os.path.join(repo_dir, "docker", docker_dir)
         print(f'---Using base image {build_base_image}')
         builder.build_and_push_kaniko(

--- a/docker/needslim
+++ b/docker/needslim
@@ -6,23 +6,23 @@ VERSION="$(../bin/garden-version)"
 if [ "$(docker image ls gardenlinux/slim --format \"{{.Repository}}:{{.Tag}}\")" == "" ]; then
 	echo "WARNING: There is no gardenlinux/slim on this box. Since this is the builder script, it will pull no binary docker images from public repos."
 	echo
-	echo "Since gardenlinux/slim is needed for almost all images we pull debian/testing-slim and rename it to gardenlinux/slim so we avoid the Chicken-and-Egg problem temporarily"
+	echo "Since gardenlinux/slim is needed for almost all images we pull debian/stable-slim and rename it to gardenlinux/slim so we avoid the Chicken-and-Egg problem temporarily"
 	echo
 	echo "Please run 'make slim' afterwards"
 	echo
-	docker pull debian:testing-slim
-	docker tag  debian:testing-slim gardenlinux/slim
-	docker tag  debian:testing-slim gardenlinux/slim:$VERSION
-	docker tag  debian:testing-slim gardenlinux/slim:latest
+	docker pull debian:stable-slim
+	docker tag  debian:stable-slim gardenlinux/slim
+	docker tag  debian:stable-slim gardenlinux/slim:$VERSION
+	docker tag  debian:stable-slim gardenlinux/slim:latest
 else
 	if [ "$(docker image ls gardenlinux/slim:latest --format \"{{.ID}}\")" == \
-	     "$(docker image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
-		echo "WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:latest!"
+	     "$(docker image ls debian:stable-slim --format \"{{.ID}}\")" ]; then
+		echo "WARNING: You are still using a debian:stable-slim as a temporary replacement of gardenlinux/slim:latest!"
 		echo
 		echo "Please run 'make slim' to fix"
 	elif [ "$(docker image ls gardenlinux/slim:$VERSION --format \"{{.ID}}\")" == \
-	       "$(docker image ls debian:testing-slim --format \"{{.ID}}\")" ]; then
-		echo "WARNING: You are still using a debian:testing-slim as a temporary replacement of gardenlinux/slim:$VERSION!"
+	       "$(docker image ls debian:stable-slim --format \"{{.ID}}\")" ]; then
+		echo "WARNING: You are still using a debian:stable-slim as a temporary replacement of gardenlinux/slim:$VERSION!"
 		echo
 		echo "Please run 'make slim' to fix"
 	fi

--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -4,5 +4,5 @@ syslinux-common
 cloud-guest-utils
 libpam-cracklib
 rng-tools5
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.133-garden-cloud-${arch}_5.10.133-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.133-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.134-garden-cloud-${arch}_5.10.134-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.134-0gardenlinux1_${arch}.deb

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -15,5 +15,5 @@ smartmontools
 bird2
 syslinux
 syslinux-common
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.133-garden-${arch}_5.10.133-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.133-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.134-garden-${arch}_5.10.134-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.134-0gardenlinux1_${arch}.deb


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/kind technical-debt
/area os
/os garden-linux

**What this PR does / why we need it**:
- Introduces Kernel 5.10.134 into Garden Linux 576 to fix several CVEs
- changes the build-image for Garden Linux 576 builds from `debian:testing-slim` to `debian:stable-slim` to fix the requirement of the `usr-is-merged` package that the latest versions of debootstrap require and which we will not include into Garden Linux 576
- adds some more files to `.gitignore`

**Special notes for your reviewer**:

This PR **must** be merged into `rel-576`, **NOT** into `main`. Please do not squash this PR but the keep the individual commits.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Introduces Kernel 5.10.134 into Garden Linux 576 to fix several CVEs
- changes the build-image for Garden Linux 576 builds from debian:testing-slim to debian:stable-slim
- adds some more files to `.gitignore`
```
