### PR TITLE
fixes to file_excluded test

### DIFF
--- a/tests/helper/tests/files_excluded.py
+++ b/tests/helper/tests/files_excluded.py
@@ -3,15 +3,16 @@ import os
 import pytest
 import string
 
+
 def files_excluded(client):
     files_to_be_excluded = []
 
     # get the list of excluded files from the current feature
-    current = (os.getenv('PYTEST_CURRENT_TEST')).split('/')[0]
+    current = (os.getenv("PYTEST_CURRENT_TEST")).split("/")[0]
     path = f"/gardenlinux/features/{current}/file.exclude"
     try:
         with open(path) as f:
-            files_to_be_excluded.append(f.read().splitlines)
+            files_to_be_excluded.extend(f.read().splitlines())
     except OSError:
         pass
 
@@ -36,5 +37,6 @@ def files_excluded(client):
         if check_file(client, excluded_file) is True:
             actually_present.append(excluded_file)
 
-    assert len(actually_present) == 0, \
-            f"{', '.join(actually_present)} must not be in the image but is actually present"
+    assert (
+        len(actually_present) == 0
+    ), f"{', '.join(actually_present)} must not be in the image but is actually present"

--- a/tests/integration/chroot.py
+++ b/tests/integration/chroot.py
@@ -276,7 +276,7 @@ class CHROOT:
             logger.info("Created {dir} with mode {mode}.".format(
                 dir=dir, mode=mode))
         except OSError:
-            logger.error("Directory {dir} already present.".format(
+            logger.warning("Directory {dir} already present.".format(
                 dir=dir))
         os.umask(orig_mask)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

The files_excluded test which was introduced in PR #1705 contained two small errors that would ignore files from a feature's `file.exclude`. Those are fixed with this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The files_excluded test now also catches files that were excluded via `file.exclude`.
```
