### PR TITLE
SAP specific changes

### DIFF
--- a/features/cloud/file.include/etc/profile.d/50-autologout.sh
+++ b/features/cloud/file.include/etc/profile.d/50-autologout.sh
@@ -1,4 +1,4 @@
 # shellcheck shell=sh disable=SC2148
-TMOUT=600
+TMOUT=900
 readonly TMOUT
 export TMOUT

--- a/features/cloud/test/test_autologout.py
+++ b/features/cloud/test/test_autologout.py
@@ -10,7 +10,7 @@ import pytest
     "file,dict",
     [
         ("/etc/profile.d/50-autologout.sh", {
-            "TMOUT": "600",
+            "TMOUT": "900",
             "readonly": "TMOUT",
             "export": "TMOUT"
         })

--- a/features/sap/exec.post
+++ b/features/sap/exec.post
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+$thisDir/garden-chroot $targetDir rm /var/log/README

--- a/features/sap/exec.post
+++ b/features/sap/exec.post
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-$thisDir/garden-chroot $targetDir rm /var/log/README
+# shellcheck shell=sh disable=SC2154
+"$thisDir/garden-chroot" "$targetDir" rm /var/log/README

--- a/features/sap/file.include/etc/issue
+++ b/features/sap/file.include/etc/issue
@@ -1,0 +1,7 @@
+ATTENTION – UNAUTHORIZED ACCESS IS PROHIBITED
+
+You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted.
+
+Unless applicable law provides otherwise, (i) any information stored in, transmitted through or processed by SAP Systems remains at all times the property of SAP, (ii) SAP has the right to scan and monitor access to and use of SAP Systems, and (iii) any information on SAP Systems and any processing activities relating to such information can be inspected by SAP at any time.
+
+Except as may be provided by applicable law, you should have no expectation of privacy as to any information stored in, transmitted through or processed by any portion of SAP Systems. Unauthorized access or use of SAP Systems may result in disciplinary and legal action.

--- a/features/sap/file.include/etc/issue.net
+++ b/features/sap/file.include/etc/issue.net
@@ -1,0 +1,7 @@
+ATTENTION – UNAUTHORIZED ACCESS IS PROHIBITED
+
+You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted.
+
+Unless applicable law provides otherwise, (i) any information stored in, transmitted through or processed by SAP Systems remains at all times the property of SAP, (ii) SAP has the right to scan and monitor access to and use of SAP Systems, and (iii) any information on SAP Systems and any processing activities relating to such information can be inspected by SAP at any time.
+
+Except as may be provided by applicable law, you should have no expectation of privacy as to any information stored in, transmitted through or processed by any portion of SAP Systems. Unauthorized access or use of SAP Systems may result in disciplinary and legal action.

--- a/features/sap/file.include/etc/motd
+++ b/features/sap/file.include/etc/motd
@@ -1,0 +1,9 @@
+#############################################
+ATTENTION – UNAUTHORIZED ACCESS IS PROHIBITED
+#############################################
+
+You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted.
+
+Unless applicable law provides otherwise, (i) any information stored in, transmitted through or processed by SAP Systems remains at all times the property of SAP, (ii) SAP has the right to scan and monitor access to and use of SAP Systems, and (iii) any information on SAP Systems and any processing activities relating to such information can be inspected by SAP at any time.
+
+Except as may be provided by applicable law, you should have no expectation of privacy as to any information stored in, transmitted through or processed by any portion of SAP Systems. Unauthorized access or use of SAP Systems may result in disciplinary and legal action.

--- a/features/sap/file.include/etc/tmpfiles.d/legacy.conf
+++ b/features/sap/file.include/etc/tmpfiles.d/legacy.conf
@@ -1,0 +1,27 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+# See tmpfiles.d(5) for details
+
+# These files are considered legacy and are unnecessary on legacy-free
+# systems.
+
+L /var/lock - - - - ../run/lock
+#L /var/log/README - - - - ../../usr/share/doc/systemd/README.logs
+
+# /run/lock/subsys is used for serializing SysV service execution, and
+# hence without use on SysV-less systems.
+
+d /run/lock/subsys 0755 root root -
+
+# /forcefsck, /fastboot and /forcequotacheck are deprecated in favor of the
+# kernel command line options 'fsck.mode=force', 'fsck.mode=skip' and
+# 'quotacheck.mode=force'
+
+r! /forcefsck
+r! /fastboot
+r! /forcequotacheck

--- a/features/sap/pkg.include
+++ b/features/sap/pkg.include
@@ -1,2 +1,4 @@
 auditd
 ca-certificates
+acl
+python3-apt


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of some extra provisioning and testing steps _python3-apt_ and _acl_ packages are needed.
Because of SAP requirements no symlinks in _/var/log/_ should point outside of _/var/log/_; _/var/log/README_ is a symlink created by tmpfilesd, so we're removing it.
Because of SAP requirements, special messages should be displayed for the user upon logon.

**Which issue(s) this PR fixes**:
Fixes #

