### PR TITLE
cleaning up containerd configs

### DIFF
--- a/features/chost/file.exclude
+++ b/features/chost/file.exclude
@@ -1,1 +1,2 @@
 /etc/init.d/apparmor
+/var/lib/containerd/opt

--- a/features/chost/file.include/etc/config.toml
+++ b/features/chost/file.include/etc/config.toml
@@ -1,0 +1,10 @@
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".cni]
+  bin_dir = "/var/lib/containerd/io.containerd.grpc.v1.cri.cni"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+  SystemdCgroup = true
+[plugins."io.containerd.internal.v1.opt"]
+  path = "/var/lib/containerd/io.containerd.internal.v1.opt"

--- a/features/chost/file.include/opt/cni/bin
+++ b/features/chost/file.include/opt/cni/bin
@@ -1,0 +1,1 @@
+/var/lib/containerd/io.containerd.grpc.v1.cri.cni

--- a/features/chost/file.include/usr/lib/cni
+++ b/features/chost/file.include/usr/lib/cni
@@ -1,0 +1,1 @@
+/var/lib/containerd/io.containerd.grpc.v1.cri.cni


### PR DESCRIPTION
containerd needs a proper setup for the cni bin folder.

overall standard is /opt/cni/bin ... this is even hardcoded in some cni's m(
the debian standard is /usr/lib/cni ... debian packages use this

i guess the intended location of containerd is /var/lib/containerd/io.containerd.grpc.v1.cri.cni

so that is why this is set.

also fixing for plugins "io.containerd.internal.v1.opt" setting to "/var/lib/containerd/io.containerd.internal.v1.opt"