### PR TITLE
feature(build-pipeline): Fetch external resources only on encrypted l…

### DIFF
--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features
 
-RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
+RUN echo "deb https://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
      && apt-get update \
      && apt-get install -y --no-install-recommends \
           curl \


### PR DESCRIPTION
feature(build-pipeline): Fetch external resources only on encrypted layer

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Fetch external resources only on encrypted layer

**Which issue(s) this PR fixes**:
Fixes #1337

**Special notes for your reviewer**:
Surprisingly, this was the only one. Everything else is one `https`, `git` (via `ssh`) or managed by repositories.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
