### PR TITLE
Improving automatic platform tests for rel-934

### DIFF
--- a/.github/workflows/aws_tests.sh
+++ b/.github/workflows/aws_tests.sh
@@ -67,10 +67,18 @@ EOF
 
 echo "### Start Integration Tests for AWS"
 env_list="$(env | cut -d = -f 1 | grep '^AWS_' | tr '\n' ',' | sed 's/,$//')"
-sudo --preserve-env="$env_list" podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
+sudo --preserve-env="$env_list" podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << _EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
-pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-aws.xml || exit 1
-exit 0
-EOF
+
+pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-aws.xml
+
+pytest_rc=\$?
+echo PyTest exited with rc=\$pytest_rc
+exit \$pytest_rc
+_EOF
+
+container_rc=$?
+echo "Test container exited with rc=$container_rc"
+exit $container_rc

--- a/.github/workflows/azure_tests.sh
+++ b/.github/workflows/azure_tests.sh
@@ -47,11 +47,18 @@ azure:
 EOF
 
 echo "### Start Integration Tests for Azure"
-sudo podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s <<EOF
+sudo podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << _EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
 
-pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-azure.xml || exit 1
-exit 0
-EOF
+pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-azure.xml
+
+pytest_rc=\$?
+echo PyTest exited with rc=\$pytest_rc
+exit \$pytest_rc
+_EOF
+
+container_rc=$?
+echo "Test container exited with rc=$container_rc"
+exit $container_rc

--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -44,11 +44,19 @@ EOF
 credFileName=$(find "$(pwd)" -maxdepth 1 -type f -name "gha-creds-*.json" | xargs basename)
 
 echo "### Start Integration Tests for gcp"
-sudo podman run -it --rm  -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s <<EOF
+sudo podman run -it --rm  -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << _EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
 export GOOGLE_APPLICATION_CREDENTIALS="/gardenlinux/$credFileName"
-pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-gcp.xml || exit 1
-exit 0
-EOF
+
+pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/gardenlinux/test-$prefix-gcp.xml
+
+pytest_rc=\$?
+echo PyTest exited with rc=\$pytest_rc
+exit \$pytest_rc
+_EOF
+
+container_rc=$?
+echo "Test container exited with rc=$container_rc"
+exit $container_rc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,9 +106,10 @@ jobs:
 
     - name: start platform test for ${{ matrix.target }}
       run: |
-        name="${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.architecture }}-$(bin/garden-version)-$(git rev-parse --short HEAD)"
+        set -o pipefail && name="${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.architecture }}-$(bin/garden-version)-$(git rev-parse --short HEAD)"
         .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.architecture }}" "${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.architecture }}-*.tar.gz" 2>&1 | tee "$name.integration-tests-log"
-
+      shell: bash
+      
     - uses: actions/upload-artifact@v2
       with:
         name: test-log-${{ matrix.architecture }}-${{ matrix.target }}${{ matrix.modifier }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Improves output of automatic platform test and actually fixes the pipeline for the platform tests in the `rel-934` branch.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Fixes the automatic test pipeline for the rel-934 release of Garden Linux.
```
