### PR TITLE
feature(pkg2deps): Add `pkg2deps` to find missing dependencies

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -39,6 +39,7 @@ By the given directory, we distinguish between scripts that are mandatory for th
 | make-gcp-ami | Integrate/orchestrate `GCP` platform by a given image  |
 | make-ova | Converts image to `.ova` file |
 | make-vhd | Converts image to `.vhd` file |
+| pkg2deps | Validates if (a specific version of) Garden Linux can fulfill the package dependencies from an external package in a remote repository | 
 
 
 ## Detail
@@ -223,3 +224,24 @@ This script converts a given `.raw` image file into a `.vhd` image file.
 **Usage:**
 
 `make-vhd /path/to/$image_name.raw`
+
+
+### pkg2deps
+Validates if (a specific version of) Garden Linux can fulfill the package dependencies from an external package in a remote repository.
+
+**Options**:
+| Option | Example | Descriptions |
+|--|--|---|
+| -r (--repository) | http://ftp.debian.org/debian | Foreign/remote repository where the new package is located |
+| -d (--dist) | trixie | The distribution to use within the remote repository |
+| -p (--package) | dpkg | The name of the remote package within the remote repository |
+| -v (--version) | 1.22.0 | The version of the remote package within the remote repository |
+| -g (--gardenlinux-version) | 934.10 | The Garden Linux version to validate the package dependencies |
+| -m (--missing) | NA | Also print completely missing packages |
+
+**Usage**:
+
+Example usage to evaluate if Garden Linux `934.10` can fulfill all package dependencies of the package `dpkg` in Debian `trixie` which is locate on the foreign/remote repository `http://ftp.debian.org/debian`.
+```
+./pkg2deps -r http://ftp.debian.org/debian -d trixie -v 1.22.0 -g 934.10 -p dpkg
+```

