### PR TITLE
test(gcp): enable uniform bucket access

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -316,6 +316,7 @@ class GCP:
         self.logger.info(f"Creating GCS bucket {name} for image upload...")
         bucket.storage_class = storage.constants.STANDARD_STORAGE_CLASS
 
+        bucket.iam_configuration.uniform_bucket_level_access_enabled = True
         bucket.iam_configuration.public_access_prevention = (
             storage.constants.PUBLIC_ACCESS_PREVENTION_ENFORCED
         )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Buckets in GCP that are used to upload the Garden Linux images to be tested in the automated platform tests are now created with [uniform bucket level access](https://cloud.google.com/storage/docs/using-uniform-bucket-level-access).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Buckets in GCP that are used to upload the Garden Linux images to be tested in the automated platform tests are now created with ["uniform bucket level access"](https://cloud.google.com/storage/docs/using-uniform-bucket-level-access).
```
