### PR TITLE
fix(build): Fix Makefile for macOS

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -1,5 +1,7 @@
 VERSION=`../bin/garden-version`
-VERSION_NUMBER=`../bin/garden-version --major | tr -d '\n'; echo -n "."; ../bin/garden-version --minor`
+VERSION_NUMBER_MAJOR=$(shell ../bin/garden-version --major)
+VERSION_NUMBER_MINOR=$(shell ../bin/garden-version --minor)
+VERSION_NUMBER=$(VERSION_NUMBER_MAJOR).$(VERSION_NUMBER_MINOR)
 ALTNAME=
 ALTNAME_INTERNAL=$(shell [ -n "$(ALTNAME)" ] && printf "%s %s" "-t" "$(ALTNAME)" )
 


### PR DESCRIPTION
fix(build): Fix Makefile for macOS

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes #1163

**Special notes for your reviewer**:
This has been tested on `macOS` with `Docker` and `Debian` with `podman` which results in:
```
localhost/gardenlinux/build-image  863.0         2283540fdcda  4 minutes ago  763 MB
```

More information about this issue can be found in #1163.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
