### PR TITLE
Validate the /usr is read-only.

### DIFF
--- a/features/base/test/test_usr_ro.py
+++ b/features/base/test/test_usr_ro.py
@@ -1,0 +1,5 @@
+
+def test_usr_read_only(client, non_chroot):
+    (exit_code, output, error) = client.execute_command("/usr/bin/touch /usr/fail-test")
+    assert exit_code == 1, "Read-only file system error expected"
+    assert error.rstrip() == "/usr/bin/touch: cannot touch '/usr/fail-test': Read-only file system"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Validates that the `/usr` directory is read-only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The test has been moved to `features/base/test`. This means that 

```
    features:
      - "base"
```

must be included in the test configuration.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
