### PR TITLE
fix(garden-feat): Fix output of `platforms` argument

### DIFF
--- a/bin/garden-feat
+++ b/bin/garden-feat
@@ -50,7 +50,7 @@ def main():
         # Write out an ordered features list based on include priorities
         print(','.join(str(s) for s in features_matrix[MATRIX_TYPE_DEP_CHAIN]))
 
-    elif args.type == 'platform':
+    elif args.type == 'platforms':
         types = ['platform']
         features = get_feature_names_by_types(all_features,
             features_matrix[MATRIX_TYPE_DEP_CHAIN], types)
@@ -90,13 +90,13 @@ def get_args():
         def _fill_text(self, text, width, indent):
             return "\n".join([textwrap.fill(line, width) for line in textwrap.indent(textwrap.dedent(text), indent).splitlines()])
 
-    descripton = f'''
+    description = f'''
         garden-feat: Managing features for Garden Linux.
 
         positional arguments description:
           cname:                Effective minimum of features equivalent to specified features (ordered)
           features:             Effective maximum of all features (each feature used, no duplicates, ordered)
-          platform:             Platforms in the featureset
+          platforms:            Platforms in the featureset
           flags:                Flags in the featureset
           elements:             All elements of the featureset (including platform because of possible execution order)
           ignore:               Ignored elements (no duplicates)
@@ -104,7 +104,7 @@ def get_args():
         '''
 
     # Load parser with custom formatter
-    parser = argparse.ArgumentParser(description=descripton, formatter_class=argparse_raw_formater)
+    parser = argparse.ArgumentParser(description=description, formatter_class=argparse_raw_formater)
 
     # Argparse help descriptions
     help_feature_dir="Directory of GardenLinux features"


### PR DESCRIPTION
Fix output of `platforms` argument:
 * Fix output of `platforms` argument
 * Fix typo for argparse description

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
`platforms` can't be evaluated

**Which issue(s) this PR fixes**:
Fixes #1476

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: bugfix
- target_group: developer
```
