### PR TITLE
fix: move pytest-results-action to gardenlinux fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
         run: ./build ${{ inputs.use_kms && '--kms' || '' }} ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
       - name: test
         run: ./test --container-image test ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
-      - uses: pmeier/pytest-results-action@main
+      - uses: gardenlinux/pytest-results-action@main
         if: always()
         with:
           path: tests/test.xml


### PR DESCRIPTION
* Pinning version by forking original upstream from pmeier
