### PR TITLE
fix(ci): info that release action requires full committish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
       commit:
         required: true
         type: string
+        description: "Full commitish"
 jobs:
   create_release:
     runs-on: ec2-gardenlinux-amd64


### PR DESCRIPTION
* The release.yml requires the full committish because the GitHub "create release API" expects the full commitish. Thus, we should add a small hint to tell the user of release action to provide the full commitish. 
* if short commitish is used the API returns 422, and the release action does not show the reason.

<img src="https://github.com/gardenlinux/gardenlinux/assets/2008076/4077c0af-516b-4537-b21c-68999f76c66e" width="200" height="200">
