### PR TITLE
feat: use cryptsetup to protect ephemeral partitions against outside manipulation at runtime

### DIFF
--- a/bin/make_repart_partition
+++ b/bin/make_repart_partition
@@ -7,6 +7,7 @@ fs=ext4
 options=ro
 type=linux
 ephemeral=0
+cryptsetup=0
 weight=1
 def_only=0
 
@@ -30,6 +31,10 @@ while [ $# -gt 0 ]; do
 			;;
 		-e|--ephemeral)
 			ephemeral="$2"
+			shift 2
+			;;
+		-c|--cryptsetup)
+			cryptsetup="$2"
 			shift 2
 			;;
 		-w|--weight)
@@ -75,7 +80,8 @@ target="$3"
 repart_uuid="$(echo "gardenlinux:$version:repart:$mount_target:$fs" | uuid_hash)"
 
 sysroot_target="/sysroot${mount_target%/}"
-sysroot_mount_unit="$(systemd-escape ""${sysroot_target#/}"").mount"
+sysroot_target_escaped="$(systemd-escape "${sysroot_target#/}")"
+sysroot_mount_unit="$sysroot_target_escaped.mount"
 
 mkdir -p "$target/etc/repart.templates"
 cp -a "$source" "$target/etc/repart.templates/$repart_uuid"
@@ -95,14 +101,35 @@ if [ ! -e "$target/etc/systemd/system/blockdev-settle@.service" ]; then
 	EOF
 fi
 
+if [ ! -e "$target/usr/bin/make_ephemeral_cryptsetup" ]; then
+	mkdir -p "$target/usr/bin/"
+	cat > "$target/usr/bin/make_ephemeral_cryptsetup" <<-EOF
+	#!/bin/bash
+
+	set -Eexufo pipefail
+
+	data_source="\$1"
+	mapper_name="\$2"
+	dev="\$3"
+
+	key_file="/run/cryptsetup-\$mapper_name.key"
+	head -c 1K < /dev/random > "\$key_file"
+
+	cryptsetup luksFormat --batch-mode --integrity hmac-sha256 --key-file "\$key_file" "\$dev"
+	cryptsetup luksOpen --key-file "\$key_file" "\$dev" "\$mapper_name"
+
+	rm "\$key_file"
+
+	mkfs.ext4 -d "\$data_source" "/dev/mapper/\$mapper_name"
+	EOF
+	chmod +x "$target/usr/bin/make_ephemeral_cryptsetup"
+fi
+
 if [ "$ephemeral" = 1 ]; then
 	mkdir -p "$target/etc/systemd/system-generators"
 	cat > "$target/etc/systemd/system-generators/repart-$repart" <<-EOF_GENERATOR
 	#!/bin/bash
 	set -ex
-
-	exec >> /etc/generator-log
-	exec 2>&1
 
 	mkdir -p "/etc/repart.uuid"
 	[ -f "/etc/repart.uuid/$repart_uuid" ] || cat /proc/sys/kernel/random/uuid > "/etc/repart.uuid/$repart_uuid"
@@ -128,6 +155,54 @@ if [ "$ephemeral" = 1 ]; then
 	Requires=\$systemd_dev_dependency
 	[Mount]
 	What=\$dev_path
+	Where=$sysroot_target
+	Options=$options
+	EOF
+
+	if ! [ -L "\$2/initrd-root-fs.target.requires/$sysroot_mount_unit" ]; then
+		[ -d "\$2/initrd-root-fs.target.requires" ] || mkdir -p "\$2/initrd-root-fs.target.requires"
+		ln -s "../$sysroot_mount_unit" "\$2/initrd-root-fs.target.requires/$sysroot_mount_unit"
+	fi
+	EOF_GENERATOR
+	chmod +x "$target/etc/systemd/system-generators/repart-$repart"
+elif [ "$cryptsetup" = 1 ]; then
+	mkdir -p "$target/etc/systemd/system-generators"
+	cat > "$target/etc/systemd/system-generators/repart-$repart" <<-EOF_GENERATOR
+	#!/bin/bash
+	set -ex
+
+	mkdir -p "/etc/repart.uuid"
+	[ -f "/etc/repart.uuid/$repart_uuid" ] || cat /proc/sys/kernel/random/uuid > "/etc/repart.uuid/$repart_uuid"
+	uuid="\$(cat "/etc/repart.uuid/$repart_uuid")"
+
+	cat > "/etc/repart.d/1.$repart.conf" << EOF
+	[Partition]
+	UUID=\$uuid
+	Type=$repart_type
+	Weight=$weight
+	FactoryReset=true
+	EOF
+
+	dev_path="/dev/disk/by-partuuid/\$uuid"
+	systemd_dev_dependency="blockdev-settle@\$(systemd-escape \${dev_path#/}).service"
+	cat > "\$2/cryptsetup-$sysroot_target_escaped.service" << EOF
+	[Unit]
+	After=systemd-repart.service
+	After=\$systemd_dev_dependency
+	Requires=\$systemd_dev_dependency
+	[Service]
+	Type=oneshot
+	RemainAfterExit=yes
+	ExecStart=/usr/bin/make_ephemeral_cryptsetup "/etc/repart.templates/$repart_uuid" "$sysroot_target_escaped" "\$dev_path"
+	EOF
+
+	cat > "\$2/$sysroot_mount_unit" << EOF
+	[Unit]
+	Before=initrd-root-fs.target
+	After=cryptsetup-$sysroot_target_escaped.service
+	Requires=cryptsetup-$sysroot_target_escaped.service
+	[Mount]
+	What=/dev/mapper/$sysroot_target_escaped
 	Where=$sysroot_target
 	Options=$options
 	EOF

--- a/bin/makepart
+++ b/bin/makepart
@@ -76,6 +76,7 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 	secureboot=0
 	syslinux=$([[ "$(cut -c -5 <<< "$target")" = "/boot" ]] && [[ -f "$rootfs/usr/bin/syslinux" ]] && echo 1 || echo 0)
 	ephemeral=0
+	ephemeral_cryptsetup=0
 	weight=1
 	is_final_partition=0
 	while IFS="=" read -r key value; do
@@ -99,6 +100,9 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 			"ephemeral")
 				ephemeral=1
 				;;
