### PR TITLE
cleanup(feature): Remove unused and deprecated devkey.sh file

### DIFF
--- a/features/_dev/devkey.sh
+++ b/features/_dev/devkey.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-ssh-keygen -b 2048 -f id_dev -N ''
-cp -p id_dev.pub file.include/authorized_keys


### PR DESCRIPTION
Remove unused and deprecated devkey.sh file

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
Remove unused and deprecated devkey.sh file

**Which issue(s) this PR fixes**:
Fixes #513

**Special notes for your reviewer**:
With #777 we already cleaned up the static ssh key injection. Now, we should also remove the unused `devkey.sh` from the `_dev` feature, because it never got used and we may use `cloud-init` for further configuration. Next to this, there's still the auto-login on tty0 present and usable.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
