### PR TITLE
fix: Mark some orphaned packages as manually installed

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -13,3 +13,15 @@ chmod u-s /bin/umount /bin/mount
 # Mark package as manual installed to pass the orphaned test
 # The package is installed and required by debootstrap 1.0.127
 apt-mark manual usr-is-merged
+
+# Issue 1305
+# Mark some packages as manual installed so that the orphaned test
+# is not complaining. These packages are installed due to a bug
+# in debootstrap 1.0.127+nmu1 which installs the dependencies of
+# 'usrmerge' but leaves the package itself behind.
+apt-mark manual \
+  libfile-find-rule-perl \
+  libgdbm-compat4 \
+  libnumber-compare-perl \
+  libperl5.34 \
+  libtext-glob-perl


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR ensures that orphaned packages that have been introduced by the new debootstrap version `1.0.127+nmu1` are marked as manually installed. 

These packages are dependencies of `usrmerge` which is excluded by debootstrap since the new version. However, the dependencies are still installed but they are orphaned. This is a bug which should be fixed in debootstrap. In order to get the build pipeline up and running again though, this PR is needed as a workaround.

**Which issue(s) this PR fixes**:
Fixes #1305 