--- a/bin/pkg2deps
+++ b/bin/pkg2deps
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+# pkg2deps:
+# Validate for unfulfilled dependencies within the Garden Linux repository of a given
+# Garden Linux release version for a given package from any external repository.
+# Author: Florian Paul Azim Hoberg @gyptazy <gyptazy@gyptazy.ch>
+#
+# Examples: 
+# $> ./pkg2deps -r http://ftp.debian.org/debian -d trixie -v 2.65 -g 934.10 -p dpkg-www
+# $> ./pkg2deps -r http://ftp.debian.org/debian -d trixie -v 1.22.0 -g 934.10 -p dpkg
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import argparse
+import os
+import sys
+import re
+import urllib.request
+import gzip
+try:
+    # Ignore warning from debian import that we do not have python3-apt installed.
+    # We only use parsing functionalities from this library.
+    import warnings
+    warnings.simplefilter("ignore", UserWarning)
+    import debian.deb822
+    from debian.debian_support import Version
+except ImportError:
+    print('Please install the python module: "debian"')
+    sys.exit(1)
+
+
+# Constants
+__META_FILE_ARCHITECTURES__ = ['binary-all','binary-amd64','binary-arm64']
+
+
+def parse_arguments():
+    """ Parse arguments by cli input """
+    args_parser = argparse.ArgumentParser(description='pk2dep', usage='%(prog)s')
+    args_parser.add_argument('-r', '--repository', type=str, help='URL of a remote repository holding the requested package.', required=True)
+    args_parser.add_argument('-p', '--package', type=str, help='Package name to lookup dependencies.', required=True)
+    args_parser.add_argument('-d', '--dist', type=str, help='Distribution to use (e.g. bookworm).', required=True)
+    args_parser.add_argument('-v', '--version', type=str, help='Package version to lookup dependencies.', required=True)
+    args_parser.add_argument('-g', '--gardenlinux-version', type=str, help='Garden Linux version to evaluate.', required=True)
+    args_parser.add_argument('-m', '--missing', action='store_true', help='Print packages that are missing in Garden Linux repository.', default=False, required=False)
+
+    return args_parser.parse_args()
+
+
+def fetch_repositories_metadata(arguments):
+    """ Fetch repository metadata """
+    repositories = [arguments.repository, 'http://repo.gardenlinux.io/gardenlinux']
+    repository_metadata = {}
+    repository_metadata['foreign'] = {}
+    repository_metadata['gardenlinux'] = {}
+
+    # Fetch the repository metadata for each architecture and
+    # repository mirror
+    for architecture in __META_FILE_ARCHITECTURES__:
+        for repository in repositories:
+
+            # Overload vars to create a common base of remote url
+            if repository == 'http://repo.gardenlinux.io/gardenlinux':
+                dist = arguments.gardenlinux_version
+                metadata_key = 'gardenlinux'
+            # Use cli defaults for foreign destination
+            else:
+                dist = arguments.dist
+                metadata_key = 'foreign'
+
+            remote_url = f'{repository}/dists/{dist}/main/{architecture}/Packages.gz'
+            content = download_repository_metadata(remote_url)
+            repository_metadata[metadata_key][architecture] = content
+    
+    return repository_metadata
+
+
+def download_repository_metadata(remote_url):
+    """ Download a compressed repository meta file """
+    with urllib.request.urlopen(remote_url) as file_name:
+        return gzip.GzipFile(fileobj=file_name).read()
+
+
+def evaluate_package_dependencies(arguments, repository_metadata):
+    """ Evaluate the binary dependencies of a given package from a foreign repository """
+    package_found = False
+
+    architectures = repository_metadata['foreign'].keys()
+    for architecture in architectures:
+
+        # Only perform this a single time. It might be that a package if present for all hardware
+        # architectures or even only in a single one
+        if not package_found:
+            for packages in debian.deb822.Packages.iter_paragraphs(repository_metadata['foreign'][architecture]):
+
+                if packages['package'] == arguments.package and packages['version'] == arguments.version:
+                    package_found = True
+
+                    # Validate if the package has any pre dependencies defined
+                    pre_depends_present = packages.get('pre-depends', False)
+
+                    # Obtain all needed binary or runtime dependencies
+                    package_dependencies = sort_packages(packages['depends'])
+                    if pre_depends_present:
+                        package_dependencies = sort_packages(packages['pre-depends'])
+
+    if package_found:
+        return package_dependencies
+    else:
+        print(f'Error: The requested package {arguments.package} (version: {arguments.version}) could not be found in foreign repository.')
+        sys.exit(1)
+
+
+def evaluate_package_version(repository_metadata, package_dependencies):
+    """ Evaluate the version of a package within the Garden Linux repository """
+    package_found = False
+
+    architectures = repository_metadata['gardenlinux'].keys()
+    for architecture in architectures:
+
+        # Only perform this a single time. It might be that a package if present for all hardware
+        # architectures or even only in a single one
+        if not package_found:
+            for packages in debian.deb822.Packages.iter_paragraphs(repository_metadata['gardenlinux'][architecture]):
+                for foreign_package in package_dependencies['foreign'].keys():
+
+                    # Add present versions from Garden Linux repository to the dictionary
+                    if packages['package'] == foreign_package:
+                        package_dependencies['gardenlinux'][foreign_package] = packages['version']
+
+
+def compare_repository_package_version(package_dependencies):
+    """ Compare package versions from foreign and Garden Linux repository """
+    packages_missing = []
+    packages_wrong_version = {}
+
+    for foreign_package in package_dependencies['foreign'].keys():
+        if not package_dependencies['gardenlinux'].get(foreign_package):
+            packages_missing.append(foreign_package)
+        else:
+            if Version(package_dependencies['foreign'][foreign_package]) >= Version(package_dependencies['gardenlinux'][foreign_package]):
+                packages_wrong_version[foreign_package] = package_dependencies['foreign'][foreign_package]
+
+    return packages_missing, packages_wrong_version
+
+
+def sort_packages(packages_versions_raw):
+    """ Sort and convert packages to a dictionary """
+    package_dependencies = {}
+    package_dependencies['foreign'] = {}
+    package_dependencies['gardenlinux'] = {}
+
+    # Convert comma separated string list to real list
+    packages_versions_raw = packages_versions_raw.replace(' ', '')
+    packages = packages_versions_raw.split(',')
+
+    for package in packages:
+        # Obtain version number from content
+        # This will remove the package name by obtaining everything within the brackets
+        # and only uses digit, points and dashes as valid chars afterwards
+        package_version = re.findall(r'\(.*?\)', package)
+        package_version = re.sub('[^0123456789\.\-]','',str(package_version))
+
+        # Obtain package name from content
+        # This will remove everything from the string until the first bracket of a potential
+        # version declaring might be found
+        package_name = re.sub(' *\\(.*', '', package)
+
+        # Finally add all packages to the dictionary
+        # Rewrite non existent version numbers for packages as a dependency from foreign repo
+        # to avoid evaluating an empty string for a Debian version compare
+        if package_version == '':
+            package_version = '0.0'
+
+        package_dependencies['foreign'][package_name] = package_version
+
+    return package_dependencies
+
+
+def write_packages_output(arguments, packages_missing, packages_wrong_version):
+    """ Write and return the output for the user of missing and wrong package dependencies """
+    if arguments.missing:
+        print('WARN: The following packages are missing:')
+        for package in packages_missing:
+            print(f'Package: {package}')
+        sys.exit(2)
+    
+    if len(packages_wrong_version.keys()) > 0:
+        print('WARN: The following packages must to be upgraded in Garden Linux:')
+        for package in packages_wrong_version.keys():
+            print(f'Package: {package} | Version needed: {packages_wrong_version[package]}')
+        sys.exit(2)
+    else:
+        print('OK: No further unfulfilled dependencies found.')
+
+
+def main():
+    """ Run the main function of pkg2deps """
+    arguments = parse_arguments()
+    repository_metadata = fetch_repositories_metadata(arguments)
+    package_dependencies = evaluate_package_dependencies(arguments, repository_metadata)
+    evaluate_package_version(repository_metadata, package_dependencies)
+    packages_missing, packages_wrong_version = compare_repository_package_version(package_dependencies)
+    write_packages_output(arguments, packages_missing, packages_wrong_version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
feature(pkg2deps): Add `pkg2deps` to find missing dependencies of a given package from foreign repos

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind enhancement
/area os
/os garden-linux

**What this PR does / why we need it**:
Add `pkg2deps` to find missing dependencies of a given package from foreign repos

Quicktest:
```
./pkg2deps -r http://ftp.debian.org/debian -d trixie -v 2.65 -g 934.10 -p dpkg-www
```
or
```
./pkg2deps -r http://ftp.debian.org/debian -d trixie -v 1.22.0 -g 934.10 -p dpkg
```

All params are documented within the docs, however for this example:
* -r | --remote | remote repo path
* -d | --distribution | Repo Distribution to use (Debian: trixie, bookworm, Sid,... | Garden Linux: 934.10,...)
* -g | --gardenlinux-version | Garden Linux Version to validate against (e.g. 934.10, today,...)
* -p | --package | Name of the package within the remote Repository
* -v | --version | Version of the package within the remote Repository

**Which issue(s) this PR fixes**:
Fixes #1780

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: feature
- target_group: developer
```
