### PR TITLE
feat(vhost): Deactivate service `dnsmasq`

### DIFF
--- a/features/vhost/exec.config
+++ b/features/vhost/exec.config
@@ -1,0 +1,1 @@
+systemctl disable dnsmasq


### PR DESCRIPTION
Deactivate service `dnsmasq`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR deactivates the `dnsmasq` service since the default is `systemd-resolved`. However, dnksmasq may be needed for libvirt on NAT networks where a dedicated process get spawned.

**Which issue(s) this PR fixes**:
Fixes #1185

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
