### PR TITLE
hack(gl-search): ignore caching query parameter

### DIFF
--- a/hack/gl-search-package.sh
+++ b/hack/gl-search-package.sh
@@ -17,7 +17,7 @@ if [ "$gls_gl_dist" != "today" ]; then
   fi
 fi  
 
-repo_url="http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/Release"
+repo_url="http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/Release?ignoreCaching=1"
 
 # Check if repo exists for user provided garden linux version string
 if curl -s $repo_url| grep -q "Error"; then
@@ -27,11 +27,11 @@ if curl -s $repo_url| grep -q "Error"; then
 fi
 
 export gls_selected_arch=$(echo -e "amd64\narm64" | fzf --header 'Select Garden Linux package architecture' )
-packages_file="$(curl -s http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages)"
+packages_file="$(curl -s http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages?ignoreCaching=1)"
 
 function filter_package_info() {
   foo=$1;
-  packages_file="$(curl -s http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages)"
+  packages_file="$(curl -s http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages?ignoreCaching=1)"
   echo "$packages_file" | sed -n "/Package: $foo$/,/^$/p"
 }
 


### PR DESCRIPTION
Patches `hack/gl-search-package.sh` to ignore caching. This should reduce confusion when using this gl-search-package.sh tool when caches of apt CDNs are not expired or invalidated yet