### PR TITLE
fix: remove haveged related leftovers

### DIFF
--- a/features/metal/exec.config
+++ b/features/metal/exec.config
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-systemctl enable haveged
 systemctl enable ipmievd
 
 update-kernel-cmdline

--- a/features/metal/file.exclude
+++ b/features/metal/file.exclude
@@ -1,7 +1,6 @@
 /etc/network
 # prefer systemd unit files
 /etc/init.d/irqbalance
-/etc/init.d/haveged
 /etc/init.d/ipmievd
 /etc/runit
 /etc/sv


### PR DESCRIPTION
**What this PR does / why we need it**:
Because haveged has been removed, we should no longer enable the service and also no longer exclude /etc/init.d/haveged
