### PR TITLE
test: remove check for storage account name

### DIFF
--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -94,11 +94,6 @@ class AZURE:
             return None
 
     def az_create_storage_account(self, name: str):
-        availability = self.sclient.storage_accounts.check_name_availability(
-            StorageAccountCheckNameAvailabilityParameters(name=name)
-        )
-        if not availability.name_available:
-            raise RuntimeError(f"Storage account name {name} not available: {availability.reason}")
         self.logger.info(f"Creating storage account {name} in resourcegroup {self._resourcegroup.name}...")
         return self.sclient.storage_accounts.begin_create(
             resource_group_name = self._resourcegroup.name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Removes a check for name availability of a storage account for platform tests on Azure. The check seems to be broken when used with a subscription only available through a shared tenant and it is unnecessary as creating the storage account would fail if the name were not available.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- test: remove check for storage account name on Az platform tests
```
