### PR TITLE
tests(clamav): Add unit tests for feature `clamav`

### DIFF
--- a/features/clamav/test/test_clamav_cron.py
+++ b/features/clamav/test/test_clamav_cron.py
@@ -1,0 +1,9 @@
+from helper.utils import execute_remote_command
+
+
+def test_clamav_cron(client):
+    # This will already fail if file is absent
+    rc, out = execute_remote_command(client, "cat /var/spool/cron/crontabs/root", skip_error=True)
+    # Validate that clamscan gets called (cron times may vary)
+    err_msg = "Cron configuration for ClamAV expected but could not be verified."
+    assert "clamscan" in out and rc == 0, f"{err_msg} Error: {out}"

--- a/features/clamav/test/test_packages_musthave.py
+++ b/features/clamav/test/test_packages_musthave.py
@@ -1,0 +1,1 @@
+from helper.tests.packages_musthave import packages_musthave as test_packages_musthave

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -127,13 +127,17 @@ def execute_local_command(cmd):
     return rc, out
 
 
-def execute_remote_command(client, cmd):
+def execute_remote_command(client, cmd, skip_error=False):
     """ Run remote command on test platform """
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)
-    assert exit_code == 0, f"no {error=} expected"
-    output = output.strip()
-    return output
+    if not skip_error:
+        assert exit_code == 0, f"no {error=} expected"
+        output = output.strip()
+        return output
+    else:
+        output = output.strip()
+        return exit_code, output
 
 
 def install_package_deb(client, pkg):


### PR DESCRIPTION
Add unit tests for feature `clamav`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Add unit tests for feature `clamav`

**Which issue(s) this PR fixes**:
Fixes #1173

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Failed**:
```
FAILED clamav/test/test_clamav_cron.py::test_clamav_cron - AssertionError: no error='cat: /var/spool/cron/crontabs/root: No such file or directory\n' expected
FAILED clamav/test/test_packages_musthave.py::test_packages_musthave - AssertionError: clamav should be installed, but are missing
```

**Passed**:
```
PASSED clamav/test/test_clamav_cron.py::test_clamav_cron
PASSED clamav/test/test_packages_musthave.py::test_packages_musthave
```
