### PR TITLE
feat: add a gardener flavour set

### DIFF
--- a/flavours.yaml
+++ b/flavours.yaml
@@ -1,5 +1,15 @@
 ---
 flavour_sets:
+  - name: 'gardener'
+    flavour_combinations:
+      - architectures: [ 'amd64' ]
+        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
+        modifiers: [ [ gardener, _prod ] ]
+        fails: [ unit, integration ]
+      - architectures: [ 'arm64' ]
+        platforms: [ aws ]
+        modifiers: [ [ gardener, _prod ] ]
+        fails: [ unit, integration ]
   - name: 'all'
     flavour_combinations:
       - architectures: [ 'amd64' ]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Introduces a `gardener` flavor-set to only contain those public cloud platforms currently used by Gardener and leave out anything bare-metal.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: add a gardener flavour set
```
