### PR TITLE
feat: upgrade to 6.1 kernel

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -6,8 +6,6 @@ ALTNAME=
 ALTNAME_INTERNAL=$(shell [ -n "$(ALTNAME)" ] && printf "%s %s" "-t" "$(ALTNAME)" )
 
 PATH_KERNEL_PACKAGES="../.packages/main/l/linux"
-KERNEL_VERSION=5.10
-
 GARDENLINUX_BUILD_CRE ?= sudo podman
 
 all: build-image build-cert build-integration-test

--- a/features/cloud/pkg.include
+++ b/features/cloud/pkg.include
@@ -4,4 +4,4 @@ fdisk
 #[${arch}=arm64] grub-cloud-arm64
 libpam-passwdqc
 rng-tools5
-linux-image-5.15-cloud-${arch}
+linux-image-6.1-cloud-${arch}

--- a/features/firecracker/pkg.include
+++ b/features/firecracker/pkg.include
@@ -1,2 +1,2 @@
-linux-image-5.15-firecracker-${arch}
+linux-image-6.1-firecracker-${arch}
 rng-tools5

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -15,5 +15,5 @@ smartmontools
 frr
 [${arch}=amd64] syslinux
 [${arch}=amd64] syslinux-common
-linux-image-5.15-${arch}
+linux-image-6.1-${arch}
 tpm2-tools


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Garden Linux aims to support the latest LTS Kernel. 
For the main branch of Garden Linux, we should upgrade to the latest LTS version of the Kernel.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Upgrade linux to 6.1
```

**Credits**:
Thanks @dnan0s for reporting this
