### PR TITLE
improvements for Garden Linux 934.3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest
-934.2
+934.3

--- a/features/azure/file.include/etc/waagent.conf
+++ b/features/azure/file.include/etc/waagent.conf
@@ -1,0 +1,83 @@
+#
+# Microsoft Azure Linux Agent Configuration
+#
+
+# Enable extension handling. Do not disable this unless you do not need password reset,
+# backup, monitoring, or any extension handling whatsoever.
+Extensions.Enabled=y
+
+# Turn off all provisioning functions
+Provisioning.Enabled=n
+
+# Format if unformatted. If 'n', resource disk will not be mounted.
+ResourceDisk.Format=y
+
+# File system on the resource disk
+# Typically ext3 or ext4. FreeBSD images should use 'ufs2' here.
+ResourceDisk.Filesystem=ext4
+
+# Mount point for the resource disk
+ResourceDisk.MountPoint=/mnt/resource
+
+# Create and use swapfile on resource disk.
+ResourceDisk.EnableSwap=n
+
+# Size of the swapfile.
+ResourceDisk.SwapSizeMB=0
+
+# Comma-separated list of mount options. See mount(8) for valid options.
+ResourceDisk.MountOptions=None
+
+# Enable verbose logging (y|n)
+Logs.Verbose=y
+
+# Enable Console logging, default is y
+# Logs.Console=y
+
+# Enable periodic log collection, default is n
+Logs.Collect=y
+
+# How frequently to collect logs, default is each hour
+Logs.CollectPeriod=3600
+
+# Is FIPS enabled
+OS.EnableFIPS=n
+
+# Root device timeout in seconds.
+OS.RootDeviceScsiTimeout=300
+
+# If "None", the system default version is used.
+OS.OpensslPath=None
+
+# Set the SSH ClientAliveInterval
+OS.SshClientAliveInterval=180
+
+# Set the path to SSH keys and configuration files
+OS.SshDir=/etc/ssh
+
+# Detect Scvmm environment, default is n
+# DetectScvmmEnv=n
+
+
+# Enable RDMA management and set up, should only be used in HPC images
+# OS.EnableRDMA=y
+
+# Enable or disable goal state processing auto-update, default is enabled
+AutoUpdate.Enabled=n
+
+# Determine the update family, this should not be changed
+# AutoUpdate.GAFamily=Prod
+
+# Determine if the overprovisioning feature is enabled. If yes, hold extension
+# handling until inVMArtifactsProfile.OnHold is false.
+# Default is enabled
+# EnableOverProvisioning=y
+
+# Allow fallback to HTTP if HTTPS is unavailable
+# Note: Allowing HTTP (vs. HTTPS) may cause security risks
+# OS.AllowHTTP=n
+
+# Add firewall rules to protect access to Azure host node services
+# Note:
+# - The default is false to protect the state of existing VMs
+OS.EnableFirewall=y

--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,3 +1,4 @@
 chrony
 cloud-init
 python3-cffi-backend
+waagent

--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -23,5 +23,5 @@ apt-mark manual \
   libfile-find-rule-perl \
   libgdbm-compat4 \
   libnumber-compare-perl \
-  libperl5.34 \
+  "libperl5.*" \
   libtext-glob-perl

--- a/features/server/file.include/etc/ssh/sshd_config
+++ b/features/server/file.include/etc/ssh/sshd_config
@@ -41,3 +41,6 @@ AuthenticationMethods publickey
 # Supported HostKey algorithms by order of preference.
 HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
+
+# Add ssh-rsa to allowed HostKeyAlgorithms
+HostKeyAlgorithms=+ssh-rsa

--- a/features/server/file.include/etc/ssh/sshd_config
+++ b/features/server/file.include/etc/ssh/sshd_config
@@ -31,8 +31,8 @@ AcceptEnv LANG
 # override default of no subsystems
 Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO
 
-# autologout inactive users after 10 minutes
-ClientAliveInterval 600
+# autologout inactive users after 3 minutes
+ClientAliveInterval 180
 ClientAliveCountMax 0
 
 # Password based logins are disabled - only public key based logins are allowed.

--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -35,5 +35,5 @@ selinux-policy-default
 gardenlinux-selinux-module
 sosreport
 policykit-1
