### PR TITLE
doc: remove unimplemented github actions docs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,24 +14,3 @@ Runs every day (enabled only for main branch):
 
 See [nightly.yml](nightly.yml) for implementation details. 
 
-## Beta Release
-Runs weekly on main branch
-1. Builds Garden Linux images
-1. Build integration test container
-1. Runs platform tests for each supported platform 
-<!-- 1. On successful tests, images are handed over to Tekton Pipeline for publishing -->
-1. Creates git tag `beta-<Major>.<Minor>` (for tested HEAD of main)
-
-See [beta.yml](beta.yml) for implementation details. 
-
-## Stable Release
-Runs on push to a release branch (enabled for `stable-**` branches)
-
-Stable branches must be manually created.
-
-1. Builds Garden Linux images
-1. Build integration test container
-1. Runs platform tests for each supported platform 
-1. On successful tests, images are handed over to Tekton Pipeline for publishing
-
-See [stable.yml](stable.yml) for implementation details. 


### PR DESCRIPTION
**What this PR does / why we need it**:
Beta and Stable releases are not yet implemented. Adding Documentation when we have implemented and signed of the process for stable and beta pipelines.

**Which issue(s) this PR fixes**:
Fixes #1282
