### PR TITLE
Merge changes for Garden Linux 576.12 into `rel-576` branch

### DIFF
--- a/ci/glci/util.py
+++ b/ci/glci/util.py
@@ -507,3 +507,8 @@ def virtual_image_artifact_for_platform(platform: glci.model.Platform) -> str:
         )
 
     return platform_to_artifact_mapping[platform]
+
+def package_aliases(package_alias_file: str = paths.package_alias_path) -> dict:
+    with open(package_alias_file) as f:
+        parsed = yaml.safe_load(f)
+    return parsed.get('aliases', {})

--- a/ci/package_aliases.yaml
+++ b/ci/package_aliases.yaml
@@ -1,0 +1,12 @@
+# This file contains a mapping of debian-package-names to a list of package-name aliases.
+# When we create a component descriptor for the gardenlinux-artefacts as part of the build process, this mapping
+# is consulted when creating the labels that provide additional information about the build's contents.
+# Ultimately, these labels are then used to be able to determine a package-version if our automated scanner isn't
+# able to by itself because the package name it knows differs from the debian-package-name.
+aliases:
+  auditd: [audit]
+  libc-bin: [glibc]
+  python3-blinker: [blinker]
+  python3-jinja2: [Jinja2]
+  python3-jwt: [PyJWT]
+  python3-markupsafe: [MarkupSafe]

--- a/ci/paths.py
+++ b/ci/paths.py
@@ -4,5 +4,7 @@ own_dir = os.path.abspath(os.path.dirname(__file__))
 repo_root = os.path.abspath(os.path.join(own_dir, os.pardir))
 
 cicd_cfg_path = os.path.join(own_dir, 'cicd.yaml')
+package_alias_path = os.path.join(own_dir, 'package_aliases.yaml')
+
 flavour_cfg_path = os.path.join(repo_root, 'flavours.yaml')
 version_path = os.path.join(repo_root, 'VERSION')

--- a/ci/steps.py
+++ b/ci/steps.py
@@ -608,7 +608,7 @@ def create_component_descriptor_step(
     ]
     step = tkn.model.TaskStep(
         name='component-descriptor',
-        image=DEFAULT_IMAGE,
+        image='eu.gcr.io/gardener-project/cc/job-image:1.1857.0',
         script=task_step_script(
             path=os.path.join(steps_dir, 'component_descriptor.py'),
             script_type=ScriptType.PYTHON3,

--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -235,6 +235,15 @@ def oci_image_resources(
                             'modifiers': release_manifest.modifiers,
                         }
                     ),
+                    cm.Label(
+                        name='cloud.gardener.cnudie/responsibles',
+                        value=[
+                            {
+                                'type': 'emailAddress',
+                                'email': 'thomas.buchner@sap.com',
+                            },
+                        ],
+                    ),
                 ]
             )
 
@@ -307,6 +316,15 @@ def _image_rootfs_resource(
               'buildTimestamp': release_manifest.build_timestamp,
               'debianPackages': [p for p in _virtual_image_packages(release_manifest, cicd_cfg)],
           }
+        ),
+        cm.Label(
+            name='cloud.gardener.cnudie/responsibles',
+            value=[
+                {
+                    'type': 'emailAddress',
+                    'email': 'thomas.buchner@sap.com',
+                },
+            ],
         ),
     ]
 

--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -4,5 +4,5 @@ syslinux-common
 cloud-guest-utils
 libpam-cracklib
 rng-tools5
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.134-garden-cloud-${arch}_5.10.134-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.134-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.141-garden-cloud-${arch}_5.10.141-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-cloud-${arch}_5.10.141-0gardenlinux1_${arch}.deb

--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -1,6 +1,6 @@
 apparmor
