### PR TITLE
Fix/upgrade plattformtests for rel 934

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -7,16 +7,15 @@ name = "pypi"
 pytest = "*"
 boto3 = "*"
 paramiko = "*"
+python-novaclient = "*"
 click = "*"
 pyyaml = "*"
 scp = "*"
 dacite = "*"
 # Google/GCP SDK packages
 google-auth = "*"
-google-cloud = "*"
+google-cloud-compute = "*"
 google-cloud-storage = "*"
-google-cloud-datastore = "*"
-google-api-python-client = "*"
 # Aliyun SDK packages
 oss2 = "*"
 aliyun-python-sdk-core = "*"
@@ -41,7 +40,7 @@ flake8 = "*"
 pylint = "*"
 
 [requires]
-python_version = "3.10"
+python_version = "3.11"
 
 [pipenv]
 allow_prereleases = true

--- a/tests/helper/tests/debsums.py
+++ b/tests/helper/tests/debsums.py
@@ -3,9 +3,7 @@ from helper import utils
 def debsums(client, debsums_exclude):
     """Check the MD5 sums of installed Debian packages"""
     utils.AptUpdate(client)
-    (exit_code, output, error) = client.execute_command(
-        "apt-get install -y --no-install-recommends debsums", quiet=True)
-    assert exit_code == 0, f"no {error=} expected"
+    utils.install_package_deb(client, "debsums")
 
     (exit_code, output, error) = client.execute_command("debsums -l",
                                                         quiet=True)

--- a/tests/helper/tests/garden_feat.py
+++ b/tests/helper/tests/garden_feat.py
@@ -5,7 +5,7 @@ import tempfile
 from helper import utils
 
 
-def garden_feat(client, test_case, config, input_features, output_features):
+def garden_feat(test_case, config, input_features, output_features):
     """Check the MD5 sums of installed Debian packages"""
 
     # Run tests for all garden-feat cli opts

--- a/tests/helper/tests/packages_musthave.py
+++ b/tests/helper/tests/packages_musthave.py
@@ -71,10 +71,6 @@ def packages_musthave(client, testconfig):
         elif package.endswith(r"-${arch}"):
             package = package.replace(r"${arch}", arch)
 
-        # check if the package has a version tag and chop it off
-        if len(package.split("=")) == 2:
-            package = package.split('=')[0]
-
         # explicitly excluded packages are allowed to miss 
         if package in exclude:
             continue

--- a/tests/helper/tests/password_hashes.py
+++ b/tests/helper/tests/password_hashes.py
@@ -1,3 +1,5 @@
+import re
+
 def password_hashes(client):
     """Check configured password hashes"""
     # Call binary on remote and get content of file
@@ -8,8 +10,10 @@ def password_hashes(client):
     # Validate that the main part is present
     match_list = []
     for line in output.split('\n'):
-        # First fetch the corresponding line(s)
-        if "[success=1 default=ignore]" in line:
+        # success=n specifies to skip the next n lines during config parsing.
+        # sssd uses success=2, and adds 2 fallback lines in case of non success.
+        # but non-sssd default is success=1
+        if re.search("^.*\[success=. default=ignore\].*", line):
             # Do not fetch comments
             if not line.startswith("#"):
                 match_list.append(line)

--- a/tests/helper/tests/rkhunter.py
+++ b/tests/helper/tests/rkhunter.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 # Execute the rkhunter test only on chroot
 # since it must install some packages that
 # may not be possible on running machines.
-def rkhunter(client, testconfig, chroot):
+def rkhunter(client, testconfig, chroot, non_container):
     """Run rkhunter to test for rootkits"""
     utils.AptUpdate(client)
     utils.install_package_deb(client, "rkhunter")

--- a/tests/helper/tests/tiger.py
+++ b/tests/helper/tests/tiger.py
@@ -7,10 +7,7 @@ from helper import utils
 def tiger(client, testconfig, chroot):
     """Run tiger to test for system security vulnerabilities"""
     utils.AptUpdate(client)
-    (exit_code, output, error) = client.execute_command(
-        "apt-get install -y --no-install-recommends tiger",
-        quiet=True)
-    assert exit_code == 0, f"no {error=} expected"
+    utils.install_package_deb(client, "tiger")
 
     enabled_features = testconfig["features"]
 

--- a/tests/helper/tests/users.py
+++ b/tests/helper/tests/users.py
@@ -1,5 +1,5 @@
 import helper.utils as utils
-
+import helper.tests.groups as groups
 
 def users(client, additional_user = "", additional_sudo_users=[]):
     # Get content from /etc/passwd
@@ -62,20 +62,21 @@ def users(client, additional_user = "", additional_sudo_users=[]):
 
 def _has_user_sudo_cmd(client, user):
     """ Check if user has any sudo permissions """
+
     # Execute command on remote platform
     cmd = f"sudo -s sudo -l -U {user}"
     out = utils.execute_remote_command(client, cmd)
 
     # Write each line as output in list
-    output_lines = [] 
+    output_lines = []
     for line in out.split("\n"):
-       output_lines.append(line)
+        output_lines.append(line)
 
     # Check if there is enough content in our list
     # and validate if there are related sudo commands
     sudo_cmd = False
     if len(output_lines) > 3:
         if "may run the following commands on" in output_lines[-2]:
-           sudo_cmd = output_lines[-1]
+            sudo_cmd = output_lines[-1]
 
     assert not sudo_cmd, f"User: {user} has sudo permissions for: {sudo_cmd}"

--- a/tests/integration/aws.py
+++ b/tests/integration/aws.py
@@ -39,13 +39,16 @@ def register_image(
     snapshot_id: str,
     image_name: str,
     architecture: str,
+    boot_mode: str='',
+    uefi_data: str='',
 ) -> str:
     '''
     @return: ami-id of registered image
     '''
     root_device_name = '/dev/xvda'
 
