### PR TITLE
test: fix tests to run with non-root user on cloud platforms

### DIFF
--- a/features/ali/test/test_users.py
+++ b/features/ali/test/test_users.py
@@ -1,0 +1,4 @@
+from helper.tests.users import users
+
+def test_users(client, ali):
+     users(client, "admin")

--- a/features/aws/test/test_users.py
+++ b/features/aws/test/test_users.py
@@ -1,0 +1,4 @@
+from helper.tests.users import users
+
+def test_users(client, aws):
+     users(client, "admin")

--- a/features/azure/test/test_users.py
+++ b/features/azure/test/test_users.py
@@ -1,0 +1,4 @@
+from helper.tests.users import users
+
+def test_users(client, azure):
+     users(client, "azureuser")

--- a/features/base/test/test_users.py
+++ b/features/base/test/test_users.py
@@ -1,4 +1,4 @@
 from helper.tests.users import users
 
-def test_users(client, non_dev, non_feature_github_action_runner, non_vhost):
+def test_users(client, non_dev, non_feature_github_action_runner, non_vhost, non_aws, non_azure, non_ali, non_gcp):
      users(client)

--- a/features/base/test/test_users.py
+++ b/features/base/test/test_users.py
@@ -1,4 +1,4 @@
 from helper.tests.users import users
 
-def test_users(client, non_dev, non_feature_github_action_runner, non_vhost, non_aws, non_azure, non_ali, non_gcp):
+def test_users(client, non_dev, non_feature_github_action_runner, non_vhost, non_hyperscalers):
      users(client)

--- a/features/gardener/test/test_dmesg.py
+++ b/features/gardener/test/test_dmesg.py
@@ -13,6 +13,6 @@ from helper.utils import execute_remote_command
 
 
 def test_dmesg(client, file, args, non_chroot):
-    cmd = "sysctl -a > /tmp/sysctl.txt"
+    cmd = "/usr/sbin/sysctl -a > /tmp/sysctl.txt"
     execute_remote_command(client, cmd)
     file_content(client, file, args)

--- a/features/gardener/test/test_systemd_units.py
+++ b/features/gardener/test/test_systemd_units.py
@@ -13,5 +13,5 @@ from helper.utils import validate_systemd_unit
 
 
 def test_systemd_unit(client, systemd_unit, non_chroot):
-    execute_remote_command(client, f"systemctl start {systemd_unit}")
+    execute_remote_command(client, f"sudo -u root systemctl start {systemd_unit}")
     validate_systemd_unit(client, f"{systemd_unit}")

--- a/features/gcp/test/test_users.py
+++ b/features/gcp/test/test_users.py
@@ -1,0 +1,4 @@
+from helper.tests.users import users
+
+def test_users(client, gcp):
+     users(client, "gardenlinux")

--- a/features/server/test/test_reset_env_vars.py
+++ b/features/server/test/test_reset_env_vars.py
@@ -2,11 +2,11 @@ from helper.tests.file_content import file_content
 import pytest
 
 @pytest.mark.parametrize(
-    "file,args",
+    "file,args,sudo",
     [
-        ("/etc/sudoers", {"Defaults": "env_reset"})
+        ("/etc/sudoers", {"Defaults": "env_reset"}, True)
     ]
 )
 
-def test_reset_env_vars(client, file, args):
-    file_content(client, file, args, invert=False, ignore_missing=False)
+def test_reset_env_vars(client, file, args, sudo):
+    file_content(client, file, args, invert=False, ignore_missing=False, sudo=sudo)

--- a/features/server/test/test_users.py
+++ b/features/server/test/test_users.py
@@ -1,4 +1,4 @@
 from helper.tests.users import users
 
-def test_users(client, non_dev, non_feature_github_action_runner, non_vhost):
+def test_users(client, non_dev, non_feature_github_action_runner, non_vhost, non_aws, non_azure, non_ali, non_gcp):
      users(client)

--- a/features/server/test/test_users.py
+++ b/features/server/test/test_users.py
@@ -1,4 +1,4 @@
 from helper.tests.users import users
 
-def test_users(client, non_dev, non_feature_github_action_runner, non_vhost, non_aws, non_azure, non_ali, non_gcp):
+def test_users(client, non_dev, non_feature_github_action_runner, non_vhost, non_hyperscalers):
      users(client)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,6 +408,11 @@ def aws(iaas):
         pytest.skip('test only supported on aws')
 
 @pytest.fixture
+def non_gcp(iaas):
+    if iaas != 'gcp':
+        pytest.skip('test only supported on gcp')
+
+@pytest.fixture
 def gcp(iaas):
     if iaas != 'gcp':
         pytest.skip('test only supported on gcp')
@@ -441,6 +446,11 @@ def non_openstack(iaas):
 def openstack(iaas):
     if iaas != 'openstack-ccee':
         pytest.skip('test only supported on openstack')
