### PR TITLE
fix(azure test): make nopasswd explicit

### DIFF
--- a/tests/helper/tests/users.py
+++ b/tests/helper/tests/users.py
@@ -62,12 +62,17 @@ def users(client, additional_user = "", additional_sudo_users=[]):
 
 def _has_user_sudo_cmd(client, user):
     """ Check if user has any sudo permissions """
+
+    # make sure executing user is in wheel group
+    cmd = "usermod -a -G wheel $(whoami)"
+    out = utils.execute_remote_command(client, cmd)
+
     # Execute command on remote platform
     cmd = f"sudo -l -U {user}"
     out = utils.execute_remote_command(client, cmd)
 
     # Write each line as output in list
-    output_lines = [] 
+    output_lines = []
     for line in out.split("\n"):
        output_lines.append(line)
 


### PR DESCRIPTION
* A test checks the permissions returned via "sudo -l -U $user" for all available users.
To perform this tests, the admin user must be
able to execute it without entering a password
in a test setup.
For all other cloud providers we do this implicitly already via cloud-init or something else.
For Azure this is not managed by garden linux,
but by the user (in this example, the platform tests.)