-    result = ec2_client.register_image(
+    # Define arguments for register_image
+    arguments = dict(
         # ImageLocation=XX, s3-url?
         Architecture=architecture,
         BlockDeviceMappings=[
@@ -62,8 +65,19 @@ def register_image(
         EnaSupport=True,
         Name=image_name,
         RootDeviceName=root_device_name,
-        VirtualizationType='hvm' # | paravirtual
+        VirtualizationType='hvm', # | paravirtual
     )
+
+    # Check if boot mode and uefi data
+    # are set properly and add them to
+    # the arguments
+    if len(boot_mode) > 0:
+        arguments['BootMode'] = boot_mode
+    if len(uefi_data) > 0:
+        arguments['UefiData'] = uefi_data
+
+    # Now, register image
+    result = ec2_client.register_image(**arguments)
 
     ec2_client.create_tags(
         Resources=[
@@ -178,6 +192,10 @@ class AWS:
             cfg['instance_type'] = "t3.micro"
         if not 'architecture' in cfg or cfg['architecture'] == "amd64":
             cfg['architecture'] = "x86_64"
+        if not 'boot_mode' in cfg:
+            cfg['boot_mode'] = ""
+        if not 'uefi_data' in cfg:
+            cfg['uefi_data'] = ""
         if not 'bucket' in cfg:
             cfg['bucket'] = f"img-{test_name}-upload"
         if not 'securitygroup_name' in cfg:
@@ -398,6 +416,9 @@ class AWS:
                     "Condition": {
                         "Bool": {
                             "aws:SecureTransport": "false"
+                        },
+                        "NumericLessThan": {
+                            "s3:TlsVersion": '1.2'
                         }
                     }
                 }
@@ -647,7 +668,9 @@ class AWS:
             ec2_client = self.ec2_client,
             snapshot_id = self._snapshot_id,
             image_name = image_name,
-            architecture = self.config["architecture"]
+            architecture = self.config["architecture"],
+            boot_mode = self.config["boot_mode"],
+            uefi_data = self.config["uefi_data"]
         )
         self.ec2_client.create_tags(
             Resources = [self._ami_id],

--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -4,6 +4,7 @@ import re
 import pytest
 import uuid
 
+from helper.utils import wait_systemd_boot
 from helper.sshclient import RemoteClient
 
 from azure.core.exceptions import (
@@ -276,7 +277,7 @@ class AZURE:
             }
         ).result()
 
-        self.logger.info(f"Creating and booting Virtual machine of size {vm_size} from image {self._image.name}...")
+        self.logger.info(f"Creating and booting virtual machine of size {vm_size} from image version {self._image.name}...")
         self._instance = self.cclient.virtual_machines.begin_create_or_update(
             resource_group_name=self._resourcegroup.name,
             vm_name=name,
@@ -376,6 +377,12 @@ class AZURE:
             cfg['resource_group'] = f"rg-{test_name}"
         if not 'storage_account_name' in cfg:
             cfg['storage_account_name'] = f"sa{re.sub('-', '', test_name)}"
+        if not 'gallery_name' in cfg:
+            cfg['gallery_name'] = f"gallery{re.sub('-', '', test_name)}"
+        if not 'gallery_image_name' in cfg:
+            cfg['gallery_image_name'] = f"galleryimage{re.sub('-', '', test_name)}"
+        if not 'gallery_image_version_name' in cfg:
+            cfg['gallery_image_version_name'] = "0.0.0"
         if not 'vm_size' in cfg:
             cfg['vm_size'] = "Standard_D4_v4"
         if not 'accelerated_networking' in cfg:
@@ -384,6 +391,16 @@ class AZURE:
             cfg['nsg_name'] = f"nsg-{test_name}"
         if not 'keep_running' in cfg:
             cfg['keep_running'] = False
+        allowed_generations = ["V1", "V2"]
+        if not 'hyper_v_generation' in cfg:
+            cfg['hyper_v_generation'] = allowed_generations[0]
+        if 'hyper_v_generation' in cfg and cfg['hyper_v_generation'] not in allowed_generations:
+            raise RuntimeError(f"Hypervisor generation '{cfg['hyper_v_generation']}' not supported. Allowed values: ({allowed_generations})")
+        allowed_architectures = ["x64", "Arm64"]
+        if not 'architecture' in cfg:
+            cfg['architecture'] = allowed_architectures[0]
+        if 'architecture' in cfg and cfg['architecture'] not in allowed_architectures:
+            raise RuntimeError(f"Architecture '{cfg['architecture']}' not supported. Allowed values: ({allowed_architectures})")
         if not 'ssh' in cfg or not cfg['ssh']:
             cfg['ssh'] = {}
         if not 'ssh_key_filepath' in cfg['ssh']:
@@ -418,6 +435,8 @@ class AZURE:
                 host=ip.ip_address,
                 sshconfig=config["ssh"],
             )
+            logger.info("Waiting for systemd to finish with boot")
+            wait_systemd_boot(ssh)
             yield ssh
         finally:
             if ssh is not None:
@@ -474,7 +493,8 @@ class AZURE:
             self.az_delete_nsg(name=self._nsg.name)
             self._nsg = None
         if self._image:
-            self.az_delete_image(name=self._image.name)
+            self.az_delete_gallery()
+            self.az_delete_image(name=self.config["image_name"])
             self._image = None
         if self._storageaccount:
             self.az_delete_storage_account(self._storageaccount.name)
@@ -581,17 +601,12 @@ class AZURE:
 
             image_uri = f"https://{self._storageaccount.name}.blob.core.windows.net/vhds/{image_name}.vhd"
 
-            allowed_generations = ["V1", "V2"]
-            hyper_v_generation = self.config.get("hyper_v_generation", allowed_generations[0])
-            if hyper_v_generation not in allowed_generations:
-                raise RuntimeError(f"Hypervisor generation '{hyper_v_generation}' not supported. Allowed values: ({allowed_generations})")
-
-            result = self.cclient.images.begin_create_or_update(
+            image = self.cclient.images.begin_create_or_update(
                 resource_group_name = self._resourcegroup.name,
                 image_name = image_name,
                 parameters = {
                     'location': self._resourcegroup.location,
-                    'hyper_v_generation': hyper_v_generation,
+                    'hyper_v_generation': self.config['hyper_v_generation'],
                     'storage_profile': {
                         'os_disk': {
                             'os_type': 'Linux',
@@ -606,6 +621,58 @@ class AZURE:
             ).result()
 
             self.logger.info(f"Image {image_file} uploaded as {image_name}")
+
+            gallery_name = self.config['gallery_name']
+            gallery_image_name = self.config['gallery_image_name']
+            gallery_image_version_name = self.config['gallery_image_version_name']
+            self.cclient.galleries.begin_create_or_update(
+                resource_group_name = self._resourcegroup.name,
+                gallery_name = gallery_name,
+                gallery = {
+                    'location': self._resourcegroup.location,
+                }
+            )
+
+            self.cclient.gallery_images.begin_create_or_update(
+                resource_group_name = self._resourcegroup.name,
+                gallery_name = gallery_name,
+                gallery_image_name = gallery_image_name,
+                gallery_image = {
+                    'location': self._resourcegroup.location,
+                    'os_type': 'Linux',
+                    'os_state': 'Generalized',
+                    'hyper_v_generation': self.config['hyper_v_generation'],
+                    'architecture': self.config['architecture'],
+                    'identifier': {
+                        'publisher': 'Gardenlinux',
+                        'offer': 'Gardenlinux',
+                        'sku': 'Gardenlinux'
+                    }
+                }
+            )
+
+            self.logger.info(f"Creating image version {gallery_image_version_name} from {image_name}...")
+
+            result = self.cclient.gallery_image_versions.begin_create_or_update(
+                resource_group_name = self._resourcegroup.name,
+                gallery_name = gallery_name,
+                gallery_image_name = gallery_image_name,
+                gallery_image_version_name = gallery_image_version_name,
+                gallery_image_version = {
+                    'location': self._resourcegroup.location,
+                    'publishing_profile': {
+                        'replica_count': 1,
+                        'storage_account_type': 'Standard_LRS',
+                        'replication_mode': 'Shallow'
+                    },
+                    'storage_profile': {
+                        'source': {
+                            'id': image.id
+                        }
+                    }
+                }
+            ).result()
+
             return result
         else:
             raise Exception("No image with name %s available and no image file given" % self.config["image_name"])
@@ -623,3 +690,51 @@ class AZURE:
         self._instance = self.az_create_vm(name=f"vm-{self.test_name}", vm_size=config["vm_size"], accelerated_networking=config["accelerated_networking"])
         self.logger.info(f"VM {self._instance.name} created with IP {self._ipaddress.ip_address}")
         return (self._instance, self._ipaddress)
+
+    def az_delete_gallery(self):
+        gallery_name = self.config['gallery_name']
+        gallery_image_name = self.config['gallery_image_name']
+        gallery_image_version_name = self.config['gallery_image_version_name']
+
+        self.logger.info(f"Deleting gallery image version {gallery_image_version_name}")
+        poller = self.cclient.gallery_image_versions.begin_delete(
+            resource_group_name = self._resourcegroup.name,
+            gallery_name = gallery_name,
+            gallery_image_name = gallery_image_name,
+            gallery_image_version_name = gallery_image_version_name
+        )
+        while not poller.done():
+            self.logger.info(f"Waiting for gallery image version {gallery_image_version_name} to disappear...")
+            poller.wait(5.0)
+
+        self.logger.info(f"Deleted gallery image version {gallery_image_version_name}")
+
+        while True:
+            try:
+                self.logger.info(f"Deleting gallery image {gallery_image_name}")
+                poller = self.cclient.gallery_images.begin_delete(
+                    resource_group_name = self._resourcegroup.name,
+                    gallery_name = gallery_name,
+                    gallery_image_name = gallery_image_name
+                )
+                while not poller.done():
+                    self.logger.info(f"Waiting for {gallery_image_name} to disappear...")
+                    poller.wait(5.0)
+
+                self.logger.info(f"Deleted gallery image {gallery_image_name}")
+                break
+            except ResourceExistsError as error:
+                #self.logger.info(error)
+                self.logger.info(f"Failed to delete {gallery_image_name}, try again...")
+                continue
+
+        self.logger.info(f"Deleting gallery {gallery_name}")
+        poller = self.cclient.galleries.begin_delete(
+            resource_group_name = self._resourcegroup.name,
+            gallery_name = gallery_name
+        )
+        while not poller.done():
+            self.logger.info(f"Waiting for {gallery_name} to disappear...")
+            poller.wait(5.0)
+
+        self.logger.info(f"Deleted gallery {gallery_name}")

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -32,6 +32,7 @@ class GCP:
 
     @classmethod
     def fixture(cls, credentials, config, imageurl, test_name):
+        GCP.set_config_defaults(config, test_name, credentials)
         GCP.validate_config(config, imageurl, test_name, credentials)
 
         logger.info(f"Setting up testbed for image {imageurl}...")
@@ -50,32 +51,25 @@ class GCP:
             if ssh is not None:
                 ssh.disconnect()
 
-
     @classmethod
-    def validate_config(cls, cfg: dict, image: str, test_name: str, credentials):
-        if not 'project' in cfg:
+    def set_config_defaults(cls, cfg: dict, test_name: str, credentials):
+        if 'project' not in cfg:
             cfg['project'] = credentials.project_id
-        if not 'image_project' in cfg:
+        if 'image_project' not in cfg:
             cfg['image_project'] = cfg['project']
-        if not 'image_region' in cfg:
+        if 'image_region' not in cfg:
             cfg['image_region'] = "eu-central-1"
-        if not 'region' in cfg:
-            pytest.exit("GCP region not specified, cannot continue.", 1)
-        if not 'zone' in cfg:
-            pytest.exit("GCP zone not specified, cannot continue.", 1)
-        if not image and not 'image_name' in cfg and not 'image' in cfg:
-            pytest.exit("Neither 'image' nor 'image_name' specified, cannot continue.", 3)
-        if not 'image_name' in cfg:
+        if 'image_name' not in cfg:
             cfg['image_name'] = f"img-{test_name}"
-        if not 'bucket' in cfg:
+        if 'bucket' not in cfg:
             cfg['bucket'] = f"gl-upload-{test_name}"
-        if not 'keep_running' in cfg:
+        if 'keep_running' not in cfg:
             cfg['keep_running'] = False
-        if not 'machine_type' in cfg:
+        if 'machine_type' not in cfg:
             cfg['machine_type'] = 'n1-standard-2'
-        if not 'ssh' in cfg or not cfg['ssh']:
+        if 'ssh' not in cfg or not cfg['ssh']:
             cfg['ssh'] = {}
-        if not 'ssh_key_filepath' in cfg['ssh']:
+        if 'ssh_key_filepath' not in cfg['ssh']:
             import tempfile
             keyfile = tempfile.NamedTemporaryFile(prefix=f"sshkey-{test_name}-", suffix=".key", delete=False)
             keyfp = RemoteClient.generate_key_pair(
@@ -83,23 +77,33 @@ class GCP:
             )
             logger.info(f"Generated SSH keypair with fingerprint {keyfp}.")
             cfg['ssh']['ssh_key_filepath'] = keyfile.name
-        if not 'ssh_key_name' in cfg['ssh']:
+        if 'ssh_key_name' not in cfg['ssh']:
             cfg['ssh']['ssh_key_name'] = f"key-{test_name}"
-        if not 'user' in cfg['ssh']:
+        if 'user' not in cfg['ssh']:
             cfg['ssh']['user'] = "gardenlinux"
-        if not 'uefi' in cfg:
+        if 'uefi' not in cfg:
             cfg['uefi'] = False
-        if not 'secureboot' in cfg:
+        if 'secureboot' not in cfg:
             cfg['secureboot'] = False
-        if not 'db_path' in cfg['secureboot_parameters']:
+        if 'secureboot_parameters' not in cfg:
+            cfg['secureboot_parameters'] = {}
+        if 'db_path' not in cfg['secureboot_parameters']:
             cfg['secureboot_parameters']['db_path'] = "/gardenlinux/cert/secureboot.db.auth"
-        if not 'kek_path' in cfg:
+        if 'kek_path' not in cfg:
             cfg['secureboot_parameters']['kek_path'] = "/gardenlinux/cert/secureboot.kek.auth"
-        if not 'pk_path' in cfg:
+        if 'pk_path' not in cfg:
             cfg['secureboot_parameters']['pk_path'] = "/gardenlinux/cert/secureboot.pk.auth"
-        if not 'cert_file_type' in cfg:
+        if 'cert_file_type' not in cfg:
             cfg['secureboot_parameters']['cert_file_type'] = 'BIN'
 
+    @classmethod
+    def validate_config(cls, cfg: dict, image: str, test_name: str, credentials):
+        if 'region' not in cfg:
+            pytest.exit("GCP region not specified, cannot continue.", 1)
+        if 'zone' not in cfg:
+            pytest.exit("GCP zone not specified, cannot continue.", 1)
+        if not image and 'image_name' not in cfg and 'image' not in cfg:
+            pytest.exit("Neither 'image' nor 'image_name' specified, cannot continue.", 3)
 
     def _gcp_create_bucket(self, bucket_name):
         bucket = self._storage.bucket(bucket_name=bucket_name)
@@ -111,12 +115,10 @@ class GCP:
         bucket.create()
         bucket.make_private()
 
-
-    def _gcp_wait_for_operation(self, operation, timeout=60):
+    def _gcp_wait_for_operation(self, operation, timeout=120):
         self.logger.info(f"Waiting for {operation.name} to complete...")
-        _ = operation.result(timeout=timeout)
+        result = operation.result(timeout=timeout)
         self.logger.info(f"{operation.name} done.")
-
 
     def _gcp_create_firewall_rules(self, fw_rest_body):
         rule_name = fw_rest_body["name"]
@@ -124,7 +126,6 @@ class GCP:
         operation = self._compute_firewalls.insert(project=self.project, firewall_resource=fw_rest_body)
         self._gcp_wait_for_operation(operation)
         return rule_name
-
 
     def _gcp_create_vpc(self):
         network_name = f"vpc-{self.test_name}"
@@ -175,6 +176,7 @@ class GCP:
 
         :param config: configuration
         """
+        GCP.set_config_defaults(config, test_name, credentials)
         self.config = config
         self.ssh_config = config["ssh"]
         self.test_name = test_name
@@ -412,7 +414,7 @@ class GCP:
             }
 
         operation = images.insert(project=self.image_project, image_resource=config)
-        self._gcp_wait_for_operation(operation, timeout=600)
+        self._gcp_wait_for_operation(operation)
         image_blob.delete()
         self.logger.info(f'Uploaded image {blob_url} to project {self.project} as {image_name}')
         self._image = images.get(image=image_name, project=self.image_project)

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -117,7 +117,7 @@ class GCP:
 
     def _gcp_wait_for_operation(self, operation, timeout=120):
         self.logger.info(f"Waiting for {operation.name} to complete...")
-        result = operation.result(timeout=timeout)
+        _ = operation.result(timeout=timeout)
         self.logger.info(f"{operation.name} done.")
 
     def _gcp_create_firewall_rules(self, fw_rest_body):
@@ -414,7 +414,7 @@ class GCP:
             }
 
         operation = images.insert(project=self.image_project, image_resource=config)
-        self._gcp_wait_for_operation(operation)
+        self._gcp_wait_for_operation(operation, timeout=600)
         image_blob.delete()
         self.logger.info(f'Uploaded image {blob_url} to project {self.project} as {image_name}')
         self._image = images.get(image=image_name, project=self.image_project)

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -114,7 +114,7 @@ class GCP:
 
     def _gcp_wait_for_operation(self, operation, timeout=60):
         self.logger.info(f"Waiting for {operation.name} to complete...")
-        result = operation.result(timeout=timeout)
+        _ = operation.result(timeout=timeout)
         self.logger.info(f"{operation.name} done.")
 
 
@@ -412,7 +412,7 @@ class GCP:
             }
 
         operation = images.insert(project=self.image_project, image_resource=config)
-        self._gcp_wait_for_operation(operation)
+        self._gcp_wait_for_operation(operation, timeout=600)
         image_blob.delete()
         self.logger.info(f'Uploaded image {blob_url} to project {self.project} as {image_name}')
         self._image = images.get(image=image_name, project=self.image_project)

--- a/tests/integration/kvm.py
+++ b/tests/integration/kvm.py
@@ -254,6 +254,7 @@ class KVM:
         if arch == "amd64":
             cmd = f"/gardenlinux/bin/start-vm \
               --daemonize \
+              --no-watchdog \
               --arch x86_64 \
               --port {port} \
               --destport 2222 \
@@ -263,6 +264,7 @@ class KVM:
         elif arch == "arm64":
             cmd = f"/gardenlinux/bin/start-vm \
               --daemonize \
+              --no-watchdog \
               --arch aarch64 \
               --port {port} \
               --destport 2222 \

--- a/tests/integration/misc/docker_registry_config_integrations_tests
+++ b/tests/integration/misc/docker_registry_config_integrations_tests
@@ -1,0 +1,20 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/docker-registry
+  delete:
+    enabled: true
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/tests/local/README.md
+++ b/tests/local/README.md
@@ -1,0 +1,47 @@
+# Local tests
+
+# Table of Content
+- [General](#general)
+- [Test oci](#test-oci)
+- [Test garden_feat](#test-garden_feat)
+
+# General
+
+Tests located in this folter `test/local` are local tests. Local tests are executed in the base-test container, the integration-test container will also work, but without spawning a `chroot` or `kvm` environment that needs to be accessed via `ssh`. The local tests are run directly in the container. The goal is to be able to write tests for the Garden Linux build pipeline.
+
+The configuration file for this tests does not need the `features` to be set, if set it will be ignored. The configuration contains a dictionary, the key should be the name of the test and under the key the configuration options for this specific test are defined. If a test does not have any configuration options it can be left out of the configuration file.
+
+To select a specific test to be executed instead of running all local tests, the `-k EXPRESSION` *pytest* option can be used. See the `pytest --help` for a more detailed explanation.
+
+```yaml
+local:
+    # configuration parameters for tests separated by test names
+    oci:
+      # Path to a final artifact. Represents the .tar.xz archive image file (required)
+      image: /build/kvm_dev_oci-amd64-today-local.oci.tar.xz
+      kernel: /build/kvm_dev_oci-amd64-today-local.vmlinuz
+
+    garden_feat:
+```
+
+# Test oci
+This test does several steps using the results of a build with _oci feature:
+- verify neccessary testconfig options are present (image, kernel)
+- install the docker-registry into the container, provide a config, start the registry
+- extracts the testconfig["image"] file to retrieve the OCI fs layout
+- tag the extracted OCI image for uploading to the registry on localhost
+- push the OCI image to the local registry
+- retrieve the url for the kernel file out of the OCI image
+- download the kernel image
+- compare the downloaded kernel with the testconfig["kernel"]
+
+Configuration options:
+- **oci** contains the configuration options for local test `test_oci`
+    - **image** the build result image used within the tests
+    - **kernel** the name for the builded kernel
+
+# Test garden_feat
+
+This test checks if the script `bin/garden-feat` is working as expected. The script creates the Garden Linux features list during build, therefore it is important to resolve dependencies between the feature properly.
+
+This test does not have any configuration options.

--- a/tests/local/test_garden_feat.py
+++ b/tests/local/test_garden_feat.py
@@ -1,0 +1,110 @@
+from helper.tests.garden_feat import garden_feat 
+import pytest
+
+@pytest.mark.parametrize(
+    "test_case,config,input_features,output_features",
+    [
+        # Basic tests for positional cli args
+        (
+            "features",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"_dev": {'description': '_dev', 'type': 'flag'}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'include': ['cloud']}}},
+                  {"cloud": {'description': 'cloud', 'type': 'element'}}
+            ],
+            "base,kvm,_dev",
+            "cloud,kvm,_slim,base,_dev"
+        ),
+        (
+            "features",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"_dev": {'description': '_dev', 'type': 'flag'}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'exclude': ['cloud']}}},
+                  {"cloud": {'description': 'cloud', 'type': 'element'}}
+            ],
+            "base,kvm,_dev",
+            "kvm,_slim,base,_dev"
+        ),
+        (
+            "features",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"_dev": {'description': '_dev', 'type': 'flag'}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'exclude': ['cloud']}}},
+                  {"cloud": {'description': 'cloud', 'type': 'element', 'features': {'exclude': ['_ssh']}}},
+                  {"_ssh": {'description': '_ssh', 'type': 'flag'}}
+            ],
+            "base,kvm,_dev",
+            "kvm,_slim,base,_dev"
+        ),
+        (
+            "cname",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"_dev": {'description': '_dev', 'type': 'flag'}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'include': ['cloud', 'chost']}}},
+                  {"cloud": {'description': 'cloud', 'type': 'element'}},
+                  {"chost": {'description': 'chost', 'type': 'element'}}
+            ],
+            "kvm,_dev,chost",
+            "kvm_dev"
+        ),
+        (
+            "flags",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim', '_dev', 'firewall']}}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'include': ['cloud']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"cloud": {'description': 'cloud', 'type': 'element'}},
+                  {"_dev": {'description': '_dev', 'type': 'flag'}},
+                  {"firewall": {'description': 'firewall', 'type': 'flag'}}
+            ],
+            "base,kvm,_dev",
+            "_slim,_dev,firewall"
+        ),
+        (
+            "elements",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'include': ['cloud']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"cloud": {'description': 'cloud', 'type': 'element'}}
+            ],
+            "base,kvm",
+            "cloud,kvm,base"
+        ),
+        (
+            "ignore",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'include': ['cloud']}}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"cloud": {'description': 'cloud', 'type': 'element'}}
+            ],
+            "base,kvm",
+            "garden-feat: warning: No feature is ignored."
+        ),
+        (
+            "params",
+            [
+                  {"base": {'description': 'base', 'type': 'element', 'features': {'include': ['_slim']}}},
+                  {"kvm": {'description': 'kvm', 'type': 'platform', 'features': {'include': ['cloud']}}},
+                  {"server": {'description': 'server', 'type': 'element'}},
+                  {"_slim": {'description': '_slim', 'type': 'flag'}},
+                  {"cloud": {'description': 'cloud', 'type': 'element', 'features': {'include': ['server']}, 'fs': [{'dest': '/', 'type': 'ext4'}], 'disk': {'label': 'gpt', 'boot': ['mbr']}, 'convert': {'format': [{'type': 'raw'}]}}}
+            ],
+            "base,kvm",
+            "raw"
+        )
+    ]
+)
+
+
+def test_garden_feat(test_case, config, input_features, output_features, local):
+    garden_feat(test_case, config, input_features, output_features)

--- a/tests/local/test_oci.py
+++ b/tests/local/test_oci.py
@@ -1,0 +1,119 @@
+from helper import utils
+import json
+import logging
+import tempfile
+import shutil
+import os
+import pytest
+
+# Define global logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+def test_oci_feat(local, testconfig):
+    """ This test does several steps using the results of a build with _oci feature:
+    - verify neccessary testconfig options are present (image, kernel)
+    - install the docker-registry into the container, provide a config, start the registry
+    - extracts the testconfig["image"] file to retrieve the OCI fs layout
+    - tag the extracted OCI image for uploading to the registry on localhost
+    - push the OCI image to the local registry
+    - retrieve the url for the kernel file out of the OCI image
+    - download the kernel image
+    - compare the downloaded kernel with the testconfig["kernel"]
+    """
+
+    # check for neccessary configuration options
+    if not "image" in testconfig["oci"]:
+        logger.error("No path to image archive defined.")
+    else:
+        image = testconfig["oci"]["image"]
+        logger.info(f"Path to image archive defined: {image}")
+    if not "kernel" in testconfig["oci"]:
+        logger.error("No kernel to compare defined.")
+    else:
+        kernelcmp = testconfig["oci"]["kernel"]
+        logger.info(f"Kernel to compare is defined: {kernelcmp}")
+
+    # update package index files
+    cmd = f"apt-get update"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Could not update Debian Package Index."
+    logger.info(f"Updated Package Index.")
+
+    # install docker-registry
+    pkg = "docker-registry"
+    cmd = f"apt-get install -y --no-install-recommends {pkg}"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Could not install Debian Package: {pkg}"
+    logger.info(f"Installed {pkg}")
+
+    # provide a config file for the registry
+    # this will enable plain http serving without authentication
+    docker_registry_config_src = "integration/misc/docker_registry_config_integrations_tests"
+    docker_registry_config_dest = "/etc/docker/registry/config.yml"
+
+    try:
+        shutil.copy(docker_registry_config_src, docker_registry_config_dest)
+        logger.info(f"Copied {docker_registry_config_src} to: {docker_registry_config_dest}")
+    except OSError:
+        logger.error(f"Could not copy {docker_registry_config_src} to: {docker_registry_config_dest}")
+
+    cmd = f"/etc/init.d/docker-registry start"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Running {pkg} failed"
+    logger.info(f"Running {pkg}")
+
+    # extract the image
+    ociextract = tempfile.mkdtemp(prefix="gl-int-oci-")
+    logger.info(f"Created ociextract in {ociextract}")
+    logger.info(f"Unarchiving image {image} to {ociextract}")
+    cmd = f"tar xJvf {image} -C {ociextract}"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Unable to extract {image} to {ociextract}"
+
+    # tag image and upload it
+    with open(os.path.join(ociextract, "onmetal", "index.json")) as indexfile:
+        onmetaldata = json.load(indexfile)
+    assert "manifests" in onmetaldata
+    assert len(onmetaldata["manifests"]) == 1
+    assert "digest" in onmetaldata["manifests"][0]
+
+    logger.info(f"Tagging image {image}")
+    digest = onmetaldata["manifests"][0]["digest"]
+    onmetalpath = os.path.join(ociextract, "onmetal")
+    cmd = f"onmetal-image tag {digest} localhost:5000/gardenlinux:latest --store-path {onmetalpath}"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Unable to tag image using onmetal-image"
+    logger.info(f"Successfully tagged image")
+
+    # push the image to the local registy
+    logger.info(f"Uploading image to local registry")
+    cmd = f"onmetal-image push localhost:5000/gardenlinux:latest --store-path {onmetalpath}"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Unable to push image using onmetal-image to local registry"
+    logger.info(f"Successfully uploaded image to local registry")
+
+    # retrieve kernel layer
+    logger.info(f"Retrieving url for kernel layer")
+    cmd = f"onmetal-image --store-path {onmetalpath} url --layer kernel localhost:5000/gardenlinux:latest"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Kernel layer url: {out}"
+
+    kernel = json.loads(out)
+    assert "url" in kernel
+    logging.info(f"URL for kernel layer: {kernel['url']}")
+
+    # download the kernel using curl
+    kernelfile = os.path.join(ociextract, "vmlinuz")
+    logging.info(f"Downloading kernel to {kernelfile}")
+    cmd = f"curl -o {kernelfile} {kernel['url']}"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"Could not download {kernel['url']} to {kernelfile}"
+
+    # compare
+    logging.info(f"Comparing {kernelfile} with {kernelcmp}")
+    cmd = f"cmp {kernelfile} {kernelcmp}"
+    rc, out = utils.execute_local_command(cmd)
+    assert rc == 0, f"{kernelcmp} differs from {kernelfile}!"
+
+

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,5 +5,5 @@ log_cli_level = INFO
 log_file = test.log
 log_file_level = INFO
 log_level = INFO
-testpaths = ../features integration
+testpaths = ../features integration local
 addopts = -rA --showlocals --iaas=gcp  --ignore=integration_tests  --ignore=ci  --import-mode=importlib

--- a/tests/tools/azure-conformance-test.py
+++ b/tests/tools/azure-conformance-test.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+#
+# See https://learn.microsoft.com/en-us/azure/marketplace/azure-vm-image-test#run-validations for what this is all about
+#
+# Requires a running VM on Azure that has a user and an SSH public-key for that user in it.
+
+import requests
+import dataclasses
+import argparse
+import pprint
+import json
+
+
+@dataclasses.dataclass
+class AzureVmToBeTested:
+    dns_name: str
+    os: str
+    ssh_port: int
+
+@dataclasses.dataclass
+class AzureVmCredentials:
+    username: str
+    password: str
+
+@dataclasses.dataclass
+class AzureServicePrincipal:
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    subscription_id: str
+
+
+def get_az_service_principal_from_spn_config(service_principal_cfg_name: str) -> AzureServicePrincipal:
+    # late import as we only need it if we want to use the cfg_factory
+    # requires gardener ci-cd utils: pip install gardener-cicd-base
+    import ci.util
+
+    cfg_factory = ci.util.ctx().cfg_factory()
+    azure_principal = cfg_factory.azure_service_principal(
+        cfg_name=service_principal_cfg_name,
+    )
+
+    azure_principal_serialized = AzureServicePrincipal(
+        tenant_id=azure_principal.tenant_id(),
+        client_id=azure_principal.client_id(),
+        client_secret=azure_principal.client_secret(),
+        subscription_id=azure_principal.subscription_id(),
+    )
+
+    return azure_principal_serialized
+
+
+def get_az_bearer_token(service_principal: AzureServicePrincipal) -> str:
+    url = f"https://login.microsoftonline.com/{service_principal.tenant_id}/oauth2/token"
+    
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": service_principal.client_id,
+        "client_secret": service_principal.client_secret,
+        "resource": "https://management.core.windows.net",        
+    }
+
+    response = requests.post(url=url, data=data, headers=headers)
+    if response.status_code != 200:
+        raise RuntimeError(f"did not obtain valid bearer token ({response.status_code=})")
+    
+    result = response.json()
+    return result.get('access_token')
+
+
+def invoke_vm_test(vm_to_be_tested: AzureVmToBeTested, vm_credentials: AzureVmCredentials, service_pricipal: AzureServicePrincipal, bearer_token: str):
+    url = "https://isvapp.azurewebsites.net/selftest-vm"
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f'Bearer {bearer_token}',
+    }
+
+    data = {
+        "DNSName": vm_to_be_tested.dns_name,
+        "UserName": vm_credentials.username,
+        "Password": vm_credentials.password,
+        "OS": vm_to_be_tested.os,
+        "PortNo": str(vm_to_be_tested.ssh_port),
+        "CompanyName": "SAP SE",
+        "AppId": service_pricipal.client_id,
+        "TenantId": service_pricipal.tenant_id,
+    }
+
+    response = requests.post(url=url, headers=headers, json=data)
+    if response.status_code != 200:
+        raise RuntimeError(f"did not obtain valid response ({response.status_code=}): {response.content=}")
+    
+    return response.json()
+
+
+def read_ssh_private_key(ssh_private_key_path: str) -> str:
+    private_key = ""
+    with open(ssh_private_key_path, "r") as f:
+        private_key = f.read()
+    return private_key
+
+
+def setup_and_run_argparser():
+    parser = argparse.ArgumentParser(description='Run Azure Marketplace conformance agains a running VM')
+    parser.add_argument('dns_name', metavar='dns_name', type=str, nargs=1, help='the DNS name/IP address to the VM')
+    parser.add_argument('-u', '--user', dest="user", type=str, default='azureuser', help='username to log in to the VM')
+    parser.add_argument('-p', '--password', dest="password", type=str, help='password to log in to the VM')
+    parser.add_argument('-s', '--ssh-private-keyfile', dest='ssh_privkey', type=str, help='path to SSH private key file to log in')
+
+    # this is used for obtaining Azure Service Principal information from Gardener/Gardenlinux CI/CD infrastructure
+    parser.add_argument('--spn-config-name', dest="sp_config_name", type=str, help='name of the service principal configuration')
+
+    # these are for providing Azure Service Principal information manually
+    parser.add_argument('--client-id', dest="az_client_id", type=str, help='Azure Client ID')
+    parser.add_argument('--client-secret', dest="az_client_secret", type=str, help='Azure Client Secret')
+    parser.add_argument('--tenant-id', dest="az_tenant_id", type=str, help='Azure Tenant ID')
+    parser.add_argument('--subscription-id', dest="az_subscription_id", type=str, help='Azure Subscription ID')
+
+    args = parser.parse_args()
+
+    if not args.dns_name or len(args.dns_name) != 1:
+        raise RuntimeError("must supply name of VM to test")
+    if not args.user:
+        raise RuntimeError("must supply username to log in to VM")
+    if not args.password and not args.ssh_privkey:
+        raise RuntimeError("must supply either password or SSH private key to log in to VM")
+    
+    if not args.sp_config_name or len(args.sp_config_name) == 0:
+        az_sp_config_count = 0
+        if args.az_client_id:
+            az_sp_config_count = az_sp_config_count + 1
+        if args.az_client_secret:
+            az_sp_config_count = az_sp_config_count + 1
+        if args.az_tenant_id:
+            az_sp_config_count = az_sp_config_count + 1
+        if args.az_subscription_id:
+            az_sp_config_count = az_sp_config_count + 1
+        if az_sp_config_count != 4:
+            raise RuntimeError("must either supply --spn-config-name or all four of --client-id, --client-secret, --tenant-id, --subscription-id")
+
+    return args
+
+
+if __name__ == "__main__":
+    args = setup_and_run_argparser()
+
+    service_principal = None
+
+    if args.sp_config_name:
+        service_principal = get_az_service_principal_from_spn_config(args.sp_config_name)
+    else:
+        service_principal = AzureServicePrincipal(
+            tenant_id=args.az_tenant_id,
+            client_id=args.az_client_id,
+            client_secret=args.az_client_secret,
+            subscription_id=args.az_subscription_id,
+        )
+    
+    bearer_token = get_az_bearer_token(service_principal)
+
+    password = ""
+    if args.ssh_privkey:
+        password = read_ssh_private_key(args.ssh_privkey)
+    else:
+        password = args.password
+
+    vm_to_test = AzureVmToBeTested(
+        dns_name=args.dns_name[0],
+        os="Linux",
+        ssh_port=22,
+    )
+
+    credentials = AzureVmCredentials(
+        username=args.user,
+        password=password,
+    )
+
+    print(f"Invoking Azure VM Self-Test (https://isvapp.azurewebsites.net/selftest-vm) on {vm_to_test.dns_name}...")
+
+    az_test_response = invoke_vm_test(
+        vm_to_be_tested=vm_to_test,
+        vm_credentials=credentials,
+        service_pricipal=service_principal,
+        bearer_token=bearer_token,
+    )
+
+    test_results = json.loads(az_test_response['Response'])
+
+    print("Azure VM Self-Test")
+    print("--------------------------------")
+    print(f"Certification Category : {test_results.get('AppCertificationCategory', 'undefined')}")
+    print(f"Created Date           : {test_results.get('CreatedDate', 'undefined')}")
+    print(f"Provider ID            : {test_results.get('ProviderID', 'undefined')}")
+    print(f"API Version            : {test_results.get('APIVersion', 'undefined')}")
+    print("")
+    print("General")
+    print("--------------------------------")
+    print(f"OS Distro  : {test_results.get('OSDistro', 'undefined')}")
+    print(f"OS Name    : {test_results.get('OSName', 'undefined')}")
+    print(f"OS Version : {test_results.get('OSVersion', 'undefined')}")
+    print("")
+    print("Test case results")
+    print("--------------------------------")
+
+    for result in sorted(test_results.get('Tests'), key=lambda id: id['TestID']):
+        print(f"Test name (ID)   : {result.get('TestCaseName')} ({result.get('TestID')})")
+        print(f"  Description    : {result.get('Description')}")
+        print(f"  Required Value : {result.get('RequiredValue', 'undefined')}")
+        print(f"  Actual Value   : {result.get('ActualValue', 'undefined')}")
+        print(f"  Result         : {result.get('Result')}")
+        print("")

--- a/tests/tools/clean_orphans_gcp.py
+++ b/tests/tools/clean_orphans_gcp.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import os
+import sys
+
+import google.cloud.compute as compute
+import google.cloud.storage as storage
+import google.oauth2
+
+
+parser = argparse.ArgumentParser(description = 'Cleanup integration test resources in GCP')
+parser.add_argument('-p', '--project', metavar='project_id', required=False, dest='project', default='sap-cp-k8s-gdnlinux-gcp-test',
+                    help='Default value is "sap-cp-k8s-gdnlinux-gcp-test"')
+parser.add_argument('-r', '--region', metavar='region', required=False, dest='region', default='europe-west1', 
+                    help='Default value is "europe-west1"')
+parser.add_argument('-z', '--zone', metavar='zone', required=False, dest='zone', default='europe-west1-d',
+                    help='Default value is "europe-west1-d"')
+parser.add_argument('-t', '--timeout', metavar='timeout', required=False, dest='timeout', default=300, type=int,
+                    help='Time to wait for an operation to finish in seconds. Defaults to 300 seconds')
+parser.add_argument('-a', '--auth', metavar='service_account.json', required=False, dest='auth_path', default='',
+                    help='Path to JSON file that holds the service account login credentials. Defaults to Google application default credentials (ADC).')
+args = parser.parse_args()
+
+if os.path.exists(args.auth_path):
+    credentials = google.oauth2.service_account.Credentials.from_service_account_file(args.auth_path)
+else:
+    credentials = None
+
+try:
+    storage_client = storage.Client(credentials=credentials, project=args.project)
+    image_client = compute.ImagesClient(credentials=credentials)
+    subnet_client = compute.SubnetworksClient(credentials=credentials)
+    firewall_client = compute.FirewallsClient(credentials=credentials)
+    network_client = compute.NetworksClient(credentials=credentials)
+    instance_client = compute.InstancesClient(credentials=credentials)
+except google.auth.exceptions.DefaultCredentialsError as e:
+    print(f"No credentials found. {e}\n\n")
+    parser.print_help()
+    sys.exit(os.EX_CONFIG)
+
+
+def wait_for_operation(operation, name):
+    print(f"Waiting for deletion of resource {name} to complete...")
+    try:
+        result = operation.result(timeout=args.timeout)
+    except Exception:
+        print(f"\nTimeout of {args.timeout}s reached, Operation wasn't finished.\n")
+        sys.exit(os.EX_IOERR)
+    print(f"\t{name} deleted.")
+
+
+def get_buckets():
+    bucket_list = list(storage_client.list_buckets())
+    return bucket_list
+
+
+def delete_bucket(name):
+    bucket = storage_client.bucket(bucket_name=name)
+    print(f"Deleting bucket {name}...")
+    bucket.delete(force=True)
+    print(f"\t{name} deleted.")
+
+
+def get_images(project):
+    image_list = image_client.list(project=project).items
+    return image_list
+
+
+def delete_image(project, name):
+    operation = image_client.delete(project=project, image=name)
+    wait_for_operation(operation, name)
+
+
+def get_subnets(project, region):
+    subnet_list = subnet_client.list(project=project, region=region).items
+    return subnet_list
+
+
+def delete_subnet(project, region, name):
+    operation = subnet_client.delete(project=project, region=region, subnetwork=name)
+    wait_for_operation(operation, name)
+
+
+def get_firewalls(project):
+    firewall_list = firewall_client.list(project=project).items
+    return firewall_list
+
+
+def delete_firewall(project, name):
+    operation = firewall_client.delete(project=project, firewall=name)
+    wait_for_operation(operation, name)
+
+
+def get_networks(project):
+    network_list = network_client.list(project=project).items
+    return network_list
+
+
+def delete_network(project, name):
+    operation = network_client.delete(project=project, network=name)
+    wait_for_operation(operation, name)
+
+
+def get_instances(project, zone):
+    instance_list = instance_client.list(project=project, zone=zone).items
+    return instance_list
+
+
+def delete_instance(project, zone, name):
+    operation = instance_client.delete(project=project, zone=zone, instance=name)
+    wait_for_operation(operation, name)
+
+
+def add_to_inventory(inventory_dict, key, value):
+    try:
+        if type(inventory_dict[key]) is dict:
+            inventory_dict[key].update(value)
+    except KeyError:
+        inventory_dict[key] = value
+    return inventory_dict
+
+
+def sanity_check(inventory_dict, dependencies):
+    for dependency in dependencies:
+        if dependency in inventory_dict:
+            return False
+    return True
+
+
+def main():
+
+    buckets = get_buckets()
+    images = get_images(args.project)
+    subnets = get_subnets(args.project, args.region)
+    firewalls = get_firewalls(args.project)
+    networks = get_networks(args.project)
+    instances = get_instances(args.project, args.zone)
+
+    # build inventory, key is the test name, value is a dict with the resources of the test
+    inventory = {}
+
+    for instance in instances:
+        inventory = add_to_inventory(inventory, instance.labels['test-name'], {"instance": instance.name})
+
+    for bucket in buckets:
+        inventory = add_to_inventory(inventory, bucket.labels['test-name'], {"bucket": bucket.name})
+
+    for image in images:
+        inventory = add_to_inventory(inventory, image.labels['test-name'], {"image": image.name})
+
+    for subnet in subnets:
+        inventory = add_to_inventory(inventory, re.sub(r"vpc-", "", subnet.name), {"subnet": subnet.name})
+
+    for firewall in firewalls:
+        inventory = add_to_inventory(inventory, re.sub(r"http.*vpc-", "", firewall.network) , {"firewall": firewall.name})
+
+    for network in networks:
+        inventory = add_to_inventory(inventory, re.sub(r"vpc-", "", network.name), {"network": network.name})
+
+    inventory_key_list = list(inventory)
+
+    if len(inventory_key_list) == 0:
+        print('No resources found/left to delete')
+        sys.exit(os.EX_OK)
+
+    for i in range(len(inventory_key_list)):
+        print(f"{i}: {inventory_key_list[i]}")
+        for key,value in inventory[inventory_key_list[i]].items():
+            print(f"\t{key}: {value}")
+        print("")
+
+    pick = input("Choose the test resources to delete (digit, any other key quits): ")
+    try:
+        pick = int(pick)
+
+        if not (pick >= 0 and pick < len(inventory_key_list)):
+            return os.EX_DATAERR
+
+        test_environment = inventory_key_list[pick]
+
+        test_inventory_key_list = list(inventory[test_environment])
+        while len(test_inventory_key_list) > 0:
+            # output the resources of the chosen test, offer option to delete one resource or all at once
+            print("")
+            for i in range(len(test_inventory_key_list)):
+                print(f"{i}: {test_inventory_key_list[i]}: {inventory[test_environment][test_inventory_key_list[i]]}")
+            print("")
+            delete_pick = input("Which resource should be deleted (digit), type 'A' for all, any other key for back: ")
+            if (delete_pick == 'A'):
+                pass
+            elif delete_pick.strip().isdigit():
+                delete_pick = int(delete_pick)
+                if (delete_pick >= 0 and delete_pick < len(test_inventory_key_list)):
+                    pass
+                else:
+                    break
+            else:
+                break
+
+            # check if resource is deletable, delete resource if possible
+            for i in range(len(test_inventory_key_list)):
+                if delete_pick == i or delete_pick == 'A':
+                    if test_inventory_key_list[i] == 'instance':
+                        print("Deleting instance...")
+                        delete_instance(args.project, args.zone, inventory[test_environment]['instance'])
+                        del inventory[test_environment]['instance']
+                    if test_inventory_key_list[i] == 'subnet':
+                        print("Deleting subnet...")
+                        if sanity_check(inventory[test_environment], ['instance']):
+                            delete_subnet(args.project, args.region, inventory[test_environment]['subnet'])
+                            del inventory[test_environment]['subnet']
+                        else:
+                            print(f"subnet {inventory[test_environment]['subnet']} is in use by an instance")
+                            continue
+                    if test_inventory_key_list[i] == 'firewall':
+                        print("Deleting firewall...")
+                        delete_firewall(args.project, inventory[test_environment]['firewall'])
+                        del inventory[test_environment]['firewall']
+                    if test_inventory_key_list[i] == 'network':
+                        print("Deleting network...")
+                        if sanity_check(inventory[test_environment], ['instance', 'subnet', 'firewall']):
+                            delete_network(args.project, inventory[test_environment]['network'])
+                            del inventory[test_environment]['network']
+                        else:
+                            print(f"network {inventory[test_environment]['network']} is in use by an instance, subnet or firewall")
+                            continue
+                    if test_inventory_key_list[i] == 'image':
+                        print("Deleting image...")
+                        delete_image(args.project, inventory[test_environment]['image'])
+                        del inventory[test_environment]['image']
+                    if test_inventory_key_list[i] == 'bucket':
+                        print("Deleting bucket...")
+                        delete_bucket(inventory[test_environment]['bucket'])
+                        del inventory[test_environment]['bucket']
+            print("")
+
+            test_inventory_key_list = list(inventory[test_environment])
+
+    except ValueError:
+        return os.EX_DATAERR
+    return os.EX_OK
+
+if __name__ == "__main__":
+    while True:
+        result = main()
+        if result != 0:
+            sys.exit(result)


### PR DESCRIPTION
**What this PR does**
This PR brings the `test` folder via the command 
`git checkout main -- tests` back to rel-934 branch. 

**Why we need this**
We need the latest test environment for all supported garden linux versions.
Garden Linux version specific tests are defined in the feature folders.
