### PR TITLE
fix: increase nslookup test timeout for azure

### DIFF
--- a/features/base/test/test_network.py
+++ b/features/base/test/test_network.py
@@ -4,14 +4,19 @@ from helper.sshclient import RemoteClient
 
 
 def test_hostname_azure(client, azure):
-    """ Test for valid hostname on azure platform """
+    """ Test for valid hostname on azure platform. 
+    The OS is responsible to register its hostname to Azure DNS.
+    This test checks if hostname registration was successfull. 
+    Only required on azure. 
+    See: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/provisioning
+    """
     start_time = datetime.datetime.now()
     (exit_code, output, error) = client.execute_command("nslookup $(hostname)")
     assert exit_code == 0, f"no {error=} expected"
     end_time = datetime.datetime.now()
     time_diff = (end_time - start_time)
     execution_time = round(time_diff.total_seconds())
-    assert execution_time <= 2, f"nslookup should not run in a timeout {error}"
+    assert execution_time <= 10, f"nslookup should not run in a timeout {error}"
 
 
 @pytest.fixture(params=["8.8.8.8", "dns.google", "heise.de"])


### PR DESCRIPTION
**How to categorize this PR?**
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Azure requires the OS to register its hostname against the azure DNS.

We have a test that checks if `nslookup $(hostname)`  does not return an error exit code 
**AND** the lookup was faster than 2 seconds.

- Increase timeout of azure specific nslookup test to 10 seconds:
    * hostname is registered on the azure dns during boot
    * registration is performed by cloud-init in our case
    * The timeout of 2 seconds can be too small, because the hostname was just registered on the
azure DNS.
    * garden linux responsibility is to register it, but garden linux has no direct impact on
dns performance
- Added description to test docstring

**Special notes for your reviewer**:
* running `nslookup $(hostname)` on a booted garden linux vm on azure returns a valid answer.
* tested with `make azure-gardener_prod` generated image of current main f130ddb

