### PR TITLE
Enable debian mirrors in a developer mode

### DIFF
--- a/bin/garden-build
+++ b/bin/garden-build
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
-	--flags 'no-build,debug,skip-tests,suite:,gardenversion:,timestamp:' \
+	--flags 'no-build,debug,debian,skip-tests,suite:,gardenversion:,timestamp:' \
 	--flags 'ports,arch:,qemu,features:,disable-features:,commitid:,userid:,usergid:' \
 	--flags 'suffix:,prefix:' \
 	--
@@ -17,7 +17,8 @@ while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
-		--debug) debug=1 ;;	# for jumping in the prepared image"
+		--debug) debug=1 ;;	# for jumping in the prepared image
+		--debian) debian=1 ;;	# Allow debian repo in Garden Linux image
 		--ports) ports=1 ;;	# for using "debian-ports"
 		--arch) arch="$1"; shift ;; # for adding "--arch" to garden-init
 		--qemu) qemu=1 ;;	# for using "qemu-debootstrap"
@@ -103,7 +104,9 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 
 	initArgs=( --arch="$dpkgArch" )
 	configArgs=( --arch="$dpkgArch" )
-	initArgs+=( --debian )
+	if [ "$debian" == "1" ]; then
+		initArgs+=( --debian )
+	fi
 	if [ -n "${ports-}" ]; then
 		initArgs+=(
 			--debian-ports

--- a/bin/garden-init
+++ b/bin/garden-init
@@ -18,7 +18,7 @@ source "$thisDir/.constants.sh" \
 	'--non-debian rootfs xenial http://archive.ubuntu.com/ubuntu'
 
 eval "$dgetopt"
-nonDebian=
+debian=
 debianPorts=
 debootstrap=
 script=
@@ -34,9 +34,9 @@ while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
-		--debian)	nonDebian= ;;
-		--debian-ports)	nonDebian= ; debianPorts=1 ;;
-		--non-debian)	nonDebian=1 ;;
+		--debian)	debian=1 ;;
+		--debian-ports)	debian=1 ; debianPorts=1 ;;
+		--non-debian)	debian= ;;
 		--debootstrap)	debootstrap="$1"; shift ;;
 		--debootstrap-script) script="$1"; shift ;;
 		--keyring)	keyring="$1"; shift ;;
@@ -64,9 +64,7 @@ version="${1:-}"; shift || eusage 'missing version'
 
 timestamp=
 mirror=
-if [ -z "$nonDebian" ]; then
-	timestamp="${1:-}"; shift || eusage 'missing timestamp'
-else
+if [ "$debian" == "1" ]; then
 	mirror="${1:-}"; shift || eusage 'missing mirror'
 
 	timestamp="$(
@@ -76,6 +74,8 @@ else
 		} |tac|tac| awk -F ': ' '$1 == "Date" { print $2; exit }'
 	)"
 	# TODO re-calculate "timestamp" during garden-tar/fixup (possibly scraping from /var/lib/apt/lists/*Release* instead?)
+else
+	timestamp="${1:-}"; shift || eusage 'missing timestamp'
 fi
 
 epoch="$(date --date "$timestamp" '+%s')"
@@ -155,7 +155,7 @@ if [[ -v PKG_DIR ]]; then
 	mount --rbind --make-rslave "$PKG_DIR" "$targetDir/run/packages"
 fi
 
-if [ -z "$nonDebian" ]; then
+if [ "$debian" == "1" ]; then
 	"$thisDir/garden-debian-sources-list" --gardenlinux-only \
 		$([ -z "$debianPorts" ] || echo '--ports') \
 		$([[ -v PKG_DIR ]] && echo --local-pkgs /run/packages) \

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/bin/.constants.sh" \
-	--flags 'skip-build,debug,lessram,manual,skip-tests,export-aws-access-key' \
+	--flags 'skip-build,debug,debian,lessram,manual,skip-tests,export-aws-access-key' \
 	--flags 'arch:,features:,disable-features:,suite:,local-pkgs:,tests:,cert:' \
 	--usage '[--skip-build] [--lessram] [--debug] [--manual] [--arch=<arch>] [--skip-tests] [--tests=<test>,<test>,...] [<output-dir>] [<version/timestamp>]' \
 	--sample '--features kvm,khost --disable-features _slim .build' \
@@ -18,6 +18,7 @@ source "$thisDir/bin/.constants.sh" \
 		can only be implicit features another feature pulls in  (default:)
 --lessram	build will be no longer in memory (default: off)
 --debug		activates basically \`set -x\` everywhere (default: off)
+--debian	allows installation of packages from debian repo
 --manual	built will stop in build environment and activate manual mode (debugging) (default:off)
 --arch		builds for a specific architecture (default: architecture the build runs on)
 --suite		specifies the debian suite to build for e.g. bullseye, potatoe (default: testing)
@@ -29,6 +30,7 @@ source "$thisDir/bin/.constants.sh" \
 eval "$dgetopt"
 build=1
 debug=
+debian=
 manual=
 lessram=
 arch=$(${thisDir}/bin/get_arch.sh)
@@ -91,6 +93,7 @@ envArgs=(
 	LC_ALL="C"
 	suite="bookworm"
 	debug=$debug
+	debian=$debian
 	manual=$manual
 	arch="$arch"
 	features="$features"


### PR DESCRIPTION
**What this PR does / why we need it**:
As a Garden Linux Developer I want to be able to include packages for example via `features/pkg.include` that are not part of the repo.gardenlinux.io. 

Using only the repo.gardenlinux.io must be the default.

**Which issue(s) this PR fixes**:
Fixes #1422

**Notes**

- instead of checking `-z $nonDebian` check for ` "$debian" == "1"` 
- build.sh accepts `--debian` flag which is passed down to garden-build -> garden-init


