### PR TITLE
fix: Use dist repo instead of the Azure one for azure-cli

### DIFF
--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -1,19 +1,23 @@
 ARG VERSION
 FROM gardenlinux/base-test:${VERSION}
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN : "Install AWS requirements" \
+     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
      && unzip awscliv2.zip \
      && ./aws/install \
-     && rm -rf ./aws \
+     && rm -rf ./aws && \
+    : "Install GCP requirements" \
      && curl -sL -o /usr/share/keyrings/cloud.google.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg \
      && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
      && apt-get update \
      && apt-get install -y google-cloud-sdk \
-     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg \
-     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ bullseye main" | tee /etc/apt/sources.list.d/azure-cli.list \
+     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg && \
+    : "Install Azure requirements" \
      && apt-get update \
-     && apt-get install -y azure-cli \
-     && pip3 install python-openstackclient \
+     && apt-get install -y azure-cli && \
+    : "Install Openstack requirements" \
+     && pip3 install python-openstackclient && \
+    : "Install AliCloud specific requirements" \
      && curl -sL -o /aliyun-cli-linux-3.0.94-amd64.tgz https://github.com/aliyun/aliyun-cli/releases/download/v3.0.94/aliyun-cli-linux-3.0.94-amd64.tgz \
      && (cd /usr/local/bin ; tar xf /aliyun-cli-linux-3.0.94-amd64.tgz) \
      && rm /aliyun-cli-linux-3.0.94-amd64.tgz \

--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -11,7 +11,6 @@ RUN : "Install AWS requirements" \
      && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
      && apt-get update \
      && apt-get install -y google-cloud-sdk \
-     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg && \
     : "Install Azure requirements" \
      && apt-get update \
      && apt-get install -y azure-cli && \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR fixes an issue with the `integration-test` container build. It replaces the Azure repo with the distribution repo for installing `azure-cli` in order to resolve an dependency issue with OpenSSL.

**Which issue(s) this PR fixes**:
Fixes #1260
