### PR TITLE
fix shellcheck erros

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -195,7 +195,7 @@ else
 
 		# Run the test container using the chroot platform
 		echo "Running pytests in chroot"
-		${gardenlinux_build_cre} run --name $containerName ${dockerArgs[@]} --rm \
+		${gardenlinux_build_cre} run --name $containerName "${dockerArgs[@]}" --rm \
 			-v `pwd`:/gardenlinux -v ${configDir}:/config \
 			"gardenlinux/base-test:$version" \
 			pytest --iaas=chroot --configfile=/config/config.yaml &
@@ -221,7 +221,7 @@ else
 
 		# Run the test container using the KVM platform
 		echo "Running pytests in KVM"
-		${gardenlinux_build_cre} run --name $containerName ${dockerArgs[@]} --rm \
+		${gardenlinux_build_cre} run --name $containerName "${dockerArgs[@]}" --rm \
 			-v /boot/:/boot -v /lib/modules:/lib/modules \
 			-v `pwd`:/gardenlinux -v ${configDir}:/config \
 			"gardenlinux/base-test:$version" \

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 own_dir="$(readlink -f "$(dirname "${0}")")"
 repo_root="$(readlink -f "${own_dir}/..")"
 bin_dir="${repo_root}/bin"

--- a/container/build/install-cfssl.sh
+++ b/container/build/install-cfssl.sh
@@ -1,4 +1,4 @@
-#!usr/bin/env bash
+#!/usr/bin/env bash
 
 # This script downloads cfssl binaries and moves them to /usr/bin/ (in PATH).
 # With cfssl installed, our central build can just refer to the existing

--- a/features/cis/test/check_scripts/1.2.1_ensure_repository_is_configured.sh
+++ b/features/cis/test/check_scripts/1.2.1_ensure_repository_is_configured.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # 1.2.1 Ensure repository is configured (Not scored)
 #
 
@@ -20,10 +21,10 @@ audit() {
     fi
 
     get_apt_gl_repo
-    if [ "$FNRET" = 0 ]; then 
+    if [ "$FNRET" = 0 ]; then
         ok "Garden Linux repository is configured"
-    else    
-        crit "Garden Linux repository is not configured" 
+    else
+        crit "Garden Linux repository is not configured"
     fi
 }
 
@@ -36,7 +37,7 @@ check_config() {
 get_apt_policy() {
     STATUS=$(apt-cache policy)
     retVal=$?
-    if [ $retVal > 0  ]; then
+    if [ $retVal -gt 0  ]; then
         FNRET=0
     else
         FNRET=1
@@ -47,7 +48,7 @@ get_apt_policy() {
 get_apt_gl_repo() {
     OUTPUT=$(apt-cache policy | grep "origin repo.gardenlinux.io" | awk {'print $2'} | tail -n1)
     retVal=$?
-    if [ $retVal > 0  ]; then
+    if [ $retVal -gt 0  ]; then
         FNRET=0
     else
         FNRET=1

--- a/features/cloud/file.include/etc/profile.d/50-autologout.sh
+++ b/features/cloud/file.include/etc/profile.d/50-autologout.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh disable=SC2148
 TMOUT=600
 readonly TMOUT
 export TMOUT

--- a/features/server/file.include/etc/profile.d/50-nohistory.sh
+++ b/features/server/file.include/etc/profile.d/50-nohistory.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh disable=SC2148
 HISTFILE=/dev/null
 readonly HISTFILE
 export HISTFILE


### PR DESCRIPTION
/kind technical-debt
/area os
/os garden-linux

**What this PR does / why we need it**:
fix errors found by shellcheck

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


```
$ find . -name '*.sh' -type f -print0 | xargs -n 1 -0 shellcheck -S error

In ./ci/lib.sh line 1:
own_dir="$(readlink -f "$(dirname "${0}")")"
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...

In ./build.sh line 197:
                ${gardenlinux_build_cre} run --name $containerName ${dockerArgs[@]} --rm \
                                                                   ^--------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In ./build.sh line 223:
                ${gardenlinux_build_cre} run --name $containerName ${dockerArgs[@]} --rm \
                                                                   ^--------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...

In ./features/cis/test/check_scripts/1.2.1_ensure_repository_is_configured.sh line 1:
# 1.2.1 Ensure repository is configured (Not scored)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In ./features/cis/test/check_scripts/1.2.1_ensure_repository_is_configured.sh line 39:
    if [ $retVal > 0  ]; then
                 ^-- SC2071 (error): > is for string comparisons. Use -gt instead.


In ./features/cis/test/check_scripts/1.2.1_ensure_repository_is_configured.sh line 50:
    if [ $retVal > 0  ]; then
                 ^-- SC2071 (error): > is for string comparisons. Use -gt instead.

For more information:
  https://www.shellcheck.net/wiki/SC2071 -- > is for string comparisons. Use ...
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...

In ./features/server/file.include/etc/profile.d/50-nohistory.sh line 1:
HISTFILE=/dev/null
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...

In ./features/cloud/file.include/etc/profile.d/50-autologout.sh line 1:
TMOUT=600
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
```
