### PR TITLE
tests: make test name for platform tests configurable

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -144,6 +144,9 @@ aws:
     # architecture of the image and VM to be used (optional)
     architecture: x86_64
 
+    # test name to be used for naming and/or tagging resources (optional)
+    test_name: my_gardenlinux_test
+
     # ssh related configuration for logging in to the VM (optional)
     ssh:
         # path to the ssh key file (optional)
@@ -174,6 +177,8 @@ aws:
 - **region** _(required)_: the AWS region in which all test relevant resources will be created
 - **instanc-type** _(optional)_: the instance type that will be used for the EC2 instance used for testing, defaults to `t3.micro` if not specified
 - **architecture** _(optional)_: the architecture under which the AMI of the image to test should be registered (`x86_64` or `arm64`), must match the instance type, defaults to `x86_64` if not specified
+
+- **test_name** _(optional)_: a name that will be used as a prefix or tag for the resources that get created in the Hyperscaler environment. Defaults to `gl-test-YYYYmmDDHHMMSS` with _YYYYmmDDHHMMSS_ being the date and time the test was started.
 
 - **ssh_key_filepath** _(optional)_: The SSH key that will be deployed to the EC2 instance and that will be used by the test framework to log on to it. Must be the file containing the private part of an SSH keypair which needs to be generated with `openssh-keygen` beforehand. If not provided, a new SSH key with 2048 bits will be generated just for the test.
 - **passphrase** _(optional)_: If the given SSH key is protected with a passphrase, it needs to be provided here.
@@ -239,6 +244,9 @@ azure:
     # enable accelerated networking for the VM on which the test runs (optional)
     accelerated_networking: false
 
+    # test name to be used for naming and/or tagging resources (optional)
+    test_name: my_gardenlinux_test
+
     # storage account to be used for image upload (optional)
     storage_account_name: stggardenlinuxtest01
     # local image file to be uploaded and to be tested (required/alternatively optional)
