### PR TITLE
test: limit azure nsg to incoming ssh from test system

### DIFF
--- a/tests/integration/azure.py
+++ b/tests/integration/azure.py
@@ -27,6 +27,7 @@ from azure.mgmt.storage.models import StorageAccountCheckNameAvailabilityParamet
 from azure.storage.blob import BlobClient
 
 from paramiko import RSAKey
+from . import util
 
 
 logger = logging.getLogger(__name__)
@@ -182,6 +183,7 @@ class AZURE:
             return None
 
     def az_create_nsg(self, name):
+        my_ip = util.get_my_ip()
         self.logger.info(f"Creating network security group {name} in resourcegroup {self._resourcegroup.name}...")
         nsg = self.nclient.network_security_groups.begin_create_or_update(
             resource_group_name = self._resourcegroup.name,
@@ -204,7 +206,7 @@ class AZURE:
                 'access': 'Allow',
                 'priority': 300,
                 'direction': 'Inbound',
-                'source_address_prefixes': {'0.0.0.0/1', '128.0.0.0/1'},
+                'source_address_prefixes': {f"{my_ip}/32"},
                 'destination_address_prefix': 'VirtualNetwork',
             }
         ).result()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

The network security group that gets created for a platform test in Azure should not allow incoming SSH traffic from 0.0.0.0/0 but only from the machine that runs and controls the tests, thus increasing security.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The network security group for Azure base platform tests will only allow incoming SSH traffic from the test system.
```