-libssl3=3.0.7-1
-openssl=3.0.7-1
+libssl3
+openssl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import os
 import sys
 import re
 
-import glci.util
 
 from typing import Iterator
 from helper.sshclient import RemoteClient
@@ -80,42 +79,6 @@ def image_suffix(iaas):
     }
     return image_suffixes[iaas]
 
-
-@pytest.fixture(scope="session")
-def s3_image_location(test_params, image_suffix):
-    ''' 
-    returns a S3Info object and gives access to the S3 bucket containing the build artifacts
-    from the current pipeline run. Typically use to be uploaded to hyperscalers for testing.
-    '''
-
-    @dataclass
-    class S3Info:
-        bucket_name: str
-        raw_image_key: str
-        target_image_name: str
-
-    cicd_cfg = glci.util.cicd_cfg(cfg_name=test_params.cicd_cfg_name)
-    find_release = glci.util.preconfigured(
-        func=glci.util.find_release,
-        cicd_cfg=cicd_cfg,
-    )
-
-    release = find_release(
-        release_identifier=glci.model.ReleaseIdentifier(
-            build_committish=test_params.committish,
-            version=test_params.version,
-            gardenlinux_epoch=int(test_params.gardenlinux_epoch),
-            architecture=glci.model.Architecture(test_params.architecture),
-            platform=test_params.platform,
-            modifiers=test_params.modifiers,
-        ),
-    )
-
-    return S3Info(
-        raw_image_key=release.path_by_suffix(image_suffix).s3_key,
-        bucket_name=release.path_by_suffix(image_suffix).s3_bucket_name,
-        target_image_name=f'integration-test-image-{test_params.committish}',
-    )
 
 
 @pytest.fixture(scope="session")
@@ -193,61 +156,10 @@ def testconfig(pipeline, iaas, pytestconfig):
 def aws_session(testconfig, pipeline, request):
     import boto3
     
-    if pipeline:
-        import ccc.aws
-
-        @dataclass
-        class AWSCfg:
-            aws_cfg_name: str
-            aws_region: str
-
-        test_params=request.getfixturevalue('test_params')
-        cicd_cfg = glci.util.cicd_cfg(cfg_name=test_params.cicd_cfg_name)
-        aws_cfg = AWSCfg(
-            aws_cfg_name=cicd_cfg.build.aws_cfg_name,
-            aws_region=cicd_cfg.build.aws_region
-        )
-        return ccc.aws.session(aws_cfg.aws_cfg_name, aws_cfg.aws_region)
-    elif "region" in testconfig:
+    if "region" in testconfig:
         return boto3.Session(region_name=testconfig["region"])
     else:
         return boto3.Session()
-
-
-@pytest.fixture(scope="session")
-def azure_cfg():
-    # late import because only needed in case of pipeline context and probably not available in standalone context
-    from util import ctx
-
-    @dataclass
-    class AzureCfg:
-        client_id: str
-        client_secret: str
-        tenant_id: str
-        subscription_id: str
-        marketplace_cfg: glci.model.AzureMarketplaceCfg
-
-    cicd_cfg = glci.util.cicd_cfg()
-    service_principal_cfg_tmp = ctx().cfg_factory().azure_service_principal(
-        cicd_cfg.publish.azure.service_principal_cfg_name,
-    )
-    service_principal_cfg = glci.model.AzureServicePrincipalCfg(
-        **service_principal_cfg_tmp.raw
-    )
-
-    azure_marketplace_cfg = glci.model.AzureMarketplaceCfg(
-        publisher_id=cicd_cfg.publish.azure.publisher_id,
-        offer_id=cicd_cfg.publish.azure.offer_id,
-        plan_id=cicd_cfg.publish.azure.plan_id,
-    )
-
-    return AzureCfg(
-        client_id=service_principal_cfg.client_id,
-        client_secret=service_principal_cfg.client_secret,
-        tenant_id=service_principal_cfg.tenant_id,
-        marketplace_cfg=azure_marketplace_cfg,
-        subscription_id=service_principal_cfg.subscription_id,
-    )
 
 
 @pytest.fixture(scope="session")
@@ -262,53 +174,33 @@ def azure_credentials(testconfig, pipeline, request):
         credential: object
         subscription_id: str
 
