### PR TITLE
do not set acl policies for S3 buckets in platform tests on AWS

### DIFF
--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -421,16 +421,6 @@ class AWS:
                             "s3:TlsVersion": '1.2'
                         }
                     }
-                },
-                {
-                    "Effect": "Allow",
-                    "Principal": "*",
-                    "Action": [
-                        "s3:GetBucketLocation",
-                        "s3:GetObject",
-                        "s3:PutObject"
-                    ],
-                    "Resource": [f"arn:aws:s3:::{name}", f"arn:aws:s3:::{name}/*"],
                 }
             ]
         }
@@ -440,6 +430,7 @@ class AWS:
             Policy=json.dumps(policy)
         )
 
+        self.logger.info(f"Setting public access block on storage bucket {name}...")
         resp = self.s3_client.put_public_access_block(
             Bucket = name,
             PublicAccessBlockConfiguration = {
@@ -641,11 +632,6 @@ class AWS:
                 },
             ))
 
-            response = self.s3_client.put_object_acl(
-                ACL = 'bucket-owner-full-control',
-                Bucket = bucket_name,
-                Key = image_key,
-            )
         elif o.scheme == "s3":
             bucket_name = o.netloc
             image_key = o.path.lstrip("/")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
AWS now recommends to use bucket ownership over ACLs to control bucket and object access, therefore, explicit setting of bucket ACLs are removed from the test code. Since a bucket is created during the test and ownership is therefore inherited, the objects to be tested will be accessible for all other test resources.

**Which issue(s) this PR fixes**:
Fixes failing nightly test runs.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Bucket and object ACLs are no longer set for AWS platform tests.
```
