### PR TITLE
fix: paramiko.py3compat was deprecated and removed from paramiko

### DIFF
--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -9,10 +9,19 @@ from binascii import hexlify
 from paramiko import SSHClient, AutoAddPolicy, RSAKey
 from paramiko.auth_handler import AuthenticationException, SSHException
 from paramiko.ssh_exception import NoValidConnectionsError
-from paramiko.py3compat import u
 from scp import SCPClient, SCPException
 
 logger = logging.getLogger(__name__)
+
+# paramiko.py3compat was removed with paramiko 3.0.0
+# https://www.paramiko.org/changelog.html
+def decode_unicode_or_bytes(s, encoding='utf8'):
+    """ decodes bytes or unicode to unicode"""
+    if isinstance(s, str):
+        return s
+    elif isinstance(s, bytes):
+        return s.decode(encoding)
+    raise TypeError("{!r} is not unicode or byte".format(s))
 
 
 class RemoteClient:
@@ -49,7 +58,7 @@ class RemoteClient:
                 f.write(f"{pub.get_name()} {pub.get_base64()}")
                 if comment:
                     f.write(f" {comment}")
-        hash = u(hexlify(pub.get_fingerprint()))
+        hash = decode_unicode_or_bytes(hexlify(pub.get_fingerprint()))
         fingerprint = ":".join([hash[i : 2 + i] for i in range(0, len(hash), 2)])
         logger.info(f"fingerprint: {bits} {fingerprint} {filename}.pub (RSA)")
         return fingerprint


### PR DESCRIPTION
**What this PR does / why we need it**:
- Paramiko.py3compat was removed from paramiko 3.0.0
- tests/helper/sshclient.py used a helper function from the removed paramiko module
- this PR implements the trivial wrapper in the helper function


**Which issue(s) this PR fixes**:
Fixes #1540 