+			"ephemeral_cryptsetup")
+				ephemeral_cryptsetup=1
+				;;
 			"weight")
 				weight="$value"
 				;;
@@ -113,7 +117,7 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 	label="$(grep -oP '(?<=^LABEL=)[a-zA-Z0-9\_\-]*$' <<< "$source" || true)"
 	repart="$(grep -oP '(?<=^REPART=)[0-9]*$' <<< "$source" || true)"
 
-	if [[ "$ephemeral" = 1 ]] && [[ -z "$repart" ]]; then
+	if [[ "$ephemeral" = 1 ]] || [[ "$ephemeral_cryptsetup" = 1 ]] && [[ -z "$repart" ]]; then
 		echo "WARNING: ephemeral flag only works for partitions created by systemd-repart"
 	fi
 
@@ -146,7 +150,7 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 			find "$data_source/boot" -type f -delete
 			echo 1 > "$root_repart"
 		fi
-		make_repart_partition -t "$target" -f "$fs" -o "$options" -g "$type" -e "$ephemeral" -w "$weight" "$repart" "$data_source" "$dracut_include"
+		make_repart_partition -t "$target" -f "$fs" -o "$options" -g "$type" -e "$ephemeral" -c "$ephemeral_cryptsetup" -w "$weight" "$repart" "$data_source" "$dracut_include"
 		find "$data_source" -depth -mindepth 1 -delete
 		continue
 	fi

--- a/bin/makesecureboot
+++ b/bin/makesecureboot
@@ -73,7 +73,7 @@ chroot "$rootfs" dracut \
 	--force \
 	--kver "$kernel_version" \
 	--modules "bash dash systemd systemd-initrd systemd-veritysetup systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown" \
-	--install "/etc/veritytab mkfs.ext4 systemd-escape" \
+	--install "/etc/veritytab cryptsetup head mkfs.ext4 systemd-escape" \
 	--include "$dracut_include" "/" \
 	--reproducible \
 	"$initrd"

--- a/features/_readonly/fstab.mod
+++ b/features/_readonly/fstab.mod
@@ -8,5 +8,5 @@ sed '/^[^[:space:]]\+[[:space:]]\+\/overlay[[:space:]]\+/d;/^[^[:space:]]\+[[:sp
 cat << EOF
 LABEL=EFI    /boot/efi    vfat    ro,umask=0077    type=uefi,size=128MiB
 LABEL=USR    /usr         ext4    ro               verity
-REPART=00    /            ext4    rw               ephemeral
+REPART=00    /            ext4    rw               ephemeral_cryptsetup
 EOF

--- a/features/_readonly/pkg.include
+++ b/features/_readonly/pkg.include
@@ -1,0 +1,1 @@
+cryptsetup


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

adds the optional ability to secure ephemeral partitions with dm-integrity and dm-crypt to protect it from outside manipulation at runtime
