### PR TITLE
remove pxe and secureboot targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
-        target: [ kvm, kvm-secureboot, metal, metal-secureboot, gcp, aws, azure, ali, openstack, vmware, pxe, githubActionRunner, metalv ]
+        target: [ kvm, metal, gcp, aws, azure, ali, openstack, vmware, githubActionRunner, metalv ]
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
       - uses: actions/checkout@v2

--- a/make_targets/kvm-secureboot
+++ b/make_targets/kvm-secureboot
@@ -1,1 +1,0 @@
-server,cloud,kvm,_secureboot

--- a/make_targets/metal-secureboot
+++ b/make_targets/metal-secureboot
@@ -1,1 +1,0 @@
-server,metal,_secureboot

--- a/make_targets/pxe
+++ b/make_targets/pxe
@@ -1,1 +1,0 @@
-metal,server,_pxe


### PR DESCRIPTION
Disabling secureboot and pxe because of this bug: https://github.com/gardenlinux/gardenlinux/issues/1537