### PR TITLE
hack(gl-search): download garden linux package

### DIFF
--- a/hack/gl-search.sh
+++ b/hack/gl-search.sh
@@ -10,8 +10,9 @@
 # - search: find what packages are available in Garden Linux apt repo
 # - dep-check: check if dependencies of a package are available in Garden Linux repo
 # - rdepends: (EXPERIMENTAL) find what package in garden linux depends on this package
+# - download: downloads the selected deb package
 
-gl_selected_action="$(echo -e "search\ndep-check\nrdepends" | fzf --header 'Select Action' )"
+gl_selected_action="$(echo -e "search\ndep-check\nrdepends\ndownload" | fzf --header 'Select Action' )"
 gls_gl_dist="$(echo "today" |fzf --header 'Enter the Garden Linux Version you are interested in, or select today' --print-query | tail -1)"
 export gls_gl_dist
 
@@ -24,7 +25,8 @@ if [ "$gls_gl_dist" != "today" ]; then
   fi
 fi  
 
-repo_url="http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/Release?ignoreCaching=1"
+base_url="http://repo.gardenlinux.io/gardenlinux"
+repo_url="$base_url/dists/${gls_gl_dist}/Release?ignoreCaching=1"
 
 # Check if repo exists for user provided garden linux version string
 if curl -s "$repo_url" | grep -q "Error"; then
@@ -38,7 +40,7 @@ export gls_selected_arch
 packages_file=$(mktemp)
 export packages_file
 trap 'rm -rf -- "$packages_file"' EXIT
-curl -s "http://repo.gardenlinux.io/gardenlinux/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages?ignoreCaching=1" > "$packages_file"
+curl -s "$base_url/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Packages?ignoreCaching=1" > "$packages_file"
 
 export packages_file
 
@@ -89,6 +91,14 @@ function rdepends_package(){
   
 }
 
+function get_filename(){
+  pkg="$1"
+  gardenlinux_packages="$(get_packages "$pkg")"
+  # check all garden linux packages
+  filename=$(sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "Filename:" | cut -d':' -f 2)
+  echo "$filename" | xargs
+   
+}
 # fzf preview requires function to be available in spawned subshell
 export -f filter_package_info
 export -f dependency_search
@@ -96,16 +106,38 @@ export -f get_dependencies
 export -f does_pkg_exist
 export -f rdepends_package
 export -f get_packages
-
+export -f get_filename
 case "$gl_selected_action" in
   "dep-check")
-    grep "^Package:.*" "$packages_file" | fzf --multi --preview "bash -c \"packages_file=$packages_file dependency_search {2}\"" --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
+    grep "^Package:.*" "$packages_file" |  cut -d' ' -f 2 | \
+      fzf \
+      --multi \
+      --preview "bash -c \"packages_file=$packages_file dependency_search {1}\"" \
+      --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
+    ;;
+  "download")
+    selected_pkg=$(grep "^Package:.*" "$packages_file" | cut -d' ' -f 2 | \
+      fzf --header 'Select Garden Linux Package you want to download.')
+    filename=$(get_filename "$selected_pkg")
+    if [ -z "$filename" ]; then
+      echo "No file found for $selected_pkg"
+    else
+      wget "$base_url/$filename"
+    fi
     ;;
   "search")
-    grep "^Package:.*" "$packages_file" | fzf --multi --preview "bash -c \"packages_file=$packages_file filter_package_info {2}\"" --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
+    grep "^Package:.*" "$packages_file" | cut -d' ' -f 2 | \
+      fzf \
+      --multi \
+      --preview "bash -c \"packages_file=$packages_file filter_package_info {1}\""\
+      --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
     ;;
   "rdepends")
-    grep "^Package:.*" "$packages_file" | fzf --multi --preview "bash -c \"packages_file=$packages_file rdepends_package {2}\"" --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
+    grep "^Package:.*" "$packages_file" | cut -d' ' -f 2 | \
+      fzf \
+      --multi \
+      --preview "bash -c \"packages_file=$packages_file rdepends_package {1}\"" \
+      --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
     ;;
   *)
     echo "Unknown action..."


### PR DESCRIPTION
**What this PR does**:
* Adds a `download` option to the `hack/gl-search` tool. Browse, select and download any package from repo.gardenlinux.io without apt 

**Why we need it**
* Convenient and apt-independent method to quickly download a garden linux package
    * Useful if you are on mac, a non-debian based distro or don't want to add repo.gardenlinux.io to your apt sources.
* option to download packages is useful if you want to debug, analyze or test a package without building a Garden Linux

**Special notes for your reviewer**:
* `gl-search` is a tool with a terminal based user interface, it is not designed for automation
* Requirement is `fzf` 
* PR includes unrelated refactor in package selection code