### PR TITLE
tests(_secureboot): Add unit tests for feature `_secureboot`

### DIFF
--- a/features/_secureboot/test/test_empty_files_boot_efi.py
+++ b/features/_secureboot/test/test_empty_files_boot_efi.py
@@ -1,0 +1,6 @@
+from helper.utils import execute_remote_command
+
+
+def test_empty_files_boot_efi(client):
+    out = execute_remote_command(client, "find /boot/efi/ -type f")
+    assert out == "", "/boot/efi/ is not empty."

--- a/features/_secureboot/test/test_packages_musthave.py
+++ b/features/_secureboot/test/test_packages_musthave.py
@@ -1,0 +1,1 @@
+from helper.tests.packages_musthave import packages_musthave as test_packages_musthave

--- a/features/_secureboot/test/test_uefi_pki_files.py
+++ b/features/_secureboot/test/test_uefi_pki_files.py
@@ -1,0 +1,18 @@
+import pytest
+from helper.utils import execute_remote_command
+
+
+@pytest.mark.parametrize(
+    "pki_file",
+    [
+            "/etc/gardenlinux/gardenlinux-secureboot.pk.auth",
+            "/etc/gardenlinux/gardenlinux-secureboot.kek.auth",
+            "/etc/gardenlinux/gardenlinux-secureboot.db.auth"
+    ]
+)
+
+
+def test_uefi_pki_files(client, pki_file):
+    rc, out = execute_remote_command(client, f"stat {pki_file}", skip_error=True)
+    err_msg = f"Could not find PKI file for secureboot: {pki_file}"
+    assert rc == 0, f"{err_msg}"


### PR DESCRIPTION
tests(_secureboot): Add unit tests for feature `_secureboot`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Add unit tests for feature `_secureboot`

**Which issue(s) this PR fixes**:
Fixes #1173

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Tests**:
```
PASSED _secureboot/test/test_empty_files_boot_efi.py::test_empty_files_boot_efi
PASSED _secureboot/test/test_packages_musthave.py::test_packages_musthave
PASSED _secureboot/test/test_uefi_pki_files.py::test_uefi_pki_files[/etc/gardenlinux/gardenlinux-secureboot.pk.auth]
PASSED _secureboot/test/test_uefi_pki_files.py::test_uefi_pki_files[/etc/gardenlinux/gardenlinux-secureboot.kek.auth]
PASSED _secureboot/test/test_uefi_pki_files.py::test_uefi_pki_files[/etc/gardenlinux/gardenlinux-secureboot.db.auth]
```