### PR TITLE
tests: exclude Azure ARM from nightly tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,9 @@ jobs:
         modifier: [ "" ]
         exclude:
           - architecture: arm64
-            target: [ gcp, azure ]
+            target: gcp
+          - architecture: arm64
+            target: azure
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Exclude Azure ARM from nightly platform tests (apparently, the syntax used in PR #1268 was wrong).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
tests: exclude Azure ARM from nightly tests
```
