### PR TITLE
fix(startvm): Do not use `-watchdog` option when using `qemu-system-aarch64` binary

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -609,7 +609,7 @@ qemu_opt_monitor () {
     fi
 
     # Add Watchdog
-    if [ $os = debian ] && [ "$no_watchdog" = 0 ]; then
+    if [ $os = debian ] && [ "$no_watchdog" = 0 ] && [ $bin_qemu != qemu-system-aarch64 ]; then
         # add a watchdog to maintain automatic reboots
         QEMU_OPTS+=("-watchdog i6300esb")
     fi


### PR DESCRIPTION
fix(startvm): Do not use `-watchdog` option when using `qemu-system-aarch64` binary

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Do not use `-watchdog` option when using `qemu-system-aarch64` binary. ARM64 version does not offer watchdog option.

**Which issue(s) this PR fixes**:
Fixes #1776

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: bugfix
- target_group: user
```
