### PR TITLE
file.include.stat extras

### DIFF
--- a/bin/garden-config
+++ b/bin/garden-config
@@ -44,7 +44,7 @@ printf "## copying from file.include\n"
 for i in $(tr ',' '\n' <<< $features); do
 	if [ -d "$featureDir/$i/file.include" ]; then
 		printf "### $i:\n"
-		tar --owner=0 --group=0 -cC $featureDir/$i/file.include . | tar -xvhC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  - | indent
+		(umask 0022; tar --mode='a+rwX' -cC $featureDir/$i/file.include . | tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvhC $targetDir 2>&1 | grep -v "^./$" | paste -sd' '  - | indent)
 	fi
 done
 

--- a/bin/garden-config
+++ b/bin/garden-config
@@ -53,10 +53,13 @@ for i in $(tr ',' '\n' <<< $features); do
         if [ -f "$featureDir/$i/file.include.stat" ]; then
                 printf "### $i:\n"
                 cat $featureDir/$i/file.include.stat | paste -sd' '  - | indent
+		"$thisDir/garden-chroot" "$targetDir" bash -c "
+		set -e
                 while read -r fileUser fileGroup filePerm fileName; do
-                        chown $fileUser:$fileGroup $targetDir$fileName
-                        chmod $filePerm $targetDir$fileName
-                done <<< $(cat $featureDir/$i/file.include.stat)
+                        chown \$fileUser:\$fileGroup \$fileName
+                        chmod \$filePerm \$fileName
+                done <<< \"$(cat $featureDir/$i/file.include.stat)\"
+		"
         fi
 done
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to #920, already handled by @gyptazy via #1331

This is just forcing sane defaults (owner root:root, permissions 755/644) for files/directories included via files.include, irrespective of their owner/permissions on the build machine; executable bit will be kept.
Of course, an override will then be possible via file.include.stat.

Setting custom permissions via file.include.stat is now done chrooted to match the users/groups from the build.

**Which issue(s) this PR fixes**:
Fixes #920