### PR TITLE
fix(ci): github actions does not set pipefail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,11 @@ jobs:
       - name: resolve version "${{ inputs.version }}"
         id: version
         run: echo version="$(bin/garden-version "${{ inputs.version }}")" | tee -a "$GITHUB_OUTPUT"
+        shell: bash
       - name: bulid certificates
         if: ${{ ! inputs.use_kms }}
         run: make cert/secureboot.db.auth
+        shell: bash
       - name: use kms backed certificates
         if: ${{ inputs.use_kms }}
         run: |
@@ -43,8 +45,10 @@ jobs:
           for f in secureboot.{{pk,null.pk,kek,db}.auth,db.{crt,arn}}; do
             ln -sr "cert/gardenlinux-$f" "cert/$f"
           done
+        shell: bash
       - name: pack certificates for following bulid stages
         run: sudo tar -czv cert > cert.tar.gz
+        shell: bash
       - uses: actions/upload-artifact@v3
         with:
           name: _cert
@@ -68,18 +72,22 @@ jobs:
           name: _cert
       - name: unpack certificates from previous build stage
         run: sudo tar -xzvf cert.tar.gz && rm cert.tar.gz
+        shell: bash
       - name: write secureboot db arn for kms backed certificates
         if: ${{ inputs.use_kms }}
         run: echo "${{ secrets.secureboot_db_kms_arn }}" > cert/gardenlinux-secureboot.db.arn
+        shell: bash
       - name: set VERSION=${{ needs.setup.outputs.version }}
         run: |
           bin/garden-version "${{ needs.setup.outputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
+        shell: bash
       - name: get cname
         run: |
           cname="$(bin/garden-feat --features ${{ matrix.target }}${{ matrix.modifier }}${{ matrix.additional_modifer }})"
           artifact_name="$cname-${{ matrix.architecture }}-${{ needs.setup.outputs.version }}-$(git rev-parse --short HEAD)"
           printf 'cname=%s\nartifact_name=%s\n' "$cname" "$artifact_name" | tee -a "$GITHUB_ENV"
+        shell: bash
       - if: ${{ inputs.use_kms }}
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -88,10 +96,12 @@ jobs:
           aws-region: ${{ secrets.aws_region }}
       - name: build Garden Linux image
         run: make BUILD_OPTS="--lessram ${{ inputs.use_kms && '--export-aws-access-key' || '' }}" "${{ env.cname }}"
+        shell: bash
       - name: pack build artifacts for upload
         run: |
           mv .build "${{ env.artifact_name }}"
           tar -czvf "${{ env.artifact_name }}.tar.gz" "${{ env.artifact_name }}"
+        shell: bash
       - uses: actions/upload-artifact@v3
         with:
           name: "build-${{ env.artifact_name }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,21 +62,26 @@ jobs:
 
     - name: login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u $ --password-stdin
+      shell: bash
 
     - name: pull container image
       run: |
         sudo podman pull "ghcr.io/gardenlinux/gardenlinux/integration-test:$GITHUB_SHA"
         sudo podman tag "ghcr.io/gardenlinux/gardenlinux/integration-test:$GITHUB_SHA" ghcr.io/gardenlinux/gardenlinux/integration-test:today
+      shell: bash
 
     - name: set VERSION=${{ inputs.version }}
       run: |
         bin/garden-version "${{ inputs.version }}" | tee VERSION
         git update-index --assume-unchanged VERSION
+      shell: bash
+
     - name: get cname
       run: |
         cname="$(bin/garden-feat --features ${{ matrix.target }}${{ matrix.modifier }}${{ matrix.additional_modifer }})"
         artifact_name="$cname-${{ matrix.architecture }}-${{ inputs.version }}-$(git rev-parse --short HEAD)"
         printf 'cname=%s\nartifact_name=%s\n' "$cname" "$artifact_name" | tee -a "$GITHUB_ENV"
+      shell: bash
 
     - uses: actions/download-artifact@v3
       with:
@@ -111,7 +116,8 @@ jobs:
 
     - name: start platform test for ${{ matrix.target }}
       run: |
-        .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.architecture }}" "${{ env.artifact_name }}.tar.gz" 2>&1 | tee "${{ env.artifact_name }}.integration-tests-log"
+        set -o pipefail && .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.architecture }}" "${{ env.artifact_name }}.tar.gz" 2>&1 | tee "${{ env.artifact_name }}.integration-tests-log"
+      shell: bash
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -79,13 +79,16 @@ jobs:
         run: |
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
+        shell: bash
       - name: get cname
         run: |
           cname="$(bin/garden-feat --features ${{ matrix.target }}${{ matrix.modifier }}${{ matrix.additional_modifer }})"
           artifact_name="$cname-${{ matrix.architecture }}-${{ inputs.version }}-$(git rev-parse --short HEAD)"
           printf 'cname=%s\nartifact_name=%s\n' "$cname" "$artifact_name" | tee -a "$GITHUB_ENV"
+        shell: bash
       - uses: actions/download-artifact@v3
         with:
           name: tests-${{ env.artifact_name }}
       - name: upload to S3 bucket ${{ secrets.bucket }}
         run: aws s3 cp "${{ env.artifact_name }}.integration-tests-log" "s3://${{ secrets.bucket }}/objects/${{ env.artifact_name }}/"
+        shell: bash


### PR DESCRIPTION
The bash set builtin "pipefail" is not set by run-actions in github actions. 
See GitHub Docs [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference) and also [here](https://github.com/actions/runner/blob/main/docs/adrs/0277-run-action-shell-options.md).

An additional keyword "shell" can be specified, which has other defaults then leaving "shell" unspecified.
"shell: bash" sets the defaults to
```
bash --noprofile --norc -eo pipefail {0}
```
If `shell: bash` is not specified, pipefail is unset.

## Why is this an issue?

The simplified code:
```
false | tee some/log/destination
```
will return a non-error code 0, if tee was successful. 
This is obviously not what we want when executing a test.

To connect the link to our test issues: we replace false with a test that returned an error exit code. In our case: 

```
.github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.architecture }}" "${{ env.artifact_name }}.tar.gz" 2>&1 | tee "${{ env.artifact_name }}.integration-tests-log"
```
Thus, we will end up with always green tests. even if the test.sh returned an error code.

bash pipefail docs [here](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html):
```
pipefail
    If set, the return value of a pipeline is the value of the last (rightmost) command to exit
    with a non-zero status, or zero if all commands in the pipeline exit successfully. 
    This option is disabled by default.
```