### PR TITLE
test(fix): wait for systemd to finish on azure

### DIFF
--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -116,6 +116,16 @@ def get_kernel_version(client):
     return output
 
 
+def wait_systemd_boot(client):
+    """ Wait for systemd to finish booting """
+
+    cmd = "systemctl is-system-running --wait"
+
+    (exit_code, output, error) = client.execute_command(cmd, quiet=False)
+
+    assert exit_code == 0, f"Failed to wait for systemd"
+
+
 def validate_systemd_unit(client, systemd_unit, active=True):
     """ Validate a given systemd unit """
     cmd = f"systemctl status {systemd_unit}.service"

--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -4,6 +4,7 @@ import re
 import pytest
 import uuid
 
+from helper.utils import wait_systemd_boot
 from helper.sshclient import RemoteClient
 
 from azure.core.exceptions import (
@@ -434,6 +435,8 @@ class AZURE:
                 host=ip.ip_address,
                 sshconfig=config["ssh"],
             )
+            logger.info("Waiting for systemd to finish with boot")
+            wait_systemd_boot(ssh)
             yield ssh
         finally:
             if ssh is not None:


### PR DESCRIPTION
Fixes #1661 

Adds a wait cmd via `systemctl is-system-running --wait` when a ssh connection has been established.

Currently, SSH is ready before systemd is on azure. This leads to failing tests when a for example a `systemd-analyze` cmd is issued, because systemd will return a non 0 exit code with the error message that systemd has not finished booting yet (please try again later).

