### PR TITLE
feat(gh_actions): version tag for container images

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version:
         type: string
-        default: today
+        default: now
       default_modifier:
         type: string
         default: ""
@@ -21,6 +21,9 @@ jobs:
         run: |
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
+      - name: get current garden linux version
+        run: |
+          echo "gl_version=$(cat VERSION)" | tee -a "$GITHUB_ENV"
       - name: get cname
         run: |
           echo "cname_amd64=$(./build --resolve-cname container${{ inputs.default_modifier }}-amd64)" | tee -a "$GITHUB_ENV"
@@ -37,12 +40,18 @@ jobs:
           tar xzv < "${{ env.cname_amd64 }}.tar.gz"
           image="$(podman load < ${{ env.cname_amd64 }}.oci | awk '{ print $NF }')"
           podman tag "$image" ghcr.io/${{ github.repository }}:amd64-nightly
+          podman tag "$image" ghcr.io/${{ github.repository }}:amd64-${{ env.gl_version }}
           podman push ghcr.io/${{ github.repository }}:amd64-nightly
           tar xzv < "${{ env.cname_arm64 }}.tar.gz"
           image="$(podman load < ${{ env.cname_arm64 }}.oci | awk '{ print $NF }')"
           podman tag "$image" ghcr.io/${{ github.repository }}:arm64-nightly
+          podman tag "$image" ghcr.io/${{ github.repository }}:arm64-${{ env.gl_version }}
           podman push ghcr.io/${{ github.repository }}:arm64-nightly
           podman manifest create ghcr.io/${{ github.repository }}:nightly
           podman manifest add ghcr.io/${{ github.repository }}:nightly ghcr.io/${{ github.repository }}:amd64-nightly
           podman manifest add ghcr.io/${{ github.repository }}:nightly ghcr.io/${{ github.repository }}:arm64-nightly
           podman push ghcr.io/${{ github.repository }}:nightly
+          podman manifest create ghcr.io/${{ github.repository }}:${{ env.gl_version }}
+          podman manifest add ghcr.io/${{ github.repository }}:nightly ghcr.io/${{ github.repository }}:amd64-${{ env.gl_version }}
+          podman manifest add ghcr.io/${{ github.repository }}:nightly ghcr.io/${{ github.repository }}:arm64-${{ env.gl_version }}
+          podman push ghcr.io/${{ github.repository }}:${{ env.gl_version }}


### PR DESCRIPTION
* The Garden Linux container will be used for Garden Linux Package builds. To build packages for supported versions, we need the corresponding package build container in the correct version. E.g. `1227` instead of `nightly`. 

* This commit uses `bin/garden-version now` instead of `bin/garden-version today` This will set the actual version, instead of the string "today".

* This commit adds version tags to the garden linux container