-    if pipeline:
-        azure_cfg = request.getfixturevalue('azure_cfg')
-        credentials = ClientSecretCredential(
-            client_id=azure_cfg.client_id,
-            client_secret=azure_cfg.client_secret,
-            tenant_id=azure_cfg.tenant_id
-        )
-        return AZCredentials(
-            credential = credentials,
-            subscription_id = azure_cfg.subscription_id
-        )
-    else:
-        credential = AzureCliCredential()
-        if 'subscription_id' in testconfig:
-            subscription_id = testconfig['subscription_id']
-        elif 'subscription' in testconfig:
-            try:
-                subscription_id = AZURE.find_subscription_id(credential, testconfig['subscription'])
-            except RuntimeError as err:
-                pytest.exit(err, 1)
-        return AZCredentials(
-            credential = credential,
-            subscription_id = subscription_id
-        )
+    credential = AzureCliCredential()
+    if 'subscription_id' in testconfig:
+        subscription_id = testconfig['subscription_id']
+    elif 'subscription' in testconfig:
+        try:
+            subscription_id = AZURE.find_subscription_id(credential, testconfig['subscription'])
+        except RuntimeError as err:
+            pytest.exit(err, 1)
+    return AZCredentials(
+        credential = credential,
+        subscription_id = subscription_id
+    )
 
 
 @pytest.fixture(scope='session')
 def gcp_credentials(testconfig, pipeline, request):
     import google.oauth2.service_account
 
-    if pipeline:
-        # late import because only needed in case of pipeline context and probably not available in standalone context
-        from util import ctx
-        gcp_cfg = ctx().cfg_factory().gcp("gardenlinux")
+    if "service_account_json_path" in testconfig:
+        service_account_json_path = path.expanduser(testconfig["service_account_json_path"])
+        with open(service_account_json_path, "r") as f:
+            service_account_json = f.read()
         return google.oauth2.service_account.Credentials.from_service_account_info(
-            gcp_cfg.service_account_key(),
+            json.loads(service_account_json)
         )
     else:
-        if "service_account_json_path" in testconfig:
-            service_account_json_path = path.expanduser(testconfig["service_account_json_path"])
-            with open(service_account_json_path, "r") as f:
-                service_account_json = f.read()
-            return google.oauth2.service_account.Credentials.from_service_account_info(
-                json.loads(service_account_json)
-            )
-        else:
-            return None
+        return None
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -3,6 +3,9 @@ import json
 import os
 import uuid
 import pytest
+import enum
+
+import botocore.client
 
 from os import path
 from urllib.parse import urlparse
@@ -14,11 +17,130 @@ from botocore.exceptions import ClientError
 from helper.sshclient import RemoteClient
 from paramiko import RSAKey
 
