### PR TITLE
feature(kernel): Disable `sysrq` completely as default

### DIFF
--- a/features/base/file.include/etc/sysctl.d/10-disable-sysrq.conf
+++ b/features/base/file.include/etc/sysctl.d/10-disable-sysrq.conf
@@ -1,0 +1,2 @@
+# Disables the magic SysRq key
+kernel.sysrq = 0

--- a/features/base/test/test_disable_sysrq.py
+++ b/features/base/test/test_disable_sysrq.py
@@ -1,0 +1,17 @@
+import pytest
+from helper.tests.file_content import file_content
+from helper.utils import execute_remote_command
+
+
+@pytest.mark.parametrize(
+    "file,args",
+    [
+        ("/etc/sysctl.d/10-disable-sysrq.conf", {"kernel.sysrq": "0"}),
+    ]
+)
+
+
+def test_dmesg(client, file, args, non_chroot):
+    cmd = "/usr/sbin/sysctl -a > /tmp/sysctl.txt"
+    execute_remote_command(client, cmd)
+    file_content(client, file, args)


### PR DESCRIPTION
feature(kernel): Disable `sysrq` completely as default
 * Disable `sysrq` completely as default
 * Add test to validate that `sysrq` is disabled

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Disable `sysrq` completely as default

**Which issue(s) this PR fixes**:
Fixes #1485

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: user
```

**Test**:
```
root@garden:~# sysctl -a | grep sysrq
kernel.sysrq = 0```