### PR TITLE
fix(vmware): Fix vmware feature in combination with ARM64 based systems

### DIFF
--- a/features/vmware/exec.config
+++ b/features/vmware/exec.config
@@ -4,4 +4,8 @@ set -Eeuo pipefail
 # growpart is done in initramfs, growroot by systemd
 mv /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak
 cat /etc/cloud/cloud.cfg.bak | grep -v "^ - growpart$" | grep -v "^ - resizefs$" | grep -v "^ - ntp$" >/etc/cloud/cloud.cfg
-rm /etc/cloud/cloud.cfg.bak 
+rm /etc/cloud/cloud.cfg.bak
+
+# Remove ignition config on arm64
+# This is incompatible in combination with arm64, vmware, readonly (ignition)
+if [ "$(uname -m)" = aarch64 ]; then  rm /etc/kernel/cmdline.d/50-ignition.cfg; fi


### PR DESCRIPTION
fix(vmware): Fix vmware feature in combination with ARM64 based systems

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug
/area os
/os garden-linux

**What this PR does / why we need it**:
Fix vmware feature in combination with ARM64 based systems.

Currently, the combination of the VMware feature, ARM64 based systems and ignition is unsupported and results in unbootable images.

**Which issue(s) this PR fixes**:
Fixes #1778

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- category: bugfix
- target_group: user
```
