### PR TITLE
fix: github actions: gcp ignore --arch arguments

### DIFF
--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -2,7 +2,7 @@
 #set -Eeuo pipefail
 
 # Name of Image to test
-image=$1
+image="${@: -1}"
 
 configFile="gcp_config"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

adding `--arch` argument to github action platform tests in #1229 broke gcp tests, this fixes the issue by using the last instead of the first argument to `gcp_tests.sh`
