### PR TITLE
test: abort all tests if SSH connection fails

### DIFF
--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -68,11 +68,15 @@ class RemoteClient:
         host,
         sshconfig,
         port="22",
-        sudo=False
+        sudo=False,
+        ssh_max_retries: int=20,
+        ssh_retry_timeout_seconds: int=15,
     ) -> None:
         self.host = host
         self.port = port
         self.sudo = sudo
+        self.ssh_max_retries = ssh_max_retries
+        self.ssh_retry_timeout_seconds = ssh_retry_timeout_seconds
         self.client = None
         self.scp = None
         self.conn = None
@@ -144,10 +148,9 @@ class RemoteClient:
                 logger.error(f"private key {self.ssh_key_filepath} not found")
                 exit(1)
 
-
-            max_errors = 5
+            logger.info(f"Attempting to establish an SSH connection to {self.host}:{self.port}...")
             errors = 0
-            while errors < max_errors:
+            while errors < self.ssh_max_retries:
                 try:
                     self.client.connect(
                         hostname=self.host,
@@ -162,11 +165,11 @@ class RemoteClient:
                     self.scp = SCPClient(self.client.get_transport())
                     break
                 except NoValidConnectionsError as e:
-                    logger.exception("Unable to connect")
-                    errors = errors + 1
-                    if errors == 5:
-                        raise Exception("Too many connection failures. Giving up.")
-                    time.sleep(5)
+                    errors += 1
+                    if errors >= self.ssh_max_retries:
+                        pytest.exit(f"Unable to establish an SSH connection after {errors*self.ssh_retry_timeout_seconds} seconds. Aborting all tests.", returncode=5)
+                    logger.warning(f"Unable to connect, retrying in {self.ssh_retry_timeout_seconds} seconds...")
+                    time.sleep(self.ssh_retry_timeout_seconds)
         except AuthenticationException as error:
             logger.exception("Authentication failed")
             raise error


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Platform tests should fail during fixture setup if an SSH connection to a VM cannot be established within time. This removes tons of unnecessary log output if the SSH connection fails to establish.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Garden Linux platform tests will fail early if an SSH connection cannot be established after a default timeout of 5 minutes.
```
