### PR TITLE
KVM ignition fixes

### DIFF
--- a/features/kvm/file.include/etc/kernel/cmdline.d/50-ignition.cfg
+++ b/features/kvm/file.include/etc/kernel/cmdline.d/50-ignition.cfg
@@ -1,1 +1,1 @@
-CMDLINE_LINUX="$CMDLINE_LINUX ignition.firstboot=1 ignition.platform.id=qemu mount.usr=/dev/disk/by-label/USR mount.usrflags=ro"
+CMDLINE_LINUX="$CMDLINE_LINUX ignition.firstboot=1 ignition.platform.id=qemu"

--- a/features/kvm/file.include/usr/local/sbin/update-bootloaders
+++ b/features/kvm/file.include/usr/local/sbin/update-bootloaders
@@ -5,5 +5,5 @@ set -e
 update-kernel-cmdline
 update-syslinux
 for kernel in /boot/vmlinuz-*; do
-   kernel-install add "${kernel#*-}" "${kernel}" "/boot/initrd.img-${kernel#*-}" 2> /dev/null
+   kernel-install add "${kernel#*-}" "${kernel}"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
As we don't have a separate /usr anymore, the mount.usr and mount.usrflags kernel cmdline parameters need to be removed.
Simplify update-bootloaders and don't pass the initrd pass as parameter.
