### PR TITLE
test: increase timeout for GCP Image import

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -117,7 +117,7 @@ class GCP:
 
     def _gcp_wait_for_operation(self, operation, timeout=120):
         self.logger.info(f"Waiting for {operation.name} to complete...")
-        result = operation.result(timeout=timeout)
+        _ = operation.result(timeout=timeout)
         self.logger.info(f"{operation.name} done.")
 
     def _gcp_create_firewall_rules(self, fw_rest_body):
@@ -414,7 +414,7 @@ class GCP:
             }
 
         operation = images.insert(project=self.image_project, image_resource=config)
-        self._gcp_wait_for_operation(operation)
+        self._gcp_wait_for_operation(operation, timeout=600)
         image_blob.delete()
         self.logger.info(f'Uploaded image {blob_url} to project {self.project} as {image_name}')
         self._image = images.get(image=image_name, project=self.image_project)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:
Importing an image to GCP for testing might take longer than two minutes which used to be the max. timeout for this operation. This PR increases the timeout to 10 minutes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
GCP platform tests now have a longer timeout of 10 minutes for the image import.
```
