### PR TITLE
fix(build): Fix `macOS` build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ By default, Garden Linux uses [Podman](https://podman.io/) as container runtime 
 > # Install needed packages
 > brew install coreutils bash gnu-getopt gnu-sed gawk podman socat
 >
+> # Install Python dependencies via pip
+> pip3 install -r requirements.txt
+>
 > # Change to bash (Default: ZSH)
 > bash
 >


### PR DESCRIPTION
fix(build): Fix macOS build support
  * Adjust documentation to install Python dependencies by pip

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Fix macOS build support by adjusting the documentation regarding missing pip modules

**Which issue(s) this PR fixes**:
Fixes #1566

**Special notes for your reviewer**:
:warning: **Warning:** Only merge after PR #1565

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: bugfix
- target_group: developer
```
