### PR TITLE
doc: description of time sources

### DIFF
--- a/docs/configuration/time-configuration.md
+++ b/docs/configuration/time-configuration.md
@@ -1,0 +1,50 @@
+---
+title: Time configuration
+weight: 10
+disableToc: false
+---
+
+This document describes the time configuration (NTP, PTP, etc.) in Garden Linux images.
+
+# Time (NTP) configuration in Garden Linux
+
+Depending on the cloud provider for which the Garden Linux is built, different time sources are configured. The configuration generally follows the recommendations of the cloud providers.
+
+If not mentioned otherwise, Garden Linux used [_systemd-timesyncd_](https://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html) for time synchronization.
+
+## AWS
+
+For AWS, NTP is used and configured to retrieve the time from Amazons NTP server at `169.254.169.123`.
+
+The time source is configured in [`features/aws/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-aws.conf`](../../features/aws/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-aws.conf).
+
+Also refer to [Amazons documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html).
+
+## GCP
+
+For GCP, NTP is used and configured to retrieve the time from Googles NTP server at `metadata.google.internal`.
+
+The time source is configured in [`features/gcp/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-gcp.conf`](../../features/gcp/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-gcp.conf).
+
+Also refer to [Googles documentation](https://cloud.google.com/compute/docs/instances/configure-ntp).
+
+## Azure
+
+For Azure, [PTP](https://en.wikipedia.org/wiki/Precision_Time_Protocol) is used instead of NTP. For that, Garden Linux uses [_chrony_](https://chrony-project.org/)
+as _systemd-timesyncd_ does not support PTP.
+
+The time is configured in [`features/azure/file.include/etc/chrony/chrony.conf`](../../features/azure/file.include/etc/chrony/chrony.conf).
+
+Also refer to [Microsofts documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync).
+
+## Alibaba Cloud
+
+For AliCloud, NTP is used and configured to retrieve the time from AliClouds NTP servers at different addresses.
+
+The time source is configured in [`features/ali/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-ali.conf`](../../features/ali/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-ali.conf).
+
+Also refer to [Alibaba Clouds documentation](https://www.alibabacloud.com/help/en/ecs/user-guide/alibaba-cloud-ntp-server).
+
+## OpenStack
+
+For OpenStack, NTP is generally used. Since individual OpenStack landscapes can be vastly different, the NTP configuration has to come in through cloud-init.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Includes a documentation that describes how Garden Linux configures NTP/PTP time sources for the different cloud providers.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
A documentation that describes how Garden Linux configures NTP/PTP time sources for the different cloud providers in included in the repo.
```
