### PR TITLE
Readme Update + StartVM Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ yum install bash sudo podman crun make gnupg git qemu-kvm qemu-img coreutils edk
 
 *Note: Running `AARCH64` on `x86_64` requires `qemu-system-aarch64` package which is not present in official repositories.*
 
+**ArchLinux/Manjaro:**
+```
+pacman -S bash sudo podman crun make coreutils gnupg git qemu-system-x86 qemu-system-aarch64 edk2-ovmf
+```
+
+
 **macOS (>=12):**
 
 Build support on `macOS` (>=12) supports `Intel` (AMD64) and `Apple Silicon` (ARM64/AARCH64) architectures. Building on macOS requires the GNU versions of multiple tools that can be installed in different ways like Brew, MacPorts or self compiled. Self compiled GNU packages must be located in `/opt/local/bin/`. However, the following build instructions only cover the recommended `Brew` way.
@@ -169,6 +175,10 @@ apt-get install binfmt-support
 **CentOS:**
 ```
 yum install qemu-user-binfmt
+```
+**ArchLinux/Manjaro:**
+```
+yay -S binfmt-qemu-static-all-arch
 ```
 
 **macOS:**

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -424,8 +424,8 @@ qemu_opt_uefi () {
                 uefi_code="${uefi_code:-/usr/share/OVMF/OVMF_CODE.secboot.fd}"
                 uefi_vars="${uefi_vars:-/usr/share/OVMF/OVMF_VARS.secboot.fd}"
             elif [ "$os" = arch ]; then
-                uefi_code="${uefi_code:-/usr/share/OVMF/OVMF_CODE.secboot.fd}"
-                uefi_vars="${uefi_vars:-/usr/share/OVMF/OVMF_VARS.secboot.fd}"
+                uefi_code="${uefi_code:-/usr/share/OVMF/x64/OVMF_CODE.fd}"
+                uefi_vars="${uefi_vars:-/usr/share/OVMF/x64/OVMF_VARS.fd}"
             else
                 echo "Error: Could not find UEFI code and vars file."
                 exit 1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
- Update for Start-VM 
- Update for Readme for crossbuild and general build on Arch/Manjaro
**Which issue(s) this PR fixes**:
Fixes start-vm boot without --ueficode and --uefivars

**Special notes for your reviewer**:

`/usr/share/OVMF/x64/OVMF_CODE.secboot.fd` exists in Arch, but does not work. Enrolling Secure Boot keys did not work with this Firmware, but with `/usr/share/OVMF/x64/OVMF_CODE.fd` it works.
