### PR TITLE
feat(_selinux): Add inital SELinux feature

### DIFF
--- a/features/_selinux/file.include/etc/selinux/config
+++ b/features/_selinux/file.include/etc/selinux/config
@@ -1,0 +1,14 @@
+# This file controls the state of SELinux on the system.
+# SELINUX= can take one of these three values:
+# enforcing - SELinux security policy is enforced.
+# permissive - SELinux prints warnings instead of enforcing.
+# disabled - No SELinux policy is loaded.
+SELINUX=enforcing
+# SELINUXTYPE= can take one of these two values:
+# default - equivalent to the old strict and targeted policies
+# mls     - Multi-Level Security (for military and educational use)
+# src     - Custom policy built from source
+SELINUXTYPE=default
+
+# SETLOCALDEFS= Check local definition changes
+SETLOCALDEFS=0

--- a/features/_selinux/info.yaml
+++ b/features/_selinux/info.yaml
@@ -1,0 +1,2 @@
+description: "enable SELinux"
+type: flag

--- a/features/_selinux/pkg.include
+++ b/features/_selinux/pkg.include
@@ -1,0 +1,2 @@
+selinux-basics
+selinux-policy-default

--- a/features/base/info.yaml
+++ b/features/base/info.yaml
@@ -1,6 +1,8 @@
 description: "base layer (debootstap --variant minbase, see docker:debian:xx-slim)"
 type: element
 features:
-  include: [ _slim ]
+  include:
+    - _slim
+    - _selinux
 tar:
   include-dev: false

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -30,7 +30,4 @@ tcpdump
 vim-tiny
 quota
 nvme-cli
-selinux-basics
-selinux-policy-default
-gardenlinux-selinux-module
 sosreport


### PR DESCRIPTION
feat(_selinux): Add inital SELinux feature

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds `SELinux` as a part of the feature system (type `flag`). The primary goal is to have a common feature for SELinux that applies all basic stuff for Garden Linux (e.g. correct policies, correct modes, etc), that should only slightly be changed by other features (or in best case situations, no changes are needed). This could affect `CIS`, as well as `FedRAMP`.

**Which issue(s) this PR fixes**:
Fixes #1184

**Special notes for your reviewer**:
We should discuss if we want to proceed with `enforcing` as default. Within this mode, one the one hand we may find faster and more missing policy rules, on the other one it may cause more trouble at the beginning.

Do NOT merge until `selinux-policy-targeted-fedora` is present in Garden Linux repositories. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: user
```
