### PR TITLE
fix: bring back latest register_image fun with boot and uefi feature

### DIFF
--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -39,13 +39,16 @@ def register_image(
     snapshot_id: str,
     image_name: str,
     architecture: str,
+    boot_mode: str='',
+    uefi_data: str='',
 ) -> str:
     '''
     @return: ami-id of registered image
     '''
     root_device_name = '/dev/xvda'
 
-    result = ec2_client.register_image(
+    # Define arguments for register_image
+    arguments = dict(
         # ImageLocation=XX, s3-url?
         Architecture=architecture,
         BlockDeviceMappings=[
@@ -62,8 +65,19 @@ def register_image(
         EnaSupport=True,
         Name=image_name,
         RootDeviceName=root_device_name,
-        VirtualizationType='hvm' # | paravirtual
+        VirtualizationType='hvm', # | paravirtual
     )
+
+    # Check if boot mode and uefi data
+    # are set properly and add them to
+    # the arguments
+    if len(boot_mode) > 0:
+        arguments['BootMode'] = boot_mode
+    if len(uefi_data) > 0:
+        arguments['UefiData'] = uefi_data
+
+    # Now, register image
+    result = ec2_client.register_image(**arguments)
 
     ec2_client.create_tags(
         Resources=[


### PR DESCRIPTION
* glci code was removed from this repo, but it did contain important changes.
* the code in gardenlinux/glci did not contain these important changes
* bringing back the outdated function from glci caused a broken setup.
* this commit fixes this issue