+
+@pytest.fixture
+def non_hyperscalers(iaas):
+    if iaas == 'aws' or iaas == 'gcp' or iaas == 'azure' or iaas == 'ali':
+        pytest.skip(f"test not supported on hyperscaler {iaas}")
 
 # This fixture is an alias of "chroot" but does not use the "chroot" env.
 # However, it only needs the underlying container for its tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,6 +398,11 @@ def azure(iaas):
         pytest.skip('test only supported on azure')
 
 @pytest.fixture
+def non_aws(iaas):
+    if iaas == 'aws':
+        pytest.skip('test not supported on aws')
+
+@pytest.fixture
 def aws(iaas):
     if iaas != 'aws':
         pytest.skip('test only supported on aws')

--- a/tests/helper/tests/capabilities.py
+++ b/tests/helper/tests/capabilities.py
@@ -5,7 +5,7 @@ import re
 def capabilities(client, testconfig):
     """ Test if only the defined capabilities are set"""
     (exit_code, output, error) = client.execute_command(
-        "find /boot /etc /usr /var -type f -exec getcap {} \\;", quiet=True)
+        "sudo -u root find /boot /etc /usr /var -type f -exec /usr/sbin/getcap {} \\;", quiet=True)
     assert exit_code == 0, f"no {error=} expected"
 
     # get capabilities.list config from enabled features

--- a/tests/helper/tests/file_content.py
+++ b/tests/helper/tests/file_content.py
@@ -1,9 +1,9 @@
 import re
 
 
-def file_content(client, fname, args, invert=False, ignore_missing=False, only_line_match=False, ignore_comments=False):
+def file_content(client, fname, args, invert=False, ignore_missing=False, only_line_match=False, ignore_comments=False, sudo=False):
     """ Performing unit test to find key/val in files """
-    content = _get_content_remote_file(client, fname)
+    content = _get_content_remote_file(client, fname, sudo)
 
     if not content:
         assert not content and ignore_missing, f"Content or file not found: {fname}."
@@ -25,9 +25,11 @@ def file_content(client, fname, args, invert=False, ignore_missing=False, only_l
                 assert len(content_keys) == 0, f"Found {args} in {fname}."
 
 
-def _get_content_remote_file(client, fname):
+def _get_content_remote_file(client, fname, sudo=False):
     """ Get the content of a remote file by the given file name """
     cmd = f"cat {fname}"
+    if sudo:
+        cmd = f"sudo -u root {cmd}"
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)
     if not "No such file or directory" in error:

--- a/tests/helper/tests/kernel_parameter.py
+++ b/tests/helper/tests/kernel_parameter.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 def kernel_parameter(client, parameter, value):
 
     (exit_code, output, error) = client.execute_command(
-        f"sysctl -n {parameter}", quiet=True)
+        f"sudo -u root /usr/sbin/sysctl -n {parameter}", quiet=True)
     assert exit_code == 0, f"no {error=} expected"
 
     running_value = output.strip(string.whitespace)

--- a/tests/helper/tests/sshd.py
+++ b/tests/helper/tests/sshd.py
@@ -3,7 +3,7 @@ def sshd(client, expected):
     option value string and the sshd_config are conterted into lists of 
     tuples"""
 
-    (exit_code, output, error) = client.execute_command("sshd -T",
+    (exit_code, output, error) = client.execute_command("sudo -u root /usr/sbin/sshd -T",
                                                         quiet=True)
     assert exit_code == 0, f"no {error=} expected"
 

--- a/tests/helper/tests/users.py
+++ b/tests/helper/tests/users.py
@@ -50,11 +50,12 @@ def users(client, additional_user = ""):
          "ls /home/", quiet=True)
     assert exit_code == 0, f"no {error=} expected"
 
-    homes = []
+    permitted_homes = [ '', additional_user ]
+    discovered_homes = []
     for line in output.split('\n'):
-        if line != '':
-            homes.append(line)
-    assert len(homes) == 0, f"Found the following home directories: {homes}"
+        if line not in permitted_homes:
+            discovered_homes.append(line)
+    assert len(discovered_homes) == 0, f"Found the following home directories: {discovered_homes}"
 
 
 def _has_user_sudo_cmd(client, user):

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -94,7 +94,7 @@ def get_architecture(client):
 
 def unset_env_var(client, env_var):
     """Unset env var on remote system"""
-    (exit_code, output, error) = client.execute_command(f'su - root -c "unset {env_var}"', quiet=True)
+    (exit_code, output, error) = client.execute_command(f'sudo -u root "unset {env_var}"', quiet=True)
     return exit_code
 
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Running the feature tests on cloud platforms such as Azure or AWS will have some problems due to the fact that the user used to log in to the test-VM has no root permissions. This PR:
- adds a `sudo` to commands that require root permissions
- gives to the full path to commands/binaries that reside in `/usr/sbin` which is not in a non-root user's `$PATH`

In addition, it makes sure that additional users that get injected by the cloud platforms are accepted and will not fail the `test_users.py` test.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
test: fix tests to run with non-root user on cloud platforms
```
