### PR TITLE
feat: Add Garden Linux Repo and onmetal-image to build container

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -18,10 +18,12 @@ needslim:
 
 .PHONY: build-image
 build-image: needslim
+	cp ../gardenlinux.asc build-image/gardenlinux.asc
 	if [ ! -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-image:$(VERSION_NUMBER) --format "{{.Repository}}:{{.Tag}}")" ]; then \
 		$(GARDENLINUX_BUILD_CRE) image rm --force $$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-image --format "{{.Repository}}:{{.Tag}}") || true; \
 	fi
 	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/build-image:$(VERSION) -t gardenlinux/build-image:$(VERSION_NUMBER) $(ALTNAME_INTERNAL) build-image; \
+	rm build-image/gardenlinux.asc
 
 .PHONY: build-cert
 build-cert: needslim

--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -1,45 +1,65 @@
-ARG build_base_image=gardenlinux/slim
-FROM 	$build_base_image
+ARG	build_base_image=gardenlinux/slim
+FROM	$build_base_image
 ARG	DEBIAN_FRONTEND=noninteractive
+ARG	GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
+ARG	VERSION
+
+COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
 
 RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		debian-ports-archive-keyring \
-		debootstrap \
-		wget ca-certificates gettext-base \
-		dosfstools mtools datefudge squashfs-tools e2fsprogs \
-		fdisk mount cryptsetup gnupg xz-utils bsdextrautils \
-		sbsigntool \
-		libcap2-bin \
-		python3 \
-		python3-mako \
-		python3-yaml \
-		qemu-user-static \
-		qemu-utils \
-		cpio \
-		syslinux:amd64 syslinux-common:amd64 isolinux:amd64 xorriso:amd64 \
-		dpkg-dev \
-		procps \
-		iproute2 \
-		rsync \
-		openssh-client \
-		qemu-system-arm \
-		qemu-system-x86 \
-		openssl \
-		libengine-pkcs11-openssl
-
-RUN arch="$(dpkg --print-architecture)" && \
-	wget "https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-sdk-cpp_$arch.deb" "https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-kms-pkcs11_$arch.deb" && \
-	apt-get install -y --no-install-recommends "./aws-sdk-cpp_$arch.deb" "./aws-kms-pkcs11_$arch.deb"
-
-RUN echo "deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
-	&& echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default-testing \
-	&& apt-get update \
-	&& apt-get install -t unstable -y --no-install-recommends binutils-x86-64-linux-gnu binutils-aarch64-linux-gnu
-
-RUN rm -rf /var/lib/apt/lists/*
+RUN : "Initialize the build container package installation" \
+		&& arch="$(dpkg --print-architecture)" \
+		&& apt-get update \
+		&& apt-get install -y --no-install-recommends \
+			wget \
+			ca-certificates \
+		&& \
+	: "Extend the sources with other required repos" \
+		&& echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
+		&& echo "deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+		&& echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default-testing \
+		&& apt-get update \
+		&& \
+	: "Make AWS Tools available for the build" \
+		&& wget \
+			"https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-sdk-cpp_$arch.deb" \
+			"https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-kms-pkcs11_$arch.deb" \
+		&& \
+	: "Install all required build tools" \
+		&& apt-get install -y --no-install-recommends \
+			debian-ports-archive-keyring \
+			debootstrap \
+			gettext-base \
+			dosfstools mtools datefudge squashfs-tools e2fsprogs \
+			fdisk mount cryptsetup gnupg xz-utils bsdextrautils \
+			sbsigntool \
+			libcap2-bin \
+			python3 \
+			python3-mako \
+			python3-yaml \
+			qemu-user-static \
+			qemu-utils \
+			cpio \
+			syslinux:amd64 syslinux-common:amd64 isolinux:amd64 xorriso:amd64 \
+			dpkg-dev \
+			procps \
+			iproute2 \
+			rsync \
+			openssh-client \
+			qemu-system-arm \
+			qemu-system-x86 \
+			openssl \
+			libengine-pkcs11-openssl \
+			onmetal-image \
+			"./aws-sdk-cpp_$arch.deb" \
+			"./aws-kms-pkcs11_$arch.deb" \
+		&& apt-get install -t unstable -y --no-install-recommends \
+			binutils-x86-64-linux-gnu \
+			binutils-aarch64-linux-gnu \
+		&& \
+	: "Clean up repo files" \
+		&& rm -rf /var/lib/apt/lists/*
 
 ENV	PATH=${PATH}:/opt/gardenlinux/bin
 RUN	echo "progress=bar:force:noscroll\nverbose=off" >> /etc/wgetrc


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adds the Garden Linux Repo to the build-image container in order to install some build tools that are built in the Gitlab Pipeline and published to the Garden Linux Repo. This makes them accessible in the Garden Linux build.

**Which issue(s) this PR fixes**:
Fixes #1304