### PR TITLE
Prepare Release of 934-4

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest
-934.3
+934.4

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -13,6 +13,7 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
      && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] http://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
      && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
+     && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources \
      && apt-get update \
      && apt-get install -y --no-install-recommends \
           curl \

--- a/container/build-cert/Dockerfile
+++ b/container/build-cert/Dockerfile
@@ -3,7 +3,7 @@ ARG build_base_image=gardenlinux/slim
 FROM $build_base_image
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list
+RUN sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget make gettext openssl libengine-pkcs11-openssl gnupg golang-cfssl efitools uuid-runtime awscli
 RUN arch="$(dpkg --print-architecture)" && \
 	wget "https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-sdk-cpp_$arch.deb" "https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-kms-pkcs11_$arch.deb" && \

--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -11,7 +11,7 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
 RUN if [ "$(dpkg --print-architecture)" != amd64 ]; then dpkg --add-architecture amd64; fi
 
 RUN : "Initialize the build container package installation" \
-		&& sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
+		&& sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources \
 		&& arch="$(dpkg --print-architecture)" \
 		&& apt-get update \
 		&& apt-get install -y --no-install-recommends \

--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -9,6 +9,7 @@ RUN	mkdir /etc/sudoers.d \
      &&	echo "#deb https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
      && echo "#deb-src https://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
      && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
+     && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources \
      && echo "APT::Install-Recommends false;\nAPT::Install-Suggests false;\nApt::AutoRemove::SuggestsImportant false;\n" > /etc/apt/apt.conf.d/no-recommends \
      &&	echo "progress=bar:force:noscroll" >> /etc/wgetrc \
      &&	echo "force-confold\nforce-confdef" > /etc/dpkg/dpkg.cfg.d/forceold


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux


**What this PR does / why we need it**:
* Build Environment Fixes
    * fix: use /etc/apt/sources.list.d to be compatible with new version of debian:testing-slim images 
* Package updates
    * Kernel 5.15.93
    * vim/2:9.0.1000-4
    * bind9/1:9.18.11-2
    * containerd/1.6.17
* Note: We needed to disable publishing via Azure Community Galleries for this Release, because it is currently not usable for Gardener because of a Bug in Azure.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
* Package Updates
    * Kernel 5.15.93
    * vim/2:9.0.1000-4
    * bind9/1:9.18.11-2
    * containerd/1.6.17
* Note: Publishing to Azure Community Gallery is disabled
```
