### PR TITLE
fix: use prefix instead of name in single yaml

### DIFF
--- a/.github/workflows/upload_to_s3.sh
+++ b/.github/workflows/upload_to_s3.sh
@@ -29,18 +29,19 @@ modifiers: [$GARDENLINUX_FEATURES]
 platform: '$platform'
 published_image_metadata: null
 s3_bucket: '$bucket'
-s3_key: 'meta/singles/$name'
+s3_key: 'meta/singles/$prefix'
 test_result: null
 version: '$GARDENLINUX_VERSION'
 paths:
 EOF
 
 for file in "$name/$prefix"*; do
+suffix="$(basename "$file" | sed "s/^$prefix//")"
 cat << EOF >> "$meta_yml"
 - name: $file
   s3_bucket_name: $bucket
-  s3_key: 'objects/$file'
-  suffix: $(basename "$file" | sed "s/${prefix}//")
+  s3_key: 'objects/$prefix/$prefix$suffix'
+  suffix: $suffix
 EOF
 done
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

#1258 changed the S3 object key to use the full prefix instead of just the make target name, but these changes were not yet reflected in the corresponding single yaml