### PR TITLE
remove _readonly from cloud feature

### DIFF
--- a/features/_readonly/fstab.mod
+++ b/features/_readonly/fstab.mod
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 sed '/^[^[:space:]]\+[[:space:]]\+\/overlay[[:space:]]\+/d;/^[^[:space:]]\+[[:space:]]\+\/[[:space:]]\+/d;/^[^[:space:]]\+[[:space:]]\+\/usr[[:space:]]\+/d;/^[^[:space:]]\+[[:space:]]\+\/boot\/efi[[:space:]]\+/d'
 
 # make usr a readonly setup
-printf "LABEL=EFI          /boot/efi    vfat      umask=0077   type=uefi,size=96MiB\n"
+printf "LABEL=EFI          /boot/efi    vfat      umask=0077   type=uefi,size=128MiB\n"
 printf "LABEL=ROOT         /            ext4      ro           verity\n"
 printf "LABEL=USR          /usr         ext4      ro           verity\n"
 printf "LABEL=OVERLAY      /overlay     ext4      rw,discard,x-initrd.mount    size=512MiB\n"

--- a/features/cloud/info.yaml
+++ b/features/cloud/info.yaml
@@ -3,6 +3,7 @@ type: element
 features:
   include:
     - server
+    - _readonly
 fs:
   - dest: /
     type: ext4

--- a/features/cloud/info.yaml
+++ b/features/cloud/info.yaml
@@ -3,7 +3,6 @@ type: element
 features:
   include:
     - server
-    - _readonly
 fs:
   - dest: /
     type: ext4


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
remove _readonly feature from cloud feature, fix disk full error in tekton pipeline
**Which issue(s) this PR fixes**:
Fixes #1155 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
