### PR TITLE
Include feature for OpenStack/CCEE bare-metal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
-        target: [ kvm, metal, gcp, aws, azure, ali, openstack, vmware, githubActionRunner, metalv ]
+        target: [ kvm, metal, gcp, aws, azure, ali, openstack, openstack-baremetal, vmware, githubActionRunner, metalv ]
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         architecture: [ amd64, arm64 ]
-        cname: [ kvm_prod, metal_prod, gcp-gardener_prod, aws-gardener_prod, azure-gardener_prod, ali-gardener_prod, openstack-gardener_prod, vmware-gardener_prod ]
+        cname: [ kvm_prod, metal_prod, gcp-gardener_prod, aws-gardener_prod, azure-gardener_prod, ali-gardener_prod, openstack-gardener_prod, openstack-baremetal-gardener_prod, vmware-gardener_prod ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
-        target: [ kvm, metal, gcp, aws, azure, ali, openstack, vmware ]
+        target: [ kvm, metal, gcp, aws, azure, ali, openstack, openstack-baremetal, vmware ]
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ __pycache__
 /tests/*.log
 /tests/*.xml
 *.cache
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,14 @@ OPENSTACK_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-openstack-dev-$(VERSION)
 openstack-dev-upload:
 	./bin/upload-openstack $(BUILDDIR)/openstack-gardener_dev-amd64-$(VERSION)-local/rootfs.vmdk $(OPENSTACK_DEV_IMAGE_NAME)
 
+OPENSTACK_BM_IMAGE_NAME=$(IMAGE_BASENAME)-openstack-baremetal-$(VERSION)
+openstack-bm-upload:
+	./bin/upload-openstack $(BUILDDIR)/openstack-baremetal-gardener-amd64-$(VERSION)-local/rootfs.vmdk $(OPENSTACK_IMAGE_NAME)
+
+OPENSTACK_BM_DEV_IMAGE_NAME=$(IMAGE_BASENAME)-openstack-baremetal-dev-$(VERSION)
+openstack-bm-dev-upload:
+	./bin/upload-openstack $(BUILDDIR)/openstack-baremetal-gardener_dev-amd64-$(VERSION)-local/rootfs.vmdk $(OPENSTACK_DEV_IMAGE_NAME)
+
 clean:
 	@echo "emptying $(BUILDDIR)"
 	@rm -rf $(BUILDDIR)/*

--- a/features/base/test/test_users.py
+++ b/features/base/test/test_users.py
@@ -1,4 +1,4 @@
 from helper.tests.users import users
 
-def test_users(client, non_dev, non_feature_githubActionRunner, non_vhost, non_hyperscalers):
+def test_users(client, non_dev, non_feature_githubActionRunner, non_vhost, non_hyperscalers, non_ccee):
      users(client)

--- a/features/openstack-baremetal/README.md
+++ b/features/openstack-baremetal/README.md
@@ -1,0 +1,18 @@
+## Feature: openstack-baremetal
+
+<website-feature> OpenStack bare-metal platform (cloud-init, metal kernel) </website-feature>
+
+---
+
+	Type: platform
+	Included Features: metal
+
+#
+
+A word of **WARNING**: Since OpenStack is an open environment, we can only provide a reference implementation at this point.
+This particular feature set for Garden Linux on OpenStack is for an OpenStack landscape with bare-metal hardware (which is why it builds on top of the `metal` feature).
+
+If you want to run Garden Linux on OpenStack, you will most likely have to create your own feature set that matches your environment and/or hypervisor.
+
+
+#

--- a/features/openstack-baremetal/convert
+++ b/features/openstack-baremetal/convert
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+# NOTE: vmdk as image format is required on the SAP CC EE
+qemu-img convert -o subformat=streamOptimized -f raw -O vmdk "$1.raw" "$1.vmdk"
+
+# NOTE: qcow2 as image format can be used on most OpenStack environments
+#       (or can be easily converted back to raw format)
+qemu-img convert -f raw -O qcow2 "$1.raw" "$1.qcow2"

--- a/features/openstack-baremetal/exec.config
+++ b/features/openstack-baremetal/exec.config
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# growpart is done in initramfs, growroot by systemd
+mv /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak
+cat /etc/cloud/cloud.cfg.bak | grep -v "^ - growpart$" | grep -v "^ - resizefs$" | grep -v "^ - ntp$" >/etc/cloud/cloud.cfg
+rm /etc/cloud/cloud.cfg.bak

--- a/features/openstack-baremetal/file.include/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg
+++ b/features/openstack-baremetal/file.include/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg
@@ -1,0 +1,13 @@
+apt_preserve_sources_list: true
+manage_etc_hosts: true
+system_info:
+  default_user:
+    name: admin
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: True
+    gecos: Debian
+    groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+

--- a/features/openstack-baremetal/file.include/etc/cloud/cloud.cfg.d/50-datasource.cfg
+++ b/features/openstack-baremetal/file.include/etc/cloud/cloud.cfg.d/50-datasource.cfg
@@ -1,0 +1,1 @@
+datasource_list: [ ConfigDrive, OpenStack, Ec2 ]

--- a/features/openstack-baremetal/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
+++ b/features/openstack-baremetal/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
@@ -1,0 +1,1 @@
+network: {config: disabled}

--- a/features/openstack-baremetal/file.include/etc/cloud/ds-identify.cfg
+++ b/features/openstack-baremetal/file.include/etc/cloud/ds-identify.cfg
@@ -1,0 +1,2 @@
+datasource: OpenStack
+policy: enabled

--- a/features/openstack-baremetal/file.include/etc/default/grub.d/90_openstack_cc_ee.cfg
+++ b/features/openstack-baremetal/file.include/etc/default/grub.d/90_openstack_cc_ee.cfg
@@ -1,0 +1,1 @@
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX product_name='OpenStack Nova'"

--- a/features/openstack-baremetal/file.include/etc/kernel/cmdline.d/40-enable-swap-cgroup-accounting.cfg
+++ b/features/openstack-baremetal/file.include/etc/kernel/cmdline.d/40-enable-swap-cgroup-accounting.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX cgroup_enable=memory swapaccount=1"

--- a/features/openstack-baremetal/file.include/etc/profile.d/50-autologout.sh
+++ b/features/openstack-baremetal/file.include/etc/profile.d/50-autologout.sh
@@ -1,0 +1,3 @@
+TMOUT=600
+readonly TMOUT
+export TMOUT

--- a/features/openstack-baremetal/file.include/etc/repart.d/root.conf
+++ b/features/openstack-baremetal/file.include/etc/repart.d/root.conf
@@ -1,0 +1,2 @@
+[Partition]
+Type=root

--- a/features/openstack-baremetal/file.include/etc/sysctl.d/20-cloud.conf
+++ b/features/openstack-baremetal/file.include/etc/sysctl.d/20-cloud.conf
@@ -1,0 +1,57 @@
+# Enable syn flood protection
+net.ipv4.tcp_syncookies = 1
+
+# Ignore source-routed packets
+net.ipv4.conf.all.accept_source_route = 0
+
+# Ignore ICMP redirects
+net.ipv4.conf.all.accept_redirects = 0
+
+# Ignore ICMP redirects from non-GW hosts
+net.ipv4.conf.all.secure_redirects = 1
+
+# Ignore ICMP redirects from non-GW hosts
+net.ipv4.conf.default.secure_redirects = 1
+
+# Ignore ICMP broadcasts to avoid participating in Smurf attacks
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+# Ignore bad ICMP errors
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+# Randomize addresses of mmap base, heap, stack and VDSO page
+kernel.randomize_va_space = 2
+
+# Provide protection from ToCToU races
+fs.protected_hardlinks=1
+
+# Provide protection from ToCToU races
+fs.protected_symlinks=1
+
+# Make locating kernel addresses more difficult
+kernel.kptr_restrict=1
+
+# Set perf only available to root
+kernel.perf_event_paranoid=2
+
+# Accept source-routed packets
+net.ipv4.conf.default.accept_source_route = 1
+
+# Accept ICMP redirects
+net.ipv4.conf.default.accept_redirects = 1
+
+# Do not log spoofed, source-routed, and redirect packets
+net.ipv4.conf.all.log_martians = 0
+
+# Enable frowarding for all interfaces
+net.ipv4.conf.all.forwarding = 1
+
+# Make forwarding the default
+net.ipv4.conf.default.forwarding = 1
+
+# Allow redirects on all interfaces and make it the default
+net.ipv4.conf.default.send_redirects = 1
+net.ipv4.conf.all.send_redirects = 1
+
+# Promote a secondary IP address in case a primary IP address is removed
+net.ipv4.conf.all.promote_secondaries = 1

--- a/features/openstack-baremetal/info.yaml
+++ b/features/openstack-baremetal/info.yaml
@@ -1,0 +1,12 @@
+description: "OpenStack baremetal platform (cloud-init, metal kernel)"
+type: platform
+features:
+  include:
+    - metal
+convert:
+  format:
+    - type: vmdk
+upload:
+  target:
+    - type: openstack-bm
+      image-name: $(OPENSTACK_BM_IMAGE_NAME)

--- a/features/openstack-baremetal/pkg.include
+++ b/features/openstack-baremetal/pkg.include
@@ -1,0 +1,5 @@
+python3-cffi-backend
+python3-boto
+cloud-init
+dmidecode
+rng-tools5

--- a/features/openstack-baremetal/test/test_check_files.py
+++ b/features/openstack-baremetal/test/test_check_files.py
@@ -1,0 +1,18 @@
+from helper.utils import check_file
+import pytest
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "/etc/cloud/ds-identify.cfg",
+        "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg",
+        "/etc/cloud/cloud.cfg.d/50-datasource.cfg",
+        "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
+    ]
+)
+
+
+def test_check_file(client, file_name):
+    exists = check_file(client, file_name)
+    assert exists, f"File {file_name} could not be found."

--- a/features/openstack-baremetal/test/test_content_in_file.py
+++ b/features/openstack-baremetal/test/test_content_in_file.py
@@ -1,0 +1,17 @@
+import pytest
+from helper.tests.file_content import file_content
+from helper.utils import execute_remote_command
+
+
+@pytest.mark.parametrize(
+    "file,args",
+    [
+        ("/etc/cloud/cloud.cfg", "ntp"),
+        ("/etc/cloud/cloud.cfg", "resizefs"),
+        ("/etc/cloud/cloud.cfg", "growpart")
+    ]
+)
+
+
+def test_file_content(client, file, args):
+    file_content(client, file, args, only_line_match=True, invert=True)

--- a/features/openstack-baremetal/test/test_packages_musthave.py
+++ b/features/openstack-baremetal/test/test_packages_musthave.py
@@ -1,0 +1,1 @@
+from helper.tests.packages_musthave import packages_musthave as test_packages_musthave

--- a/features/openstack-baremetal/test/test_users.py
+++ b/features/openstack-baremetal/test/test_users.py
@@ -1,0 +1,6 @@
+from helper.tests.users import users
+
+additional_user="admin"
+
+def test_users(client, ccee):
+     users(client=client, additional_user=additional_user, additional_sudo_users=[additional_user])

--- a/features/server/test/test_users.py
+++ b/features/server/test/test_users.py
@@ -1,4 +1,4 @@
 from helper.tests.users import users
 
-def test_users(client, non_dev, non_feature_githubActionRunner, non_vhost, non_hyperscalers):
+def test_users(client, non_dev, non_feature_githubActionRunner, non_vhost, non_hyperscalers, non_ccee):
      users(client)

--- a/flavours.yaml
+++ b/flavours.yaml
@@ -3,7 +3,7 @@ flavour_sets:
   - name: 'gardener'
     flavour_combinations:
       - architectures: [ 'amd64' ]
-        platforms: [ ali, aws, azure, gcp, openstack, vmware ]
+        platforms: [ ali, aws, azure, gcp, openstack, openstack-baremetal, vmware ]
         modifiers: [ [ gardener, _prod ] ]
         fails: [ unit, integration ]
       - architectures: [ 'arm64' ]

--- a/make_targets/openstack-baremetal
+++ b/make_targets/openstack-baremetal
@@ -1,0 +1,1 @@
+server,gardener,openstack-baremetal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,6 +356,16 @@ def non_hyperscalers(iaas):
     if iaas == 'aws' or iaas == 'gcp' or iaas == 'azure' or iaas == 'ali':
         pytest.skip(f"test not supported on hyperscaler {iaas}")
 
+@pytest.fixture
+def ccee(iaas):
+    if iaas != 'openstack-ccee' and iaas != 'openstack-baremetal-ccee':
+        pytest.skip(f"test only supported on ccee")
+
+@pytest.fixture
+def non_ccee(iaas):
+    if iaas == 'openstack-ccee' or iaas == 'openstack-baremetal-ccee':
+        pytest.skip(f"test not supported on ccee")
+
 # This fixture is an alias of "chroot" but does not use the "chroot" env.
 # However, it only needs the underlying container for its tests.
 @pytest.fixture


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:

Introduces a new `openstack-baremetal` feature to enable Garden Linux to run on OpenStack/CCEE bare metal nodes to be used as worker nodes with Gardener.

**Important note for the reviewer:**

This is for Garden Linux **934**. Must be merged into the `rel-934` branch, NOT into the `main` branch.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The openstack-baremetal feature will produce Gardener compatible images of Garden Linux that run on OpenStack/CCEE bare metal machines.
```
