### PR TITLE
feat: disable rd.shell in secureboot

### DIFF
--- a/bin/make_repart_partition
+++ b/bin/make_repart_partition
@@ -196,6 +196,13 @@ elif [ "$cryptsetup" = 1 ]; then
 	ExecStart=/usr/bin/make_ephemeral_cryptsetup "/etc/repart.templates/$repart_uuid" "$sysroot_target_escaped" "\$dev_path"
 	EOF
 
+	systemd_mapper_dev_dropin="\$2/$(systemd-escape "dev/mapper/$sysroot_target_escaped").device.d"
+	mkdir -p "\$systemd_mapper_dev_dropin"
+	cat > "\$systemd_mapper_dev_dropin/override.conf" << EOF
+	[Unit]
+	JobRunningTimeoutSec=infinity
+	EOF
+
 	cat > "\$2/$sysroot_mount_unit" << EOF
 	[Unit]
 	Before=initrd-root-fs.target

--- a/features/_secureboot/file.include/etc/kernel/cmdline.d/99-no-rd-shell.cfg
+++ b/features/_secureboot/file.include/etc/kernel/cmdline.d/99-no-rd-shell.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$(echo "$CMDLINE_LINUX" | sed -E 's/ *rd.(shell|emergency)(=[a-zA-Z0-9]*)?//g') rd.shell=0 rd.emergency=poweroff"


### PR DESCRIPTION
ensure waiting for /dev/mapper/sysroot does not timeout

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

- disable rd.shell in secureboot
- ensure waiting for /dev/mapper/sysroot does not timeout
