### PR TITLE
bug: build fails on mac because there is no /bin/true

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,8 +61,8 @@ while true; do
 done
 
 dpkgArch="${arch:-$(dpkg --print-architecture | awk -F- "{ print \$NF }")}"
-outputDir="${1:-$output}";	shift || /bin/true
-version="$(${thisDir}/bin/garden-version ${1:-})";	shift || /bin/true
+outputDir="${1:-$output}";	shift || true
+version="$(${thisDir}/bin/garden-version ${1:-})";	shift || true
 
 mkdir -p "$outputDir"
 outputDir="$(readlink -f "$outputDir")"


### PR DESCRIPTION
**How to categorize this PR?**
/bug 

**What this PR does / why we need it**:
it allows to run build on mac. if you run build you can face:
```
./build.sh: line 65: /bin/true: No such file or directory
A83502232@T000cac27a gardenlinux % which -a true                            
true: shell built-in command
/usr/bin/true
A83502232@T000cac27a gardenlinux % sudo ln -s /usr/bin/true /bin/true  
```

**Which issue(s) this PR fixes**:
there are no issues

**Special notes for your reviewer**:

**Release note**:
- bugfix: builds on mac

