### PR TITLE
server exec.conf fixes

### DIFF
--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -27,3 +27,6 @@ sed -r '/^auth\s+sufficient\s+pam_rootok\.so/a auth       required pam_wheel.so'
 # set permissions to 0640 to /etc/skel/*
 chmod 0640 /etc/skel/.bash*
 chmod 0640 /etc/skel/.profile
+
+# remove nis
+sed -r '/^netgroup:\s+nis/d' -i /etc/nsswitch.conf

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -20,3 +20,6 @@ addgroup --system wheel
 
 # fix file system permissions for higher security
 chmod g-w / /etc/hosts
+
+# allow su only for members of wheel
+sed -r '/^auth\s+sufficient\s+pam_rootok\.so/a auth       required pam_wheel.so' -i /etc/pam.d/su

--- a/features/server/exec.config
+++ b/features/server/exec.config
@@ -23,3 +23,7 @@ chmod g-w / /etc/hosts
 
 # allow su only for members of wheel
 sed -r '/^auth\s+sufficient\s+pam_rootok\.so/a auth       required pam_wheel.so' -i /etc/pam.d/su
+
+# set permissions to 0640 to /etc/skel/*
+chmod 0640 /etc/skel/.bash*
+chmod 0640 /etc/skel/.profile


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of SAP requirements we need to force that only the members of _wheel_ are allowed to run _su_.
We also need to force that a new user's permissions for .bashrc, _.profile_ and _.bash_logout_ to be 0640.
We also need to remove "netgroup: nis" from nsswitch.conf .

**Which issue(s) this PR fixes**:
Fixes #
