### PR TITLE
fix: remove test_loadavg

### DIFF
--- a/features/base/test/test_basics.py
+++ b/features/base/test/test_basics.py
@@ -10,14 +10,6 @@ def test_no_man(client):
     assert "man: command not found" in error
 
 
-def test_loadavg(client, non_kvm, non_chroot):
-    """ This test does not produce any load. Make sure no other process does """
-    (exit_code, output, error) = client.execute_command("cat /proc/loadavg")
-    assert exit_code == 0, f"Expected to be able to show contents of /proc/loadavg"
-    load =  float(output.split(" ")[1])
-    assert load  < 0.5, f"Expected load to be less than 0.5 but is {load}"
-
-
 def test_ls(client):
     """ Test for regular linux folders/mounts """
     (exit_code, output, error) = client.execute_command("ls /")


### PR DESCRIPTION
# What does this PR
This PR removes the `test_loadavg` test. See Background below for why we remove this test.

The `features/base/test/test_basicy.py:test_startup_time` is a test we can use to identify if something during boot time took significantly longer than expected. This startup_time test does not provide enough information to identify the causes, but it does identify that we need to investigate.  So we don't lose information when removing `test_loadavg`. 


The `startup_time` test could be enhanced to show more information if it failed. 

# Background

This loadavg test is failing for our azure images in our nightlies (for a while now).

*What does this test do?*

This test reads the second value returned by `/proc/loadavg`, and asserts that it is smaller than `0.5`. If it is greater than 0.5, the test fails.

*What does a `loadavg` number mean?*

`loadavg` of 0 means that the system is idle. For each process entering in one of the states _running_, _queued_, or _uninterruptible sleep_, the load is increased. If a process transitions out of these states, then the load is decremented again. Thus, if we have an `loadavg` of 1 over the past 5 minutes, then on average 1 process is in one of the states:
* _running_
* _queued_
* _uninterruptible sleep_

Well this is a simplification. In reality the sum is an exponentially decaying average of the processes in running, queued, or uninterruptible sleep. Also calculation for a `NO_HZ` kernel (which we have) is a bit more complicated. But in the end the simplification is good enough for a valid intuition. (in case you are curious and don't accept a simplification: https://elixir.bootlin.com/linux/latest/source/kernel/sched/loadavg.c#L162)

*Why is a value above 0.5 considered too high?*
A value above 0.5 is too high if we expected the system to idle a lot in the the recent past of the time window (last 5 minutes).

Now this is where I got confused. The time we read the `loadavg` value of the past 5 minutes include multiple tasks:
* boot process (including systemd, cloud init) * We expect the available CPUs to be fully utilised during boot. While on the other hand we want to reduced the time processes are blocked by i/o.
* Test overhead * (network) initialise first ssh connection between tester machine and tested VM [see](https://github.com/gardenlinux/gardenlinux/blob/main/tests/helper/sshclient.py#L133). initialisation time is variable depending on how fast the tester can connect to the tested VM * (network) SSH connections to send commands to execute and read output values * (local process) execution test commands on that machine

Multiple problems here.
1. Why do we expect the system to idle if we put load on the system?
2. The start of `test_loadavg` is variable depending on network. The `loadavg` 5 minute window is fixed, while we do not know what is included in that 5 minutes window.
3. `loadavg` does not differentiate between running processes and processes blocked by I/O.
4. The VMs we use to run the tests on have different amounts of CPUs per cloud provider: (azure: Standard_D4_v4  `4 cpus`, aws: t3.micro `2 cpus`, gcp: n1-standard-2 `2 cpus`)
5. Systemd and cloud-init both have components that can be executed concurrently.
6. The test does not always fail. Thus, we can not trust this test setup if it is green

A test that just checks if the system is booting fast enough is implemented with [test_startup_time](https://github.com/gardenlinux/gardenlinux/blob/main/features/base/test/test_basics.py#L49).

*What can cause a high `loadavg` during a given time period?*
* Obviously, a high demand on computing time during that time window.
* A process that is in uninterruptible sleep because of a blocking i/o operation. And I think, this is where it gets interesting. Remember, we are talking about having failing tests on azure: loadavg and also boot time taking too long.

*Conclusion*
We remove `test_loadavg`