### PR TITLE
feat: garden-feat use venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ __pycache__
 /tests/*.log
 /tests/*.xml
 make_targets.cache
+bin/garden-feat.venv

--- a/bin/garden-feat
+++ b/bin/garden-feat
@@ -1,3 +1,21 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+exec 3>&1
+exec 4>&2
+exec 1>/dev/null
+exec 2>/dev/null
+
+venv="$(dirname "$BASH_SOURCE")/garden-feat.venv"
+python3 -m venv "$venv"
+source "$venv/bin/activate"
+pip install pyyaml networkx
+
+exec 1>&3
+exec 1>&4
+exec python <(sed -n '/^#!\/usr\/bin\/env python3$/,$ p' < "$BASH_SOURCE") "$@"
+
 #!/usr/bin/env python3
 
 import os


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

add wrapper to garden-feat to run itself in a python venv to ensure all dependencies are available


**TODO**:

- [ ] update github action runner image to include `python3-venv` instead of `python3-networkx`
