### PR TITLE
arptables and ebtables missing for legacy

### DIFF
--- a/features/gardener/pkg.include
+++ b/features/gardener/pkg.include
@@ -13,3 +13,5 @@ ipvsadm
 cifs-utils
 nfs-common
 netcat-openbsd
+ebtables
+arptables


### PR DESCRIPTION
legacy fix for iptables-nft

