### PR TITLE
Add specific onmetal (vm) udev rules

### DIFF
--- a/features/kvm/file.include/etc/udev/rules.d/60-onmetal.rules
+++ b/features/kvm/file.include/etc/udev/rules.d/60-onmetal.rules
@@ -1,0 +1,13 @@
+# e.g. on guest vdc with serial oda-abcdefabcdefabcd
+# /dev/vdc 
+# symlink /dev/onmetal/oda -> /dev/vdc
+# symlink /dev/disk/by-id/wwn-abcdefabcdefabcd -> /dev/vdc
+#
+# /dev/vdc3
+# symlink /dev/onmetal/oda3 -> /dev/vdc3
+# symlink /dev/disk/by-id/wwn-abcdefabcdefabcd-part3 -> /dev/vdc3
+
+KERNEL=="*d*[!0-9]", ATTRS{serial}=="[a-z]d[a-z]-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]", PROGRAM="/bin/sh -ec 'SERIAL=$attr{serial}; echo $${SERIAL%%-*} $${SERIAL#*-}'", SYMLINK+="onmetal/$result{1}", SYMLINK+="disk/by-id/wwn-$result{2}"
+
+# partition
+KERNEL=="*d*[0-9]", ATTRS{serial}=="[a-z]d[a-z]-[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]", PROGRAM="/bin/sh -ec 'SERIAL=$attr{serial}; echo $${SERIAL%%-*} $${SERIAL#*-}'", SYMLINK+="onmetal/$result{1}%n", SYMLINK+="disk/by-id/wwn-$result{2}-part%n"


### PR DESCRIPTION
**What this PR does / why we need it**:
For the onmetal project, we run KVM VMs with Gardenlinux.
For the disks that are attached to the VMs, the actual device name specified in the libvirt domain xml is not guaranteed to map to the device name in the guest OS, Gardenlinux in our case.

As discussed with @gehoern, the disks used are going to have serial numbers in the form of "odX-abcdefabcdefabcd", where: 
- odX will be used as a new device name for the specific disk and will be a symlink `/dev/onmetal/odX -> actual_kernel_device_name`
- the serial abcdefabcdefabcd will be used as WWN and another symlink will get created `/dev/disk/by-id/wwn-abcdefabcdefabcd -> actual_kernel_device_name`
