### PR TITLE
tests: include full feature tests into nightly run

### DIFF
--- a/.github/workflows/aws_tests.sh
+++ b/.github/workflows/aws_tests.sh
@@ -56,6 +56,13 @@ aws:
     ssh:
       user: admin
     keep_running: false
+    features:
+      - aws
+      - gardener
+      - cloud
+      - server
+      - base
+      - _slim
 EOF
 
 echo "### Start Integration Tests for AWS"
@@ -64,6 +71,6 @@ sudo --preserve-env="$env_list" podman run -it --rm -e 'AWS_*' -v "$(pwd):/garde
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
-pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-aws.xml integration || exit 1
+pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-aws.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/azure_tests.sh
+++ b/.github/workflows/azure_tests.sh
@@ -37,6 +37,13 @@ azure:
     ssh:
       user: azureuser
     keep_running: false
+    features:
+      - azure
+      - gardener
+      - cloud
+      - server
+      - base
+      - _slim
 EOF
 
 echo "### Start Integration Tests for Azure"
@@ -45,6 +52,6 @@ mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
 
-pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-azure.xml integration || exit 1
+pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-azure.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -32,6 +32,13 @@ gcp:
     image: file:///artifacts/$(basename "$image_file")
     ssh:
         user: gardenlinux
+    features:
+      - gcp
+      - gardener
+      - cloud
+      - server
+      - base
+      - _slim
 EOF
 
 credFileName=$(find "$(pwd)" -maxdepth 1 -type f -name "gha-creds-*.json" | xargs basename)
@@ -42,6 +49,6 @@ mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
 export GOOGLE_APPLICATION_CREDENTIALS="/gardenlinux/$credFileName"
-pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-gcp.xml integration || exit 1
+pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-gcp.xml || exit 1
 exit 0
 EOF


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Integration/platform tests run in nightly currently run the tests in `test_gardenlinux.py` and omit all feature defined tests. This PR adds the list of features to test to the test configuration to have a wider test coverage.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
tests: include full feature tests into nightly run
```
