### PR TITLE
Exclude firewall feature from gardener feature

### DIFF
--- a/features/gardener/info.yaml
+++ b/features/gardener/info.yaml
@@ -6,3 +6,4 @@ features:
     - sap
   exclude:
     - _selinux
+    - firewall

--- a/features/gardener/test/file.exclude.d/file.exclude.list
+++ b/features/gardener/test/file.exclude.d/file.exclude.list
@@ -1,0 +1,2 @@
+/etc/nft.d/default.conf
+/etc/nftables.conf

--- a/features/gardener/test/test_files_excluded.py
+++ b/features/gardener/test/test_files_excluded.py
@@ -1,0 +1,1 @@
+from helper.tests.files_excluded import files_excluded as test_file_excluded

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,1 @@
+Containerfile

--- a/tests/helper/tests/files_excluded.py
+++ b/tests/helper/tests/files_excluded.py
@@ -1,0 +1,40 @@
+from helper.utils import check_file
+import os
+import pytest
+import string
+
+def files_excluded(client):
+    files_to_be_excluded = []
+
+    # get the list of excluded files from the current feature
+    current = (os.getenv('PYTEST_CURRENT_TEST')).split('/')[0]
+    path = f"/gardenlinux/features/{current}/file.exclude"
+    try:
+        with open(path) as f:
+            files_to_be_excluded.append(f.read().splitlines)
+    except OSError:
+        pass
+
+    # get an additional/optional list of files that must not be present in the image
+    path = f"/gardenlinux/features/{current}/test/file.exclude.d/file.exclude.list"
+    try:
+        with open(path) as f:
+            for file in f:
+                file = file.strip(string.whitespace)
+                # Skip comment lines
+                if file.startswith("#"):
+                    continue
+                files_to_be_excluded.append(file)
+    except OSError:
+        pass
+
+    if len(files_to_be_excluded) == 0:
+        pytest.skip(f"Feature {current} does not require any files to be excluded.")
+
+    actually_present = []
+    for excluded_file in files_to_be_excluded:
+        if check_file(client, excluded_file) is True:
+            actually_present.append(excluded_file)
+
+    assert len(actually_present) == 0, \
+            f"{', '.join(actually_present)} must not be in the image but is actually present"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:

The `firewall` feature would configure nftables with a default policy to DROP everything on the input chain that is not SSH. This severely harms any kind of Kubernetes operation as it interferes with CNI. Therefore, the firewall feature must not be used with the Gardener feature.

Additionally: a test that can check for the presence of undesired files (like `/etc/nft.d` and `/etc/nftables.conf` in this case) and which will fail if these files were found in the image.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `firewall` feature is excluded from the `gardener` feature as it will severely interfere with Kubernetes and CNI operations.
```
