### PR TITLE
doc(Makefile): Adjust docs for auto generated make targets from flavour.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ $(SECUREBOOT_CRT): | container-cert
 
 .PHONY: container-build container-cert container-test container-integration
 
+generate-targets:
+	@printf "%s\n" "All available targets have been generated and written to the 'make_targets.cache' file."
+
 container-build:
 	make --directory=container build-image
 

--- a/README.md
+++ b/README.md
@@ -149,19 +149,27 @@ To build all supported images you may just run the following command:
     make all
 ```
 
-However, to save time you may also build just a platform specific image by running one of the following commands. Related dev images can be created by appending the '-dev' suffix (e.g. "make aws-dev").
+However, to save time you may also build just a platform specific image by running one of the following commands. Related dev images can be created by appending the '_dev' suffix (e.g. "make aws_dev").
 ```
-    make aws
-    make gcp
-    make azure
     make ali
-    make vmware
-    make openstack
+    make aws
+    make azure
+    make container
+    make firecracker
+    make gcp
     make kvm
     make metal
+    make openstack
+    make vmware
 ```
 
-Artifacts are located in the `.build/` folder of the project's build directory.
+You may also generate a list of all default targets by running:
+```
+make generate-targets
+```
+Afterwards, all targets are located within the `make_targets.cache` file in the project's root directory.
+
+After building, all artifacts are located in the `.build/` folder of the project's root directory.
 
 ### Cross-Build Support
 The Garden Linux pipeline supports cross-building on Linux based systems and requires `binfmt` support. `binfmt` support can easily be installed via packages from the used distribution. Afterwards, the build option `--arch` must be defined to the target arch (e.g. `--arch arm64`). Currently, `amd64` and `arm64` are supported and must be explicitly defined for cross-building.

--- a/bin/README.md
+++ b/bin/README.md
@@ -20,6 +20,7 @@ By the given directory, we distinguish between scripts that are mandatory for th
 | garden-slimify | Creates a slimifyed version of Garden Linux |
 | garden-tar | Creates a `.tar.xf` image of the build env from `chroot` env |
 | garden-version | Creates a version schema |
+| gen_make_targets | Generates `make` targets from the `flavour.yaml` |
 | get-arch | Evaluates the base arch of the build host |
 | makedisk | Creates the disks during the build process in the `chroot` env |
 | makepart | Creates the partitions during the build process in the `chroot` env |

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -36,11 +36,11 @@ Creating your own build also allows to customize the image to your requirements.
 Use the [Makefile](/Makefile) to build a Garden Linux Image with a pre-defined set of features.
 ```
 # Example
-make metal-dev
+make metal_dev
 ```
-For more targets, checkout the [Makefile](/Makefile). The targets call `build.sh` with a pre-defined set of features.
+For more targets, simply run `make generate-targets` which generates the defaults build targets in `make_targets.cache`. The build targets call the [build.sh](/build.sh) with a pre-defined set of features.
 
-You can also customize a Makefile target to your needs, e.g. by adding a feature.
+You can also customize the build target to your needs, e.g. by adding a feature, platform or modifier by editing the [flavours.yaml](/flavours.yaml) and rerunning `make generate-targets`. You may also pass the options directly to the
 
 ## Build via build.sh
 If you really want to directly call build.sh, you can checkout [Makefile](/Makefile) for some good examples and start from there.


### PR DESCRIPTION
doc(Makefile): Adjust docs for auto generated make targets from flavour.yaml

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Adjust docs for auto generated make targets from flavour.yaml

**Which issue(s) this PR fixes**:
Fixes #1462

**Special notes for your reviewer**:
Update the docs to avoid further confusions regarding the `make` targets, how to handle and edit them. Added an additional target which just uses the regular mechanism to generate the cache file where a regular user can look up the default targets according to the `flavor.yaml` (which contains the default base targets).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: doc
- target_group: user
```
