### PR TITLE
disable cryptsetup for _readonly feature

### DIFF
--- a/features/_readonly/fstab.mod
+++ b/features/_readonly/fstab.mod
@@ -8,5 +8,5 @@ sed '/^[^[:space:]]\+[[:space:]]\+\/overlay[[:space:]]\+/d;/^[^[:space:]]\+[[:sp
 cat << EOF
 LABEL=EFI    /boot/efi    vfat    ro,umask=0077    type=uefi,size=128MiB
 LABEL=USR    /usr         ext4    ro               verity
-REPART=00    /            ext4    rw               ephemeral_cryptsetup
+REPART=00    /            ext4    rw               ephemeral
 EOF


### PR DESCRIPTION
While `ephemeral_cryptsetup` mode provides better security than just `ephemeral` (protection against root partition being modified externally while system is running) it does significantly slow down system boot up, because the dm-integrity partition needs to be initialized.
Therefore it should be disabled by default.