### PR TITLE
fix(github runner): include python dependencies via apt

### DIFF
--- a/features/githubActionRunner/pkg.include
+++ b/features/githubActionRunner/pkg.include
@@ -1,4 +1,5 @@
 awscli
+azure-cli
 curl
 git
 gnupg
@@ -6,4 +7,5 @@ jq
 make
 nodejs
 podman
-azure-cli
+python3-networkx
+python3-yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently have python dependencies to build Garden Linux.
The user needs to decide how these python dependencies are installed in a build environment.

In case of the GitHub Action Runner, we should use apt as long as we are going the "self-hosted" ami route. 

This PR just adds missing dependencies to: 
`features/githubActionRunner`.

For a public runner, we may want to use the requirements.txt and something else to install CRE and stuff (not topic of this PR)