### PR TITLE
fix(_dev): move _dev/exec.config to _dev/exec.post

### DIFF
--- a/features/_dev/exec.config
+++ b/features/_dev/exec.config
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -Eeuo pipefail
-
-adduser dev --disabled-password --gecos dev
-adduser dev wheel
-mkdir /home/dev/.ssh
-chmod 750 /home/dev/
-chmod 700 /home/dev/.ssh
-chown dev:dev -R /home/dev/.ssh

--- a/features/_dev/exec.post
+++ b/features/_dev/exec.post
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+$thisDir/garden-chroot $targetDir adduser dev --disabled-password --gecos dev
+$thisDir/garden-chroot $targetDir adduser dev wheel
+$thisDir/garden-chroot $targetDir mkdir /home/dev/.ssh
+$thisDir/garden-chroot $targetDir chmod 750 /home/dev/
+$thisDir/garden-chroot $targetDir chmod 700 /home/dev/.ssh
+$thisDir/garden-chroot $targetDir chown dev:dev -R /home/dev/.ssh


### PR DESCRIPTION
**What this PR does / why we need it**:
* moves `features/_dev/exec.config` to `features/_dev/exec.post`. This is required because the new implementation of garden-feat orders features differently. Now, `_dev/exec.config` would run before `server/exec.config`, which leads to a broken `_dev/exec.config.
* Since `_dev` requires group "wheel" to be created first, we simply move _dev configuration to exec.post
* Since exec.post is not executed in chroot, we need to do it now in the features/_dev/exec.post explicitly.
