### PR TITLE
Add a feature for using with lima-vm

### DIFF
--- a/features/lima/README.md
+++ b/features/lima/README.md
@@ -4,7 +4,9 @@
 This feature flag produces an image suitable for using with [lima](https://lima-vm.io)
 </website-feature>
 
-Example config:
+Build the image with `./build kvm-lima`
+
+Example config (build image locally, adapt path, save config as `gardenlinux.yaml`):
 
 ```
 images:
@@ -12,6 +14,14 @@ images:
   arch: "x86_64"
 - location: "path/to/kvm-lima-arm64-today-local.raw"
   arch: "aarch64"
+```
+
+Example usage:
+
+```
+$ cat gardenlinux.yaml | limactl create --name=gardenlinux -
+$ limactl start gardenlinux
+$ limactl shell gardenlinux
 ```
 
 Known limitations:

--- a/features/lima/README.md
+++ b/features/lima/README.md
@@ -1,0 +1,19 @@
+## Feature: lima
+### Description
+<website-feature>
+This feature flag produces an image suitable for using with [lima](https://lima-vm.io)
+</website-feature>
+
+Example config:
+
+```
+images:
+- location: "path/to/kvm-lima-amd64-today-local.raw"
+  arch: "x86_64"
+- location: "path/to/kvm-lima-arm64-today-local.raw"
+  arch: "aarch64"
+```
+
+Known limitations:
+
+- Mounting host directories into the VM is not supported yet

--- a/features/lima/info.yaml
+++ b/features/lima/info.yaml
@@ -1,0 +1,2 @@
+description: "image suitable for using with [lima](https://lima-vm.io)"
+type: flag

--- a/features/lima/pkg.include
+++ b/features/lima/pkg.include
@@ -1,0 +1,1 @@
+cloud-init


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Adds a feature that allows to build a GL image that is usable with [lima](https://lima-vm.io).
This makes it convenient to manage virtual machines and ssh into them which will help (potential) users/admins of GL-based systems to test/integrate the system.

**Which issue(s) this PR fixes**:
Implements a part of #1727

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
