### PR TITLE
ci: skip static source check for Garden Linux repo

### DIFF
--- a/ci/steps/component_descriptor.py
+++ b/ci/steps/component_descriptor.py
@@ -440,6 +440,15 @@ def _base_component_descriptor(
                         commit=commit,
                     ),
                     version=version,
+                    labels=[
+                        cm.Label(
+                            name='cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1',
+                            value={
+                                'policy': 'skip',
+                                'comment': 'repo only contains build instructions, source in this repo will not get incoroprated into the final artefact'
+                            }
+                        )
+                    ],
                 )
             ],
             componentReferences=[],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Disables Checkmarx static code checks for the Garden Linux repo as it only contains build instructions for the final artefact and no source code that will end up in the final artefact.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
ci: skip static source check for Garden Linux repo
```
