### PR TITLE
tests(firecracker): Add unit tests for feature `firecracker`

### DIFF
--- a/features/firecracker/test/test_packages_musthave.py
+++ b/features/firecracker/test/test_packages_musthave.py
@@ -1,0 +1,1 @@
+from helper.tests.packages_musthave import packages_musthave as test_packages_musthave

--- a/features/firecracker/test/test_systemd_unit.py
+++ b/features/firecracker/test/test_systemd_unit.py
@@ -1,0 +1,25 @@
+import pytest
+from helper.utils import execute_remote_command
+from helper.utils import validate_systemd_unit
+from helper.utils import get_architecture
+
+
+@pytest.mark.parametrize(
+    "systemd_unit",
+    [
+        "rngd"
+    ]
+)
+
+
+def test_systemd_unit(client, systemd_unit, non_chroot):
+    arch = get_architecture(client)
+    active = True
+
+    # We assume that on arm64, the systemd
+    # unit should not be active after a start
+    if arch == "arm64":
+        active = False
+
+    execute_remote_command(client, f"systemctl start {systemd_unit}")
+    validate_systemd_unit(client, f"{systemd_unit}", active=active)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -449,6 +449,15 @@ def openstack_flavor():
     return OpenStackCCEE.instance().flavor
 
 @pytest.fixture
+def non_amd64(client):
+    (exit_code, output, error) = client.execute_command("dpkg --print-architecture", quiet=True)
+    if exit_code != 0:
+        logger.error(error)
+        sys.exit(exit_code)
+    if "amd64" in output:
+        pytest.skip('test not supported on amd64 architecture')
+
+@pytest.fixture
 def non_arm64(client):
     (exit_code, output, error) = client.execute_command("dpkg --print-architecture", quiet=True)
     if exit_code != 0:
@@ -486,3 +495,11 @@ def non_vhost(testconfig):
     features = testconfig.get("features", [])
     if "vhost" in features:
         pytest.skip('test not supported with vhost feature enabled')
+
+@pytest.fixture
+# After solving #1240 define "firecracker" as IAAS
+def firecracker(testconfig):
+    features = testconfig.get("features", [])
+    if "firecracker" in features:
+        skip_msg = "Currently unsupported. Please see: https://github.com/gardenlinux/gardenlinux/issues/1240"
+        pytest.skip(skip_msg)

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -106,17 +106,22 @@ def get_kernel_version(client):
     return output
 
 
-def validate_systemd_unit(client, systemd_unit):
+def validate_systemd_unit(client, systemd_unit, active=True):
     """ Validate a given systemd unit """
     cmd = f"systemctl status {systemd_unit}.service"
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)
-    assert exit_code == 0, f"systemd-unit: {systemd_unit} exited with 1."
 
+    assert exit_code == 0, f"systemd-unit: {systemd_unit} exited with 1."
     # Validate output lines of systemd-unit
     for line in output.splitlines():
+        # This 'active' is realted to systemd's output
         if "Active:" in line:
-            assert not "dead" in line, f"systemd-unit: {systemd_unit} did not start."
+            # This active is set by the function's header
+            if active:
+                assert not "dead" in line, f"systemd-unit: {systemd_unit} did not start."
+            else:
+                assert "condition failed" in line, f"systemd-unit: {systemd_unit} condition for architecture failed."
 
 
 def execute_local_command(cmd):


### PR DESCRIPTION
Add unit tests for feature `firecracker`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds additional unit tests for the `firecracker` feature. However, we can only run some in on IAAS `chroot` or for development cases on `kvm`. While these ones are already working, we should add a new IAAS type `firecracker` (see also: #1240).

**Which issue(s) this PR fixes**:
Fixes #1173 

**Special notes for your reviewer**:
 * RNG is disabled by systemd architecture condition on `arm64` by droplet
 * We can already perform tests on IAAS `chroot`
 * Other ones can currently only be used by devs via IAAS `kvm`
 * We need to implement a new IAAS `firecracker` (#1240)
 * This may help people to not encounter further unit testing issues within the current state

However, this can already be merged.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Test**:
Following output will be provided when running feature/iaas `firecracker` tests:
```
SKIPPED [1] conftest.py:505: Currently unsupported. Please see: https://github.com/gardenlinux/gardenlinux/issues/1240
```
