### PR TITLE
feature(build): Integrate `garden-repo-manager`

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -12,7 +12,6 @@ By the given directory, we distinguish between scripts that are mandatory for th
 | garden-build | Main script to build Garden Linux (creates a `chroot` env in a Docker container) |
 | garden-chroot | Performs all necessary steps to integrate Garden Linux features |
 | garden-config | Performs adjustments by activated `features` |
-| garden-debian-sources-list | Adjusts the Garden Linux repository and pins priorities |
 | garden-feat.go | Helper script to validate defined `features` (include, exclude, depends) |
 | garden-fixup | Helper script to clean up uneeded files after build process |
 | garden-fs | Creates the filesystem layout by `features` (creates: `fstab`) |

--- a/bin/garden-build
+++ b/bin/garden-build
@@ -178,14 +178,11 @@ gpg --batch --no-default-keyring --keyring "$keyring" --import "$keyringPlain"
 
 		tarArgs+=( --include-dev )
 
-		if [ "$variant" != "sbuild" ]; then
-			garden-debian-sources-list "${sourcesListArgs[@]}" "$rootfs" "$suite" "$version"
-		else
-			# sbuild needs "deb-src" entries
-			garden-debian-sources-list --deb-src "${sourcesListArgs[@]}" "$rootfs" "$suite" "$version"
-
-			# schroot is picky about "/dev" (which is excluded by default in "garden-tar")
-			# see https://github.com/debuerreotype/debuerreotype/pull/8#issuecomment-305855521
+		# Add source repository on sbuild variants
+		if [ "$variant" = "sbuild" ]; then
+			garden-chroot "$rootfs" bash -c "
+				/sbin/garden-repo-manager add gardenlinux -s -a $arch
+			"
 		fi
 
 		garden-tar "${tarArgs[@]}" "$rootfs" "$targetBase.tar.xz"

--- a/bin/garden-init
+++ b/bin/garden-init
@@ -66,7 +66,6 @@ fi
 
 suite="${1:-}"; shift || eusage 'missing suite'
 version="${1:-}"; shift || eusage 'missing version'
-
 timestamp=
 mirror=
 
