### PR TITLE
Prepare 934.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ __pycache__
 /test_results.json
 /tests/*.log
 /tests/*.xml
+*.cache

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest
-934.1
+934.2

--- a/bin/makepart
+++ b/bin/makepart
@@ -28,7 +28,9 @@ if ! grep _secureboot <<<"$features" > /dev/null; then
 	mkdir -p "$rootfs_work/boot/efi/loader/"
 	touch "$rootfs_work/boot/efi/loader/loader.conf"
 	touch "$rootfs_work/boot/efi/loader/entries.srel"
+	mount -t proc none "$rootfs_work/proc"
 	chroot "$rootfs_work" /usr/bin/env -i SYSTEMD_ESP_PATH="/boot/efi" bootctl --no-variables --make-machine-id-directory=no install
+	umount "$rootfs_work/proc"
 	echo type1 > "$rootfs_work/boot/efi/loader/entries.srel"
 	rm -f "${rootfs_work}/boot/efi/loader/random-seed"
 	umount "${rootfs_work}/etc/machine-id"

--- a/container/Makefile
+++ b/container/Makefile
@@ -39,9 +39,11 @@ build-deb: build
 
 .PHONY: build-base-test
 build-base-test: needslim
+	cp -p ../gardenlinux.asc base-test/gardenlinux.asc
 	mkdir -p base-test/_pipfiles
 	cp ../tests/Pipfile* base-test/_pipfiles
-	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/base-test:$(VERSION) base-test
+	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/base-test:$(VERSION) base-test
+	rm base-test/gardenlinux.asc
 
 .PHONY: build-integration-test
 build-integration-test: build-base-test

--- a/container/Makefile
+++ b/container/Makefile
@@ -39,11 +39,9 @@ build-deb: build
 
 .PHONY: build-base-test
 build-base-test: needslim
-	cp -p ../gardenlinux.asc base-test/gardenlinux.asc
 	mkdir -p base-test/_pipfiles
 	cp ../tests/Pipfile* base-test/_pipfiles
 	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/base-test:$(VERSION) base-test
-	rm base-test/gardenlinux.asc
 
 .PHONY: build-integration-test
 build-integration-test: build-base-test

--- a/container/Makefile
+++ b/container/Makefile
@@ -39,9 +39,11 @@ build-deb: build
 
 .PHONY: build-base-test
 build-base-test: needslim
+	cp -p ../gardenlinux.asc base-test/gardenlinux.asc
 	mkdir -p base-test/_pipfiles
 	cp ../tests/Pipfile* base-test/_pipfiles
 	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/base-test:$(VERSION) base-test
+	rm base-test/gardenlinux.asc
 
 .PHONY: build-integration-test
 build-integration-test: build-base-test

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -3,9 +3,6 @@ FROM gardenlinux/slim
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features
-ARG GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
-ARG VERSION
-
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
      && apt-get update \

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -3,8 +3,16 @@ FROM gardenlinux/slim
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features
+ARG GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
+ARG VERSION
+
+COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
+RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
+        && chmod 644 $GARDENLINUX_MIRROR_KEY
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
+     && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] http://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
+     && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
      && apt-get update \
      && apt-get install -y --no-install-recommends \
           curl \

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -3,6 +3,9 @@ FROM gardenlinux/slim
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features
+ARG GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
+ARG VERSION
+
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
      && apt-get update \

--- a/container/build-cert/Dockerfile
+++ b/container/build-cert/Dockerfile
@@ -3,6 +3,7 @@ ARG build_base_image=gardenlinux/slim
 FROM $build_base_image
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget make gettext openssl libengine-pkcs11-openssl gnupg golang-cfssl efitools uuid-runtime awscli
 RUN arch="$(dpkg --print-architecture)" && \
 	wget "https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-sdk-cpp_$arch.deb" "https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-kms-pkcs11_$arch.deb" && \

--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -5,6 +5,8 @@ ARG	GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
 ARG	VERSION
 
 COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
+RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
+        && chmod 644 $GARDENLINUX_MIRROR_KEY
 
 RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
 

--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -11,6 +11,7 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
 RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
 
 RUN : "Initialize the build container package installation" \
+		&& sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
 		&& arch="$(dpkg --print-architecture)" \
 		&& apt-get update \
 		&& apt-get install -y --no-install-recommends \
@@ -19,7 +20,7 @@ RUN : "Initialize the build container package installation" \
 		&& \
 	: "Extend the sources with other required repos" \
 		&& echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
-		&& echo "deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+		&& echo "deb https://cdn-aws.deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
 		&& echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default-testing \
 		&& apt-get update \
 		&& \

--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -8,19 +8,20 @@ RUN	mkdir /etc/sudoers.d \
      && echo "deb-src https://deb.debian.org/debian testing main" >> /etc/apt/sources.list \
      &&	echo "#deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
      && echo "#deb-src https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+     && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
      && echo "APT::Install-Recommends false;\nAPT::Install-Suggests false;\nApt::AutoRemove::SuggestsImportant false;\n" > /etc/apt/apt.conf.d/no-recommends \
      &&	echo "progress=bar:force:noscroll" >> /etc/wgetrc \
      &&	echo "force-confold\nforce-confdef" > /etc/dpkg/dpkg.cfg.d/forceold
 
 ARG	BUILDARCH=amd64
 
-ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/gcc_10.2.1-1_${BUILDARCH}.deb /
-ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/g++_10.2.1-1_${BUILDARCH}.deb /
-ADD	https://deb.debian.org/debian/pool/main/g/gcc-defaults/cpp_10.2.1-1_${BUILDARCH}.deb /
+ADD	https://cdn-aws.deb.debian.org/debian/pool/main/g/gcc-defaults/gcc_10.2.1-1_${BUILDARCH}.deb /
+ADD	https://cdn-aws.deb.debian.org/debian/pool/main/g/gcc-defaults/g++_10.2.1-1_${BUILDARCH}.deb /
+ADD	https://cdn-aws.deb.debian.org/debian/pool/main/g/gcc-defaults/cpp_10.2.1-1_${BUILDARCH}.deb /
 
 RUN	apt-get update \
      && apt-get install -y wget ca-certificates \
-     &&	if [ "${BUILDARCH}" = "amd64" ] ; then wget https://deb.debian.org/debian/pool/main/g/gcc-defaults/gcc-multilib_10.2.1-1_${BUILDARCH}.deb; fi \
+     && if [ "${BUILDARCH}" = "amd64" ] ; then wget https://cdn-aws.deb.debian.org/debian/pool/main/g/gcc-defaults/gcc-multilib_10.2.1-1_${BUILDARCH}.deb; fi \
      &&	apt-get install -y -f /*.deb \
      &&	apt-mark auto gcc g++ cpp gcc-multilib \
      &&	rm -f /*.deb \

--- a/features/githubActionRunner/exec.config
+++ b/features/githubActionRunner/exec.config
@@ -27,3 +27,9 @@ version="$(basename "$(curl -s -f --head "https://github.com/actions/runner/rele
 curl -s -f -L "https://github.com/actions/runner/releases/download/$version/actions-runner-linux-$([ "$arch" = amd64 ] && echo x64 || echo "$arch")-${version:1}.tar.gz" | gzip -d | tar -x
 
 chown -R github_action_runner:github_action_runner /opt/github_action_runner
+
+# Issue 1463
+# Mark some packages as manual installed so that the orphaned test
+# is not complaining.
+apt-mark manual \
+  containernetworking-plugins

--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -255,15 +255,15 @@ class CHROOT:
 
     def _create_dir(self, dir, mode):
         """ Helper func: Create directory by given path and mode """
+        orig_mask = os.umask(000)
         try:
-            orig_mask = os.umask(000)
             os.makedirs(dir, mode)
-            os.umask(orig_mask)
             logger.info("Created {dir} with mode {mode}.".format(
                 dir=dir, mode=mode))
         except OSError:
             logger.error("Directory {dir} already present.".format(
                 dir=dir))
+        os.umask(orig_mask)
 
 
     def _port_val(self, host, port):


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
* Build Environment Fixes
    * explicitly set `gardenlinux.asc` file permissions via 889aa02
    * use cdn-aws debian mirros via a8178f1
    * git ignore *.cache files (e.g. make_targets.cache) via a49d72e
    * bootctl requires /proc mounted manually - taken from 
b372a91b8ab4a17465ac5e465427f00f8dfd85bb
    * fix tests that could not connect via paramiko in test environment - taken from  cae061aaca34d0608ee25a20fd96615b351dae89
    * make githubactionsrunner feature tests green for this PR - taken from  28c011ce420c9a7af46642d3693b9c2a21613bf0
* upgrade kernel to 5.15.81-0gardenlinux1
    * Fixes CVE-2022-3169 via 5.15.80
    * Fixes CVE-2022-3435 via garden linux backported patch
    * mbcache deadlock fix: https://lore.kernel.org/linux-ext4/20221122115715.kxqhsk2xs4nrofyb@quack3/T/#ma65f0113b4b2f9259b8f7d8af16b8cb351728d20


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
* Kernel Upgrade to 5.15.81
    * Fixes CVE-2022-3169 via 5.15.80
    * Fixes CVE-2022-3435 via garden linux backported patch
    * mbcache deadlock fix: https://lore.kernel.org/linux-ext4/20221122115715.kxqhsk2xs4nrofyb@quack3/T/#ma65f0113b4b2f9259b8f7d8af16b8cb351728d20


```