-import glci.aws
-from glci.aws import response_ok
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+class TaskStatus(enum.Enum):
+    ACTIVE = 'active'
+    COMPLETED = 'completed'
+    DELETED = 'deleted' # indicates an error (image was rejected)
+
+def response_ok(response: dict):
+    resp_meta = response['ResponseMetadata']
+    if (status_code := resp_meta['HTTPStatusCode']) == 200:
+        return response
+
+    raise RuntimeError(f'rq {resp_meta["RequestId"]=} failed {status_code=}')
+
+def register_image(
+    ec2_client: 'botocore.client.EC2',
+    snapshot_id: str,
+    image_name: str,
+    architecture: str,
+) -> str:
+    '''
+    @return: ami-id of registered image
+    '''
+    root_device_name = '/dev/xvda'
+
+    result = ec2_client.register_image(
+        # ImageLocation=XX, s3-url?
+        Architecture=architecture,
+        BlockDeviceMappings=[
+            {
+                'DeviceName': root_device_name,
+                'Ebs': {
+                    'DeleteOnTermination': True,
+                    'SnapshotId': snapshot_id,
+                    'VolumeType': 'gp2',
+                }
+            }
+        ],
+        Description='gardenlinux',
+        EnaSupport=True,
+        Name=image_name,
+        RootDeviceName=root_device_name,
+        VirtualizationType='hvm' # | paravirtual
+    )
+
+    ec2_client.create_tags(
+        Resources=[
+            result['ImageId'],
+        ],
+        Tags=[
+            {
+                'Key': 'sec-by-def-public-image-exception',
+                'Value': 'enabled',
+            },
+        ]
+    )
+
+    # XXX need to wait until image is available (before publishing)
+    return result['ImageId']
+
+def import_snapshot(
+    ec2_client: 'botocore.client.EC2',
+    s3_bucket_name: str,
+    image_key: str,
+) -> str:
+    '''
+    @return import_task_id (use for `wait_for_snapshot_import`)
+    '''
+    res = ec2_client.import_snapshot(
+        ClientData={
+            'Comment': 'uploaded by gardenlinux-cicd',
+        },
+        Description='uploaded by gardenlinux-cicd',
+        DiskContainer={
+            'UserBucket': {
+                'S3Bucket': s3_bucket_name,
+                'S3Key': image_key,
+            },
+            'Format': 'raw',
+            'Description': 'uploaded by gardenlinux-cicd',
+        },
+        Encrypted=False,
+    )
+
+    import_task_id = res['ImportTaskId']
+    return import_task_id
+
+
+def wait_for_snapshot_import(
+    ec2_client: 'botocore.client.EC2',
+    snapshot_task_id: str,
+    polling_interval_seconds: int=15,
+):
+    '''
+    @return snapshot_id
+    '''
+    def describe_import_snapshot_task():
+        status = ec2_client.describe_import_snapshot_tasks(
+            ImportTaskIds=[snapshot_task_id]
+        )['ImportSnapshotTasks'][0]
+        return status
+
+    def current_status() -> TaskStatus:
+        status = describe_import_snapshot_task()
+        status = TaskStatus(status['SnapshotTaskDetail']['Status'])
+        return status
+
+    def snapshot_id():
+        status = describe_import_snapshot_task()
+        task_id = status['SnapshotTaskDetail']['SnapshotId']
+        return task_id
+
+    while not (status := current_status()) is TaskStatus.COMPLETED:
+        logger.info(f'{snapshot_task_id=}: {status=}')
+
+        if status is TaskStatus.DELETED:
+            status = describe_import_snapshot_task()
+            details = status['SnapshotTaskDetail']
+            raise RuntimeError(f'image uploaded by {snapshot_task_id=} was rejected: {details=}')
+        time.sleep(polling_interval_seconds)
+
+    return snapshot_id()
 
 class AWS:
     """Handle resources in AWS cloud"""
@@ -509,13 +631,13 @@ class AWS:
             raise NotImplementedError("Only local image file uploads and S3 buckets are implemented.")
 
         self.logger.info(f"Importing snapshot from S3 object {image_key} in bucket {bucket_name}...")
-        snapshot_task_id = glci.aws.import_snapshot(
+        snapshot_task_id = import_snapshot(
             ec2_client = self.ec2_client,
             s3_bucket_name = bucket_name,
             image_key = image_key,
         )
         try:
-            self._snapshot_id = glci.aws.wait_for_snapshot_import(
+            self._snapshot_id = wait_for_snapshot_import(
                 ec2_client = self.ec2_client,
                 snapshot_task_id = snapshot_task_id,
             )
@@ -534,7 +656,7 @@ class AWS:
         )
 
         self.logger.info(f"Registering ami from snapshot {self._snapshot_id}...")
-        self._ami_id = glci.aws.register_image(
+        self._ami_id = register_image(
             ec2_client = self.ec2_client,
             snapshot_id = self._snapshot_id,
             image_name = image_name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Adds all improvements planned for Garden Linux 934 patch release 3, i.e. `934.3` to the `rel-934` branch. 

Those are in particular:

- bump version to 934.3 in VERSION 
- fix: Fix perl version in base feature
- fix(tests): remove dependency to glci

The following are required to pass Azure Marketplace certification:

- enable ssh-rsa as HostKeyAlgorithm
- fix: set ClientAliveInterval to 180 secs in sshd_config
- feat(azure): add waagent but disable provisioning

**Special notes for your reviewer**:

Must be merged to `rel-934`, NOT to `main`. Please do not squash commits in this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- enable ssh-rsa as HostKeyAlgorithm
- bump version to 934.3 in VERSION 
- fix: Fix perl version in base feature
- fix(tests): remove dependency to glci
- fix: set ClientAliveInterval to 180 secs in sshd_config
- feat(azure): add waagent but disable provisioning
```