### PR TITLE
doc(adr): Introduce Architecture Decision Records (ADR) to Garden Linux

### DIFF
--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,21 @@
+# 1. Adopting Architecture Decision Records (ADR) for Garden Linux
+
+Date: 2023-08-23
+
+## Status
+
+Accepted
+
+## Context
+
+To ensure clarity and traceability of architectural decisions in Garden Linux, we recognized the need for a structured documentation approach. Refer to [Issue #1742](https://github.com/gardenlinux/gardenlinux/issues/1742) for more details. Please note that, Garden Linux has daily versions, with select versions being designated as "supported". ADRs in Garden Linux reflect the current state and decisions of the repository/branch they reside in. Unless otherwise specified, they do not retroactively apply to past versions that are still supported. 
+
+For more context about ADR itself please refer to https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+
+## Decision
+
+We've chosen to adopt the ADR methodology using [adr-tools](https://github.com/npryce/adr-tools) for documenting architectural decisions in Garden Linux. Decisions documented will pertain to the current state of Garden Linux and won't retroactively affect past versions unless explicitly stated in the respective ADR.
+
+## Consequences
+
+The [adr-tools](https://github.com/npryce/adr-tools) will be our primary tool for managing and recording architecture decisions. This will ensure a consistent and traceable record of decisions made throughout the project's lifecycle.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records (ADR) for Garden Linux
+
+In Garden Linux, we use Architecture Decision Records (ADR) to capture important architectural decisions made about the system. This provides context, clarity, and documentation about the decisions we make.
+
+## Installation
+
+### MacOS
+```
+brew install adr-tools
+```
+
+### Linux
+
+For installation instructions, please refer to the [official installation guide](https://github.com/npryce/adr-tools/blob/master/INSTALL.md).
+In short, it is either 
+1. https://github.com/npryce/adr-tools/releases download, extract and place `src/` folder in your PATH
+2. Same as option 1, but you use git clone instead of downloading the release
+
+## ADRs for past Versions of Garden Linux
+
+ADRs in Garden Linux reflect the current state and decisions of the repository/branch they reside in. Unless otherwise specified, they do not retroactively apply to past versions that are still supported.
+
+## Further Read
+For a deeper understanding of the value and context of ADRs, we recommend reading [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) by Michael Nygard.


### PR DESCRIPTION
* fixes #1742

This PR introduces the use of Architecture Decision Records (ADR) within the Garden Linux project. ADRs provide a structured format to capture, document, and share important architectural decisions.

- Added the first ADR entry, highlighting the adoption of ADR for Garden Linux.
- Created a README explaining the purpose of ADRs, installation instructions for adr-tools, and the significance of ADRs in the context of Garden Linux.


Kudos to @fwilhe  for the introduction and the initial idea. 