### PR TITLE
hotfix(selinux): Temporary deactivate gardenlinux-selinux-module

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -32,5 +32,5 @@ quota
 nvme-cli
 selinux-basics
 selinux-policy-default
-gardenlinux-selinux-module
+#gardenlinux-selinux-module
 sosreport


### PR DESCRIPTION
hotfix(selinux): Temporary deactivate gardenlinux-selinux-module

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
  This fixes the currently broken build pipeline where the new
  selinux-policy-default isn't compatible with our gardenlinux-
  selinux-module anymore. This package will be reenabled soon.

**Which issue(s) this PR fixes**:
Fixes #1196

**Special notes for your reviewer**:
This may be reenabled together with the new refpolicy or completely replaced by the `selinux-fedroa` policy set. While the new `refpolicy` seems to fix our main issues, this could be a game changer. Unfortunately, I need some more time if this is a usable way.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
