### PR TITLE
Fix pxe feature

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
@@ -1,49 +1,132 @@
 #!/bin/bash
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh
-
 set -e
+
+# TODO: change the parameter name to illustrate better what it's used for
+# should be gl.squashfs=url=http://...
+# or gl.squashfs=dev=/dev/vdx
+
+url=$(getarg gl.url=)
+if [ -z "${url#gl.url=}" ] && [ ! -f /root.squashfs ]; then
+	exit 0
+fi
 
 GENERATOR_DIR="$1"
 
-mkdir -p /run/rootfs
-
-if [ ! -e /run/root.squashfs ]; then
-	if [ -e /root.squashfs ]; then
-		mv /root.squashfs /run/root.squashfs
-	else
-		getarg gl.url= > /dev/null || exit 0
-		cat >"${GENERATOR_DIR}/live-get-squashfs.service" <<-EOF
-		[Unit]
-		Description=Download squashfs image
-
-		After=network-online.target systemd-resolved.service
-		Wants=network-online.target systemd-resolved.service
-
-		OnFailure=emergency.target
-		OnFailureJobMode=isolate
-		DefaultDependencies=no
-
-		[Service]
-		Type=oneshot
-		TimeoutStartSec=600
-		RemainAfterExit=yes
-		ExecStart=/sbin/live-get-squashfs
-		EOF
-	fi
+# generator already ran, exit
+if [ -e "${GENERATOR_DIR}/run-rootfs.mount" ]; then
+	exit 0
 fi
 
-cat >"${GENERATOR_DIR}/run-rootfs.mount" <<EOF
-[Unit]
-After=live-get-squashfs.service
-Wants=live-get-squashfs.service
-After=dracut-pre-mount.service
-Before=initrd-root-fs.target
-DefaultDependencies=no
+# squashfs embedded into the initrd
+if [ -f /root.squashfs ]; then
+	cat >"${GENERATOR_DIR}/run-rootfs.mount" <<-EOF
+	[Unit]
+	After=dracut-pre-mount.service
+	Before=initrd-root-fs.target
+	DefaultDependencies=no
 
-[Mount]
-What=/run/root.squashfs
-Where=/run/rootfs
-Type=squashfs
-Options=loop
-EOF
+	[Mount]
+	What=/run/root.squashfs
+	Where=/run/rootfs
+	Type=squashfs
+	Options=loop
+	EOF
+	cat >"${GENERATOR_DIR}/move-squashfs.service" <<-EOF
+	[Unit]
+	Description=Movesquashfs image
+
+	OnFailure=emergency.target
+	OnFailureJobMode=isolate
+	DefaultDependencies=no
+
+	[Service]
+	Type=oneshot
+	TimeoutStartSec=600
+	RemainAfterExit=yes
+	ExecStart=/bin/bash -c "mv /root.squashfs /run/root.squashfs"
+	EOF
+        mkdir -p "$GENERATOR_DIR"/basic.target.wants
+        ln -s ../symlink-squashfs.service "$GENERATOR_DIR"/basic.target.wants/symlink-squashfs.service
+	exit 0
+fi
+
+# we have squashfs attached as dev
+if [[ "$url" == "/dev/"* ]]; then
+	devname=$(dev_unit_name "$url")
+
+	mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target
+	ln -s ../"${devname}".device "$GENERATOR_DIR"/initrd-root-fs.target/"${devname}".device
+
+	mkdir -p "$GENERATOR_DIR"/"${devname}".device.d
+	{
+	echo "[Unit]"
+	echo "JobTimeoutSec=30"
+	echo "JobRunningTimeoutSec=30"
+	} > "$GENERATOR_DIR"/"${devname}".device.d/timeout.conf
+
+	cat >"${GENERATOR_DIR}/run-rootfs.mount" <<-EOF
+	[Unit]
+	After=$devname.device
+	Wants=$devname.device
+
+	After=dracut-pre-mount.service
+	Before=initrd-root-fs.target
+	DefaultDependencies=no
+
+	[Mount]
+	What=/run/root.squashfs
+	Where=/run/rootfs
+	Type=squashfs
+	Options=loop
+	EOF
+	cat >"${GENERATOR_DIR}/symlink-squashfs.service" <<-EOF
+	[Unit]
+	Description=Symlink squashfs image
+
+	OnFailure=emergency.target
+	OnFailureJobMode=isolate
+	DefaultDependencies=no
+
+	[Service]
+	Type=oneshot
+	TimeoutStartSec=600
+	RemainAfterExit=yes
+	ExecStart=/bin/bash -c "ln -s $url /run/root.squashfs"
+	EOF
+        mkdir -p "$GENERATOR_DIR"/basic.target.wants
+        ln -s ../symlink-squashfs.service "$GENERATOR_DIR"/basic.target.wants/symlink-squashfs.service
+# we have a url
+elif [[ "$url" == "http"* ]]; then
+	cat >"${GENERATOR_DIR}/live-get-squashfs.service" <<-EOF
+	[Unit]
+	Description=Download squashfs image
+
+	After=network-online.target systemd-resolved.service
+	Wants=network-online.target systemd-resolved.service
+
+	OnFailure=emergency.target
+	OnFailureJobMode=isolate
+	DefaultDependencies=no
+
+	[Service]
+	Type=oneshot
+	TimeoutStartSec=600
+	RemainAfterExit=yes
+	ExecStart=/sbin/live-get-squashfs
+	EOF
+	cat >"${GENERATOR_DIR}/run-rootfs.mount" <<-EOF
+	[Unit]
+	After=live-get-squashfs.service
+	Wants=live-get-squashfs.service
+	After=dracut-pre-mount.service
+	Before=initrd-root-fs.target
+	DefaultDependencies=no
+	[Mount]
+	What=/run/root.squashfs
+	Where=/run/rootfs
+	Type=squashfs
+	Options=loop
+	EOF
+fi

