### PR TITLE
Exec in chroot by default

### DIFF
--- a/bin/garden-config
+++ b/bin/garden-config
@@ -29,13 +29,15 @@ indent() { sed 's/^/  /'; }
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 
+cp -r $featureDir $targetDir/tmp/
 printf "## executing exec.pre\n"
 for i in $(tr ',' '\n' <<< $features); do
         if [ -x $featureDir/$i/exec.pre ]; then
                 printf "### $i:\n"
-                thisDir=$thisDir targetDir=$targetDir $featureDir/$i/exec.pre "$targetDir" | indent
+                "$thisDir/garden-chroot" "$targetDir" env arch="$arch" targetDir=$targetDir thisDir=$thisDir "/tmp/$(basename $featureDir)/$i/exec.pre" | indent
         fi
 done
+rm -rf "$targetDir/tmp/$(basename $featureDir)"
 
 printf "## copying from file.include\n"
 for i in $(tr ',' '\n' <<< $features); do
@@ -68,7 +70,6 @@ for i in $(tr ',' '\n' <<< $features); do
 		"$thisDir/garden-chroot" "$targetDir" env arch="$arch" "/tmp/$(basename $featureDir)/$i/exec.config" 2>&1 | indent
 	fi
 done
-
 rm -rf "$targetDir/tmp/$(basename $featureDir)"
 
 printf "## deleting file.exclude\n"
@@ -82,10 +83,12 @@ for i in $(tr ',' '\n' <<< $features); do
 	fi
 done
 
+cp -r $featureDir $targetDir/tmp/
 printf "## executing exec.post\n"
 for i in $(tr ',' '\n' <<< $features); do
 	if [ -x $featureDir/$i/exec.post ]; then
 		printf "### $i:\n"
-		thisDir=$thisDir targetDir=$targetDir $featureDir/$i/exec.post "$targetDir" | indent
+		"$thisDir/garden-chroot" "$targetDir" env arch="$arch" targetDir=$targetDir thisDir=$thisDir "/tmp/$(basename $featureDir)/$i/exec.post" | indent
 	fi
 done
+rm -rf "$targetDir/tmp/$(basename $featureDir)"

--- a/features/_dev/exec.post
+++ b/features/_dev/exec.post
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -Exeuo pipefail
 
 adduser dev --disabled-password --gecos dev
 adduser dev wheel

--- a/features/server/exec.post
+++ b/features/server/exec.post
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 # remove python's __pycache__
-$thisDir/garden-chroot $targetDir find /usr/lib -type d -name __pycache__ -exec rm -rf {} +
+find /usr/lib -type d -name __pycache__ -exec rm -rf {} +
 
 if [ -d "$targetDir/etc/nvme" ]; then
 	rm "$targetDir/etc/nvme/hostid" "$targetDir/etc/nvme/hostnqn"


### PR DESCRIPTION
**What this PR does / why we need it**:
* This Pr changes garden-config so that `exec.post` and `exec.pre` bash files are executed in garden-chroot context
* Please note, this is already the default behavior for `exec.config`
* moves `_dev/exec.config` to `_dev/exec.post` because _dev requires `exec.config` stage to create the `wheel` group before. previously the ordering was different, so _dev/exec.config was executed after server/exec.config, which creates the `wheel` group. 

**Special notes for your reviewer**:
* Copying the feature dir before the exec.pre and exec.post stages are analog to exec.config. If you know that this is not required, we can reduce it to one `cp` at the beginning and one `rm` at the end. However, to not introduce hidden breaking changes, I copied the logic to work on temporary feature dirs (as exec.config does) 