### PR TITLE
tests(cloud): Add unit test for RNG's systemd unit

### DIFF
--- a/features/cloud/test/test_systemd_unit.py
+++ b/features/cloud/test/test_systemd_unit.py
@@ -1,0 +1,25 @@
+import pytest
+from helper.utils import execute_remote_command
+from helper.utils import validate_systemd_unit
+from helper.utils import get_architecture
+
+
+@pytest.mark.parametrize(
+    "systemd_unit",
+    [
+        "rngd"
+    ]
+)
+
+
+def test_systemd_unit(client, systemd_unit, non_chroot):
+    arch = get_architecture(client)
+    active = True
+
+    # We assume that on arm64, the systemd
+    # unit should not be active after a start
+    if arch == "arm64":
+        active = False
+
+    execute_remote_command(client, f"systemctl start {systemd_unit}")
+    validate_systemd_unit(client, f"{systemd_unit}", active=active)


### PR DESCRIPTION
tests(cloud): Add unit test for RNG's systemd unit

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Add unit test for RNG's systemd unit

**Which issue(s) this PR fixes**:
Fixes #1173

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
