### PR TITLE
fix(tests): workaround for azure sudo -l -U check

### DIFF
--- a/tests/helper/tests/users.py
+++ b/tests/helper/tests/users.py
@@ -64,7 +64,7 @@ def _has_user_sudo_cmd(client, user):
     """ Check if user has any sudo permissions """
 
     # Execute command on remote platform
-    cmd = f"sudo -l -U {user}"
+    cmd = f"sudo -s sudo -l -U {user}"
     out = utils.execute_remote_command(client, cmd)
 
     # Write each line as output in list


### PR DESCRIPTION
**How to categorize this PR?**
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
The user tests are performed by the azureuser
on azure. In theory, azureuser should have full admin priviledges and, just like root, no requirement
to enter a password for sudo.

However:
* `sudo -l -U` requires a password
* `sudo -s sudo -l -U` works passwordless
* this commit is a workaround so the test can do the actual check if any user on the image
has un-intendet sudo priviledges.

**Special notes for your reviewer**:
