### PR TITLE
Remove systemd-coredump from _prod

### DIFF
--- a/features/_prod/file.exclude
+++ b/features/_prod/file.exclude
@@ -1,0 +1,2 @@
+/etc/systemd/system/systemd-coredump@.service.d/override.conf
+/etc/systemd/system/systemd-coredump@.service.d

--- a/features/_prod/pkg.exclude
+++ b/features/_prod/pkg.exclude
@@ -1,0 +1,1 @@
+systemd-coredump


### PR DESCRIPTION
**What this PR does / why we need it**:
After some discussions with @gehoern it was decided that coredumps should be disabled when using the _prod feature - coredumps are disabled by default (ulimit soft 0, hard unlimited) so removing systemd-coredump is enough.
