### PR TITLE
fix: Fix wrong error handling in the chroot platform

### DIFF
--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -270,15 +270,15 @@ class CHROOT:
 
     def _create_dir(self, dir, mode):
         """ Helper func: Create directory by given path and mode """
+        orig_mask = os.umask(000)
         try:
-            orig_mask = os.umask(000)
             os.makedirs(dir, mode)
-            os.umask(orig_mask)
             logger.info("Created {dir} with mode {mode}.".format(
                 dir=dir, mode=mode))
         except OSError:
             logger.error("Directory {dir} already present.".format(
                 dir=dir))
+        os.umask(orig_mask)
 
 
     def _port_val(self, host, port):


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This PR fixes the `chroot` platform so that unit tests are working again. As of now all chroot tests are failing which blocks the nightly builds. This is due to a bug that doesn't let the SSH server run probably. Therefore, pytest can connect to the Garden Linux instance via SSH.

**Which issue(s) this PR fixes**:
Fixes #1456 
