### PR TITLE
fix: use libaws-sdk-cpp-dev

### DIFF
--- a/container/build-cert/Dockerfile
+++ b/container/build-cert/Dockerfile
@@ -12,6 +12,6 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
 RUN sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget make gettext openssl libengine-pkcs11-openssl gnupg golang-cfssl efitools uuid-runtime awscli python3 python3-pip python3-crc32c git
 RUN echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list  && \
-	apt-get update && apt-get install -y --no-install-recommends aws-sdk-cpp aws-kms-pkcs11
+	apt-get update && apt-get install -y --no-install-recommends libaws-sdk-cpp-dev aws-kms-pkcs11
 
 RUN pip install git+https://github.com/awslabs/python-uefivars

--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -52,7 +52,7 @@ RUN : "Initialize the build container package installation" \
 			libengine-pkcs11-openssl \
 			onmetal-image \
 			oras \
-			aws-sdk-cpp \
+			libaws-sdk-cpp-dev \
 			aws-kms-pkcs11 \
 			systemd \
 		&& apt-get install -t unstable -y --no-install-recommends \


### PR DESCRIPTION

**What this PR does / why we need it**:

Package `aws-sdk-cpp` was renamed to `libaws-sdk-cpp-dev` 
https://gitlab.com/gardenlinux/gardenlinux-package-aws-sdk-cpp/-/commit/00a1219156dbf1115f0e6c4463d9d0c03ea8255c

**Note**
Please note that the aws-sdk-cpp was also broken, latest libaws-sdk-cpp-dev package fixes the `CURLOPT_PUT` issue.
short:
- aws cpp sdk uses deprecated CURLOPT_PUT: https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp#L421
- Garden Linux patch fixes use of deprecated `CURLOPT_PUT` https://gitlab.com/gardenlinux/gardenlinux-package-aws-sdk-cpp/-/blob/main/patches/curlopt_fix.patch 

