### PR TITLE
ci: add python3-click as dependency to auto generate release notes

### DIFF
--- a/features/githubActionRunner/pkg.include
+++ b/features/githubActionRunner/pkg.include
@@ -7,5 +7,6 @@ jq
 make
 nodejs
 podman
+python3-click
 python3-networkx
 python3-yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
The `release` github action in our gardenlinux/gardenlinux repository generates a release item on https://github.com/gardenlinux/gardenlinux/releases

To automatically generate the notes included for this release item, we use the python script [generate_release_note.py](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/generate_release_note.py).

Arguments and parameters are parsed via the python library `click`. This PR adds the dependency to the githubRunner feature.
