### PR TITLE
feat: use apparmor as lsm for Gardener feature

### DIFF
--- a/features/gardener/file.include/etc/kernel/cmdline.d/90-lsm.cfg
+++ b/features/gardener/file.include/etc/kernel/cmdline.d/90-lsm.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX security=apparmor"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

As some Gardener users are relying on AppArmor to be the configured LSM on their worker nodes, this PR sets AppArmor to be the default LSM in the `gardener` feature.

Test for active AppArmor was already filed with PR #1139 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- use apparmor as lsm for Gardener feature
```
