### PR TITLE
fix: differential-shellcheck on push event

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,5 +1,9 @@
 name: Differential ShellCheck
 on:
+  push:
+    branches:
+    - main
+    - rel-*
   pull_request:
     branches:
     - main


### PR DESCRIPTION
Run differential-shellcheck on push event to avoid comments from github-code-scanning on every PR.
* see https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215
