### PR TITLE
Add feature for vagrant libvirt box

### DIFF
--- a/.github/workflows/vagrant-libvirt.yaml
+++ b/.github/workflows/vagrant-libvirt.yaml
@@ -15,16 +15,13 @@ jobs:
     - name: Setup
       run: |
         sudo apt-get update
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static qemu-utils
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static
 
     - name: Build
       run: |
         ./build kvm-vagrant-${{ matrix.arch }}
 
-    - run: qemu-img convert -f raw -O qcow2  .build/kvm*-${{ matrix.arch }}-today-*.raw  gl.qcow2
-    - run: mv gl.qcow2 box.img; cp features/vagrant/Vagrantfile .; cp features/vagrant/metadata.json .
-    - run: tar cvzf gardenlinux_libvirt-${{ matrix.arch }}.box ./metadata.json ./Vagrantfile ./box.img
     - uses: actions/upload-artifact@v3
       with:
         name: gardenlinux-vagrant-libvirt-${{ matrix.arch }}
-        path: gardenlinux_libvirt-${{ matrix.arch }}.box
+        path: .build/kvm-vagrant-${{ matrix.arch }}*.box

--- a/.github/workflows/vagrant-libvirt.yaml
+++ b/.github/workflows/vagrant-libvirt.yaml
@@ -1,0 +1,30 @@
+name: Build Garden Linux Vagrant Libvirt Image
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64, arm64 ]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup
+      run: |
+        sudo apt-get update
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-user-static qemu-utils
+
+    - name: Build
+      run: |
+        ./build kvm-vagrant-${{ matrix.arch }}
+
+    - run: qemu-img convert -f raw -O qcow2  .build/kvm*-${{ matrix.arch }}-today-*.raw  gl.qcow2
+    - run: mv gl.qcow2 box.img; cp features/vagrant/Vagrantfile .; cp features/vagrant/metadata.json .
+    - run: tar cvzf gardenlinux_libvirt-${{ matrix.arch }}.box ./metadata.json ./Vagrantfile ./box.img
+    - uses: actions/upload-artifact@v3
+      with:
+        name: gardenlinux-vagrant-libvirt-${{ matrix.arch }}
+        path: gardenlinux_libvirt-${{ matrix.arch }}.box

--- a/features/vagrant/README.md
+++ b/features/vagrant/README.md
@@ -8,6 +8,8 @@ This feature flag adds vagrant libvirt to the Garden Linux artifact.
 
 Only tested on linux hosts so far.
 
