### PR TITLE
fix: Remove orphaned packages from usrmerge

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -13,3 +13,8 @@ chmod u-s /bin/umount /bin/mount
 # Mark package as manual installed to pass the orphaned test
 # The package is installed and required by debootstrap 1.0.127
 apt-mark manual usr-is-merged
+
+# Issue 1301
+# Remove orphaned package introduced by
+# new debootstrap version 1.0.127+nmu1
+apt-get remove -y --auto-remove usrmerge


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that orphaned packages of usrmerge which have been introduced by debootstrap `1.0.127+nmu1` are removed during the build process. This resolves the issue with the corresponding orphaned unit test.

**Which issue(s) this PR fixes**:
Fixes #1305 