### PR TITLE
Force permissions for gardenlinux.asc

### DIFF
--- a/bin/garden-init
+++ b/bin/garden-init
@@ -188,7 +188,7 @@ fi
 if [ -z "$nonDebian" ]; then
 
 	# Copy Garden Linux repository key
-	cp "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"
+	install -o root -g root -m 644 "$keyringPlain" "$targetDir/etc/apt/trusted.gpg.d/gardenlinux.asc"	
 
 	# Add repositories to Garden Linux
 	if [ $debianMirror -eq 1 ]; then


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
/etc/apt/trusted.gpg.d/gardenlinux.asc will have whatever permissions the file has on the build system.
This is usually problematic when cloning the repo on machines with strict umasks. 
So we should force 644 as permissions for the file (force root:root as owner as well, not really needed, but just to be clearer).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: