### PR TITLE
tests: improve resource leakage

### DIFF
--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -143,6 +143,16 @@ class AZURE:
                 'tags': self._tags
             }
         )
+    
+    def az_delete_ssh_key(self, name: str, force: bool = False):
+        key = self.az_get_ssh_key(name)
+        if key.tags == self._tags or force:
+            self.cclient.ssh_public_keys.delete(
+                resource_group_name = self._resourcegroup.name,
+                ssh_public_key_name = name
+            )
+        else:
+            self.logger.info(f"Keeping SSH public key {name} as it was not created by this test.")
 
 
     def az_get_image(self, name: str):
@@ -499,8 +509,11 @@ class AZURE:
         if self._storageaccount:
             self.az_delete_storage_account(self._storageaccount.name)
             self._storageaccount = None
+        if self._ssh_key:
+            self.az_delete_ssh_key(self._ssh_key.name)
+            self._ssh_key = None
         if self._resourcegroup:
-            self.az_delete_resourcegroup(name=self._resourcegroup.name, wait_for_completion=False)
+            self.az_delete_resourcegroup(name=self._resourcegroup.name, wait_for_completion=True)
             self._resourcegroup = None
 
     def init_environment(self):

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -415,8 +415,9 @@ class GCP:
 
         operation = images.insert(project=self.image_project, image_resource=config)
         self._gcp_wait_for_operation(operation, timeout=600)
-        image_blob.delete()
         self.logger.info(f'Uploaded image {blob_url} to project {self.project} as {image_name}')
+        image_blob.delete()
+        self._delete_bucket(name=self._bucket.name)
         self._image = images.get(image=image_name, project=self.image_project)
 
     def _delete_image(self, image_name):


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

This PR introduces two small fixes to the platform tests which - under certain conditions - could leak resources in GCP and Azure:

- on GCP, the GCS bucket used for uploaded the image to test will be deleted immediately after the image is inserted into GCE (so far, we only deleted the image blob immediately after import but left the empty bucket)
- on Azure, the SSH key used for the test will be explicitely removed and a longer timeout is granted for deleting the resource group of the test 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The cleanup code for automatic Garden Linux platform tests was improved to prevent resource leakage.
```
