### PR TITLE
enable ssh-rsa as HostKeyAlgorithm

### DIFF
--- a/features/ssh/file.include/etc/ssh/sshd_config
+++ b/features/ssh/file.include/etc/ssh/sshd_config
@@ -41,3 +41,6 @@ AuthenticationMethods publickey
 # Supported HostKey algorithms by order of preference.
 HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
+
+# Add ssh-rsa to allowed HostKeyAlgorithms
+HostKeyAlgorithms=+ssh-rsa


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind impediment
/area os
/os garden-linux

**What this PR does / why we need it**:

`ssh-rsa` was dropped from the list of key algorithms fom OpenSSH 8.8 as it is considered insecure (ref https://www.openssh.com/txt/release-8.8). 

While it is reasonable for SSH clients not to use this algorithm anymore, the SSH server sshd should still advertise it as valid algorithm for host-key verification since there are still clients out there (such as Microsofts _Certification Test Tool for Azure Certified_) which will simply be unable to establish a connection without.

**Special notes for your reviewer**:

Needs to ported to `rel-934` as well - cherry-pick is not enough since the file-structure changed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
enable ssh-rsa as HostKeyAlgorithm in sshd
```
