### PR TITLE
feature(firewall): Switch to "allow" for output & forward, allow ICMP

### DIFF
--- a/features/firewall/file.include/etc/nft.d/default.conf
+++ b/features/firewall/file.include/etc/nft.d/default.conf
@@ -4,25 +4,18 @@ table inet filter {
                 policy drop
                 iifname "lo" counter accept
                 ip daddr 127.0.0.1 counter accept
+                icmp type echo-request limit rate 5/second accept
                 ip6 saddr ::1 ip6 daddr ::1 counter accept
+                icmpv6 type { echo-request, nd-router-advert, nd-neighbor-solicit, nd-router-advert, nd-neighbor-advert } accept
                 ct state related,established counter accept
                 tcp dport ssh ct state new counter accept
                 rt type 0 counter drop
                 meta l4proto ipv6-icmp counter accept
         }
         chain forward {
-                counter
-                policy drop
-                rt type 0 counter drop
+                type filter hook forward priority 0; policy accept;
         }
         chain output {
-                counter
-                policy drop
-                oifname "lo" counter accept
-                ip saddr 127.0.0.1 counter accept
-                ip6 saddr ::1 ip6 daddr ::1 counter accept
-                rt type 0 counter  drop
-                meta l4proto ipv6-icmp counter accept
-                counter accept
+                type filter hook output priority 0; policy accept;
         }
 }


### PR DESCRIPTION
feature(firewall): Switch to "allow" for output & forward, allow ICMP:
 * Switch to default policy allow for output instead of drop
 * Switch to default policy allow for forward instead of drop
 * Allow ICMP and ICMPv6 for input

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Switch to "allow" for output & forward, allow ICMP:
 * Switch to default policy allow for output instead of drop
 * Switch to default policy allow for forward instead of drop
 * Allow ICMP and ICMPv6 for input

**Which issue(s) this PR fixes**:
Fixes #1447

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
