### PR TITLE
Set SYSTEMD_ESP_PATH to /boot/efi for kernel-install

### DIFF
--- a/features/_boot/exec.late
+++ b/features/_boot/exec.late
@@ -16,7 +16,7 @@ for kernel in /boot/vmlinuz-*; do
 	--reproducible \
 	"/boot/initrd.img-${kernel#*-}"
 
-	kernel-install add "${kernel#*-}" "${kernel}"
+	SYSTEMD_ESP_PATH=/boot/efi kernel-install add "${kernel#*-}" "${kernel}"
 done
 
 sed 's/boot\/efi\///' -i /boot/efi/loader/entries/*.conf


### PR DESCRIPTION
**What this PR does / why we need it**:
With the latest systemd version (254), the _kernel-install_ commands from __boot/exec.late_ no longer produce the loader entries and the build fails.

**Which issue(s) this PR fixes**:
Fixes #