### PR TITLE
fix(azure): cloud-init configuration

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# disable cloud-init network configuration
-echo -e "network:\n  config: disabled\n" >> /etc/cloud/cloud.cfg.d/00_azure.cfg

--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/02_azure-datasources.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/02_azure-datasources.cfg
@@ -1,0 +1,1 @@
+datasource_list: [ Azure ]

--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/03_azure-modules.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/03_azure-modules.cfg
@@ -7,6 +7,7 @@ cloud_init_modules:
  - update_etc_hosts
  - ca-certs
  - users-groups
+ - ssh
 
 cloud_config_modules:
  - ssh-import-id

--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/03_azure-modules.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/03_azure-modules.cfg
@@ -1,0 +1,42 @@
+cloud_init_modules:
+ - seed_random
+ - bootcmd
+ - write-files
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - ca-certs
+ - users-groups
+
+cloud_config_modules:
+ - ssh-import-id
+ - locale
+ - set-passwords
+ - apt-pipelining
+ - timezone
+ - runcmd
+ - byobu
+
+cloud_final_modules:
+ - package-update-upgrade-install
+ - fan
+ - landscape
+ - lxd
+ - write-files-deferred
+ - puppet
+ - mcollective
+ - salt-minion
+ - reset_rmc
+ - refresh_rmc_and_interface
+ - rightscale_userdata
+ - scripts-vendor
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - install-hotplug
+ - phone-home
+ - final-message
+ - power-state-change

--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
@@ -1,0 +1,1 @@
+network: {config: disabled}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Cloud init on azure was not optimal, some modules were redundant to our garden linux configuration (ntp).

* Disable network via config
* Configure datasource to speed up boot process
* Disable the following cloud-init modules
```
<  - migrator
<  - growpart
<  - resizefs
<  - disk_setup
<  - mounts
<  - rsyslog
<  - snap
<  - keyboard
<  - grub-dpkg
<  - apt-configure
<  - ntp
<  - disable-ec2-metadata
<  - chef
<  - power-state-change
```

**Which issue(s) this PR fixes**:
Fixes #1633 
This PR should be used instead of increasing the time thresholds (e.g. via #1634)

Credits for this PR also to @MrBatschner and @marwinski.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
