### PR TITLE
feature(container): Preserve file permissions when copying GL repo key

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -18,7 +18,7 @@ needslim:
 
 .PHONY: build-image
 build-image: needslim
-	cp ../gardenlinux.asc build-image/gardenlinux.asc
+	cp -p ../gardenlinux.asc build-image/gardenlinux.asc
 	if [ -n "$$($(GARDENLINUX_BUILD_CRE) image ls gardenlinux/build-image:$(VERSION_NUMBER) --format "{{.Repository}}:{{.Tag}}")" ]; then \
 		$(GARDENLINUX_BUILD_CRE) image rm --force gardenlinux/build-image:$(VERSION_NUMBER) || true; \
 	fi


### PR DESCRIPTION
Preserve file permissions when copying GL repo key

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Preserve file permissions when copying GL repo key

**Which issue(s) this PR fixes**:
Fixes #1408

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: bugfix
- target_group: user, developer, operator
```
