### PR TITLE
Add gardenlinux repo to base-test container

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -39,7 +39,7 @@ build-deb: build
 
 .PHONY: build-base-test
 build-base-test: needslim
-	cp ../gardenlinux.asc base-test/gardenlinux.asc
+	cp -p ../gardenlinux.asc base-test/gardenlinux.asc
 	mkdir -p base-test/_pipfiles
 	cp ../tests/Pipfile* base-test/_pipfiles
 	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/base-test:$(VERSION) base-test

--- a/container/Makefile
+++ b/container/Makefile
@@ -39,9 +39,11 @@ build-deb: build
 
 .PHONY: build-base-test
 build-base-test: needslim
+	cp ../gardenlinux.asc base-test/gardenlinux.asc
 	mkdir -p base-test/_pipfiles
 	cp ../tests/Pipfile* base-test/_pipfiles
-	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/base-test:$(VERSION) base-test
+	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/base-test:$(VERSION) base-test
+	rm base-test/gardenlinux.asc
 
 .PHONY: build-integration-test
 build-integration-test: build-base-test

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -9,7 +9,7 @@ ARG VERSION
 COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
-     && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
+     && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] http://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
      && apt-get update \
      && apt-get install -y --no-install-recommends \
           curl \

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -3,8 +3,13 @@ FROM gardenlinux/slim
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features
+ARG GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
+ARG VERSION
+
+COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
+     && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
      && apt-get update \
      && apt-get install -y --no-install-recommends \
           curl \


### PR DESCRIPTION
How to categorize this PR?
/kind enhancement
/area os
/os garden-linux

What this PR does / why we need it:
This PR adds the Garden Linux Repo to the base-test container in order to install some build tools that are built in the Gitlab Pipeline and published to the Garden Linux Repo. This makes them accessible in the Garden Linux base test.

Which issue(s) this PR fixes:
Fixes https://github.com/gardenlinux/gardenlinux/issues/1349