### PR TITLE
Enable secure boot on AWS

### DIFF
--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -129,11 +129,15 @@ def register_image(
     snapshot_id: str,
     image_name: str,
     architecture: str,
+    boot_mode: str,
 ) -> str:
     '''
     @return: ami-id of registered image
     '''
     root_device_name = '/dev/xvda'
+
+    # Ensure to choose the proper
+    if len(boot_mode) == 0:
 
     result = ec2_client.register_image(
         # ImageLocation=XX, s3-url?
@@ -152,7 +156,8 @@ def register_image(
         EnaSupport=True,
         Name=image_name,
         RootDeviceName=root_device_name,
-        VirtualizationType='hvm' # | paravirtual
+        VirtualizationType='hvm', # | paravirtual
+        BootMode=boot_mode
     )
 
     ec2_client.create_tags(

--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -137,9 +137,6 @@ def register_image(
     '''
     root_device_name = '/dev/xvda'
 
-    # Ensure to choose the proper
-    if len(boot_mode) == 0:
-
     result = ec2_client.register_image(
         # ImageLocation=XX, s3-url?
         Architecture=architecture,

--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -129,7 +129,8 @@ def register_image(
     snapshot_id: str,
     image_name: str,
     architecture: str,
-    boot_mode: str,
+    boot_mode: str='',
+    uefi_data: str='',
 ) -> str:
     '''
     @return: ami-id of registered image
@@ -157,7 +158,8 @@ def register_image(
         Name=image_name,
         RootDeviceName=root_device_name,
         VirtualizationType='hvm', # | paravirtual
-        BootMode=boot_mode
+        BootMode=boot_mode,
+        UefiData=uefi_data,
     )
 
     ec2_client.create_tags(

--- a/ci/glci/aws.py
+++ b/ci/glci/aws.py
@@ -137,7 +137,8 @@ def register_image(
     '''
     root_device_name = '/dev/xvda'
 
-    result = ec2_client.register_image(
+    # Define arguments for register_image
+    arguments = dict(
         # ImageLocation=XX, s3-url?
         Architecture=architecture,
         BlockDeviceMappings=[
@@ -155,9 +156,18 @@ def register_image(
         Name=image_name,
         RootDeviceName=root_device_name,
         VirtualizationType='hvm', # | paravirtual
-        BootMode=boot_mode,
-        UefiData=uefi_data,
     )
+
+    # Check if boot mode and uefi data
+    # are set properly and add them to
+    # the arguments
+    if len(boot_mode) > 0:
+        arguments['BootMode'] = boot_mode
+    if len(uefi_data) > 0:
+        arguments['UefiData'] = uefi_data
+
+    # Now, register image
+    result = ec2_client.register_image(**arguments)
 
     ec2_client.create_tags(
         Resources=[

--- a/docs/deployment/aws-secureboot.md
+++ b/docs/deployment/aws-secureboot.md
@@ -1,0 +1,191 @@
+---
+title: Enable secure boot for Garden Linux on AWS
+weight: 10
+disableToc: false
+---
+
+# Enable secure boot for Garden Linux on AWS
+
+This article describes all steps needed to spawn a secure enabled Garden Linux image on AWS. Thereby, it uses the integration testing platform for spawning all required AWS resources. For more information about the integration testing platform used for Garden Linux, take a look [here](../../tests/README.md)
+
+## Table of Content
+
+- [Create image](#create-image)
+- [Prepare spawning](#prepare-spawning)
+  - [UEFI variables](#uefi-variables)
+  - [Integration test configuration](#integration-test-configuration)
+- [Spawn environment](#spawn-environment)
+- [Use secure boot enabled Garden Linux](#use-secure-boot-enabled-garden-linux)
+- [Cleanup everything](#cleanup-everything)
+
+## Create image
+
+Before spawning a secure boot enabled Garden Linux instance, we have to create the corresponding artifact for this. In order to create it, you must have the Garden Linux repo checked out and execute the following make target from within the root directory of the repository:
+
+```
+make aws-secureboot-dev
+```
+
+For our test, we are creating a dev image, which will give us root access for further testing later on. If your build system doesn't have enough memory to build this image, you can add the following attribute to the `make` command:
+
+```
+make aws-secureboot-dev BUILD_OPTS="--lessram"
+```
+
+## Prepare spawning
+This chapter describes what steps are required to successfully spawn an AWS instance with Garden Linux running with secure boot.
+
+### UEFI variables
+
+Once you have build a new Garden Linux image using the secure boot feature, there will also be signature databases which are required for secure boot. These databases must be uploaded to AWS as UEFI vars, so that UEFI can verify the integrity of the booted system during the startup process.
+
+The signature databases are created in the [cert/](../../cert/) directory during the build of the image. There, you will find the following files:
+* secureboot.db.esl
+* secureboot.kek.esl
+* secureboot.pk.esl
+
+These files are required during startup. Therefore, they must be added to the spawned AWS instance as UEFI variables. In order to achieve this, Amazon provides a tool for creating a file blob, that can be added to the spawning AWS instance. These blob is then used as UEFI variables during boot to verify the booted system.
+
+The tool can be found here:
+* https://github.com/awslabs/python-uefivars
+
+Simply checkout the git repository and execute the `uefivars.py` script within the repo. If you run this command on Debian bullseye, make sure to install the `crc32c` python module. Unfortunately, there is no debian package for `crc32c` at the moment, but you can install it via `pip` for example.
+
+Once downloaded, the signature databases must be converted to the secure boot file blob:
+```
+./uefivars.py \
+  -i none \
+  -o aws \
+  -O secure_boot_blob.bin \
+  -P cert/secureboot.pk.esl \
+  -K cert/secureboot.kek.esl \
+  --db cert/secureboot.pk.esl
+```
+If the execution was successful, there should be a file called `secure_boot_blob.bin`. The content of the file can now be added to the created AWS instance. Since this documentation uses the integration test platform for spawning all required AWS resources and the integration test platform uses its own configuration, the content of the created file must be added to the integration test configuration. The configuration and its required values are described in the next chapter.
+
+### Integration test configuration
+Before one can spawn the required AWS environment, a configuration for the integration test platform is needed.
+
+The following example shows such a configuration. For test purposes, it uses the `eu-west-1` region, a small instance type, an image with `amd64` architecture and most importantly the `UEFI` boot mode.
+
+In general, there is no need to adjust this configuration, if you have created the Garden Linux image as described in this [chapter](#create-image).
+
+However, you may need to adjust the path to your image artifact which should look like `aws-gardener_secureboot_dev-amd64-today-<commit hash|local>.raw` and you have to paste the content of the `secure_boot_blob.bin` to the `uefi_data` attribute.
+
+```
+aws:
+    # region
+    region: eu-west-1
+    # machine/instance type of the test VM - not all machines are available in all regions (optional)
+    instance_type: t3.micro
+    # architecture of the image and VM to be used (optional)
+    architecture: amd64
+    # boot mode
+    boot_mode: uefi
+    # UEFI data. This contains the UEFI variables
+    uefi_data: <content of secure_boot_blob.bin>
+
+    # local/S3 image file to be uploaded for the test (optional/alternatively required)
+    image: file:/build/aws-gardener_secureboot_dev-amd64-today-local.raw
+
+    # keep instance running after tests finishes (optional)
+    keep_running: true
+
+```
+
+The content must be saved into a YAML file and it must be mounted to the integration test container later on. For this, create a folder in your home directory and place the YAML in there. This folder will be mounted to the integration test container then. The configuration could be called `aws-secureboot.yaml` for example.
+
+## Spawn environment
+
+The environment can now be spawned by using the integration test platform. As described in the corresponding [documentation](../../tests/README.md#prerequisites-1), you must have the integration test container in place.
+As described there, the following command is used:
+
+```
+make --directory=container build-integration-test
+```
+
+Then, make sure you have API access to AWS by having your credentials in your home directory. There should be a file called `~/.aws/credentials`. If it's not there, you need to login via the following command:
+```
+aws configure
+```
+
+After that, the integration test container can be started like this. Make sure that you are in the Garden Linux repo while executing this command.
+```
+sudo podman run -it --rm -v `pwd`:/gardenlinux -v `pwd`/.build/:/build -v $HOME/.aws:/root/.aws -v $HOME/.ssh:/root/.ssh -v ~/config:/config gardenlinux/integration-test:`bin/garden-version` /bin/bash
+```
+
+As you can see, the current Garden Linux repo is mounted into the container (`/gardenlinux`). Moreover, it also gets access to the AWS credentials, the SSH directory and the previously created configuration (`~/config`).
+
+Once you executed the command, you should have access to the bash terminal within the container. From there, you can execute the integration test, which will create all required AWS resources for you. Since we've set the `keep_running` parameter to `true`, the created resources will remain after the execution, so that we can access the instance via SSH for further testing afterwards.
+
+```
+pytest --iaas=aws --configfile=/config/aws-secureboot.yaml
+```
+
+## Use secure boot enabled Garden Linux
+
+After you have run the integration test from the previous chapter, you should still have the bash terminal open within the integration test container.
+
+From there, you can now use `ssh` to connect to the remote AWS instance running Garden Linux with secure boot enabled. The SSH key can be found in the `/tmp` directory of the integration test container. 
+
+During integration test (right at the beginning), the output shows the location of the used SSH key:
+
+```
+INFO     helper.sshclient:sshclient.py:47 generated RSA key pair: /tmp/sshkey-gl-test-20221123084607-c6hhy6_k.key
+```
+
+Additionally, the output also contains which address can be used to access the remote machine:
+```
+INFO     aws-testbed:aws.py:634 Ec2 instance is accessible through ec2-54-246-161-244.eu-west-1.compute.amazonaws.com
+```
+
+The instances is running with the so called `admin` user, so you can access this machine by the following command:
+```
+ssh -i /tmp/sshkey-gl-test-20221123084607-c6hhy6_k.key admin@ec2-54-246-161-244.eu-west-1.compute.amazonaws.com
+```
+
+Now, you are connected to the Garden Linux instance. In order to check if the instance is started with secure boot, you can use the following command:
+
+```
+$ journalctl | grep -i "Secure Boot"
+Nov 23 08:52:37 localhost kernel: Kernel is locked down from EFI Secure Boot; see man kernel_lockdown.7
+Nov 23 08:52:37 localhost kernel: secureboot: Secure boot enabled
+```
+
+Typically, you could also use the `mokutil` tool but it is not installed by default. If it would be installed, you could run it like this:
+
+```
+mokutil --sb-state
+```
+
+If the output shows `SecureBoot enabled.`, the Garden Linux instance has successfully been started with secure boot enabled.
+
+## Cleanup everything
+
+Within the integration-test container, execute the following command. The integration container can be started as stated in the [Running the tests](../../tests/README.md#running-the-tests) documentation of AWS within the `tests/` directory or in the previous chapter [Spawn environment](#spawn-environment).
+```
+/gardenlinux/tests/tools/clean_orphans_aws.py
+```
+
+
+This command is an interactive tool for cleaning up your AWS environment. Thereby, it will only focus on resources which have been created by the integration test scripts before. This is achieved by using corresponding tags. 
+Once executed, the `clean_orphans_aws.py` script will ask for the following resources:
+* EC2 Instances
+* Security Groups
+* Images/AMIs
+* Snapshots
+* SSH Key Pairs
+* S3 Buckets
+
+Each resource and the removal of it will only be executed by pressing the `y` button into the prompt. You can also skip some of the resources by pressing `N`.
+
+Since an environment can also run other integration test resources which may not be removed, you can identify each resource by corresponding tags and a created UUID for each test run. At the beginning of the integration test for example, the integration test prints the information about the used UUID which can then be used for identifying the proper AWS resources easily:
+
+```
+INFO     aws-testbed:aws.py:426 This test's tags are:
+INFO     aws-testbed:aws.py:428 	component: gardenlinux
+INFO     aws-testbed:aws.py:428 	test-type: integration-test
+INFO     aws-testbed:aws.py:428 	test-name: gl-test-20221123084607
+INFO     aws-testbed:aws.py:428 	test-uuid: cc250a12-48d5-46e4-a1e7-a01fe74d837b
+```
+The `clean_orphans_aws.py` script will always print the tags of AWS resources as well once it ask you to remove them, so it should be possible to identify the correct resources and skip them if they do not belong to the integration test of this documentation.

--- a/make_targets/aws-secureboot
+++ b/make_targets/aws-secureboot
@@ -1,0 +1,1 @@
+server,cloud,gardener,aws,_secureboot

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,6 +175,8 @@ aws:
     instance_type: t3.micro
     # architecture of the image and VM to be used (optional)
     architecture: amd64
+    # boot mode of the VM. One can choose between "uefi" and "legacy-bios" (optional)
+    boot_mode: legacy-bios
 
     # test name to be used for naming and/or tagging resources (optional)
     test_name: my_gardenlinux_test
@@ -213,6 +215,7 @@ aws:
 - **region** _(required)_: the AWS region in which all test relevant resources will be created
 - **instance-type** _(optional)_: the instance type that will be used for the EC2 instance used for testing, defaults to `t3.micro` if not specified
 - **architecture** _(optional)_: the architecture under which the AMI of the image to test should be registered (`amd64` or `arm64`), must match the instance type, defaults to `amd64` if not specified
+- **boot_mode** _(optional)_: the bood mode that the AMI of the image should be started with. Keep in mind that Graviton (`arm64`) can only use UEFI. Choose between `uefi` and `legacy-bios`.
 
 - **test_name** _(optional)_: a name that will be used as a prefix or tag for the resources that get created in the hyperscaler environment. Defaults to `gl-test-YYYYmmDDHHMMSS` with _YYYYmmDDHHMMSS_ being the date and time the test was started.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -177,6 +177,8 @@ aws:
     architecture: amd64
     # boot mode of the VM. One can choose between "uefi" and "legacy-bios" (optional)
     boot_mode: legacy-bios
+    # UEFI data which is a base64 representation of the UEFI variable store
+    # uefi_data: "dGVzdAo=..."
 
     # test name to be used for naming and/or tagging resources (optional)
     test_name: my_gardenlinux_test
@@ -215,7 +217,8 @@ aws:
 - **region** _(required)_: the AWS region in which all test relevant resources will be created
 - **instance-type** _(optional)_: the instance type that will be used for the EC2 instance used for testing, defaults to `t3.micro` if not specified
 - **architecture** _(optional)_: the architecture under which the AMI of the image to test should be registered (`amd64` or `arm64`), must match the instance type, defaults to `amd64` if not specified
-- **boot_mode** _(optional)_: the bood mode that the AMI of the image should be started with. Keep in mind that Graviton (`arm64`) can only use UEFI. Choose between `uefi` and `legacy-bios`.
+- **boot_mode** _(optional)_: the boot mode that the AMI of the image should be started with. Keep in mind that Graviton (`arm64`) can only use UEFI. Choose between `uefi` and `legacy-bios`.
+- **uefi_data** _(optional)_: Base64 representation of the non-volatile UEFI variable store. You can inspect and modify the UEFI data by using the python-uefivars tool on GitHub.
 
 - **test_name** _(optional)_: a name that will be used as a prefix or tag for the resources that get created in the hyperscaler environment. Defaults to `gl-test-YYYYmmDDHHMMSS` with _YYYYmmDDHHMMSS_ being the date and time the test was started.
 

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -56,7 +56,9 @@ class AWS:
         if not 'architecture' in cfg or cfg['architecture'] == "amd64":
             cfg['architecture'] = "x86_64"
         if not 'boot_mode' in cfg:
-            cfg['boot_mode'] = None
+            cfg['boot_mode'] = ""
+        if not 'uefi_data' in cfg:
+            cfg['uefi_data'] = ""
         if not 'bucket' in cfg:
             cfg['bucket'] = f"img-{test_name}-upload"
         if not 'securitygroup_name' in cfg:
@@ -541,7 +543,8 @@ class AWS:
             snapshot_id = self._snapshot_id,
             image_name = image_name,
             architecture = self.config["architecture"],
-            boot_mode = self.config["boot_mode"]
+            boot_mode = self.config["boot_mode"],
+            uefi_data = self.config["uefi_data"]
         )
         self.ec2_client.create_tags(
             Resources = [self._ami_id],

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -55,6 +55,8 @@ class AWS:
             cfg['instance_type'] = "t3.micro"
         if not 'architecture' in cfg or cfg['architecture'] == "amd64":
             cfg['architecture'] = "x86_64"
+        if not 'boot_mode' in cfg:
+            cfg['boot_mode'] = None
         if not 'bucket' in cfg:
             cfg['bucket'] = f"img-{test_name}-upload"
         if not 'securitygroup_name' in cfg:
@@ -538,7 +540,8 @@ class AWS:
             ec2_client = self.ec2_client,
             snapshot_id = self._snapshot_id,
             image_name = image_name,
-            architecture = self.config["architecture"]
+            architecture = self.config["architecture"],
+            boot_mode = self.config["boot_mode"]
         )
         self.ec2_client.create_tags(
             Resources = [self._ami_id],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR adjust the integration tests for AWS, so that a user can define the `boot_mode` and the `uefi_data` which is required to run AWS instances with secure boot enabled.

In addition, it provides a documentation showing what must be done to run Garden Linux with secure boot enabled on AWS.

**Which issue(s) this PR fixes**:
Fixes #1324 