@@ -280,6 +288,8 @@ Only three parameters are required for the test: the Azure `subscription` or `su
     - 'V1': Boot = PCAT, Disk controllers = IDE
     - 'V2': Boot = UEFI, Disk controllers = SCSI
 - **accelerated_networking** _(optional)_: Enables [Azure Accelerated Networking](https://docs.microsoft.com/en-us/azure/virtual-network/accelerated-networking-overview) for the VM on which the test is going to run. Defaults to `false`, thus accelerated networking disabled.
+
+- **test_name** _(optional)_: a name that will be used as a prefix or tag for the resources that get created in the Hyperscaler environment. Defaults to `gl-test-YYYYmmDDHHMMSS` with _YYYYmmDDHHMMSS_ being the date and time the test was started.
 
 - **storage_account_name** _(optional)_: the storage account to which the image gets uploaded
 - **image_name** _(optional/required)_: If the tests should get executed against an already existing Image, this is its name. Either **image_name** or **image** must be supplied but not both.
@@ -395,6 +405,8 @@ The URI can be:
 - **bucket**:  # my-test-upload-bucket
 - **bucket_path**: integration-test
 
+- **test_name** _(optional)_: a name that will be used as a prefix or tag for the resources that get created in the Hyperscaler environment. Defaults to `gl-test-YYYYmmDDHHMMSS` with _YYYYmmDDHHMMSS_ being the date and time the test was started.
+
 - **ssh_key_filepath** _(required)_: The SSH key that will be deployed to the ECS instance and that will be used by the test framework to log on to it. Must be the file containing the private part of an SSH keypair which needs to be generated with `openssh-keygen` beforehand.
 - **key_name** _(required)_: The SSH key gets uploaded to ECS, this is the name of the key object resource.
 - **passphrase** _(optional)_: If the given SSH key is protected with a passphrase, it needs to be provided here.
@@ -456,6 +468,9 @@ gcp:
 
     # GCE machine type (optional)
     machine_type: n1-standard-2
+
+    # test name to be used for naming and/or tagging resources (optional)
+    test_name: my_gardenlinux_test
 
     # ssh related configuration for logging in to the VM (required)
     ssh:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import json
+import time
 import yaml
 import sys
 import os
@@ -315,16 +316,17 @@ def gcp_credentials(testconfig, pipeline, request):
 @pytest.fixture(scope="session")
 def client(testconfig, iaas, imageurl, request) -> Iterator[RemoteClient]:
     logger.info(f"Testconfig for {iaas=} is {testconfig}")
+    test_name = testconfig.get('test_name', f"gl-test-{time.strftime('%Y%m%d%H%M%S')}")
     if iaas == "aws":
         session = request.getfixturevalue('aws_session')
-        yield from AWS.fixture(session, testconfig, imageurl)
+        yield from AWS.fixture(session, testconfig, imageurl, test_name)
     elif iaas == "gcp":
         credentials = request.getfixturevalue('gcp_credentials')
         logger.info("Requesting GCP fixture")
-        yield from GCP.fixture(credentials, testconfig, imageurl)
+        yield from GCP.fixture(credentials, testconfig, imageurl, test_name)
     elif iaas == "azure":
         credentials = request.getfixturevalue('azure_credentials')
-        yield from AZURE.fixture(credentials, testconfig, imageurl)
+        yield from AZURE.fixture(credentials, testconfig, imageurl, test_name)
     elif iaas == "openstack-ccee":
         yield from OpenStackCCEE.fixture(testconfig)
     elif iaas == "chroot":
@@ -332,7 +334,7 @@ def client(testconfig, iaas, imageurl, request) -> Iterator[RemoteClient]:
     elif iaas == "kvm":
         yield from KVM.fixture(testconfig)
     elif iaas == "ali":
-        yield from ALI.fixture(testconfig)
+        yield from ALI.fixture(testconfig, test_name)
     elif iaas == "manual":
         yield from Manual.fixture(testconfig)
     else:

--- a/tests/integration/ali.py
+++ b/tests/integration/ali.py
@@ -38,9 +38,7 @@ class ALI:
     """Handle Ali"""
 
     @classmethod
-    def fixture(cls, config):
-
-        test_name = "gl-test-" + str(int(time.time()))
+    def fixture(cls, config, test_name):
         config["test-name"] = test_name
         if not("image_name" in config and config["image_name"] != None):
             config["image_name"] = test_name

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import json
 import os
 import uuid
@@ -23,8 +22,7 @@ class AWS:
     """Handle resources in AWS cloud"""
 
     @classmethod
-    def fixture(cls, session, config, image) -> RemoteClient:
-        test_name = f"gl-test-{time.strftime('%Y%m%d%H%M%S')}"
+    def fixture(cls, session, config, image, test_name) -> RemoteClient:
         AWS.validate_config(config, test_name, image)
 
         logger.info(f"Using security group {config['securitygroup_name']}")

--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import time
 import re
 import pytest
 import uuid
@@ -407,8 +406,7 @@ class AZURE:
 
 
     @classmethod
-    def fixture(cls, credentials, config, imageurl) -> RemoteClient:
-        test_name = f"gl-test-{time.strftime('%Y%m%d%H%M%S')}"
+    def fixture(cls, credentials, config, imageurl, test_name) -> RemoteClient:
         AZURE.validate_config(config, imageurl, test_name)
 
         logger.info(f"Setting up testbed for image {imageurl}...")

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -34,8 +34,7 @@ class GCP:
     """Handle resources in GCP"""
 
     @classmethod
-    def fixture(cls, credentials, config, imageurl):
-        test_name = f"gl-test-{time.strftime('%Y%m%d%H%M%S')}"
+    def fixture(cls, credentials, config, imageurl, test_name):
         GCP.validate_config(config, imageurl, test_name, credentials)
 
         logger.info(f"Setting up testbed for image {imageurl}...")


### PR DESCRIPTION
... and avoid code-duplication

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Allows to configure the name of a test-run for the platform test and as such, modify the prefix that is used for allocated resources in the cloud providers. Of course, not specifying a `test_name` manually will still fall back to the default that was used before: `gl-test-<YYYYmmDDHHMMSS>`.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
tests: make test name for platform tests configurable
```
