### PR TITLE
fix(resolved): disable LLMNR and mDNS

### DIFF
--- a/features/server/file.include/etc/systemd/resolved.conf.d/00-disable-llmnr.conf
+++ b/features/server/file.include/etc/systemd/resolved.conf.d/00-disable-llmnr.conf
@@ -1,0 +1,2 @@
+[Resolve]
+LLMNR=no

--- a/features/server/file.include/etc/systemd/resolved.conf.d/01-disable-mdns.conf
+++ b/features/server/file.include/etc/systemd/resolved.conf.d/01-disable-mdns.conf
@@ -1,0 +1,2 @@
+[Resolve]
+MulticastDNS=no


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of security implications, after discussions with @gehoern and @damyan we decided to disable LLMNR and mDNS in systemd-resolved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
