### PR TITLE
chore: Gitignore uefi vars files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ __pycache__
 /tests/*.log
 /tests/*.xml
 make_targets.cache
+/bin/*.vars


### PR DESCRIPTION
Those binary files are created by the 'start-vm' script and most likely should not be committed.
