### PR TITLE
feat(doc): Add secure boot documentation for enrolling keys internally

### DIFF
--- a/docs/deployment/aws-secureboot.md
+++ b/docs/deployment/aws-secureboot.md
@@ -38,13 +38,13 @@ make aws-secureboot-dev BUILD_OPTS="--lessram"
 ## Prepare spawning
 This chapter describes what steps are required to successfully spawn an AWS instance with Garden Linux running with secure boot. There are two options to choose from.
 
-You can either enable secure boot internally. This way you simply need to spawn the Garden Linux image and execute the `enroll-gardenlinux-secureboot-keys`, which will prepare the Garden Linux image for secure boot by using UEFI's setup mode. After a reboot, the Garden Linux image will then run with secure boot enabled.
+You can either enable secure boot internally. This way you simply need to spawn the Garden Linux image and execute the `enroll-gardenlinux-secureboot-keys`, which will prepare the Garden Linux image for secure boot by using UEFI's setup mode. Ensure to reboot the system to have secure boot fully enabled.
 
-Besides of this, you can also enable secure boot externally. This way, you have secure boot enabled right at the first start, but you need to provide all information during  the creation of the instances, which also requires some additional tools to be executed on your workstation.
+Besides of this, you can also enable secure boot externally. This way, you have secure boot enabled right at the first start, but you need to provide all information during the creation of the instances, which also requires some additional tools to be executed on your workstation.
 
 ### Option A: Enable secure boot internally
 
-By creating a Garden Linux with the secure boot feature enabled and by using UEFI's setup mode, you can activate secure boot from within the AWS instance once the Garden Linux image has been spawned successfully. As long as you do not enable secure boot from within the instance, the Garden Linux image will simply spawn without secure boot enabled. This must be kept in mind.
+By creating a Garden Linux with the secure boot feature enabled and by using UEFI's setup mode, you can activate secure boot from within the AWS instance once the Garden Linux image has been spawned successfully. As long as you do not enable secure boot within the instance, the Garden Linux image will simply spawn without secure boot enabled. This must be kept in mind.
 
 #### Integration test configuration
 Before starting the required AWS environment, a configuration for the integration test platform is needed.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR explains what needs to be done to enable secure boot on AWS from within a running Garden Linux instance. The current documentation only explains the procedure for enabling secure boot externally.

**Which issue(s) this PR fixes**:
Fixes #1324 

