### PR TITLE
fix(ci): turn off auto release note gen

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -38,7 +38,8 @@ case "$action" in
 		tag="$1"; shift
 		commit="$1"; shift
 		name="$1"; shift
-		body="$(.github/workflows/generate_release_note.py generate --version "$name" --commitish "$commit")"
+		#		body="$(.github/workflows/generate_release_note.py generate --version "$name" --commitish "$commit")"
+		body="Placeholder."
 		release="$(get "releases/tags/$tag" | jq -r '.id' || true)"
 		[ ! "$release" ] || delete "releases/$release"
 


### PR DESCRIPTION
* the github action runner require python3-click installed as dependency.
* Open PR: https://github.com/gardenlinux/gardenlinux/pull/1654
* disable auto generation until dependency is available
