### PR TITLE
fix(start-vm): add garden as supported host_dist

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -55,7 +55,7 @@ get_os () {
         # Evaluate Distribution
         if [ $host_dist = "centos" ]; then
             os="centos"
-        elif [ $host_dist = "debian" ]; then
+        elif [ $host_dist = "debian" ] || [ $host_dist = "garden" ]; then
             os="debian"
         elif [ $host_dist = "ubuntu" ]; then
             os="ubuntu"


### PR DESCRIPTION
**What this PR does / why we need it**:
We should be able to use the start-vm script when running on a Garden Linux host.

**Which issue(s) this PR fixes**:
Fixes #
