### PR TITLE
fix: move login.defs umask to base feature

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# set default umask to a more conservative value
+sed -i 's/UMASK\t\t022/UMASK\t\t077/' /etc/login.defs
+
 # set Garden Linux as default for dpkg
 ln -sf /etc/dpkg/origins/gardenlinux /etc/dpkg/origins/default
 

--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 # set default umask to a more conservative value
-sed -i 's/UMASK\t\t022/UMASK\t\t077/' /etc/login.defs
+sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 
 # set Garden Linux as default for dpkg
 ln -sf /etc/dpkg/origins/gardenlinux /etc/dpkg/origins/default

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.parametrize(
     "file,dict",
     [
-        ("/etc/login.defs", {"UMASK": "077"})
+        ("/etc/login.defs", {"UMASK": "027"})
     ]
 )
 

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.parametrize(
     "file,dict",
     [
-        ("/etc/login.defs", {"UMASK": "027"})
+        ("/etc/login.defs", {"UMASK": "077"})
     ]
 )
 

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# set default umask to a more conservative value
-sed -i 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs
 #cat <<EOF >>/etc/pam.d/common-session
 # Allow umask to be changed
 #session optional pam_umask.so


### PR DESCRIPTION
**What this PR does / why we need it**:

- Move setting of login.defs umask 027 to base feature 
    - including test_umask

**Which issue(s) this PR fixes**:
Fixes #39 

**Notes**
- Noticed during testing: when creating a user with adduser, files from `/etc/skel/*` are copied to the users new home directory. Permission of these files will not respect the umask value of login.defs. 