### PR TITLE
CI: publish images on Azure using shared image gallery

### DIFF
--- a/ci/glci/az.py
+++ b/ci/glci/az.py
@@ -727,7 +727,7 @@ def publish_azure_shared_image_gallery(
         transport_state=glci.model.AzureTransportState.RELEASED,
         publish_operation_id='',
         golive_operation_id='',
-        urn=shared_img.id,
+        id=shared_img.id,
     )
 
     return dataclasses.replace(release, published_image_metadata=published_image)

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -357,7 +357,8 @@ class AzurePublishedImage:
     '''
 
     transport_state: AzureTransportState
-    urn: str
+    urn: typing.Optional[str]
+    id: typing.Optional[str]
     publish_operation_id: str
     golive_operation_id: str
 

--- a/ci/glci/model.py
+++ b/ci/glci/model.py
@@ -614,7 +614,7 @@ class AzurePublishCfg:
     plan_id: str
     service_principal_cfg_name: str
     storage_account_cfg_name: str
-    shared_gallery_cfg_name: str
+    shared_gallery_cfg_name: typing.Optional[str]
     notification_emails: typing.Tuple[str, ...]
 
 

--- a/ci/promote.py
+++ b/ci/promote.py
@@ -69,9 +69,10 @@ def publish_image(
         publish_function = _publish_gcp_image
         cleanup_function = None
     elif release.platform == 'azure':
-        publish_function = _publish_azure_image
-        # For publishing using community gallery use:
-        # publish_function = _publish_azure_shared_image_gallery
+        if cicd_cfg.publish.azure.shared_gallery_cfg_name:
+            publish_function = _publish_azure_shared_image_gallery
+        else:
+            publish_function = _publish_azure_image
         cleanup_function = None
     elif release.platform == 'openstack':
         publish_function = _publish_openstack_image


### PR DESCRIPTION
Update the release manifest we generate so that we can later on determine the way the image was published (needed for gardener `cloudprofile` generation) and enable publishing via shared image gallery.