### PR TITLE
fix: update openssl to 3.0.7

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest
-today
+934.1

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -35,3 +35,5 @@ selinux-policy-default
 gardenlinux-selinux-module
 sosreport
 policykit-1
+libssl3=3.0.7-1
+openssl=3.0.7-1

--- a/tests/helper/tests/packages_musthave.py
+++ b/tests/helper/tests/packages_musthave.py
@@ -71,6 +71,10 @@ def packages_musthave(client, testconfig):
         elif package.endswith(r"-${arch}"):
             package = package.replace(r"${arch}", arch)
 
+        # check if the package has a version tag and chop it off
+        if len(package.split("=")) == 2:
+            package = package.split('=')[0]
+
         # explicitly excluded packages are allowed to miss 
         if package in exclude:
             continue


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

Updates OpenSSL for Garden Linux 934 to `3.0.7`  to provide fixes for CVE-2022-3602 and CVE-2022-3786.

**Special notes for your reviewer**:

Only to be merged once the packages are available in [repo.gardenlinux.io](https://repo.gardenlinux.io). Must be merged into `rel-934`, not into `main`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
fix: update openssl to 3.0.7
```
