### PR TITLE
fix: serial console default on cloud provider

### DIFF
--- a/features/ali/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/ali/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/aws/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/aws/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/azure/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/azure/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/cloud/file.include/etc/kernel/cmdline.d/00-default.cfg
+++ b/features/cloud/file.include/etc/kernel/cmdline.d/00-default.cfg
@@ -1,5 +1,5 @@
 # DO NOT CHANGE THIS FILE! USE /etc/kernel/cmdline.d
-CMDLINE_LINUX="ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0"
+CMDLINE_LINUX="ro earlyprintk=ttyS0,115200 consoleblank=0"
 DEVICE="LABEL=ROOT"
 # WARNING! 0 disables the TIMEOUT
 TIMEOUT=1

--- a/features/gardener/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/gardener/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/gcp/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/gcp/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/kvm/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/kvm/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/metal/file.include/etc/kernel/cmdline.d/00-default.cfg
+++ b/features/metal/file.include/etc/kernel/cmdline.d/00-default.cfg
@@ -1,5 +1,5 @@
 # DO NOT CHANGE THIS FILE! USE /etc/kernel/cmdline.d
-CMDLINE_LINUX="ro console=ttyS0,115200 console=tty0 earlyprintk=ttyS0,115200 consoleblank=0"
+CMDLINE_LINUX="ro earlyprintk=ttyS0,115200 consoleblank=0"
 DEVICE="LABEL=ROOT"
 # WARNING! 0 disables the TIMEOUT
 TIMEOUT=1

--- a/features/metal/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/metal/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0,115200 $CMDLINE_LINUX" 

--- a/features/openstack/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/openstack/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/vmware/file.include/etc/kernel/cmdline.d/00-default.cfg
+++ b/features/vmware/file.include/etc/kernel/cmdline.d/00-default.cfg
@@ -1,5 +1,5 @@
 # DO NOT CHANGE THIS FILE! USE /etc/kernel/cmdline.d
-CMDLINE_LINUX="ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0"
+CMDLINE_LINUX="ro console=ttyS0,115200 console=tty0 earlyprintk=ttyS0,115200 consoleblank=0"
 DEVICE="LABEL=ROOT"
 # WARNING! 0 disables the TIMEOUT
 TIMEOUT=1

--- a/features/vmware/file.include/etc/kernel/cmdline.d/00-default.cfg
+++ b/features/vmware/file.include/etc/kernel/cmdline.d/00-default.cfg
@@ -1,5 +1,0 @@
-# DO NOT CHANGE THIS FILE! USE /etc/kernel/cmdline.d
-CMDLINE_LINUX="ro console=ttyS0,115200 console=tty0 earlyprintk=ttyS0,115200 consoleblank=0"
-DEVICE="LABEL=ROOT"
-# WARNING! 0 disables the TIMEOUT
-TIMEOUT=1

--- a/features/vmware/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/vmware/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=ttyS0,115200 console=tty0 $CMDLINE_LINUX"


### PR DESCRIPTION
See #1614 for the reason why vmware needs a different order
Other cloud flavors should keep the serial console as default, also the start-vm feature does not work if serial console is not default.