### PR TITLE
feat(test): Move LSM tests to dedicated gardener test folder

### DIFF
--- a/features/gardener/test/test_lsm.py
+++ b/features/gardener/test/test_lsm.py
@@ -1,0 +1,20 @@
+import pytest
+from helper.utils import execute_remote_command
+
+
+@pytest.mark.parametrize(
+    "lsm,active",
+    [
+        ("selinux", False),
+        ("apparmor", True),
+    ]
+)
+
+
+def test_lsm(client, lsm, active, non_chroot):
+    out = execute_remote_command(client, "cat /sys/kernel/security/lsm")
+
+    if active:
+        assert lsm in out, "Expected LSM should be enabled: {lsm}"
+    else:
+        assert lsm not in out, "Expected LSM should NOT be enabled: {lsm}"

--- a/tests/integration/test_gardenlinux.py
+++ b/tests/integration/test_gardenlinux.py
@@ -368,13 +368,3 @@ def test_aws_ena_driver(client, aws):
     (exit_code, output, error) = client.execute_command("/sbin/ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
     assert exit_code == 0, f"no {error=} expected"
     assert output.rstrip() == "ena", "Expected network interface to run with ena driver"
-
-def test_apparmor(client, non_chroot):
-    (exit_code, output, error) = client.execute_command("grep apparmor /sys/kernel/security/lsm")
-    assert exit_code == 0, f"no {error=} expected"
-    assert "apparmor" in output.rstrip(), "expected AppArmor to be in ist of lsms"
-
-def test_selinux(client, non_chroot):
-    (exit_code, output, error) = client.execute_command("grep selinux /sys/kernel/security/lsm")
-    assert exit_code == 1, f"expected selinux not in list of lsms"
-    assert "selinux" not in output.rstrip(), "Expected SELinux not to be enabled."


### PR DESCRIPTION
feat(test): Move LSM tests to dedicated gardener test folder

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Move LSM tests to dedicated gardener test folder and use PyTest syntax.

**Which issue(s) this PR fixes**:
Fixes #1170

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Test(s)**:
```
PASSED gardener/test/test_lsm.py::test_lsm[selinux-False]
PASSED gardener/test/test_lsm.py::test_lsm[apparmor-True]
```
