### PR TITLE
New kernelmodule build container

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -58,13 +58,10 @@ build-integration-test: build-base-test
 	rm integration-test/cloud.google.gpg
 
 .PHONY: build-kernelmodule
-build-kernelmodule: build
-	rm -rf build-kernelmodule/packages
-	mkdir -p build-kernelmodule/packages/
-	cp ../.packages/main/l/linux/linux-kbuild*$(KERNEL_VERSION)*.deb build-kernelmodule/packages/ || (echo "Error: Build Kernel packages first." && exit 1)
-	cp ../.packages/main/l/linux/linux-compiler-gcc*$(KERNEL_VERSION)*.deb build-kernelmodule/packages/ || (echo "Error: Build Kernel packages first." && exit 1)
-	cp ../.packages/main/l/linux/linux-headers*$(KERNEL_VERSION)*.deb build-kernelmodule/packages/ || (echo "Error: Build Kernel packages first." && exit 1)
-	@$(GARDENLINUX_BUILD_CRE) build -t gardenlinux/build-kernelmodule:$(KERNEL_VERSION) build-kernelmodule
+build-kernelmodule:
+	cp -p ../gardenlinux.asc build-kernelmodule/gardenlinux.asc
+	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/build-kernelmodule:$(VERSION) build-kernelmodule
+	rm build-kernelmodule/gardenlinux.asc
 
 .PHONY: clean
 clean:

--- a/container/Makefile
+++ b/container/Makefile
@@ -60,7 +60,16 @@ build-integration-test: build-base-test
 .PHONY: build-kernelmodule
 build-kernelmodule:
 	cp -p ../gardenlinux.asc build-kernelmodule/gardenlinux.asc
-	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/build-kernelmodule:$(VERSION) build-kernelmodule
+	@$(GARDENLINUX_BUILD_CRE) build \
+			--build-arg VERSION=$(VERSION) \
+			--build-arg ARCH="arm64" \
+			--build-arg GNU_TYPE_PACKAGE="aarch64-linux-gnu"\
+			-t gardenlinux/build-kernelmodule-arm64:$(VERSION) build-kernelmodule
+	@$(GARDENLINUX_BUILD_CRE) build \
+			--build-arg VERSION=$(VERSION) \
+			--build-arg ARCH="amd64" \
+			--build-arg GNU_TYPE_PACKAGE="x86-64-linux-gnu" \
+			-t gardenlinux/build-kernelmodule-amd64:$(VERSION) build-kernelmodule
 	rm build-kernelmodule/gardenlinux.asc
 
 .PHONY: clean

--- a/container/build-kernelmodule/.gitignore
+++ b/container/build-kernelmodule/.gitignore
@@ -1,1 +1,1 @@
-packages/
+*.asc

--- a/container/build-kernelmodule/Dockerfile
+++ b/container/build-kernelmodule/Dockerfile
@@ -1,12 +1,27 @@
-ARG build_base_image=gardenlinux/build
-FROM	$build_base_image
+# TODO: switch to gardenlinux-slim
+FROM debian:bookworm-slim
+ARG	GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
+ARG VERSION
 
-RUN	sudo apt-get update \
-     &&	sudo apt-get install -y \
-		libelf1 git vim build-essential dh-make devscripts dkms
+# Setup Garden Linux Repository
+COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
+RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
+        && chmod 644 $GARDENLINUX_MIRROR_KEY
 
-# Install Garden Linux Kernel Build Dependencies for out of tree modules
-COPY packages/ /packages
-RUN sudo dpkg -i /packages/linux-kbuild*.deb
-RUN sudo dpkg -i /packages/linux-compiler-gcc*.deb
-RUN sudo dpkg -i /packages/linux-headers*.deb
+# ca-certificates is required to verify repo.gardenlinux.io
+RUN apt-get update && apt-get install -qy --no-install-recommends ca-certificates
+ADD ./gardenlinux-apt-preferences /etc/apt/preferences.d/gardenlinux
+
+RUN echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list.d/gardenlinux-$VERSION.list 
+
+
+
+# Install kernel live patch builder dependency
+RUN apt-get update && \
+    apt-get install -qy --no-install-recommends \
+    linux-image-6.1-amd64-dbg \
+    linux-headers-6.1-amd64 \
+    linux-kbuild-6.1 \
+    kpatch \
+    kpatch-build
+    

--- a/container/build-kernelmodule/Dockerfile
+++ b/container/build-kernelmodule/Dockerfile
@@ -2,6 +2,11 @@
 FROM debian:bookworm-slim
 ARG	GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
 ARG VERSION
+ARG GNU_TYPE_PACKAGE
+ARG ARCH
+
+
+RUN dpkg --add-architecture "$ARCH"
 
 # Setup Garden Linux Repository
 COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
@@ -10,18 +15,44 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
 
 # ca-certificates is required to verify repo.gardenlinux.io
 RUN apt-get update && apt-get install -qy --no-install-recommends ca-certificates
+
+# Pin linux-* packages to the garden linux repo, while keeping build dependency tools in debian mirror repo
 ADD ./gardenlinux-apt-preferences /etc/apt/preferences.d/gardenlinux
 
 RUN echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list.d/gardenlinux-$VERSION.list 
 
-
-
-# Install kernel live patch builder dependency
+# Install garden linux kernel header and debug definitions
 RUN apt-get update && \
     apt-get install -qy --no-install-recommends \
-    linux-image-6.1-amd64-dbg \
-    linux-headers-6.1-amd64 \
-    linux-kbuild-6.1 \
-    kpatch \
-    kpatch-build
+    linux-headers-6.1-${ARCH} \
+    linux-image-6.1-${ARCH}-dbg \
+    linux-kbuild-6.1
     
+# Install general kernel module build dependencies
+RUN apt-get update && \
+    apt-get install -qy --no-install-recommends \
+    bc \
+    build-essential \
+    cpio \
+    curl \
+    devscripts \
+    dkms \
+    dwarves \
+    flex \
+    git \
+    gnupg \
+    kernel-wedge \
+    kmod \
+    kpatch \
+    kpatch-build \
+    libelf-dev \
+    libncurses5-dev \
+    libssl-dev \
+    pristine-lfs \
+    python3 \
+    python3-debian \
+    quilt \
+    rsync \
+    sudo \
+    vim \
+    wget    

--- a/container/build-kernelmodule/gardenlinux-apt-preferences
+++ b/container/build-kernelmodule/gardenlinux-apt-preferences
@@ -1,0 +1,15 @@
+Package: *
+Pin: release o=GardenLinux
+Pin-Priority: 1000
+
+Package: linux-*
+Pin: release o=bookworm
+Pin-Priority: -1
+
+Package: linux-*
+Pin: release o=sid
+Pin-Priority: -1
+
+Package: linux-*
+Pin: release o=experimental
+Pin-Priority: -1


### PR DESCRIPTION
### What is different now?
* Deliver linux-image debug symbols via gardenlinux apt repo
* Pins `linux-*` packages to gardenlinux apt repo, but keeps debian repo as package repo for typical build dependencies
* arm64 and amd64 build container
* Version of kernelmodule build container matches the target Garden Linux Version
    * e.g. a  `gardenlinux/build-kernelmodule-amd64:1079`  container has the header and debug symbols installed for garden linux 1079