### PR TITLE
release: prepare 934.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - if: ${{ inputs.use_kms }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.aws_kms_role }}
           role-session-name: ${{ secrets.aws_oidc_session }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: release
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: release
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
     - if: ${{ matrix.target }} == 'aws'
       id: 'auth_aws'
       name: 'Authenticate to AWS'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: ${{ secrets.aws_role }}
         role-session-name: ${{ secrets.aws_session }}

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -28,7 +28,7 @@ jobs:
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
       - uses: actions/checkout@v2
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: ${{ secrets.session }}
@@ -56,7 +56,7 @@ jobs:
             target: azure
     steps:
       - uses: actions/checkout@v2
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: ${{ secrets.session }}

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # the version defined in this file specifies the _next_ release version of gardenlinux, as well as
 # (implicitly) the gardenlinux epoch (days since 2020-04-01) to use as dependency timestamp.
 # use `today` to build against latest
-934.7
+934.8

--- a/bin/make_reproducible_ext4
+++ b/bin/make_reproducible_ext4
@@ -9,6 +9,7 @@ label=
 quota=0
 resize=0
 size_padding=0
+large_journal=0
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -40,6 +41,10 @@ while [ $# -gt 0 ]; do
 			size_padding="$2"
 			shift 2
 			;;
+		-j|--large-journal)
+			large_journal=1
+			shift
+			;;
 		*)
 			break
 			;;
@@ -58,6 +63,12 @@ export E2FSPROGS_FAKE_TIME=$timestamp
 # set uuid and HTREE hash_seed to reproducible values instead of default random generated ones
 uuid=${uuid:-$(echo -n "$hash_prefix:uuid" | uuid_hash)}
 hash_seed=$(echo -n "$hash_prefix:hash_seed" | uuid_hash)
+
+if [ "$resize" = 1 ] && [ "$large_journal" = 1 ]; then
+	# pretend disk is 64GB in size to get sane defaults for journal size
+	truncate -s 64G "$target"
+fi
+
 mke2fs -t ext4 -b 4096 -E hash_seed="$hash_seed" -U "$uuid" ${label:+"-L"} ${label:+"$label"} -I 256 -d "$source" "$target"
 
 if [ "$quota" = 1 ]; then

--- a/bin/makepart
+++ b/bin/makepart
@@ -112,7 +112,7 @@ sed 's/#.*//;/^[[:blank:]]*$/d' \
 
 	case "$fs" in
 		"ext4")
-			make_reproducible_ext4 -t "$timestamp" -h "gardenlinux:$version:partition:$target" ${uuid:+"-u"} ${uuid:+"$uuid"} ${label:+"-l"} ${label:+"$label"} -q $([ "$resize" = 0 ] || echo "-m") -p 16 "$rootfs_work$target" "$file"
+			make_reproducible_ext4 -t "$timestamp" -h "gardenlinux:$version:partition:$target" ${uuid:+"-u"} ${uuid:+"$uuid"} ${label:+"-l"} ${label:+"$label"} -q $([ "$resize" = 0 ] || echo "-m") $(grep -v x-systemd.growfs <<< "$options" &> /dev/null || echo "-j") -p 16 "$rootfs_work$target" "$file"
 			;;
 		"vfat")
 			make_reproducible_vfat -t "$timestamp" -h "gardenlinux:$version:partition:$target" ${uuid:+"-u"} ${uuid:+"$uuid"} ${label:+"-l"} ${label:+"$label"} "$rootfs_work$target" "$file"


### PR DESCRIPTION
Prepare release for Garden Linux 934.8
- update packages for security (see https://gitlab.com/gardenlinux/gardenlinux-package-build/-/blob/main/packages/934.8.yaml)
-  increased journal size 
- update configure-aws-crendentials github actions from v1 to v2