### PR TITLE
fix: Fix perl version in base feature (#1491)

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -23,5 +23,5 @@ apt-mark manual \
   libfile-find-rule-perl \
   libgdbm-compat4 \
   libnumber-compare-perl \
-  libperl5.34 \
+  "libperl5.*" \
   libtext-glob-perl


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes new 934.3 build via backport of https://github.com/gardenlinux/gardenlinux/commit/70479be1039b9deb073380d839b5b1ed664057b2
