### PR TITLE
fix: disable unneeded kernel modules

### DIFF
--- a/features/azure/file.exclude
+++ b/features/azure/file.exclude
@@ -1,1 +1,2 @@
 /etc/systemd/system/systemd-timesyncd.service.d/override.conf
+/etc/modprobe.d/disabled_udf.conf

--- a/features/cloud/file.include/etc/modprobe.d/disabled_firewire.conf
+++ b/features/cloud/file.include/etc/modprobe.d/disabled_firewire.conf
@@ -1,0 +1,2 @@
+blacklist firewire-core
+install firewire-core /bin/true

--- a/features/cloud/file.include/etc/modprobe.d/disabled_fs.conf
+++ b/features/cloud/file.include/etc/modprobe.d/disabled_fs.conf
@@ -1,0 +1,10 @@
+blacklist cramfs
+install cramfs /bin/true
+blacklist freevxfs
+install freevxfs /bin/true
+blacklist jffs2
+install jffs2 /bin/true
+blacklist hfs
+install hfs /bin/true
+blacklist hfsplus
+install hfsplus /bin/true

--- a/features/cloud/file.include/etc/modprobe.d/disabled_net.conf
+++ b/features/cloud/file.include/etc/modprobe.d/disabled_net.conf
@@ -1,0 +1,8 @@
+blacklist dccp
+install dccp /bin/true
+blacklist sctp
+install sctp /bin/true
+blacklist rds
+install rds /bin/true
+blacklist tipc
+install tipc /bin/true

--- a/features/cloud/file.include/etc/modprobe.d/disabled_udf.conf
+++ b/features/cloud/file.include/etc/modprobe.d/disabled_udf.conf
@@ -1,0 +1,2 @@
+blacklist udf
+install udf /bin/true

--- a/features/cloud/file.include/etc/modprobe.d/disabled_usb.conf
+++ b/features/cloud/file.include/etc/modprobe.d/disabled_usb.conf
@@ -1,0 +1,6 @@
+blacklist usbcore
+install usbcore /bin/true
+blacklist usb-common
+install usb-common /bin/true
+blacklist usb-storage
+install usb-storage /bin/true


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of SAP requirements, we're disabling various unneeded kernel modules.

**Which issue(s) this PR fixes**:
Fixes #