### PR TITLE
ci: add differential-shellcheck action

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,33 @@
+name: Differential ShellCheck
+on:
+  pull_request:
+    branches:
+    - main
+    - rel-*
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a gh action to run shellcheck on new code without throwing warning for long-time running existing code.
Re-uses the shared GH action: https://github.com/redhat-plumbers-in-action/differential-shellcheck

**Which issue(s) this PR fixes**:
Fixes #1577 

**Special notes for your reviewer**:
Runs for PRs against main and rel- branches.
