### PR TITLE
hack(gl-search): fix bash subshell function export

### DIFF
--- a/hack/.gl-search-functions.sh
+++ b/hack/.gl-search-functions.sh
@@ -3,17 +3,28 @@
 
 function filter_package_info() {
   pkg=$1;
+  if [ -z "${packages_file}" ]; then
+    echo "Error: The variable 'packages_file' is not set or is empty."
+    exit 1
+  fi
   sed -n "/Package: $pkg$/,/^$/p" "$packages_file"
 }
 
 function get_dependencies(){
   pkg=$1;
+  if [ -z "${packages_file}" ]; then
+    echo "Error: The variable 'packages_file' is not set or is empty."
+    exit 1
+  fi
   sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "^Depends:" | sed -e "s/^Depends://" | sed -e "s/(.*)//" | sed -e "s/|/,/" | sed -r "s/,/ /g" 
 }
 
 function does_pkg_exist(){
   pkg=$1;
-
+  if [ -z "${packages_file}" ]; then
+    echo "Error: The variable 'packages_file' is not set or is empty."
+    exit 1
+  fi
   sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep -q "Package"  
 }
 
@@ -31,6 +42,10 @@ function dependency_search(){
 }
 
 function get_packages(){
+    if [ -z "${packages_file}" ]; then
+        echo "Error: The variable 'packages_file' is not set or is empty."
+        exit 1
+    fi
     grep "^Package: " "$packages_file"
 }
 
@@ -51,6 +66,10 @@ function rdepends_package(){
 function get_filename(){
   pkg="$1"
   gardenlinux_packages="$(get_packages "$pkg")"
+  if [ -z "${packages_file}" ]; then
+    echo "Error: The variable 'packages_file' is not set or is empty."
+    exit 1
+  fi
   # check all garden linux packages
   filename=$(sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "Filename:" | cut -d':' -f 2)
   echo "$filename" | xargs

--- a/hack/.gl-search-functions.sh
+++ b/hack/.gl-search-functions.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+
+function filter_package_info() {
+  pkg=$1;
+  sed -n "/Package: $pkg$/,/^$/p" "$packages_file"
+}
+
+function get_dependencies(){
+  pkg=$1;
+  sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "^Depends:" | sed -e "s/^Depends://" | sed -e "s/(.*)//" | sed -e "s/|/,/" | sed -r "s/,/ /g" 
+}
+
+function does_pkg_exist(){
+  pkg=$1;
+
+  sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep -q "Package"  
+}
+
+function dependency_search(){
+  dependencies="$(get_dependencies "$1"  | sed -r "s/,/ /g")"
+
+  for dep in ${dependencies}
+  do
+    if does_pkg_exist "$dep"; then
+      echo "Covered Dependency: $dep"
+    else 
+      echo "Foreign Dependency: $dep"
+    fi
+  done
+}
+
+function get_packages(){
+    grep "^Package: " "$packages_file"
+}
+
+
+function rdepends_package(){
+  pkg="$1"
+  gardenlinux_packages="$(get_packages "$pkg")"
+  # check all garden linux packages
+  for chk_pkg in ${gardenlinux_packages} 
+  do
+    if get_dependencies "$chk_pkg" | grep -q "$pkg"; then
+      echo "Reverse Dependency: ${chk_pkg}"
+    fi
+  done
+  
+}
+
+function get_filename(){
+  pkg="$1"
+  gardenlinux_packages="$(get_packages "$pkg")"
+  # check all garden linux packages
+  filename=$(sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "Filename:" | cut -d':' -f 2)
+  echo "$filename" | xargs
+   
+}

--- a/hack/gl-search.sh
+++ b/hack/gl-search.sh
@@ -12,6 +12,10 @@
 # - rdepends: (EXPERIMENTAL) find what package in garden linux depends on this package
 # - download: downloads the selected deb package
 
+THIS_DIR="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+# shellcheck source=/dev/null
+source "${THIS_DIR}/.gl-search-functions.sh"
+
 gl_selected_action="$(echo -e "search\ndep-check\nrdepends\ndownload" | fzf --header 'Select Action' )"
 gls_gl_dist="$(echo "today" |fzf --header 'Enter the Garden Linux Version you are interested in, or select today' --print-query | tail -1)"
 export gls_gl_dist
@@ -44,75 +48,12 @@ curl -s "$base_url/dists/${gls_gl_dist}/main/binary-${gls_selected_arch}/Package
 
 export packages_file
 
-function filter_package_info() {
-  pkg=$1;
-  sed -n "/Package: $pkg$/,/^$/p" "$packages_file"
-}
-
-function get_dependencies(){
-  pkg=$1;
-  sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "^Depends:" | sed -e "s/^Depends://" | sed -e "s/(.*)//" | sed -e "s/|/,/" | sed -r "s/,/ /g" 
-}
-
-function does_pkg_exist(){
-  pkg=$1;
-
-  sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep -q "Package"  
-}
-
-function dependency_search(){
-  dependencies="$(get_dependencies "$1"  | sed -r "s/,/ /g")"
-
-  for dep in ${dependencies}
-  do
-    if does_pkg_exist "$dep"; then
-      echo "Covered Dependency: $dep"
-    else 
-      echo "Foreign Dependency: $dep"
-    fi
-  done
-}
-
-function get_packages(){
-    grep "^Package: " "$packages_file"
-}
-
-
-function rdepends_package(){
-  pkg="$1"
-  gardenlinux_packages="$(get_packages "$pkg")"
-  # check all garden linux packages
-  for chk_pkg in ${gardenlinux_packages} 
-  do
-    if get_dependencies "$chk_pkg" | grep -q "$pkg"; then
-      echo "Reverse Dependency: ${chk_pkg}"
-    fi
-  done
-  
-}
-
-function get_filename(){
-  pkg="$1"
-  gardenlinux_packages="$(get_packages "$pkg")"
-  # check all garden linux packages
-  filename=$(sed -n "/Package: $pkg$/,/^$/p" "$packages_file" | grep "Filename:" | cut -d':' -f 2)
-  echo "$filename" | xargs
-   
-}
-# fzf preview requires function to be available in spawned subshell
-export -f filter_package_info
-export -f dependency_search
-export -f get_dependencies
-export -f does_pkg_exist
-export -f rdepends_package
-export -f get_packages
-export -f get_filename
 case "$gl_selected_action" in
   "dep-check")
     grep "^Package:.*" "$packages_file" |  cut -d' ' -f 2 | \
       fzf \
       --multi \
-      --preview "bash -c \"packages_file=$packages_file dependency_search {1}\"" \
+      --preview "bash -c \"source ${THIS_DIR}/.gl-search-functions.sh; packages_file=$packages_file dependency_search {1}\"" \
       --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
     ;;
   "download")
