### PR TITLE
tests: allow additional sudo users

### DIFF
--- a/features/ali/test/test_users.py
+++ b/features/ali/test/test_users.py
@@ -1,4 +1,6 @@
 from helper.tests.users import users
 
+additional_user="admin"
+
 def test_users(client, ali):
-     users(client, "admin")
+     users(client=client, additional_user=additional_user, additional_sudo_users=[additional_user])

--- a/features/aws/test/test_users.py
+++ b/features/aws/test/test_users.py
@@ -1,4 +1,6 @@
 from helper.tests.users import users
 
+additional_user="admin"
+
 def test_users(client, aws):
-     users(client, "admin")
+     users(client=client, additional_user=additional_user, additional_sudo_users=[additional_user])

--- a/features/azure/test/test_users.py
+++ b/features/azure/test/test_users.py
@@ -1,4 +1,6 @@
 from helper.tests.users import users
 
+additional_user="azureuser"
+
 def test_users(client, azure):
-     users(client, "azureuser")
+     users(client=client, additional_user=additional_user, additional_sudo_users=[additional_user])

--- a/features/gcp/test/test_users.py
+++ b/features/gcp/test/test_users.py
@@ -1,4 +1,6 @@
 from helper.tests.users import users
 
+additional_user="gardenlinux"
+
 def test_users(client, gcp):
-     users(client, "gardenlinux")
+     users(client=client, additional_user=additional_user, additional_sudo_users=[additional_user])

--- a/tests/helper/tests/users.py
+++ b/tests/helper/tests/users.py
@@ -1,7 +1,7 @@
 import helper.utils as utils
 
 
-def users(client, additional_user = ""):
+def users(client, additional_user = "", additional_sudo_users=[]):
     # Get content from /etc/passwd
     (exit_code, output, error) = client.execute_command(
         "getent passwd", quiet=True)
@@ -30,8 +30,10 @@ def users(client, additional_user = ""):
                         or gid in [0, 65534], ("Unexpected shell found in " +
                                     f"/etc/passwd for user/service: {user}")
 
-            # Test for sudo priviledges for each user
-            if user != "root":
+            # Test for sudo priviledges for each user 
+            # (additional users may have sudo access)
+            additional_sudo_users.append("root")
+            if user not in additional_sudo_users:
                 _has_user_sudo_cmd(client, user)
 
     # Permissions for '/root' should be set to 700


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Allows to have configurable additional users (other than root) to have sudo capabilities in platform tests.

**Which issue(s) this PR fixes**:
Failing platform test due to users injected by cloud-init having sudo access.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- tests: allow additional sudo users
```
