### PR TITLE
fix: Fix typo of the integration test container Dockerfile

### DIFF
--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -10,7 +10,7 @@ RUN : "Install AWS requirements" \
      && curl -sL -o /usr/share/keyrings/cloud.google.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg \
      && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
      && apt-get update \
-     && apt-get install -y google-cloud-sdk \
+     && apt-get install -y google-cloud-sdk && \
     : "Install Azure requirements" \
      && apt-get update \
      && apt-get install -y azure-cli && \


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR fixes a typo of the integration test container Dockerfile introduced due to #1261.

**Which issue(s) this PR fixes**:
Fixes #1260 