### PR TITLE
feat(hack): add cli package search tool

### DIFF
--- a/hack/gl-search-package.sh
+++ b/hack/gl-search-package.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Requirements: fzf
+#   Installation of fzf documented here: https://github.com/junegunn/fzf#installation
+#   - debian: sudo apt install fzf
+#   - arch:  sudo pacman -S fzf
+#   - osx: brew install fzf
+
+# Select Garden Linux Distribution by setting env variable "gl_dist=934.3"
+# Default: today
+
+
+# TODO:
+# - user select architecture via fzf 
+# - user select version via fzf
+
+export gls_selected_arch=$(echo -e "amd64\narm64" | fzf --header 'Select Garden Linux package architecture' )
+
+
+export gls_gl_dist="${gl_dist:-today}"
+packages_file="$(curl -s http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages)"
+
+function filter_package_info() {
+  foo=$1;
+  packages_file="$(curl -s http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages)"
+  echo "$packages_file" | sed -n "/Package: $foo$/,/^$/p"
+}
+
+# fzf preview requires function to be available in spawned subshell
+export -f filter_package_info
+echo -e "$packages_file" | grep "^Package:.*" | fzf --multi --preview 'bash -c "filter_package_info {2}"' --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'


### PR DESCRIPTION
**What this PR does / why we need it**:
This `gl-search-package.sh` script downloads the Packages file from repo.gardenlinux.io, and uses [fzf](https://github.com/junegunn/fzf) for easy to read and filter presentation of available gardenlinux packages.

**Special notes for your reviewer**:

fzf is a requirement, you can install it via 
```
sudo apt install fzf
```

Select target Garden Linux version by setting `gl_dist` in your env to the target gardenlinux version.
```
gl_dist=934.4 && ./gl-search-package.sh
```
