### PR TITLE
fix(startvm): Add note regarding UEFI firmware for ARM64 guests

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -72,6 +72,13 @@ This script allows to inject a SSH pubkey to a final Garden Linux image to ensur
 ### start-vm
 This script starts a given `.raw` or `.qcow2` image in a local QEMU/KVM VM and supports `amd64` and `arm64 builds`. Keep in mind, that running different architectures may be very slow. However, it may still be useful for validating and running unit tests. A spawned VM runs in `textmode` which a `hostfwd` (portforward) for SSH on `tcp/2222`. By the given options this allows the user to user copy/paste in the terminal, as well as connecting to the sshd. *(Hint: Custom SSH pubkeys can be injected with `inject-sshkey`.)*
 
+**UEFI ARM64 Files**
+Running ARM64 based images requires ARM64 UEFI firmware. This can be installed for QEMU on Debian systems by installing the following packages:
+
+```
+apt-get install ovmf qemu-efi-aarch64
+```
+
 **Acceleration Support:**
 
 Currently, `start-vm` supports `KVM` and `HVF` acceleration. While `HVF` is only supported on macOS, `KVM` will mostly be used. When using `KVM` acceleration you need to ensure that `/dev/kvm` can be used by your user account. However, if `/dev/kvm` is not usable it will fallback to a non accelerated support that may still work but may be slower. Setting permissions on `/dev/kvm` can be don is several ways; for example:

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -495,8 +495,8 @@ qemu_opt_uefi () {
     # Define UEFI options for QEMU
     if [ $uefi ]; then
 
-        [ -r $uefi_code ] || eusage "Missing uefi code at $uefi_code.\n Run: apt-get install ovmf"
-        [ -r $uefi_vars ] || eusage "Missing uefi vars at $uefi_vars.\n Run: apt-get install ovmf"
+        [ -r $uefi_code ] || eusage "Missing uefi code at $uefi_code.\n Run: apt-get install ovmf qemu-efi-aarch64"
+        [ -r $uefi_vars ] || eusage "Missing uefi vars at $uefi_vars.\n Run: apt-get install ovmf qemu-efi-aarch64"
 
         [ -e $CURR_DIR/$mac.vars ] || cp $uefi_vars $CURR_DIR/$mac.vars
 


### PR DESCRIPTION
fix(startvm): Add note regarding UEFI firmware for ARM64 guests

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Add note regarding UEFI firmware for ARM64 guests

**Which issue(s) this PR fixes**:
Fixes #1773

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: doc
- target_group: user
```
