### PR TITLE
fix(SELinux): Reenable `setfiles` for `SELinux` file contexts

### DIFF
--- a/bin/makepart
+++ b/bin/makepart
@@ -6,6 +6,7 @@ set -Eeuo pipefail
 exec 3>&1
 exec 1>&2
 
+thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 rootfs="$1"
 arch="${2:-$arch}"
 timestamp=$(garden-version --epoch "$version")
@@ -16,10 +17,9 @@ mkdir -p "$rootfs_work/overlay"/{etc,var}/{upper,work}
 
 find "$rootfs_work/var/log/" -type f -delete
 
+# SELinux 'default' policy file contexts
 chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
-# Temporary deactivated until this is fixed by upstream:
-# GitHub: https://github.com/gardenlinux/gardenlinux/issues/1014
-#chroot "$rootfs_work" /usr/bin/env -i /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
+"$thisDir/garden-chroot" "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
 rm "$rootfs_work/.autorelabel"
 
 if ! grep _secureboot <<<"$features" > /dev/null; then

--- a/features/_pxe/image
+++ b/features/_pxe/image
@@ -2,6 +2,7 @@
 
 set -Eeuxo pipefail
 
+thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 rootfs=$1
 targetBase=$2
 targetBaseDir=$(dirname "$targetBase")
@@ -26,9 +27,8 @@ cp -a "$rootfs/." "$rootfs_work"
 find "$rootfs_work/var/log/" -type f -delete
 
 chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
-# Temporary deactivated until this is fixed by upstream:
-# GitHub: https://github.com/gardenlinux/gardenlinux/issues/1014
-#chroot "$rootfs_work" /usr/bin/env -i /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
+# SELinux 'default' policy file contexts
+"$thisDir/../../bin/garden-chroot" "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
 rm "$rootfs_work/.autorelabel"
 
 # create the squashfs to include the fully generate image


### PR DESCRIPTION
fix(SELinux): Reenable `setfiles` for `SELinux` file contexts

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Reenable `setfiles` for `SELinux` file contexts

**Which issue(s) this PR fixes**:
Fixes #1014

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```

**Test(s)**:
```
root@localhost:~# sestatus -v
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             default
Current mode:                   permissive
Mode from config file:          permissive
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33

Process contexts:
Current context:                unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
Init context:                   system_u:system_r:init_t:s0
/usr/sbin/sshd                  system_u:system_r:sshd_t:s0

File contexts:
Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
/etc/passwd                     system_u:object_r:etc_t:s0
/etc/shadow                     system_u:object_r:shadow_t:s0
/bin/bash                       system_u:object_r:shell_exec_t:s0
/bin/login                      system_u:object_r:login_exec_t:s0
/bin/sh                         system_u:object_r:bin_t:s0 -> system_u:object_r:shell_exec_t:s0
/sbin/agetty                    system_u:object_r:getty_exec_t:s0
/sbin/init                      system_u:object_r:bin_t:s0 -> system_u:object_r:init_exec_t:s0
/usr/sbin/sshd                  system_u:object_r:sshd_exec_t:s0


root@localhost:~# ls -alZ /bin/bash
-rwxr-xr-x. 1 root root system_u:object_r:shell_exec_t:s0 1230360 Aug 15 00:00 /bin/bash
```