### PR TITLE
Lima: Convert image to qcow2 for smaller download size

### DIFF
--- a/features/lima/README.md
+++ b/features/lima/README.md
@@ -10,9 +10,9 @@ Example config (build image locally, adapt path, save config as `gardenlinux.yam
 
 ```
 images:
-- location: "path/to/kvm-lima-amd64-today-local.raw"
+- location: "path/to/kvm-lima-amd64-today-local.qcow2"
   arch: "x86_64"
-- location: "path/to/kvm-lima-arm64-today-local.raw"
+- location: "path/to/kvm-lima-arm64-today-local.qcow2"
   arch: "aarch64"
 ```
 

--- a/features/lima/convert.qcow2
+++ b/features/lima/convert.qcow2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+qemu-img convert -f raw -O qcow2 "$1" "$2"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Convert image files from raw to qcow2 in the lima feature.
As it is common for lima to download images via http, having raw images means a lot of useless traffic will happen so it makes sense to convert the images to qcow2 as they are smaller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
