### PR TITLE
fix(ci): check packages should return None in good case

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -41,16 +41,20 @@ jobs:
           source venv/bin/activate
           pip install requests pyyaml
 
-      - name: Run script
-        id: run-script
+      - name: Generate report
+        id: generate_report
         run: |
           source venv/bin/activate
-          python .github/workflows/generate_package_report.py > report.yaml
-          if [[ -s report.yaml ]]; then
-            echo "Package Report:"
-            cat report.yaml
-            exit 1
+          echo "::set-output name=report::$(python .github/workflows/generate_package_report.py)"
+        env:
+          GITLAB_PRIVATE_TOKEN: ${{ secrets.GITLAB_PRIVATE_TOKEN }}
+
+      - name: Print report
+        run: |
+          echo "${{ steps.generate_report.outputs.report }}"
+          if [ "${{ steps.generate_report.outputs.report }}" = "None" ]
+          then
+            echo "No failed package pipelines detected."
           else
-            echo "All package pipelines are successful"
-          fi
-          
+            exit 1
+          fi          

--- a/.github/workflows/generate_package_report.py
+++ b/.github/workflows/generate_package_report.py
@@ -54,4 +54,7 @@ for project in projects:
 
 sorted_report = sorted(report.items(), key=lambda x: x[1]['pipeline_status'] != 'failed', )
 
-print(yaml.dump(dict(sorted_report)))
+if sorted_report:
+    print(yaml.dump(dict(sorted_report)))
+else:
+    print("None")


### PR DESCRIPTION
The generate_package_report.py returns None if no package pipeline failed.
