### PR TITLE
make secureboot_parameters parameter optional

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -91,6 +91,8 @@ class GCP:
             cfg['uefi'] = False
         if not 'secureboot' in cfg:
             cfg['secureboot'] = False
+        if not 'secureboot_parameters' in cfg:
+            cfg['secureboot_parameters'] = {}
         if not 'db_path' in cfg['secureboot_parameters']:
             cfg['secureboot_parameters']['db_path'] = "/gardenlinux/cert/secureboot.db.auth"
         if not 'kek_path' in cfg:
@@ -112,7 +114,7 @@ class GCP:
         bucket.make_private()
 
 
-    def _gcp_wait_for_operation(self, operation, timeout=60):
+    def _gcp_wait_for_operation(self, operation, timeout=120):
         self.logger.info(f"Waiting for {operation.name} to complete...")
         result = operation.result(timeout=timeout)
         self.logger.info(f"{operation.name} done.")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
make the secureboot_parameters parameter optional in the config for tests on gcp
**Which issue(s) this PR fixes**:
Fixes #1478 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
