### PR TITLE
Add lima/vscode ssh plugin dev environment

### DIFF
--- a/hack/lima-dev-env.yaml
+++ b/hack/lima-dev-env.yaml
@@ -1,0 +1,56 @@
+# Development environment for Garden Linux using lima (https://github.com/lima-vm/lima)
+# This is intended to be used with the VS Code SSH Remote plugin: https://code.visualstudio.com/docs/remote/ssh
+# Usage instructions:
+# Make sure lima and qemu are installed.
+#
+# Run the following commands:
+#
+#  limactl create --name gl-dev hack/lima-dev-env.yaml
+#  echo "Include ${LIMA_HOME:-$HOME/.lima}/gl-dev/ssh.config" >> ~/.ssh/config
+#  limactl start gl-dev
+#
+# Connect to host 'lima-gl-dev' in VS Code via the SSH Remote plugin
+
+vmType: qemu
+os: Linux
+memory: 8GiB
+ssh:
+  loadDotSSHPubKeys: true
+containerd:
+  system: false
+  user: false
+
+images:
+  - location: "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-amd64-daily.qcow2"
+    arch: "x86_64"
+  - location: "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-arm64-daily.qcow2"
+    arch: "aarch64"
+
+mounts:
+  - location: "~"
+  - location: "/tmp/lima"
+    writable: true
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      command -v podman >/dev/null 2>&1 && exit 0
+      apt-get -y install podman
+      apt-get -y install git
+      apt-get -y install qemu-system-x86 qemu-system-arm qemu-efi-aarch64 qemu-user-static
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      systemctl --user enable --now podman.socket
+
+      if [ ! -d ~/gardenlinux ]
+      then
+        git clone https://github.com/gardenlinux/gardenlinux ~/gardenlinux
+      else
+        echo Local checkout of Garden Linux already exists
+      fi


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Adds a definition for a Garden Linux dev environment using [lima](https://github.com/lima-vm/lima) which can be used with the [VS Code SSH Remote plugin](https://code.visualstudio.com/docs/remote/ssh).

This adds a free software alternative for Garden Linux dev environments on non-linux host OS (except for the non-OSS VS Code parts).

SSH remote development allows a almost 'native' feel for editing/development in VS Code.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
