### PR TITLE
add vmware ovf properties for ignition

### DIFF
--- a/features/vmware/vmware.ovf.template
+++ b/features/vmware/vmware.ovf.template
@@ -50,6 +50,18 @@
           <Label>Default User's password</Label>
           <Description>If set, the default user's password will be set to this value to allow password based login.  The password will be good for only a single login.  If set to the string 'RANDOM' then a random password will be generated, and written to the console.</Description>
       </Property>
+      <Property ovf:key="guestinfo.ignition.config.data" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>Ignition config data</Label>
+        <Description>Inline Ignition config data</Description>
+      </Property>
+      <Property ovf:key="guestinfo.ignition.config.data.encoding" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>Ignition config data encoding</Label>
+        <Description>Encoding for Ignition config data</Description>
+      </Property>
+      <Property ovf:key="guestinfo.ignition.config.url" ovf:type="string" ovf:userConfigurable="true" ovf:value="">
+        <Label>Ignition config url</Label>
+        <Description>URL to Ignition config</Description>
+      </Property>
     </ProductSection>
 
     <VirtualHardwareSection ovf:transport="iso">


### PR DESCRIPTION
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Supports ignition ovf properties. I think it still needs the logic added to act upon these params during the first boot.