-https://gitlab.com/gardenlinux/gardenlinux-package-containerd/-/jobs/2412559315/artifacts/raw/_output/containerd_1.5.11-1gardenlinux~0.531054003.c1a628c0_amd64.deb
-https://gitlab.com/gardenlinux/gardenlinux-package-runc/-/jobs/2419399276/artifacts/raw/_output/runc_1.0.3-2gardenlinux~0.532276027.ddafebce_amd64.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/c/containerd/containerd_1.5.13-1gardenlinux~576.1_amd64.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/r/runc/runc_1.0.3+ds1-1gardenlinux~576.1_amd64.deb
 https://snapshot.debian.org/archive/debian/20220502T032918Z/pool/main/d/docker.io/docker.io_20.10.14+dfsg1-1+b1_amd64.deb
 ethtool
 ipvsadm

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -15,5 +15,5 @@ smartmontools
 bird2
 syslinux
 syslinux-common
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.134-garden-${arch}_5.10.134-0gardenlinux1_${arch}.deb
-https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.134-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10.141-garden-${arch}_5.10.141-0gardenlinux1_${arch}.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-signed-5.10-${arch}/linux-image-5.10-${arch}_5.10.141-0gardenlinux1_${arch}.deb

--- a/features/server/file.include/etc/systemd/system/systemd-coredump@.service.d/override.conf
+++ b/features/server/file.include/etc/systemd/system/systemd-coredump@.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStopPost=/bin/sh -c "rmdir /run/systemd/propagate/systemd-coredump@%i.service"

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -52,5 +52,8 @@ https://snapshot.debian.org/archive/debian-security/20220125T173322Z/pool/update
 https://snapshot.debian.org/archive/debian-security/20220125T173322Z/pool/updates/main/p/policykit-1/libpolkit-agent-1-0_0.105-31%2Bdeb11u1_amd64.deb
 https://snapshot.debian.org/archive/debian-security/20220125T173322Z/pool/updates/main/p/policykit-1/libpolkit-gobject-1-0_0.105-31%2Bdeb11u1_amd64.deb
 https://snapshot.debian.org/archive/debian-security/20220401T152139Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2%2Bdeb11u1_amd64.deb
-https://gitlab.com/gardenlinux/gardenlinux-package-openssl/-/jobs/2298329340/artifacts/raw/output/libssl1.1_1.1.1n-1gardenlinux_amd64.deb
+https://gitlab.com/gardenlinux/legacy-packages/gardenlinux-package-openssl/-/jobs/2446212494/artifacts/raw/output/libssl1.1_1.1.1o-1gardenlinux1_amd64.deb
 https://gitlab.com/gardenlinux/legacy-packages/gardenlinux-package-openssl/-/jobs/2446212494/artifacts/raw/output/openssl_1.1.1o-1gardenlinux1_amd64.deb
+https://repo.gardenlinux.io/gardenlinux/pool/main/g/gnutls28/libgnutls30_3.7.7-2gardenlinux~576.1_amd64.deb
+https://snapshot.debian.org/archive/debian-security/20220807T085555Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1%2Bdeb11u1_amd64.deb
+https://snapshot.debian.org/archive/debian/20220818T100320Z/pool/main/z/zlib/zlib1g_1.2.11.dfsg-4.1_amd64.deb


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Introduces updates for Garden Linux 576.12 into the `rel-576` branch:
 - ci: freeze cd-step image
 - ci: change the way package versions are represented in the CD
   
    instead of putting the package versions into the CD as part of the rather generic 'build-metadata'-label, put them in their own label in a better parseable format. Also provide an initial alias-file.
 - ci: add component-responsible-labels (#1140)
 - fix: systemd-coredump remove dirs
 - fix: upgrade several packages
    
    - Linux Kernel 5.10.141
    
    - libgnutls30 3.7.7 to provide a fix for CVE-2022-2509
    - libtirpc3 1.3.1-1+deb11u1 to provide a fix for CVE-2021-46828
    - zlib1g 1.2.11.dfsg-4.1 to provide a fix for CVE-2022-37434
    
    - containerd 1.5.13 (built with golang 1.17.13)
    - runc 1.0.3 (built with golang 1.17.13)
    - both packages are getting pulled in from repo.gardenlinux.io

**Special notes for your reviewer**:

Must be merged into the `rel-576` branch, not into `main`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- ci: freeze cd-step image
- ci: change the way package versions are represented in the CD
- ci: add component-responsible-labels
- fix: systemd-coredump remove dirs
- fix: upgrade several packages
```
