### PR TITLE
doc: update security contacts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,13 +14,12 @@ disclosure but will need help from relevant developers and release managers
 to successfully run this process. The Garden Linux Security Team consists of the
 following volunteers:
 
-* Christian Cwienk, (**[@ccwienk](https://github.com/ccwienk)**)
-* Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
 * Andre Russ, (**[@gehoern](https://github.com/gehoern)**)
-* Matthias Sohn, (**[@msohn](https://github.com/msohn)**)
+* Vincent Riesop (**[@vincinator](https://github.com/vincinator/)**)
+* Nikolas Kraetzschmar (**[@nkraetzschmar](https://github.com/nkraetzschmar/)**)
 * Frederik Thormaehlen, (**[@ThormaehlenFred](https://github.com/ThormaehlenFred)**)
-* Martin Vladev, (**[@mvladev](https://github.com/mvladev)**)
-
+* Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
+* Christian Cwienk, (**[@ccwienk](https://github.com/ccwienk)**)
 
 ## Disclosures
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,7 @@ following volunteers:
 * Andre Russ, (**[@gehoern](https://github.com/gehoern)**)
 * Vincent Riesop (**[@vincinator](https://github.com/vincinator/)**)
 * Nikolas Kraetzschmar (**[@nkraetzschmar](https://github.com/nkraetzschmar/)**)
+* Florian Wilhelm (**[@fwilhe](https://github.com/fwilhe/)**)
 * Frederik Thormaehlen, (**[@ThormaehlenFred](https://github.com/ThormaehlenFred)**)
 * Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
 * Christian Cwienk, (**[@ccwienk](https://github.com/ccwienk)**)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,10 +17,9 @@ following volunteers:
 * Andre Russ, (**[@gehoern](https://github.com/gehoern)**)
 * Vincent Riesop (**[@vincinator](https://github.com/vincinator/)**)
 * Nikolas Kraetzschmar (**[@nkraetzschmar](https://github.com/nkraetzschmar/)**)
+* Stefan Catargiu (**[@5kt](https://github.com/5kt/)**)
 * Florian Wilhelm (**[@fwilhe](https://github.com/fwilhe/)**)
 * Frederik Thormaehlen, (**[@ThormaehlenFred](https://github.com/ThormaehlenFred)**)
-* Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
-* Christian Cwienk, (**[@ccwienk](https://github.com/ccwienk)**)
 
 ## Disclosures
 


### PR DESCRIPTION
Updating the security contacts.

Adding Niko, Florian, Stefan and myself.

Removing @msohn and @mvladev as person of contact for security issues (please let me know if you still volunteer and want to be mentioned in that SECURITY.md, happily add you again  just let me know) 



