### PR TITLE
fix: systemd-coredump remove dirs

### DIFF
--- a/features/server/file.include/etc/systemd/system/systemd-coredump@.service.d/override.conf
+++ b/features/server/file.include/etc/systemd/system/systemd-coredump@.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStopPost=/bin/sh -c "rmdir /run/systemd/propagate/systemd-coredump@%i.service"


### PR DESCRIPTION
**What this PR does / why we need it**:
More details explained in #1226; this fix removes directories left over in /run/systemd/propagate from the instantiated services of systemd-coredump.

**Which issue(s) this PR fixes**:
Fixes #1226 