### PR TITLE
container: garden linux driver build container

### DIFF
--- a/container/driver-build/Dockerfile
+++ b/container/driver-build/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/gardenlinux/gardenlinux:nightly
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV SHELL /bin/bash
+
+RUN apt-get update && \
+    apt-get install -y  \
+        sudo vim git rsync wget curl gnupg python3 build-essential bc kmod cpio \
+        flex libelf-dev libssl-dev dwarves \
+        devscripts kernel-wedge pristine-lfs python3-debian quilt dkms
+
+# Install Garden Linux Kernel meta packages 
+# Note: https://gitlab.com/gardenlinux/gardenlinux-package-linux
+RUN ARCH=$(dpkg --print-architecture) && \
+    apt-get update && \
+    apt-get install -y \
+        kmod \
+        linux-headers-cloud-${ARCH} \
+        linux-headers-${ARCH}

--- a/container/driver-build/Dockerfile
+++ b/container/driver-build/Dockerfile
@@ -9,11 +9,15 @@ RUN apt-get update && \
         flex libelf-dev libssl-dev dwarves \
         devscripts kernel-wedge pristine-lfs python3-debian quilt dkms
 
-# Install Garden Linux Kernel meta packages 
+RUN sudo dpkg --add-architecture arm64
+RUN sudo dpkg --add-architecture amd64
+
+# Install Garden Linux kernel header meta packages 
 # Note: https://gitlab.com/gardenlinux/gardenlinux-package-linux
-RUN ARCH=$(dpkg --print-architecture) && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y \
         kmod \
-        linux-headers-cloud-${ARCH} \
-        linux-headers-${ARCH}
+        linux-headers-cloud-amd64 \
+        linux-headers-cloud-arm64 \
+        linux-headers-amd64 \
+        linux-headers-arm64


### PR DESCRIPTION
* based on gardenlinux nightly until we have garden linux base images also published with their respective garden linux version number.
* installed typiall kernel driver build dependencies
* installed linux kernel headers via garden linux meta package


## Notes
When we do a release of Garden Linux, we must also publish the matching driver build container. 
If, let's say `1234.0` would be published, we would need to publish a `gardenlinux-driverbuild:1234.0` container as well. 
This  `gardenlinux-driverbuild:1234.0` must be based on `ghcr.io/gardenlinux/gardenlinux:1234.0`


