### PR TITLE
[cloud] console order in in 00-default.cfg

### DIFF
--- a/features/cloud/file.include/etc/kernel/cmdline.d/00-default.cfg
+++ b/features/cloud/file.include/etc/kernel/cmdline.d/00-default.cfg
@@ -1,5 +1,5 @@
 # DO NOT CHANGE THIS FILE! USE /etc/kernel/cmdline.d
-CMDLINE_LINUX="ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0"
+CMDLINE_LINUX="ro console=ttyS0,115200 console=tty0 earlyprintk=ttyS0,115200 consoleblank=0"
 DEVICE="LABEL=ROOT"
 # WARNING! 0 disables the TIMEOUT
 TIMEOUT=1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

When testing ignition on vmware image I was not getting any kernel output in the console - was not able to see why ignition run was failing. This changed order fixes the issue for vmware environment. Kindly verify the behaviour in other environments.

I noticed that [metal](https://github.com/gardenlinux/gardenlinux/blob/main/features/metal/file.include/etc/kernel/cmdline.d/00-default.cfg) uses the same configuration.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Here is how the output looked before (not able to do anything here):
![Screenshot 2023-03-30 at 17 53 43](https://user-images.githubusercontent.com/13087245/229113428-0d82a09d-2bff-41f9-9b32-a94c5d6b6e7e.png)

And this is how it looks after. I'm now able to see a failed igntion run, enter emergency shell, etc.
![Screenshot 2023-03-31 at 14 54 59](https://user-images.githubusercontent.com/13087245/229113701-44a20909-7d4b-4ca2-a68f-49ec10c2e845.png)
