### PR TITLE
fix: makepart use fullfeatures

### DIFF
--- a/bin/garden-build
+++ b/bin/garden-build
@@ -55,6 +55,7 @@ export arch="$arch"
 export debianMirror=$debianMirror
 
 fullfeatures="$(garden-feat --featureDir "$featureDir" --features "$features" --ignore "$disablefeatures" features)"
+export fullfeatures
 targetPlatform="$(garden-feat --featureDir "$featureDir" --features "$features" --ignore "$disablefeatures" platforms)"
 
 # Using the native Debian repository on production builds (_prod) is not supported

--- a/bin/makepart
+++ b/bin/makepart
@@ -16,14 +16,14 @@ cp -a "$rootfs/." "$rootfs_work"
 
 find "$rootfs_work/var/log/" -type f -delete
 
-if grep _selinux <<<"$features" > /dev/null; then
+if grep _selinux <<< "$fullfeatures" > /dev/null; then
   # SELinux 'default' policy file contexts
   chcon -R system_u:object_r:unlabeled_t:s0 "$rootfs_work"
   "$thisDir/garden-chroot" "$rootfs_work" /sbin/setfiles /etc/selinux/default/contexts/files/file_contexts /
   rm "$rootfs_work/.autorelabel"
 fi
 
-if ! grep _secureboot <<<"$features" > /dev/null; then
+if ! grep _secureboot <<< "$fullfeatures" > /dev/null; then
 	machineid="$(mktemp)"
 	mount --rbind "${machineid}" "${rootfs_work}/etc/machine-id"
 	mkdir -p "$rootfs_work/boot/efi/loader/"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

use `$fullfeatures` instead of `$features` in makepart to check if `_selinux` is enabled

**Which issue(s) this PR fixes**:

fixes issue with selinux relabeling running on first boot if `_selinux` feature is included by other features instead of explicitly added to feature set
