### PR TITLE
fix: fix content and permissions on audit rules

### DIFF
--- a/features/log/file.include.stat
+++ b/features/log/file.include.stat
@@ -1,0 +1,1 @@
+root root 0640 /etc/audit/rules.d/*-*.rules

--- a/features/sap/file.include.stat
+++ b/features/sap/file.include.stat
@@ -1,0 +1,3 @@
+root	root	0640 /etc/audit/rules.d/privilege_escalation.rules
+root	root	0640 /etc/audit/rules.d/privileged_special.rules
+root	root	0640 /etc/audit/rules.d/system_integrity.rules

--- a/features/sap/file.include/etc/audit/rules.d/privilege_escalation.rules
+++ b/features/sap/file.include/etc/audit/rules.d/privilege_escalation.rules
@@ -1,5 +1,4 @@
 -a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation
 -a exit,always -F arch=b32 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation
-
 -a exit,always -F arch=b64 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation
 -a exit,always -F arch=b32 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation

--- a/features/sap/file.include/etc/audit/rules.d/system_integrity.rules
+++ b/features/sap/file.include/etc/audit/rules.d/system_integrity.rules
@@ -5,3 +5,7 @@
 -a exit,always -F dir=/usr -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/opt -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/root -F perm=wa -F key=system_integrity
+-a exit,always -F dir=/lib -F perm=wa -F key=system_integrity
+-a exit,always -F dir=/libx32 -F perm=wa -F key=system_integrity
+-a exit,always -F dir=/lib32 -F perm=wa -F key=system_integrity
+-a exit,always -F dir=/lib64 -F perm=wa -F key=system_integrity


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of SAP requirements, the audit rules files should have 0640 permissions.

**Which issue(s) this PR fixes**:
Fixes #