--- a/features/_pxe/image.pxe.tar.gz
+++ b/features/_pxe/image.pxe.tar.gz
@@ -58,11 +58,9 @@ rm "$chroot_dir/root.squashfs"
 case "$BUILDER_ARCH" in
 	amd64)
 		uefi_arch=x64
-		gnu_arch=x86_64
 		;;
 	arm64)
 		uefi_arch=aa64
-		gnu_arch=aarch64
 		;;
 esac
 

--- a/features/_pxe/image.pxe.tar.gz
+++ b/features/_pxe/image.pxe.tar.gz
@@ -59,21 +59,19 @@ case "$BUILDER_ARCH" in
 	amd64)
 		uefi_arch=x64
 		gnu_arch=x86_64
-		initrd_vma=0x3000000
 		;;
 	arm64)
 		uefi_arch=aa64
 		gnu_arch=aarch64
-		initrd_vma=0x4000000
 		;;
 esac
 
-# create unified image
-"${gnu_arch}-linux-gnu-objcopy" \
-	--add-section .cmdline=cmdline --change-section-vma .cmdline=0x1000000 \
-	--add-section .linux=vmlinuz --change-section-vma .linux=0x2000000 \
-	--add-section .initrd=tmp_initrd --change-section-vma .initrd="$initrd_vma" \
-	"$chroot_dir/usr/lib/systemd/boot/efi/linux$uefi_arch.efi.stub" unified_image
+/lib/systemd/ukify build \
+	--stub "${chroot_dir}/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
+	--linux "vmlinuz" \
+	--initrd "tmp_initrd" \
+	--cmdline "cmdline" \
+	--output "unified_image"
 
 export PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
 cert_base="/builder/cert/secureboot.db"


### PR DESCRIPTION
**What this PR does / why we need it**:
For onmetal the squashfs is usually attached to the VM and presented as a block device - the gl.url parameter is used as gl.url=/dev/disk/by-id... - this PR is adding support for that.

We also need to switch to ukify to generate the unified images - the offsets used when using objcopy are no longer correct and the generation of the unified image fails.

**Which issue(s) this PR fixes**:
Fixes #
