### PR TITLE
feature(vmware): switch ovf transport to vmware tools

### DIFF
--- a/features/vmware/vmware.ovf.template
+++ b/features/vmware/vmware.ovf.template
@@ -64,7 +64,7 @@
       </Property>
     </ProductSection>
 
-    <VirtualHardwareSection ovf:transport="iso">
+    <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">
       <Info>Virtual hardware requirements</Info>
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**: this is required for ignition to read data from vApp properties and not use iso by default.

From the [documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-14A25C25-A6F8-4818-9D0C-C0247C0672FA.html):
```
If you select ISO image, an ISO image that contains the OVF template information is mounted in the CD-ROM drive.

If you select VMware Tools, the VMware Tools guestInfo.ovfEnv variable is initialized with the OVF environment document.
```

Currently OVA file produced by `make vmware` would expect that template config comes from a mounted ISO image. I am not sure if this is what cloud-init requires.

In the case of ignition, one would usually provide ignition config data via vApp properties (when creating a VM from OVA). But for this to happen, the ovf transport has to be set to `com.vmware.guestInfo`. 

![image](https://user-images.githubusercontent.com/13087245/228565611-6c9d6030-5582-45b8-a2fb-c072f9401756.png)

