### PR TITLE
Pin debian images for dev env

### DIFF
--- a/hack/lima-dev-env.yaml
+++ b/hack/lima-dev-env.yaml
@@ -23,8 +23,10 @@ containerd:
 images:
   - location: "https://cloud.debian.org/images/cloud/trixie/daily/20231010-1529/debian-13-genericcloud-amd64-daily-20231010-1529.qcow2"
     arch: "x86_64"
+    digest: "sha512:e27e58a8f1d2448ee5e98bba3d178b277645075e558e48d3959df41f9c0a540a1b9d5a684fa627536bf5eaa36c5a7ce8738acdb4c7e33c42fb8c8d23f3cfe288"
   - location: "https://cloud.debian.org/images/cloud/trixie/daily/20231010-1529/debian-13-genericcloud-arm64-daily-20231010-1529.qcow2"
     arch: "aarch64"
+    digest: "sha512:1d6858baab7bdf75f5e01e9035dc7738f05fbb557ed724c4c666fd13a93ce88d880443a8719b1afe905ffe0bf9b0eb07419bb8141d191c2efa1267d5fabc956c"
 
 mounts:
   - location: "~"

--- a/hack/lima-dev-env.yaml
+++ b/hack/lima-dev-env.yaml
@@ -21,9 +21,9 @@ containerd:
   user: false
 
 images:
-  - location: "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-amd64-daily.qcow2"
+  - location: "https://cloud.debian.org/images/cloud/trixie/daily/20231010-1529/debian-13-genericcloud-amd64-daily-20231010-1529.qcow2"
     arch: "x86_64"
-  - location: "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-genericcloud-arm64-daily.qcow2"
+  - location: "https://cloud.debian.org/images/cloud/trixie/daily/20231010-1529/debian-13-genericcloud-arm64-daily-20231010-1529.qcow2"
     arch: "aarch64"
 
 mounts:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind technical-debt
/area os
/os garden-linux

**What this PR does / why we need it**:

Pin the images for dev env to a specific debian testing image. Currently there is a incompatible combination of the kernel and crun in debian testing ([bug report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1053821)), the selected images are old enough to not have this issue.

It might make sense to always have pinned images here but they would need to be updated from time to time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
