### PR TITLE
feat: enable ipv6 forwarding by default

### DIFF
--- a/features/cloud/file.include/etc/sysctl.d/20-cloud.conf
+++ b/features/cloud/file.include/etc/sysctl.d/20-cloud.conf
@@ -1,24 +1,3 @@
-# Enable syn flood protection
-net.ipv4.tcp_syncookies = 1
-
-# Ignore source-routed packets
-net.ipv4.conf.all.accept_source_route = 0
-
-# Ignore ICMP redirects
-net.ipv4.conf.all.accept_redirects = 0
-
-# Ignore ICMP redirects from non-GW hosts
-net.ipv4.conf.all.secure_redirects = 1
-
-# Ignore ICMP redirects from non-GW hosts
-net.ipv4.conf.default.secure_redirects = 1
-
-# Ignore ICMP broadcasts to avoid participating in Smurf attacks
-net.ipv4.icmp_echo_ignore_broadcasts = 1
-
-# Ignore bad ICMP errors
-net.ipv4.icmp_ignore_bogus_error_responses = 1
-
 # Randomize addresses of mmap base, heap, stack and VDSO page
 kernel.randomize_va_space = 2
 
@@ -33,25 +12,3 @@ kernel.kptr_restrict=1
 
 # Set perf only available to root
 kernel.perf_event_paranoid=2
-
-# Accept source-routed packets
-net.ipv4.conf.default.accept_source_route = 1
-
-# Accept ICMP redirects
-net.ipv4.conf.default.accept_redirects = 1
-
-# Do not log spoofed, source-routed, and redirect packets
-net.ipv4.conf.all.log_martians = 0
-
-# Enable frowarding for all interfaces
-net.ipv4.conf.all.forwarding = 1
-
-# Make forwarding the default
-net.ipv4.conf.default.forwarding = 1
-
-# Allow redirects on all interfaces and make it the default
-net.ipv4.conf.default.send_redirects = 1
-net.ipv4.conf.all.send_redirects = 1
-
-# Promote a secondary IP address in case a primary IP address is removed
-net.ipv4.conf.all.promote_secondaries = 1

--- a/features/cloud/file.include/etc/sysctl.d/21-ipv4-settings.conf
+++ b/features/cloud/file.include/etc/sysctl.d/21-ipv4-settings.conf
@@ -28,7 +28,7 @@ net.ipv4.conf.default.accept_redirects = 1
 # Do not log spoofed, source-routed, and redirect packets
 net.ipv4.conf.all.log_martians = 0
 
-# Enable frowarding for all interfaces
+# Enable forwarding for all interfaces
 net.ipv4.conf.all.forwarding = 1
 
 # Make forwarding the default

--- a/features/cloud/file.include/etc/sysctl.d/21-ipv4-settings.conf
+++ b/features/cloud/file.include/etc/sysctl.d/21-ipv4-settings.conf
@@ -1,0 +1,42 @@
+# Enable syn flood protection
+net.ipv4.tcp_syncookies = 1
+
+# Ignore source-routed packets
+net.ipv4.conf.all.accept_source_route = 0
+
+# Ignore ICMP redirects
+net.ipv4.conf.all.accept_redirects = 0
+
+# Ignore ICMP redirects from non-GW hosts
+net.ipv4.conf.all.secure_redirects = 1
+
+# Ignore ICMP redirects from non-GW hosts
+net.ipv4.conf.default.secure_redirects = 1
+
+# Ignore ICMP broadcasts to avoid participating in Smurf attacks
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+# Ignore bad ICMP errors
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+# Accept source-routed packets
+net.ipv4.conf.default.accept_source_route = 1
+
+# Accept ICMP redirects
+net.ipv4.conf.default.accept_redirects = 1
+
+# Do not log spoofed, source-routed, and redirect packets
+net.ipv4.conf.all.log_martians = 0
+
+# Enable frowarding for all interfaces
+net.ipv4.conf.all.forwarding = 1
+
+# Make forwarding the default
+net.ipv4.conf.default.forwarding = 1
+
+# Allow redirects on all interfaces and make it the default
+net.ipv4.conf.default.send_redirects = 1
+net.ipv4.conf.all.send_redirects = 1
+
+# Promote a secondary IP address in case a primary IP address is removed
+net.ipv4.conf.all.promote_secondaries = 1

--- a/features/cloud/file.include/etc/sysctl.d/22-ipv6-settings.conf
+++ b/features/cloud/file.include/etc/sysctl.d/22-ipv6-settings.conf
@@ -1,4 +1,4 @@
-# Enable frowarding for all interfaces
+# Enable forwarding for all interfaces
 net.ipv6.conf.all.forwarding = 1
 
 # Make forwarding the default

--- a/features/cloud/file.include/etc/sysctl.d/22-ipv6-settings.conf
+++ b/features/cloud/file.include/etc/sysctl.d/22-ipv6-settings.conf
@@ -1,0 +1,5 @@
+# Enable frowarding for all interfaces
+net.ipv6.conf.all.forwarding = 1
+
+# Make forwarding the default
+net.ipv6.conf.default.forwarding = 1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Introduces the `net.ipv6.conf.all.forwarding = 1` and the `net.ipv6.conf.default.forwarding = 1` sysctl setting upon popular request from Gardener development.
To make the file structure in /etc/sysctl.d more concise, rearranges all ` ipv4` and `ipv6` related settings into dedicated files and leaves all other settings in the old `20-cloud.conf`.

**Special notes for your reviewer**:

Consider cherry-picking to `rel-934` after merging this to `main`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: enable ipv6 forwarding by default
```
