### PR TITLE
fix(pxe): enable gl-live dracut module, remove extra dracut run

### DIFF
--- a/features/_pxe/exec.config
+++ b/features/_pxe/exec.config
@@ -1,7 +1,1 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
-
-# rebuild the initramfs
-for kernel in /boot/vmlinuz-*; do 
-   dracut -f /boot/initrd.img-${kernel#*-} ${kernel#*-} -m "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown systemd-networkd systemd-resolved gardenlinux-live ignition" --reproducible
-done

--- a/features/_pxe/file.include/etc/dracut.conf.d/20-gl-live.conf
+++ b/features/_pxe/file.include/etc/dracut.conf.d/20-gl-live.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" gardenlinux-live "

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-sysroot-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-sysroot-generator.sh
@@ -6,6 +6,7 @@ set -e
 
 GENERATOR_DIR=$1
 
+getarg gl.ovl= > /dev/null || exit 0
 ovlconf=$(getarg gl.ovl=)
 ovlconf=${ovlconf#gl.ovl=}
 

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
@@ -12,6 +12,7 @@ if [ ! -e /run/root.squashfs ]; then
 	if [ -e /root.squashfs ]; then
 		mv /root.squashfs /run/root.squashfs
 	else
+		getarg gl.url= > /dev/null || exit 0
 		cat >"${GENERATOR_DIR}/live-get-squashfs.service" <<-EOF
 		[Unit]
 		Description=Download squashfs image


### PR DESCRIPTION
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
As stated in #1601 ignition doesn't seem to work properly when building *_pxe and this is because it's not booting properly, because the gardenlinux-live dracut module is not added when the initrd is generated. This is happening because the order of features, when building, has changed. 
These changes here ensure the gardenlinux-live dracut module is enabled when _pxe is used and an extra initrd generation is not needed (done in cloud/metal).

**Which issue(s) this PR fixes**:
Fixes #1601 