### PR TITLE
GitHub actions: S3 upload use full prefix in object key

### DIFF
--- a/.github/workflows/upload_to_s3.sh
+++ b/.github/workflows/upload_to_s3.sh
@@ -46,5 +46,5 @@ done
 
 cat "$meta_yml"
 
-aws s3 cp --recursive "$name" "s3://$bucket/objects/$name"
-aws s3 cp --content-type "text/yaml" "$meta_yml" "s3://$bucket/meta/singles/$name"
+aws s3 cp --recursive "$name" "s3://$bucket/objects/$prefix"
+aws s3 cp --content-type "text/yaml" "$meta_yml" "s3://$bucket/meta/singles/$prefix"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Use the full prefix (including the minimal feature set) in the S3 object key rather than just the make target.
This will make it easier for the tekton pipeline to find the uploaded images for publishing.
