### PR TITLE
test: remove python pinning from test container

### DIFF
--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -41,6 +41,6 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc
 # pipenv package was removed from bookworm https://tracker.debian.org/pkg/pipenv
 RUN pip install pipenv==2022.4.8
 COPY _pipfiles /_pipfiles
-RUN cd /_pipfiles && pipenv --python 3.10 install --system --skip-lock --dev && cd / && rm -rf /_pipfiles
+RUN cd /_pipfiles && pipenv install --system --skip-lock --dev && cd / && rm -rf /_pipfiles
 
 WORKDIR /gardenlinux/tests


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Removes static pinning to a specific python version for the Garden Linux test containers to always use the latest version found in an upstream repo.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
test: remove python pinning from test container
```
