### PR TITLE
Rel 934 kms fix

### DIFF
--- a/container/build-image/Dockerfile
+++ b/container/build-image/Dockerfile
@@ -24,11 +24,6 @@ RUN : "Initialize the build container package installation" \
 		&& echo 'APT::Default-Release "testing";' > /etc/apt/apt.conf.d/default-testing \
 		&& apt-get update \
 		&& \
-	: "Make AWS Tools available for the build" \
-		&& wget \
-			"https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-sdk-cpp_$arch.deb" \
-			"https://gardenlinux-aws-kms-pkcs11.s3.eu-central-1.amazonaws.com/aws-kms-pkcs11_$arch.deb" \
-		&& \
 	: "Install all required build tools" \
 		&& apt-get install -y --no-install-recommends \
 			debian-ports-archive-keyring \
@@ -55,8 +50,8 @@ RUN : "Initialize the build container package installation" \
 			openssl \
 			libengine-pkcs11-openssl \
 			onmetal-image \
-			"./aws-sdk-cpp_$arch.deb" \
-			"./aws-kms-pkcs11_$arch.deb" \
+			aws-sdk-cpp \
+			aws-kms-pkcs11 \
 		&& apt-get install -t unstable -y --no-install-recommends \
 			binutils-x86-64-linux-gnu \
 			binutils-aarch64-linux-gnu \


### PR DESCRIPTION
Running `nightly`  build pipeline with rel-934 fails for all flavors requiring keys from aws kms (pxe and secureboot).

```
Unable to load module /usr/lib/aarch64-linux-gnu/pkcs11/aws_kms_pkcs11.so
PKCS11_get_private_key returned NULL
``` 

Note: currently debugging. Changes in this PR may not be final