### PR TITLE
fix(start-vm): Fix running `start-vm` inside a container

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -38,8 +38,19 @@ get_os () {
         os="macos"
     elif [ $host_os = "Linux" ]; then
         os="linux"
-        # Obtain the currently used Linux distribution
-        host_dist="$(hostnamectl | grep "Operating System:" | awk {'print tolower($3)}')"
+
+        # Validate if this process is running inside a
+        # a container (like Docker) by checking what
+        # init process is used and set a default OS in
+        # case it is not systemd and a container then.
+        # Otherwise, If this is nativly running
+        # on a host, evaluate the running OS
+        init_system="$(cat /proc/1/sched | awk 'NR==1{print $1}')"
+        if [ $init_system != "systemd" ]; then
+            host_dist="debian"
+        else
+            host_dist="$(hostnamectl | grep "Operating System:" | awk {'print tolower($3)}')"
+        fi
 
         # Evaluate Distribution
         if [ $host_dist = "centos" ]; then


### PR DESCRIPTION
Fix running `start-vm` inside a container

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Fix running `start-vm` inside a container (e.g. needed for `KVM` unit tests).

**Which issue(s) this PR fixes**:
Fixes #1234

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
