### PR TITLE
fix: move update-bootloaders to _boot and run update-syslinux last

### DIFF
--- a/features/_boot/file.include/usr/local/sbin/update-bootloaders
+++ b/features/_boot/file.include/usr/local/sbin/update-bootloaders
@@ -3,7 +3,7 @@
 set -e
 
 update-kernel-cmdline
-update-syslinux
 for kernel in /boot/vmlinuz-*; do
    kernel-install add "${kernel#*-}" "${kernel}"
 done
+update-syslinux

--- a/features/vmware/file.include/usr/local/sbin/update-bootloaders
+++ b/features/vmware/file.include/usr/local/sbin/update-bootloaders
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-update-kernel-cmdline
-update-syslinux
-for kernel in /boot/vmlinuz-*; do
-   kernel-install add "${kernel#*-}" "${kernel}"
-done


### PR DESCRIPTION
**What this PR does / why we need it**:
_update-syslinux_ should run last when using the _update-bootloaders_
Also, it should be part of the _boot feature.

**Which issue(s) this PR fixes**:
Fixes #