### PR TITLE
fix: set file attributes of key in Dockerfile

### DIFF
--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -6,7 +6,9 @@ ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinu
 ARG GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
 ARG VERSION
 
-COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
+COPY gardenlinux.asc $GARDENLINUX_MIRROR
+RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
+        && chmod 644 $GARDENLINUX_MIRROR_KEY
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
      && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] http://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \

--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -5,6 +5,8 @@ ARG	GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
 ARG	VERSION
 
 COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
+RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
+        && chmod 644 $GARDENLINUX_MIRROR_KEY
 
 RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Explicitly sets the file permissions as required by the container image.,

**Which issue(s) this PR fixes**:
Fixes #1420 

Kudos to @5kt 