### PR TITLE
tests(_readonly): Add unit tests for feature `_readonly`

### DIFF
--- a/features/_readonly/test/test_mount.py
+++ b/features/_readonly/test/test_mount.py
@@ -1,0 +1,13 @@
+from helper.tests.mount import mount
+import pytest
+
+
+@pytest.mark.parametrize(
+    "mount_point,opt,test_type,test_val",
+    [
+        ("/opt", "ro", "opt_in_option", True)
+    ]
+)
+
+def test_mount(client, mount_point, opt, test_type, test_val, non_chroot):
+     mount(client, mount_point, opt, test_type, test_val)

--- a/tests/helper/tests/mount.py
+++ b/tests/helper/tests/mount.py
@@ -1,0 +1,51 @@
+import uuid
+import os
+import pytest
+from helper.utils import execute_remote_command
+
+
+def mount(client, mount_point, opt, test_type, test_val):
+    """ Testing options on defined mount points """
+    fstab_file = execute_remote_command(client, "cat /etc/fstab")
+    fstab = _parse_fstab(fstab_file)
+
+    # Run desired test types
+
+    # Test for defined options
+    if test_type == "opt_in_option":
+        opt_in_option(client, mount_point, opt, fstab, test_val)
+
+
+def opt_in_option(client, mount_point, opt, fstab, test_val):
+    """ Validate if a specific option is present """
+    assert mount_point in fstab, f"Could not find mount {mount_point} in /etc/fstab."
+    assert opt in fstab[mount_point]["opts"], f"Could not find option {opt} for mount {mount_point} in /etc/fstab."
+
+    # Validate the expected state by performing test(s)
+    if test_val:
+        _write_file(client, mount_point, fail=True)
+
+
+def _write_file(client, mount_point, fail):
+    """ Writes a random file on a specific mount """
+    file_name = uuid.uuid4()
+    rc, out = execute_remote_command(client, f"touch {mount_point}/{file_name}", skip_error=fail)
+    if fail:
+        assert rc == 1, f"Could write on mount {mount_point}."
+    else:
+        assert rc == 0, f"Could not write on mount {mount_point}."
+
+
+def _parse_fstab(fstab_file):
+    """ Parse a fstab file line for line and convert it to Py dict """
+    fstab = {}
+    for line in fstab_file.splitlines():
+        fs_entry = line.split()
+        mount = fs_entry[1]
+        fstab[mount] = {} 
+        fstab[mount]["device"] = fs_entry[0]
+        fstab[mount]["mount"] = fs_entry[1]
+        fstab[mount]["fs"] = fs_entry[2]
+        # Convert comma separated options to list
+        fstab[mount]["opts"] = fs_entry[3].split(",")
+    return fstab


### PR DESCRIPTION
tests(_readonly): Add unit tests for feature `_readonly`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Add unit tests for feature `_readonly`

**Which issue(s) this PR fixes**:
Fixes #1173

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

**Test(s)**:
Fail:
```
FAILED _readonly/test/test_mount.py::test_mount[/opt-ro-opt_in_option-True] - AssertionError: Could write on mount /opt.
FAILED _readonly/test/test_mount.py::test_mount[/foo-ro-opt_in_option-True] - AssertionError: Could not find option ro for mount /foo in /etc/fstab.
```

Passed:
```
PASSED _readonly/test/test_mount.py::test_mount[/opt-ro-opt_in_option-False]
PASSED _readonly/test/test_mount.py::test_mount[/opt-ro-opt_in_option-True]
```