@@ -129,14 +70,14 @@ case "$gl_selected_action" in
     grep "^Package:.*" "$packages_file" | cut -d' ' -f 2 | \
       fzf \
       --multi \
-      --preview "bash -c \"packages_file=$packages_file filter_package_info {1}\""\
+      --preview "bash -c \"source ${THIS_DIR}/.gl-search-functions.sh; packages_file=$packages_file filter_package_info {1}\""\
       --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
     ;;
   "rdepends")
     grep "^Package:.*" "$packages_file" | cut -d' ' -f 2 | \
       fzf \
       --multi \
-      --preview "bash -c \"packages_file=$packages_file rdepends_package {1}\"" \
+      --preview "bash -c \"source ${THIS_DIR}/.gl-search-functions.sh; packages_file=$packages_file rdepends_package {1}\"" \
       --header 'Select Garden Linux Package to see details on the right window. You can type to filter.'
     ;;
   *)

--- a/hack/gl-search.sh
+++ b/hack/gl-search.sh
@@ -12,7 +12,7 @@
 # - rdepends: (EXPERIMENTAL) find what package in garden linux depends on this package
 # - download: downloads the selected deb package
 
-THIS_DIR="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+THIS_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[@]}")")"
 # shellcheck source=/dev/null
 source "${THIS_DIR}/.gl-search-functions.sh"
 


### PR DESCRIPTION
This PR fixes hack/gl-search.sh for osx users.

The issue was that osx bash does not load exported functions into sub shells automatically.
This commit puts the functions in a separate file, which is then sourced on demand.

@fwilhe Thanks for reporting!
