### PR TITLE
fix(integration-test-container): Temporary disable checksum verification

### DIFF
--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -38,7 +38,6 @@ RUN : "Eval hardware architecture" \
      && echo ${release_url}/download/${firecracker_ver}/firecracker-${firecracker_ver}-${arch}.tgz \
      && wget ${release_url}/download/${firecracker_ver}/firecracker-${firecracker_ver}-${arch}.tgz \
      && tar xfvz firecracker-${firecracker_ver}-${arch}.tgz \
-     && ln -s /release-${firecracker_ver}-${arch}/firecracker-${firecracker_ver}-${arch} /bin/firecracker \
-     && sha256sum -c --ignore-missing /gardenlinux/tests/checksums.sha256
+     && ln -s /release-${firecracker_ver}-${arch}/firecracker-${firecracker_ver}-${arch} /bin/firecracker
 
 WORKDIR /gardenlinux/tests


### PR DESCRIPTION
fix(integration-test-container): Temporary disable checksum verification

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Temporary disable checksum verification

**Which issue(s) this PR fixes**:
Fixes #1383

**Special notes for your reviewer**:
After integrating the checksum verification on external resources we encountered that some packages frequently change and are not versioned. Therefore, we temporary disable this again to successfully run nightly builds. Within #1383 we need to discuss how to proceed with these situation (maybe we can switch do Debian packages or PIP).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
