### PR TITLE
feature(container): Obtain `awscliv2` from pip instead `aws`

### DIFF
--- a/container/integration-test/Dockerfile
+++ b/container/integration-test/Dockerfile
@@ -9,11 +9,8 @@ RUN : "Eval hardware architecture" \
      && [ $arch = "x86_64" ] && aliyun_arch=amd64 || aliyun_arch=arm64 \
      && [ $arch = "x86_64" ] && ossutil_arch=64 || ossutil_arch=arm64 \
     : "Install AWS requirements" \
-     && curl "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip" -o "awscliv2.zip" \
-     && ln -s awscliv2.zip awscli-exe-linux-${aws_arch}.zip \
-     && unzip awscliv2.zip \
-     && ./aws/install \
-     && rm -rf ./aws && \
+      && pip install awscliv2 \
+      && awsv2 --install \
     : "Install GCP requirements" \
      && curl -sL -o /usr/share/keyrings/cloud.google.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg \
      && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \


### PR DESCRIPTION
feature(container): Obtain `awscliv2` from pip instead `aws`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
Obtain `awscliv2` from pip instead `aws`

**Which issue(s) this PR fixes**:
Fixes #1405

**Special notes for your reviewer**:
Should be validated by running the full integration tests for `AWS`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