+Based on [this StackExchange answer](https://unix.stackexchange.com/questions/222427/how-to-create-custom-vagrant-box-from-libvirt-kvm-instance/222907#222907).
+
 Ensure [vagrant](https://developer.hashicorp.com/vagrant/downloads?product_intent=vagrant), [libvirt](https://libvirt.org) and [the libvirt provider for vagrant](https://github.com/vagrant-libvirt/vagrant-libvirt) are set up.
 
 Download the built artifact with a name like `gardenlinux_libvirt*.box`, where the cpu architecture matches yours.

--- a/features/vagrant/README.md
+++ b/features/vagrant/README.md
@@ -1,0 +1,25 @@
+## Feature: vagrant
+### Description
+<website-feature>
+This feature flag adds vagrant libvirt to the Garden Linux artifact.
+</website-feature>
+
+```
+vagrant box add --name gardenlinux gardenlinux_libvirt.box
+vagrant init gardenlinux
+vagrant up --provider=libvirt
+```
+
+### Features
+**Warning**: Never use this feature on production!
+
+### Unit testing
+This feature does not support unit tests.
+
+### Meta
+|||
+|---|---|
+|type|flag|
+|artifact|None|
+|included_features|None|
+|excluded_features|None|

--- a/features/vagrant/README.md
+++ b/features/vagrant/README.md
@@ -4,6 +4,16 @@
 This feature flag adds vagrant libvirt to the Garden Linux artifact.
 </website-feature>
 
+## Setup
+
+Only tested on linux hosts so far.
+
+Ensure [vagrant](https://developer.hashicorp.com/vagrant/downloads?product_intent=vagrant), [libvirt](https://libvirt.org) and [the libvirt provider for vagrant](https://github.com/vagrant-libvirt/vagrant-libvirt) are set up.
+
+Download the built artifact with a name like `gardenlinux_libvirt*.box`, where the cpu architecture matches yours.
+
+Run the following commands to create and start a vagrant vm with Garden Linux:
+
 ```
 vagrant box add --name gardenlinux gardenlinux_libvirt.box
 vagrant init gardenlinux

--- a/features/vagrant/Vagrantfile
+++ b/features/vagrant/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+    config.vm.provider :libvirt do |libvirt|
+         libvirt.driver = "kvm"
+         libvirt.host = 'localhost'
+         libvirt.uri = 'qemu:///system'
+    end
+    config.vm.define "new" do |gardenlinux|
+         gardenlinux.vm.box = "gardenlinux"
+         gardenlinux.vm.provider :libvirt do |test|
+            test.memory = 1024
+            test.cpus = 1
+         end
+    end
+end

--- a/features/vagrant/convert.box
+++ b/features/vagrant/convert.box
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+input="$1"
+output="$2"
+
+tmp="$(mktemp -d)"
+
+qemu-img convert -f raw -O qcow2 "$input" "$tmp"/gl.qcow2
+mv "$tmp"/gl.qcow2 "$tmp"/box.img
+
+cp features/vagrant/metadata.json "$tmp"/metadata.json
+cp features/vagrant/Vagrantfile "$tmp"/Vagrantfile
+
+# Ensure all files in the tarball are in top level, not in sub directories
+tar cvzf "$output" --directory="$tmp" metadata.json Vagrantfile box.img

--- a/features/vagrant/exec.late
+++ b/features/vagrant/exec.late
@@ -8,6 +8,8 @@ id vagrant
 
 # vagrant user needs password vagrant, but chpasswd seems not to accept the password because it is too simple
 grep --invert-match vagrant /etc/shadow > /tmp/shadow
+# Ignore shellcheck false positive: No expansion wanted here
+# shellcheck disable=SC2016
 echo 'vagrant:$y$j9T$FBmWMMaSAZXFfooUf9ZFb/$M/XrMBIsmpqK5FrsZQS1hgwmMFWjLNoaM9np87KqNWB:19445:0:99999:7:::' >> /tmp/shadow
 mv /tmp/shadow /etc/shadow
 

--- a/features/vagrant/exec.late
+++ b/features/vagrant/exec.late
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+# Configure box for vagrant, cf https://unix.stackexchange.com/a/222907
+useradd --user-group --groups wheel --create-home vagrant
+id vagrant
+
+# vagrant user needs password vagrant, but chpasswd seems not to accept the password because it is too simple
+grep --invert-match vagrant /etc/shadow > /tmp/shadow
+echo 'vagrant:$y$j9T$FBmWMMaSAZXFfooUf9ZFb/$M/XrMBIsmpqK5FrsZQS1hgwmMFWjLNoaM9np87KqNWB:19445:0:99999:7:::' >> /tmp/shadow
+mv /tmp/shadow /etc/shadow
+
+mkdir /home/vagrant/.ssh
+chmod -R 700 /home/vagrant/.ssh
+curl -o /home/vagrant/.ssh/authorized_keys https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
+chown -R vagrant:vagrant /home/vagrant/.ssh
+find /home/vagrant -printf '%M %u:%g %p\n'
+
+echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+sed -i -e 's/Defaults    requiretty/### Defaults    requiretty/g' /etc/sudoers

--- a/features/vagrant/info.yaml
+++ b/features/vagrant/info.yaml
@@ -1,0 +1,2 @@
+description: "vagrant libvirt"
+type: flag

--- a/features/vagrant/metadata.json
+++ b/features/vagrant/metadata.json
@@ -1,0 +1,5 @@
+{
+    "provider"     : "libvirt",
+    "format"       : "qcow2",
+    "virtual_size" : 40
+  }

--- a/features/vagrant/pkg.include
+++ b/features/vagrant/pkg.include
@@ -1,0 +1,2 @@
+nfs-common
+vim

--- a/features/vagrant/pkg.include
+++ b/features/vagrant/pkg.include
@@ -1,2 +1,3 @@
 nfs-common
+qemu-guest-agent
 vim


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind poc
/area os
/os garden-linux

**What this PR does / why we need it**:

This feature builds a [vagrant](https://www.vagrantup.com) box for the [libvirt](http://vagrant-libvirt.github.io) provider.

This is useful to get a more comfortable environment for using gardenlinux on the cli as ssh integration and few more things are handled by vagrant.

I've tested the resulting box on linux/amd64.

It might work on macos/arm64, at least there is a [libvirt version for macos](https://www.libvirt.org/macos.html) but I could not get this working easily.

**Which issue(s) this PR fixes**:
Fixes #1717 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
