### PR TITLE
ci: move workflow-telemetry-action to gardenlinux org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: nkraetzschmar/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
@@ -79,7 +79,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: nkraetzschmar/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
@@ -104,7 +104,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: nkraetzschmar/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10


### PR DESCRIPTION
* move workflow-telemetry-action to gardenlinux org
