### PR TITLE
feature(_prod): Disable core dumps (legacy & systemd)

### DIFF
--- a/features/_prod/file.include/etc/security/limits.conf
+++ b/features/_prod/file.include/etc/security/limits.conf
@@ -1,0 +1,3 @@
+# Disable core dumps for production systems
+* hard core 0
+* soft core 0

--- a/features/_prod/file.include/etc/sysctl.d/99-disable-core-dump.conf
+++ b/features/_prod/file.include/etc/sysctl.d/99-disable-core-dump.conf
@@ -1,0 +1,2 @@
+fs.suid_dumpable=0
+kernel.core_pattern=|/bin/false

--- a/features/_prod/file.include/etc/systemd/coredump.conf.d/disable_coredump.conf
+++ b/features/_prod/file.include/etc/systemd/coredump.conf.d/disable_coredump.conf
@@ -1,0 +1,3 @@
+[Coredump]
+Storage=none
+ProcessSizeMax=0


### PR DESCRIPTION
feature(_prod): Disable core dumps (legacy & systemd)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Disable core dumps (legacy & systemd) when using `_prod` feature:
 * Disable for services that are started by systemd
 * Disable for legacy apps that are invoked in any other way
 * Have a fallback if a future feature removes systemd

This will only apply on artefacts built with `_prod` feature. As a result, all other ones may still create core dumps for debugging any issues during the development.

**Which issue(s) this PR fixes**:
Fixes #38

**Special notes for your reviewer**:
Just test it by creating an artefact by running:
```
make kvm_prod
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: user
```
