### PR TITLE
fix: kvm platform tests

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -100,6 +100,7 @@ set_defaults () {
     monitor=1
     bridge=
     daemonize=
+    no_watchdog=0
     pxe=
     pxe_binary=
     pxefile=${CURR_DIR}/../examples/ipxe/start-vm.ipxe
@@ -143,14 +144,14 @@ set_defaults () {
 # passed to this script
 get_opts () {
 source "${CURR_DIR}/.constants.sh" \
-    --flags 'daemonize,uefi,skipkp,vnc' \
+    --flags 'daemonize,no-watchdog,uefi,skipkp,vnc' \
     --flags 'cpu:,mem:,bridge:,port:,mac:,arch:' \
     --flags 'pxe:' \
     --flags 'ignfile:' \
     --flags 'pidfile:' \
     --flags 'ueficode:,uefivars:' \
     --flags 'destport:' \
-    --usage '[ --daemonize ] [ --cpu:<#> ] [ --mem:<size> ] [ --pxe:<dir> ] [<image file>[,<size>]]*' \
+    --usage '[ --daemonize ] [--no-watchdog] [ --cpu:<#> ] [ --mem:<size> ] [ --pxe:<dir> ] [<image file>[,<size>]]*' \
     --sample '.build/rootfs.raw' \
     --sample ',1G ubuntu-16.04.7-server-amd64.iso' \
     --help  "Starts a virtual machine with the most basic environment, needed. Perfect use for test cases and running samples of GardenLinux. This script can run unprivileged but it should have the possibility to use kvm (group kvm) otherwise it will be super slow. If not being root, the network will be slow and no ICMP (ping) capabilities are with the VM.
@@ -168,6 +169,7 @@ source "${CURR_DIR}/.constants.sh" \
 --ignfile   <path>        Provide an ignition file when pxe booting. Can be used standalone.
 --pidfile   <path>        Provide a file where to store the pid of the started qemu vm.
 --daemonize <bool>        Start the virtual machine in background, console deactivated (default: no).
+--no-watchdog <bool>        Disables the watchdog qemu option. Used for kvm tests on podman
 --skipkp    <bool>        Skip the keypress to the verify status before execute.
 --vnc       <bool>        Sitches from serial console to vnc graphics console / enables vnc in --daemonize.
 <image file>              A file containing the image to boot. Format is determined by the extension (raw, vdi, vpc, vhd, vhdx, vmdk, qcow2, iso)."
@@ -181,6 +183,7 @@ while true; do
         --arch)         arch="$1";      shift ;;
         --mem)          memory="$1";    shift ;;
         --daemonize)    daemonize=1;    keypress=; ;;
+        --no-watchdog)  no_watchdog=1;        ;;
         --vnc)          vnc=1;                ;;
         --uefi)         uefi=1;               ;;
         --mac)          mac="$1";       shift ;;
@@ -599,7 +602,7 @@ qemu_opt_monitor () {
     fi
 
     # Add Watchdog
-    if [ $os = debian ]; then
+    if [ $os = debian ] && [ "$no_watchdog" = 0 ]; then
         # add a watchdog to maintain automatic reboots
         QEMU_OPTS+=("-watchdog i6300esb")
     fi

--- a/tests/integration/kvm.py
+++ b/tests/integration/kvm.py
@@ -254,6 +254,7 @@ class KVM:
         if arch == "amd64":
             cmd = f"/gardenlinux/bin/start-vm \
               --daemonize \
+              --no-watchdog \
               --arch x86_64 \
               --port {port} \
               --destport 2222 \
@@ -263,6 +264,7 @@ class KVM:
         elif arch == "arm64":
             cmd = f"/gardenlinux/bin/start-vm \
               --daemonize \
+              --no-watchdog \
               --arch aarch64 \
               --port {port} \
               --destport 2222 \


### PR DESCRIPTION
* using start-vm inside the test container (podman) does not work, since the watchdog option is not available
* kvm tests can not connect, because the start-vm never started
