### PR TITLE
fix(integration-test): Add missing arch eval after moving to new test container

### DIFF
--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -22,6 +22,7 @@ RUN : "Install AWS requirements" \
      && apt-get clean && rm -rf /var/lib/apt/lists/* \
      && mkdir -p /root/.aws /root/.ssh /config && \
    : "Install firecracker specific binaries" \
+     && arch="$(uname -m)" \
      && firecracker_ver="v1.1.1" \
      && release_url="https://github.com/firecracker-microvm/firecracker/releases" \
      && echo ${release_url}/download/${firecracker_ver}/firecracker-${firecracker_ver}-${arch}.tgz \


### PR DESCRIPTION
fix(integration-test): Add missing arch eval after moving to new test container

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
I missed a line while copying the Firecracker binaries from `base-test` to `integration-test` container. (Rel. #1318)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
