### PR TITLE
hack: script to lists download paths of a given apt package

### DIFF
--- a/hack/gl-pkg-url.sh
+++ b/hack/gl-pkg-url.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Parameter 1: garden linux version
+# Parameter 2: ARCH (arm64, amd64, all)
+# Parameter 3: package name (wildcard allowed, but then you must enclouse parameter with quotes)
+# Outputs a list of kernel packages
+#
+# Example: ./gl-pkg-url.sh 934.10 amd64 linux-headers
+
+GL_VERSION=${1:-today}
+GL_ARCH=${2:-"amd64"}
+GL_PKG_NAME=${3:-"linux*"}
+
+packages_url="http://repo.gardenlinux.io/gardenlinux/dists/${GL_VERSION}/main/binary-${GL_ARCH}/Packages"
+
+packages=$(curl -s "$packages_url" | grep "Filename: pool/main/.*/$GL_PKG_NAME" | cut -d':' -f 2)
+
+for p in $packages; do
+    echo "http://repo.gardenlinux.io/gardenlinux/$p"
+done


### PR DESCRIPTION
If a developer needs to download packages but has no access to apt, this script can be used to list urls to binary packages of the repo.gardenlinux.io packages.

We still need package build container, kernel module build container, and an automation. this is just a snippet. 

##  Example

```
./gl-pkg-url.sh 934.10 amd64 linux-headers
```

outputs: 
```
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15-amd64_5.15.125-0gardenlinux1_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15-cloud-amd64_5.15.125-0gardenlinux1_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15-firecracker-amd64_5.15.125-0gardenlinux1_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.125-gardenlinux-amd64_5.15.125-0gardenlinux1_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.125-gardenlinux-cloud-amd64_5.15.125-0gardenlinux1_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.125-gardenlinux-common_5.15.125-0gardenlinux1_all.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/l/linux-5.15/linux-headers-5.15.125-gardenlinux-firecracker-amd64_5.15.125-0gardenlinux1_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/g/gardenlinux-kernel/linux-headers-amd64_5.15_amd64.deb
http://repo.gardenlinux.io/gardenlinux/pool/main/g/gardenlinux-kernel/linux-headers-cloud-amd64_5.15_amd64.deb
```