### PR TITLE
Fix: use venv for container

### DIFF
--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc
           gnupg \
           python3-pip \
           python3-pytest \
+          python3-venv \
           vim \
           procps \
           openssh-client \
@@ -38,6 +39,11 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc
           build-essential \
           libpython3-dev \
           onmetal-image
+
+# Prepare virtual environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # pipenv package was removed from bookworm https://tracker.debian.org/pkg/pipenv
 RUN pip install pipenv==2022.4.8

--- a/container/build-cert/Dockerfile
+++ b/container/build-cert/Dockerfile
@@ -10,8 +10,13 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
         && chmod 644 $GARDENLINUX_MIRROR_KEY
 
 RUN sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget make gettext openssl libengine-pkcs11-openssl gnupg golang-cfssl efitools uuid-runtime awscli python3 python3-pip python3-crc32c git
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget make gettext openssl libengine-pkcs11-openssl gnupg golang-cfssl efitools uuid-runtime awscli python3 python3-pip python3-venv python3-crc32c git
 RUN echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list  && \
 	apt-get update && apt-get install -y --no-install-recommends libaws-sdk-cpp-dev aws-kms-pkcs11
+
+# Prepare virtual environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip install git+https://github.com/awslabs/python-uefivars


### PR DESCRIPTION
***Why do we need this?*** 
* A new debian python update causes pip to refuse installation of packages if environment is marked as externally managed. This issue breaks our dev and nightly
* https://github.com/pypa/pip/issues/11381
* alternatively, we can delete the EXTERNALLY-MANAGED files


***Reproduce issue***
```
make --directory=container build-cert
```

Before this PR we run into this:
```
STEP 10: RUN pip install git+https://github.com/awslabs/python-uefivars
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.
