### PR TITLE
fix(pipeline): Fix docker CRE support for unit testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,7 +124,7 @@ dockerinfo="$(${gardenlinux_build_cre} info)"       || eusage "${gardenlinux_bui
 grep -q apparmor <<< $dockerinfo  && securityArgs+=( --security-opt apparmor=unconfined )
 
 # external variable BUILD_IMAGE forces a different buildimage name
-buildImage=${BUILD_IMAGE:-"localhost/gardenlinux/build-image:$version"}
+buildImage=${BUILD_IMAGE:-"gardenlinux/build-image:$version"}
 [ $build ] && make --directory=${thisDir}/container ALTNAME=$buildImage build-image
 
 # using the buildimage in a temporary container with


### PR DESCRIPTION
Fix docker CRE support for unit testing

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
This will redefine the correct image label name to support Podman and Docker as CRE.

**Which issue(s) this PR fixes**:
Fixes #1455

**Special notes for your reviewer**:
Tests for Docker and Podman...

**Docker**:
```
Running pytests in chroot
+ wait %1
++ pwd
+ docker run --name 7F1B417D-A933-4A99-9798-082DBEB6D592 --cap-add sys_admin --cap-add mknod --cap-add audit_write --cap-add net_raw --security-opt apparmor=unconfined --rm -v /Users/florian/development/opensource/gardenlinux/github/gardenlinux:/gardenlinux -v /var/folders/b4/wlfrdg9556907s9g1zkk_j0c0000gn/T/tmp.PNnSAvFP:/config gardenlinux/base-test:today pytest --iaas=chroot --configfile=/config/config.yaml
============================= test session starts ==============================
platform linux -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0+repack
rootdir: /gardenlinux/tests, configfile: pytest.ini, testpaths: ../features, integration
collected 171 items
```

**Podman**:
```
Running pytests in chroot
+ wait %1
++ pwd
+ sudo podman run --name 958cea24-6663-4ae9-bd7d-bb292aa21204 --cap-add sys_admin --cap-add mknod --cap-add audit_write --cap-add net_raw --security-opt apparmor=unconfined --rm -v /home/vagrant/gardenlinux/gardenlinux:/gardenlinux -v /tmp/tmp.8upS7LKIDk:/config gardenlinux/base-test:today pytest --iaas=chroot --configfile=/config/config.yaml
============================= test session starts ==============================
platform linux -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0+repack
rootdir: /gardenlinux/tests, configfile: pytest.ini, testpaths: ../features, integration
collected 171 items
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
