### PR TITLE
fix(ci): nightly for 934 must be triggered with version

### DIFF
--- a/.github/workflows/nightly-rel934.yml
+++ b/.github/workflows/nightly-rel934.yml
@@ -6,4 +6,17 @@ jobs:
   trigger_workflow_dispatch:
     runs-on: ubuntu-latest
     steps:
-      - run: curl -vv --fail-with-body -X POST -u "token:${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/workflows/28837699/dispatches" -d '{"ref":"rel-934"}'
+
+      - name: Checkout 934 branch
+        uses: actions/checkout@v2
+        with:
+          ref: 'rel-934'
+
+      - name: Get the latest 934 version (including minor version)
+        run: echo "VERSION=$(./bin/garden-version)" >> $GITHUB_ENV
+
+      - name: Trigger nightly for rel-934 with version input
+        run: |
+          curl -vv --fail-with-body -X POST -u "token:${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/workflows/28837699/dispatches" -d "{\"ref\":\"rel-934\", \"inputs\":{\"version\":\"$VERSION\"}}"
+
+


### PR DESCRIPTION
**What this PR does / why we need it**:

The nightly for rel-934 is configured to build with the wrong version ([see log](https://github.com/gardenlinux/gardenlinux/actions/runs/5758958280/job/15612307141#step:8:6067
)). It uses the default `now` which evaluates to the current dates Garden Linux version. But the expected behaviour is to use the version specified in the VERSION file of the target branch. 

This PR explicitly sets the version as input, by reading the content of the VERSION file used in the rel-934 branch.

