### PR TITLE
feature(devel): Add new build command `--debian-mirror`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ If `Podman` was already present please add the repository yourself to `unqualifi
 | --arch | Builds for a specific architecture (default: architecture the build runs on) |
 | --suite | Specifies the debian suite to build for e.g. bullseye, potatoe (default: testing) |
 | --skip-tests | Deactivating tests (default: off) |
+| --debian-mirror | Adds the native Debian repository (default: off [*only for development available*]) |
 | --tests | Test suite to use, available tests are unittests, kvm, chroot (default: unittests) |
 | --skip-build | Do not create the build container |
 

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
-	--flags 'no-build,debug,skip-tests,suite:,gardenversion:,timestamp:' \
+	--flags 'no-build,debug,skip-tests,suite:,debian-mirror,gardenversion:,timestamp:' \
 	--flags 'ports,arch:,qemu,features:,disable-features:,commitid:,userid:,usergid:' \
 	--flags 'suffix:,prefix:' \
 	--
@@ -13,25 +13,28 @@ export REPO_ROOT="$(readlink -f "${thisDir}/..")"
 
 commitid="${commitid:-local}"
 eval "$dgetopt"
+
+# Update all param flags
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
-		--debug) debug=1 ;;	# for jumping in the prepared image"
-		--ports) ports=1 ;;	# for using "debian-ports"
-		--arch) arch="$1"; shift ;; # for adding "--arch" to garden-init
-		--qemu) qemu=1 ;;	# for using "qemu-debootstrap"
-		--features) features="$1"; shift ;; # adding features
-		--disable-features) disablefeatures="$1"; shift ;; # ignoring features
-		--suite) suite="$1"; shift ;; # suite is a parameter this time
-		--gardenversion|--timestamp) version="$1"; shift ;; # timestamp is a parameter this time
-		--suffix) suffix="$1"; shift ;; # target name prefix
-		--prefix) prefix="$1"; shift ;; # target name suffix
-		--commitid) commitid="$1"; shift ;; # build commit hash
-		--commitid-long) commitid_long="$1"; shift ;; # build commit hash, untruncated - used for /etc/os-release only
-		--skip-tests) tests=0 shift ;; # skip tests
-		--userid) userID="$1" shift ;;
-		--usergid) userGID="$1" shift ;;
+		--debug)			debug=1 ;;			# for jumping in the prepared image"
+		--debian-mirror)		debianMirror=1 ;;		# for adding Debian native mirrors (only dev; default: 0)
+		--ports) 			ports=1 ;;			# for adding Debian native "debian-ports" repository
+		--arch) 			arch="$1"; shift ;; 		# for adding "--arch" to garden-init
+		--qemu) 			qemu=1 ;;			# for using "qemu-debootstrap"
+		--features) 			features="$1"; shift ;; 	# adding features
+		--disable-features)		disablefeatures="$1"; shift ;; 	# ignoring features
+		--suite)			suite="$1"; shift ;; 		# suite is a parameter this time
+		--gardenversion|--timestamp)	version="$1"; shift ;; 		# timestamp is a parameter this time
+		--suffix) 			suffix="$1"; shift ;; 		# target name prefix
+		--prefix) 			prefix="$1"; shift ;; 		# target name suffix
+		--commitid) 			commitid="$1"; shift ;; 	# build commit hash
+		--commitid-long) 		commitid_long="$1"; shift ;; 	# build commit hash, untruncated - used for /etc/os-release only
+		--skip-tests) 			tests=0 shift ;; 		# skip unit tests
+		--userid) 			userID="$1" shift ;;
+		--usergid)			userGID="$1" shift ;;
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -49,9 +52,18 @@ epoch="$(garden-version --epoch "$version")"
 serial="$(garden-version --date "$version")"
 dpkgArch="${arch:-$(dpkg --print-architecture | awk -F- "{ print \$NF }")}"
 export arch="$arch"
+export debianMirror=$debianMirror
 
 fullfeatures="$(garden-feat --featureDir $featureDir --features "$features" --ignore "$disablefeatures" features)"
 targetPlatform="$(garden-feat --featureDir $featureDir --features "$features" --ignore "$disablefeatures")"
+
+# Using the native Debian repository on production builds (_prod) is not supported
+if [ $debianMirror -eq 1 ]; then
+	if [[ $fullfeatures = *_prod* ]]; then
+		echo "Using the native Debian repository on production builds (_prod) is not supported."
+		exit 1
+	fi
+fi
 
 if [ -z "${prefix+x}" ]; then
 	prefix="/$(garden-feat --featureDir $featureDir --features "$features" --ignore "$disablefeatures" cname)-$dpkgArch-$version-$commitid"
@@ -104,12 +116,18 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 	initArgs=( --arch="$dpkgArch" )
 	configArgs=( --arch="$dpkgArch" )
 	initArgs+=( --debian )
+
+	if [ $debianMirror -eq 1 ]; then
+		initArgs+=( --debian-mirror )
+	fi
+
 	if [ -n "${ports-}" ]; then
 		initArgs+=(
 			--debian-ports
 			--include=debian-ports-archive-keyring
 		)
 	fi
+
 	initArgs+=( --keyring "$keyring" --keyring-plain "$keyringPlain" )
 	initArgs+=( --debootstrap-script "$suite" )
 

--- a/bin/garden-debian-sources-list
+++ b/bin/garden-debian-sources-list
@@ -1,43 +1,47 @@
 #!/usr/bin/env bash
-
 # Contains sources from https://github.com/debuerreotype/debuerreotype
-
 set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'ports' \
 	--flags 'deb-src' \
-	--flags 'gardenlinux-only' \
+	--flags 'debian-mirror' \
 	--flags 'local-pkgs:' \
 	-- \
-	'[--deb-src] [--ports] [--gardenlinux-only] <target-dir> <suite> <version>' \
+	'[--deb-src] [--ports] <target-dir> <suite> <version>' \
 	'rootfs stretch 520.0'
 
 eval "$dgetopt"
-gardenlinuxOnly=
+gardenlinuxOnly=1
 ports=
+debianMirror=0
 debSrc=
 local_pkgs=
+
+# Update all param flags
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
-		--gardenlinux-only) gardenlinuxOnly=1 ;;
-		--ports) ports=1 ;;
-		--deb-src) debSrc=1 ;;
-		--local-pkgs) local_pkgs="$1"; shift ;;
+		--gardenlinux-only)	gardenlinuxOnly=1 ;;
+		--ports) 		ports=1 ;;
+		--debian-mirror) 	debianMirror=1 ;;
+		--deb-src)		debSrc=1 ;;
+		--local-pkgs)		local_pkgs="$1"; shift ;;
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
 done
 
-targetDir="${1:-}"; shift || eusage 'missing target-dir'
-suite="${1:-}"; shift || eusage 'missing suite'
-version="${1:-}"; shift || eusage 'missing version'
+targetDir="${1:-}";	shift || eusage 'missing target-dir'
+suite="${1:-}";		shift || eusage 'missing suite'
+version="${1:-}";	shift || eusage 'missing version'
+
 [ -n "$targetDir" ]
 
 epoch="$(< "$targetDir/garden-epoch")"
+
 
 # Garden Linux Repository configuration
 gardenlinuxMirror='https://repo.gardenlinux.io/gardenlinux'
@@ -74,6 +78,7 @@ deb() {
 
 # https://github.com/tianon/go-aptsources/blob/e066ed9cd8cd9eef7198765bd00ec99679e6d0be/target.go#L16-L58
 {
+	# Add local packages
 	if [ -n "$local_pkgs" ]; then
 		echo "deb [trusted=yes] file:$local_pkgs ./"
 		if [ -n "$debSrc" ]; then
@@ -81,8 +86,13 @@ deb() {
 		fi
 	fi
 
-	printf "# Gardenlinux Repo\n"
+        # Add Debian native mirror
+        if [ $debianMirror -eq 1 ]; then
+                echo "deb https://deb.debian.org/debian testing main"
+        fi
 
+
+	printf "# Gardenlinux Repo\n"
 	deb "$version" main gardenlinux
 
 	if [[ -z "$gardenlinuxOnly" ]]; then
@@ -107,14 +117,29 @@ deb() {
 		esac
 	fi
 } > "$targetDir/etc/apt/sources.list"
+# Adjust file permission for sources file
 chmod 0644 "$targetDir/etc/apt/sources.list"
 
+
+## Adjust repository priorities
+## Highest priority (600): Local packages
+## Regular priority (500/550): Garden Linux repository (550 when Debian Mirror is activated)
+## Lowest priority (500): Additional repositories like native Debian repository
+
+# Adjust repository priority for local packages
 if [ -n "$local_pkgs" ]; then
 	printf 'Package: *\nPin: origin ""\nPin-Priority: 600\n' > "$targetDir/etc/apt/preferences.d/local_pkgs"
 else
 	rm -f "$targetDir/etc/apt/preferences.d/local_pkgs"
 fi
 
+# Adjust repository priority for Garden Linux
+if [ $debianMirror -eq 1 ]; then
+	printf 'Package: *\nPin: origin repo.gardenlinux.io\nPin-Priority: 550\n' > "$targetDir/etc/apt/preferences.d/gardenlinux"
+fi
+
+
+# Validate sources.list file
 if [ ! -s "$targetDir/etc/apt/sources.list" ]; then
 	echo >&2 "error: sources.list ended up empty -- something is definitely wrong"
 	exit 1

--- a/bin/garden-init
+++ b/bin/garden-init
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
-
 # Contains sources from https://github.com/debuerreotype/debuerreotype
+set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
-	--flags 'debian,debian-ports,non-debian' \
+	--flags 'debian,debian-ports,debian-mirror,non-debian' \
 	--flags 'debootstrap:' \
 	--flags 'debootstrap-script:' \
 	--flags 'keyring:,keyring-plain:,arch:,include:,exclude:,features:' \
@@ -20,6 +19,7 @@ source "$thisDir/.constants.sh" \
 eval "$dgetopt"
 nonDebian=
 debianPorts=
+debianMirror=0
 debootstrap=
 script=
 keyring=
@@ -30,30 +30,35 @@ exclude=
 features=
 noMergedUsr=
 noCheckGpg=
+
+# Update all param flags
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
-		--debian)	nonDebian= ;;
-		--debian-ports)	nonDebian= ; debianPorts=1 ;;
-		--non-debian)	nonDebian=1 ;;
-		--debootstrap)	debootstrap="$1"; shift ;;
-		--debootstrap-script) script="$1"; shift ;;
-		--keyring)	keyring="$1"; shift ;;
-		--keyring-plain) keyringPlain="$1"; shift ;;
-		--arch)		arch="$1"; shift ;;
-		--include)	include="${include:+$include,}$1"; shift ;;
-		--exclude)	exclude="${exclude:+$exclude,}$1"; shift ;;
-		--features)	features="${features:+$features,}$1"; shift ;;
-		--check-gpg)	noCheckGpg=  ;;
-		--no-check-gpg)	noCheckGpg=1 ;;
+		--debian)		nonDebian= ;;
+		--debian-ports)		nonDebian= ; debianPorts=1 ;;
+		--debian-mirror)	debianMirror=1 ;;
+		--non-debian)		nonDebian=1 ;;
+		--debootstrap)		debootstrap="$1"; shift ;;
+		--debootstrap-script) 	script="$1"; shift ;;
+		--keyring)		keyring="$1"; shift ;;
+		--keyring-plain) 	keyringPlain="$1"; shift ;;
+		--arch)			arch="$1"; shift ;;
+		--include)		include="${include:+$include,}$1"; shift ;;
+		--exclude)		exclude="${exclude:+$exclude,}$1"; shift ;;
+		--features)		features="${features:+$features,}$1"; shift ;;
+		--check-gpg)		noCheckGpg=  ;;
+		--no-check-gpg)		noCheckGpg=1 ;;
 		--) break ;;
 		*)		eusage "unknown flag '$flag'" ;;
 	esac
 done
 
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
+
 [ -n "$targetDir" ] || eusage 'target-dir required' # must be non-empty
+
 if [ -e "$targetDir" ] && [ -z "$(find "$targetDir" -maxdepth 0 -empty)" ]; then
 	echo >&2 "error: '$targetDir' already exists (and isn't empty)!"
 	exit 1
@@ -64,6 +69,7 @@ version="${1:-}"; shift || eusage 'missing version'
 
 timestamp=
 mirror=
+
 if [ -z "$nonDebian" ]; then
 	timestamp="${1:-}"; shift || eusage 'missing timestamp'
 else
@@ -98,6 +104,7 @@ include_aptversion=
 include_aptfile=
 include_wget=
 exclude="$(filter_comment <<< $exclude | filter_variables | filter_if)"
+
 for i in $(filter_comment <<< $include | filter_variables | filter_if | grep -v -f <(echo "$exclude")); do
     if [[ $i = *.deb ]]; then
 	if [[ $i = *://* ]]; then	include_wget+="$i "
@@ -128,6 +135,7 @@ debootstrapArgs+=(
 
 : "${debootstrap:=debootstrap}"
 echo "$debootstrap ${debootstrapArgs[@]}"
+
 if ! "$debootstrap" "${debootstrapArgs[@]}"; then
 	if [ -f "$targetDir/debootstrap/debootstrap.log" ]; then
 		echo >&2
@@ -144,6 +152,7 @@ if ! "$debootstrap" "${debootstrapArgs[@]}"; then
 	fi
 	exit 1
 fi
+
 echo "$epoch" > "$targetDir/garden-epoch"
 
 if [[ -v PKG_DIR ]]; then
@@ -156,11 +165,29 @@ if [[ -v PKG_DIR ]]; then
 fi
 
 if [ -z "$nonDebian" ]; then
-	"$thisDir/garden-debian-sources-list" --gardenlinux-only \
-		$([ -z "$debianPorts" ] || echo '--ports') \
-		$([[ -v PKG_DIR ]] && echo --local-pkgs /run/packages) \
-		"$targetDir" "$suite" "$version"
-	cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
+
+	if [ $debianMirror -eq 1 ]; then
+
+		# Integrate Garden Linux repository with additional Debian native mirror
+		"$thisDir/garden-debian-sources-list" --debian-mirror \
+			$([ -z "$debianPorts" ] || echo '--ports') \
+			$([[ -v PKG_DIR ]] && echo --local-pkgs /run/packages) \
+			"$targetDir" "$suite" "$version"
+		cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
+
+
+	else
+		# Integrate Garden Linux repository
+		"$thisDir/garden-debian-sources-list" \
+			$([ -z "$debianPorts" ] || echo '--ports') \
+			$([[ -v PKG_DIR ]] && echo --local-pkgs /run/packages) \
+			"$targetDir" "$suite" "$version"
+		cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
+
+
+	fi
+
+	# Update repositories
 	"$thisDir/garden-apt-get" "$targetDir" update -qq
 	"$thisDir/garden-apt-get" "$targetDir" upgrade -y
 fi
@@ -179,6 +206,7 @@ fi
 
 set -x
 tmp=$(mktemp -d -p $targetDir)
+
 if [ "${include_wget}" != "" ]; then
 	for pkg in $include_wget; do
 		wget -O "${tmp}/$(${thisDir}/get_filename ${pkg})" "$(${thisDir}/urlescape ${pkg})"

--- a/features/example/README.md
+++ b/features/example/README.md
@@ -126,7 +126,9 @@ irssi
 
 
 ### pkg.include
-Installs given packages from an included repository or by a given file path with minimal and needed dependency handling (recommended dependencies are ignored). Package(s) must be present within the used repositories or file system. Additional third-party repositories may be included (see [docs](../docs)). Packages will be installed before any further configuration starts. This may let you install packages and configure them afterwards.
+Installs given packages from the Garden Linux repository or by a given file path or file uri with minimal and needed dependency handling (recommended dependencies are ignored). Packages will be installed before any further configuration starts. This may let you install packages and configure them afterwards.
+
+*Hint: During the feature development the native Debian repository can additionally be used by adding `--debian-mirror` to the `build.sh`. Please take note that this is not supported for production builds and will raise an error. Therefore, needed packages must be repackaged or be mirrored on the Garden Linux repository.*
 
 **Usage:**
 

--- a/tests/helper/tests/debsums.py
+++ b/tests/helper/tests/debsums.py
@@ -3,9 +3,7 @@ from helper import utils
 def debsums(client, debsums_exclude):
     """Check the MD5 sums of installed Debian packages"""
     utils.AptUpdate(client)
-    (exit_code, output, error) = client.execute_command(
-        "apt-get install -y --no-install-recommends debsums", quiet=True)
-    assert exit_code == 0, f"no {error=} expected"
+    utils.install_package_deb(client, "debsums")
 
     (exit_code, output, error) = client.execute_command("debsums -l",
                                                         quiet=True)

--- a/tests/helper/tests/tiger.py
+++ b/tests/helper/tests/tiger.py
@@ -7,10 +7,7 @@ from helper import utils
 def tiger(client, testconfig, chroot):
     """Run tiger to test for system security vulnerabilities"""
     utils.AptUpdate(client)
-    (exit_code, output, error) = client.execute_command(
-        "apt-get install -y --no-install-recommends tiger",
-        quiet=True)
-    assert exit_code == 0, f"no {error=} expected"
+    utils.install_package_deb(client, "tiger")
 
     enabled_features = testconfig["features"]
 

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -157,6 +157,17 @@ def execute_remote_command(client, cmd, skip_error=False):
 
 def install_package_deb(client, pkg):
     """ Installs (a) Debian packagei(s) on a target platform """
+    # Packages for testing may not be included within the Garden Linux
+    # repository. We may add a native Debian repo to the temp chroot for
+    # further unit testing
+    (exit_code, output, error) = client.execute_command(
+        "grep 'https://deb.debian.org/debian bookworm main' /etc/apt/sources.list", quiet=True)
+    if exit_code > 0:
+       (exit_code, output, error) = client.execute_command(
+           "echo 'deb https://deb.debian.org/debian bookworm main' >> /etc/apt/sources.list && apt-get update", quiet=True)
+       assert exit_code == 0, f"Could not add native Debian repository."
+
+    # Finally, install the package
     (exit_code, output, error) = client.execute_command(
         f"apt-get install -y --no-install-recommends {pkg}", quiet=True)
     assert exit_code == 0, f"Could not install Debian Package: {error}"


### PR DESCRIPTION
feature(devel): Add new build command `--debian-mirror`
 Add possibility to add the native Debian repository to chroot when
 installing package via `pkg.include` function (only in dev mode).

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Add new build command `--debian-mirror`. This adds the possibility to add the native Debian repository to chroot when
 installing package via `pkg.include` function and will only work on non production builds. When building a prod artifact this will fail with the following message:
```
Using the native Debian repository on production builds (_prod) is not supported.
```

**Which issue(s) this PR fixes**:
Fixes #1422

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: developer
```