@@ -115,15 +114,21 @@ for i in $(filter_comment <<< $include | filter_variables | filter_if | grep -v 
 done
 exclude="$(paste -sd, - <<< $exclude)"
 
+## Define debootstrap arguments
 debootstrapArgs=()
 
+# Set GPG check
 if [ -z "$noCheckGpg" ]; then
 	debootstrapArgs+=( --force-check-gpg )
 else
 	debootstrapArgs+=( --no-check-gpg )
 fi
 
+# Set variant
 debootstrapArgs+=( --variant=minbase )
+
+# Set custom package includes from Garden Linux repository
+debootstrapArgs+=( --include=garden-repo-manager )
 
 [ -z "$keyring" ] || debootstrapArgs+=( --keyring="$keyring" )
 [ -z "$arch" ] || debootstrapArgs+=( --arch="$arch" )
@@ -155,36 +160,49 @@ fi
 
 echo "$epoch" > "$targetDir/garden-epoch"
 
+# Set DEB822 as default
+echo "Prepare DEB822 repo format"
+"$thisDir/garden-chroot" "$targetDir" bash -c "
+	rm /etc/apt/sources.list
+"
+
+# Add support for local packages
 if [[ -v PKG_DIR ]]; then
+	# Create repository Packages file
 	pushd "$PKG_DIR"
 	dpkg-scanpackages --multiversion . /dev/null > Packages
 	popd
 
+	# Mount package directroy
 	mkdir "$targetDir/run/packages"
-	mount --rbind --make-rslave "$PKG_DIR" "$targetDir/run/packages"
+	mount --rbind --make-rslave "$PKG_DIR" "$targetDir/run"
+
+	# Add local package reposiotiry
+	echo "Local packages will be added as a repository"
+	"$thisDir/garden-chroot" "$targetDir" bash -c "
+		/sbin/garden-repo-manager add local -p /run/ -a $arch
+	"
 fi
 
+# Add basic repositories
 if [ -z "$nonDebian" ]; then
 
+	# Copy Garden Linux repository key
+	cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
+
+	# Add repositories to Garden Linux
 	if [ $debianMirror -eq 1 ]; then
-
 		# Integrate Garden Linux repository with additional Debian native mirror
-		"$thisDir/garden-debian-sources-list" --debian-mirror \
-			$([ -z "$debianPorts" ] || echo '--ports') \
-			$([[ -v PKG_DIR ]] && echo --local-pkgs /run/packages) \
-			"$targetDir" "$suite" "$version"
-		cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
-
-
+		# DO NOT USE THIS FOR PRODUCTION RELEASES
+		"$thisDir/garden-chroot" "$targetDir" bash -c "
+			/sbin/garden-repo-manager add gardenlinux -a $arch && \
+			/sbin/garden-repo-manager add debian testing -c main contrib -a $arch
+		"
 	else
 		# Integrate Garden Linux repository
-		"$thisDir/garden-debian-sources-list" \
-			$([ -z "$debianPorts" ] || echo '--ports') \
-			$([[ -v PKG_DIR ]] && echo --local-pkgs /run/packages) \
-			"$targetDir" "$suite" "$version"
-		cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
-
-
+		"$thisDir/garden-chroot" "$targetDir" bash -c "
+			/sbin/garden-repo-manager add gardenlinux -a $arch -t $version
+		"
 	fi
 
 	# Update repositories
@@ -233,12 +251,12 @@ chmod 0755 "$targetDir"
 # inject qemu-arm-static binary
 chrootUsrBinDir="/usr/bin/"
 
-if [ "$arch" = x86_64 ]; then
+# Set qemu static binary for crosscompile
+if [ "$arch" = amd64 ]; then
     qemuStaticBin="/usr/bin/qemu-x86_64-static"
 else
     qemuStaticBin="/usr/bin/qemu-aarch64-static"
 fi
-
 cp "$qemuStaticBin" "$targetDir/$chrootUsrBinDir"
 
 # https://bugs.debian.org/857803

--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -19,9 +19,11 @@ apt-mark manual usr-is-merged
 # is not complaining. These packages are installed due to a bug
 # in debootstrap 1.0.127+nmu1 which installs the dependencies of
 # 'usrmerge' but leaves the package itself behind.
+# garden-repo-manager gets installed during the debootstarp process
 apt-mark manual \
   libfile-find-rule-perl \
   libgdbm-compat4 \
   libnumber-compare-perl \
   libperl5.34 \
-  libtext-glob-perl
+  libtext-glob-perl \
+  garden-repo-manager


### PR DESCRIPTION
Integrate `garden-repo-manager` for repository management

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind cleanup
/area os
/os garden-linux

**What this PR does / why we need it**:
 * Integrate `garden-repo-manager` for repository management
 * Fix crosscompile in `arm64` (to create `amd64`)
 * Fix `local_packages` support

**Which issue(s) this PR fixes**:
Fixes #1433
Fixes #1470 
Fixes #1473

**Special notes for your reviewer**:
This is based on the new `garden-repo-manager` package for Garden Linux.
See also: https://gitlab.com/gardenlinux/gardenlinux-package-gardenlinux-repo-manager


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: user, operator, developer
```

**WIP**

## Tests

### Default
Within the default case, only the Garden Linux repository will be added:
```
# cat /etc/apt/sources.list.d/GRM_gardenlinux_today.sources 
X-Repolib-Name: Managed_gardenlinux_today
Enabled: yes
URIs: https://repo.gardenlinux.io/gardenlinux
Types: deb
Architectures: amd64
Suites: today
Components: main
Signed-By: /etc/apt/trusted.gpg.d/gardenlinux.asc
```

### Debian Mirror
Next to the default, Garden Linux provides the way to add Debian repositories at build time by defining `
--debian-mirror`. This adds next to the Garden Linux repository the Debian ones:
```
# ls /etc/apt/sources.list.d/GRM_*
/etc/apt/sources.list.d/GRM_debian_testing.sources
/etc/apt/sources.list.d/GRM_gardenlinux_today.sources
```

Configuration of repo metadata:
```
# cat /etc/apt/sources.list.d/GRM_*
X-Repolib-Name: Managed_debian_testing
Enabled: yes
URIs: https://deb.debian.org/debian
Types: deb
Architectures: amd64
Suites: testing
Components: main contrib

X-Repolib-Name: Managed_gardenlinux_today
Enabled: yes
URIs: https://repo.gardenlinux.io/gardenlinux
Types: deb
Architectures: amd64
Suites: today
Components: main
Signed-By: /etc/apt/trusted.gpg.d/gardenlinux.asc
```

### Local packages as Mirror
Additionally, Garden Linux provides possibilities to inject local packages in `.deb` fomat to its artifacts by creating a `packages` folder and placing `.deb` files in it. However, this was tested during the creation of `garden-repo-manager` itself but is currently broken within the Garden Linux build pipeline. As a result, we should currently ignore this case which'll be fixed in https://github.com/gardenlinux/gardenlinux/issues/1473 and is unrelated to the introduction of the `garden-repo-manager` itself.