### PR TITLE
test(aws): add encryption exception tag to volumes

### DIFF
--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -559,6 +559,9 @@ class AWS:
         instance_tags = self._tags.copy()
         instance_tags.append({'Key': 'Name', 'Value': name})
 
+        volume_tags = self._tags.copy()
+        volume_tags.append({'Key': 'sec-by-def-ebs-encryption-exception', 'Value': 'enabled'})
+
         instance = self.ec2_resource.create_instances(
             BlockDeviceMappings=[
                 {
@@ -578,10 +581,16 @@ class AWS:
             MaxCount=1,
             MinCount=1,
             SecurityGroupIds=[self._security_group_id],
-            TagSpecifications=[{
-                "ResourceType": "instance",
-                "Tags": instance_tags
-            }],
+            TagSpecifications=[
+                {
+                    "ResourceType": "instance",
+                    "Tags": instance_tags
+                },
+                {
+                    "ResourceType": "volume",
+                    "Tags": volume_tags
+                },
+            ],
         )
         return instance[0]
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Add a tag to AWS EBS volumes that get created during a platform to tell Minerva to ignore this unencrypted volume in its scans.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- test(aws): add encryption exception tag to volumes
```
