### PR TITLE
Fix : rootfs not resized properly sometimes

### DIFF
--- a/bin/makesecureboot
+++ b/bin/makesecureboot
@@ -64,7 +64,7 @@ kernel_version="${kernel_file#*-}"
 chroot "$rootfs" dracut \
 	--force \
 	--kver "$kernel_version" \
-	--modules "bash dash systemd systemd-initrd systemd-repart systemd-veritysetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown" \
+	--modules "bash dash systemd systemd-initrd systemd-veritysetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown" \
 	--install "/etc/veritytab" \
 	--reproducible \
 	"$initrd"

--- a/features/cloud/exec.config
+++ b/features/cloud/exec.config
@@ -18,7 +18,7 @@ for kernel in /boot/vmlinuz-*; do
    dracut\
    --force\
    --kver "${kernel#*-}"\
-   --modules "bash dash systemd systemd-initrd systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown"\
+   --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown"\
    --reproducible\
    "/boot/initrd.img-${kernel#*-}"
 

--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -12,7 +12,7 @@ for kernel in /boot/vmlinuz-*; do
    dracut\
    --force\
    --kver "${kernel#*-}"\
-   --modules "bash dash systemd systemd-initrd systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown"\
+   --modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown"\
    --reproducible\
    "/boot/initrd.img-${kernel#*-}"
 

--- a/features/server/file.include/etc/systemd/system/systemd-growfs@.service.d/override.conf
+++ b/features/server/file.include/etc/systemd/system/systemd-growfs@.service.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=systemd-repart.service


### PR DESCRIPTION
**What this PR does / why we need it**:
rootfs is not properly resized all the time, growfs is running before or in parallel with systemd-repart.
More information : [here](https://github.com/systemd/systemd/commit/7b45d6b6f64e9f5c006bdf31559a77294dbe00ad)