### PR TITLE
feat(start-vm): add --pidfile flag

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -104,6 +104,7 @@ set_defaults () {
     pxe_binary=
     pxefile=${CURR_DIR}/../examples/ipxe/start-vm.ipxe
     ignfile=
+    pidfile=
     uefi=
     uefi_code=
     uefi_vars=
@@ -146,6 +147,7 @@ source "${CURR_DIR}/.constants.sh" \
     --flags 'cpu:,mem:,bridge:,port:,mac:,arch:' \
     --flags 'pxe:' \
     --flags 'ignfile:' \
+    --flags 'pidfile:' \
     --flags 'ueficode:,uefivars:' \
     --flags 'destport:' \
     --usage '[ --daemonize ] [ --cpu:<#> ] [ --mem:<size> ] [ --pxe:<dir> ] [<image file>[,<size>]]*' \
@@ -164,6 +166,7 @@ source "${CURR_DIR}/.constants.sh" \
 --mac       <macaddr>     The mac address is usually randomized. It is used to identify the monitoring port, the mac address of the machine and the UUID. Can be set to this value.
 --pxe       <bool>        Enables pxe boot on the vm. Minimum one image file must be a directory.
 --ignfile   <path>        Provide an ignition file when pxe booting. Can be used standalone.
+--pidfile   <path>        Provide a file where to store the pid of the started qemu vm.
 --daemonize <bool>        Start the virtual machine in background, console deactivated (default: no).
 --skipkp    <bool>        Skip the keypress to the verify status before execute.
 --vnc       <bool>        Sitches from serial console to vnc graphics console / enables vnc in --daemonize.
@@ -186,6 +189,7 @@ while true; do
         --bridge)       bridge="$1";    shift ;;
         --pxe )         pxe="$(realpath $1)";      shift ;;
         --ignfile )     ignfile="$(realpath $1)";  shift ;;
+        --pidfile)      pidfile="$(realpath $1)";  shift ;;
         --port)         port="$1";      shift ;;
         --destport)     port_dest="$1"; shift ;;
         --skipkp)       keypress=;            ;;
@@ -681,6 +685,10 @@ qemu_opt_misc () {
         # Add random number generator (RNG) to the host
         QEMU_OPTS+=("-device virtio-rng-pci,rng=rng0"
                     "-object rng-random,id=rng0,filename=/dev/random")
+    fi
+
+    if [ $pidfile ]; then
+	QEMU_OPTS+=("-pidfile $pidfile")
     fi
 
     # Set QEMU start options depending on


### PR DESCRIPTION
**What this PR does / why we need it**:
Passes the `--pidfile file` flag to qemu. 

**Which issue(s) this PR fixes**:
Fixes #1415 

**Special notes for your reviewer**:

```
./bin/start-vm --daemonize --pidfile somepidfilename.pid ./build/<some image you build before>
```