### PR TITLE
fix(syslinux): use full name for initrd

### DIFF
--- a/features/cloud/file.include/usr/local/sbin/update-syslinux
+++ b/features/cloud/file.include/usr/local/sbin/update-syslinux
@@ -15,7 +15,7 @@ check_version() {
 	if [ ! -f "$kernelDir/$v/linux" ]; then
 		return 1
 	fi
-	if [ ! -f "$kernelDir/$v/initrd" ]; then
+	if [ ! -f "$kernelDir/$v/initrd.img-$v" ]; then
 		return 1
 	fi
 	return 0
@@ -62,7 +62,7 @@ readarray -t vSorted < <(printf '%s\n' "${versions[@]}" | sort -rV)
 		echo "LABEL Linux $v"
 		echo " LINUX ../Default/$v/linux"
 		echo " APPEND root=${DEVICE} ${CMDLINE_LINUX}"
-		echo " INITRD ../Default/${v}/initrd"
+		echo " INITRD ../Default/${v}/initrd.img-$v"
 		echo
 	done
 } > "${configFile}.new" 

--- a/features/metal/file.include/usr/local/sbin/update-syslinux
+++ b/features/metal/file.include/usr/local/sbin/update-syslinux
@@ -15,7 +15,7 @@ check_version() {
 	if [ ! -f "$kernelDir/$v/linux" ]; then
 		return 1
 	fi
-	if [ ! -f "$kernelDir/$v/initrd" ]; then
+	if [ ! -f "$kernelDir/$v/initrd.img-$v" ]; then
 		return 1
 	fi
 	return 0
@@ -62,7 +62,7 @@ readarray -t vSorted < <(printf '%s\n' "${versions[@]}" | sort -rV)
 		echo "LABEL Linux $v"
 		echo " LINUX ../Default/$v/linux"
 		echo " APPEND root=${DEVICE} ${CMDLINE_LINUX}"
-		echo " INITRD ../Default/${v}/initrd"
+		echo " INITRD ../Default/${v}/initrd.img-$v"
 		echo
 	done
 } > "${configFile}.new" 


### PR DESCRIPTION
**What this PR does / why we need it**:
update-syslinux fails at the moment as the initrd file cannot be found. We need to use the full path when testing and using, e.g. initrd.img-VERSION.