### PR TITLE
test: remove deprecated u import

### DIFF
--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -9,7 +9,6 @@ from binascii import hexlify
 from paramiko import SSHClient, AutoAddPolicy, RSAKey
 from paramiko.auth_handler import AuthenticationException, SSHException
 from paramiko.ssh_exception import NoValidConnectionsError
-from paramiko.util import u
 from scp import SCPClient, SCPException
 
 logger = logging.getLogger(__name__)
@@ -49,7 +48,7 @@ class RemoteClient:
                 f.write(f"{pub.get_name()} {pub.get_base64()}")
                 if comment:
                     f.write(f" {comment}")
-        hash = u(hexlify(pub.get_fingerprint()))
+        hash = hexlify(pub.get_fingerprint()).decode(encoding="utf-8")
         fingerprint = ":".join([hash[i : 2 + i] for i in range(0, len(hash), 2)])
         logger.info(f"fingerprint: {bits} {fingerprint} {filename}.pub (RSA)")
         return fingerprint


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Removes the (upstream) deprecated import `paramiko.util.u` which is not used in our test code.

Fixes #1799.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
An unnecessary import was removed from the Garden Linux test harness.
```
