### PR TITLE
test: allow missing packages to be ignored

### DIFF
--- a/features/server/test/pkg.ignore
+++ b/features/server/test/pkg.ignore
@@ -1,0 +1,1 @@
+systemd-coredump

--- a/tests/helper/tests/packages_musthave.py
+++ b/tests/helper/tests/packages_musthave.py
@@ -32,6 +32,22 @@ def packages_musthave(client, testconfig):
         except OSError:
             continue
 
+    # collect packages that should be ignored by the test 
+    # e.g. because they got excluded by later features
+    ignore = []
+    for feature in features:
+        path = f"/gardenlinux/features/{feature}/test/pkg.ignore"
+        try:
+            with open(path) as f:
+                for package in f:
+                    package = package.strip(string.whitespace)
+                    # Skip comment lines
+                    if package.startswith("#"):
+                        continue
+                    ignore.append(package)
+        except OSError:
+            continue
+    
     arch = get_architecture(client)
 
     missing = []
@@ -57,6 +73,10 @@ def packages_musthave(client, testconfig):
 
         # explicitly excluded packages are allowed to miss 
         if package in exclude:
+            continue
+
+        # packages that should be ignored should be ignored
+        if package in ignore:
             continue
 
         if not (package in installed_package_list or


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
If a less significant feature installs a package via `pkg.include` and a more significant feature uninstalls the package via `pkg.exclude` again, the test `packages_musthave` will fail for the less significant feature. This PR adds the (debatable) `pkg.ignore` file to the `test` folder of a feature that can tell the test to ignore a missing package.

**Which issue(s) this PR fixes**:
Fixes failing nightlies.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- test: allow missing packages to be ignored
```
