### PR TITLE
Pin all gh actions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - name: resolve version "${{ inputs.version }}"
         id: version
         run: echo version="$(bin/garden-version "${{ inputs.version }}")" | tee -a "$GITHUB_OUTPUT"
@@ -51,7 +51,7 @@ jobs:
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
@@ -85,7 +85,7 @@ jobs:
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
@@ -110,7 +110,7 @@ jobs:
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: ./.github/actions/setup
       - name: build test container
         run: |
@@ -150,7 +150,7 @@ jobs:
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
@@ -196,7 +196,7 @@ jobs:
         run: ./build ${{ inputs.use_kms && '--kms' || '' }} ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
       - name: test
         run: ./test --container-image test ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
-      - uses: pmeier/pytest-results-action@8104ed7b3d3ba4bb0d550e406fc26aa756630fcc
+      - uses: pmeier/pytest-results-action@v0.3.0
         if: always()
         with:
           path: tests/test.xml
@@ -226,7 +226,7 @@ jobs:
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - name: resolve version "${{ inputs.version }}"
         id: version
         run: echo version="$(bin/garden-version "${{ inputs.version }}")" | tee -a "$GITHUB_OUTPUT"
@@ -45,13 +45,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: gardenlinux/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@6f19ac2411a52a120abb74c812592b44f165d05c # pin@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
@@ -67,7 +67,7 @@ jobs:
           for f in secureboot.{{pk,null.pk,kek,db}.auth,db.{crt,arn}}; do
             ln -sr "cert/gardenlinux-$f" "cert/$f"
           done
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: cert
           key: cert-${{ github.run_id }}
@@ -79,13 +79,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: gardenlinux/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@6f19ac2411a52a120abb74c812592b44f165d05c # pin@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
@@ -93,7 +93,7 @@ jobs:
           git update-index --assume-unchanged VERSION
       - name: build base-amd64 base-arm64
         run: ./build base-amd64 base-arm64
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: .build
           key: base-${{ github.run_id }}
@@ -104,20 +104,20 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: gardenlinux/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@6f19ac2411a52a120abb74c812592b44f165d05c # pin@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup
       - name: build test container
         run: |
           podman build --squash --tag test --build-arg base="$(./build --print-container-image)" tests
           podman save --format oci-archive test > test.oci
       - name: upload test container
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: test.oci
           key: test_container:${{ github.run_id }}
@@ -144,20 +144,20 @@ jobs:
             arch: arm64
             modifier: ""
     steps:
-      - uses: gardenlinux/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@6f19ac2411a52a120abb74c812592b44f165d05c # pin@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
           bin/garden-version "${{ needs.version.outputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - name: load cert cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: cert
           key: cert-${{ github.run_id }}
@@ -167,19 +167,19 @@ jobs:
         run: echo "${{ secrets.secureboot_db_kms_arn }}" > cert/gardenlinux-secureboot.db.arn
       - name: configure aws credentials for kms signing
         if: ${{ inputs.use_kms }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_kms_role }}
           role-session-name: ${{ secrets.aws_oidc_session }}
           aws-region: ${{ secrets.aws_region }}
       - name: load bootstrap stage cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: .build
           key: base-${{ github.run_id }}
           fail-on-cache-miss: true
       - name: download test container cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: test.oci
           key: test_container:${{ github.run_id }}
@@ -196,7 +196,7 @@ jobs:
         run: ./build ${{ inputs.use_kms && '--kms' || '' }} ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
       - name: test
         run: ./test --container-image test ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
-      - uses: pmeier/pytest-results-action@v0.3.0
+      - uses: pmeier/pytest-results-action@a2c1430e2bddadbad9f49a6f9b879f062c6b19b1 # pin@v0.3.0
         if: always()
         with:
           path: tests/test.xml
@@ -204,7 +204,7 @@ jobs:
         run: echo "cname=$(basename "$(realpath ".build/${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}")" .artifacts)" | tee -a "$GITHUB_ENV"
       - name: pack build artifacts for upload
         run: tar -cSzvf "${{ env.cname }}.tar.gz" -C .build -T ".build/${{ env.cname }}.artifacts"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
         with:
           name: "${{ env.cname }}"
           path: "${{ env.cname }}.tar.gz"
@@ -220,20 +220,20 @@ jobs:
         arch: [ amd64, arm64 ]
         config: [ libc, python, nodejs, sapmachine ]
     steps:
-      - uses: gardenlinux/workflow-telemetry-action@v1
+      - uses: gardenlinux/workflow-telemetry-action@6f19ac2411a52a120abb74c812592b44f165d05c # pin@v1
         with:
           metric_frequency: 1
           proc_trace_min_duration: 10
           proc_trace_chart_max_count: 50
           comment_on_pr: false
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup
       - name: set VERSION=${{ needs.version.outputs.version }}
         run: |
           bin/garden-version "${{ needs.version.outputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - name: load bootstrap stage cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # pin@v3
         with:
           path: .build
           key: base-${{ github.run_id }}
@@ -244,7 +244,7 @@ jobs:
           find .build -exec touch -d "@$t" {} +
       - name: build
         run: ./build_distroless --arch "${{ matrix.arch }}" "${{ matrix.config }}"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
         with:
           name: "distroless-${{ matrix.config }}-${{ matrix.arch }}"
           path: ".build/distroless/${{ matrix.config }}-${{ matrix.arch }}.oci"

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -8,7 +8,7 @@ jobs:
     name: make integration test container
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
 
       - name: login to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -8,7 +8,7 @@ jobs:
     name: make integration test container
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
 
       - name: login to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   check-pkgs:
     runs-on: ubuntu-latest
-    
+
     permissions:
       security-events: write
       actions: read
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
       - name: Check for missing packages in repo
         run: |
           ./bin/check-pkgs-availability.py -d $(bin/garden-version)
-        
+
       - name: Generate report
         id: generate_report
         run: |

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    
+
     permissions:
       # required for all workflows
       security-events: write
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
         with:
           fetch-depth: 0
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@aa647ec4466543e8555c2c3b648124a9813cee44
+        uses: redhat-plumbers-in-action/differential-shellcheck@aa647ec4466543e8555c2c3b648124a9813cee44 # pin@aa647ec4466543e8555c2c3b648124a9813cee44
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-rel934.yml
+++ b/.github/workflows/nightly-rel934.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
 
       - name: Checkout 934 branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
         with:
           ref: 'rel-934'
 
@@ -18,5 +18,3 @@ jobs:
       - name: Trigger nightly for rel-934 with version input
         run: |
           curl -vv --fail-with-body -X POST -u "token:${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/workflows/28837699/dispatches" -d "{\"ref\":\"rel-934\", \"inputs\":{\"version\":\"$VERSION\"}}"
-
-

--- a/.github/workflows/nightly-rel934.yml
+++ b/.github/workflows/nightly-rel934.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
 
       - name: Checkout 934 branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v4.1.1
         with:
           ref: 'rel-934'
 

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - name: set VERSION=${{ inputs.version }}
         run: |
           bin/garden-version "${{ inputs.version }}" | tee VERSION
@@ -54,7 +54,7 @@ jobs:
       matrix:
         config: [ libc, python, nodejs, sapmachine ]
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: actions/download-artifact@v3
         with:
           name: distroless-${{ matrix.config }}-amd64

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - name: set VERSION=${{ inputs.version }}
         run: |
           bin/garden-version "${{ inputs.version }}" | tee VERSION
@@ -22,10 +22,10 @@ jobs:
         run: |
           echo "cname_amd64=$(./build --resolve-cname container-amd64)" | tee -a "$GITHUB_ENV"
           echo "cname_arm64=$(./build --resolve-cname container-arm64)" | tee -a "$GITHUB_ENV"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: ${{ env.cname_amd64 }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: ${{ env.cname_arm64 }}
       - name: publish gardenlinux container base image
@@ -54,11 +54,11 @@ jobs:
       matrix:
         config: [ libc, python, nodejs, sapmachine ]
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: distroless-${{ matrix.config }}-amd64
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: distroless-${{ matrix.config }}-arm64
       - run: ls -lah

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - name: create GitHub release
         run: .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create "${{ inputs.type == 'beta' && 'beta_' || '' }}${{ inputs.version }}" "${{ inputs.commit }}" "${{ inputs.version }}" > .github_release
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
         with:
           name: release
           path: .github_release
@@ -39,11 +39,11 @@ jobs:
         architecture: [ amd64, arm64 ]
         cname: [ kvm-gardener_prod, metal-gardener_prod, gcp-gardener_prod, aws-gardener_prod, azure-gardener_prod, ali-gardener_prod, openstack-gardener_prod, openstackbaremetal-gardener_prod, vmware-gardener_prod, metal-gardener_prod_pxe ]
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: release
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
@@ -80,11 +80,11 @@ jobs:
           - architecture: arm64
             cname: azure-gardener_prod
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: release
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - name: create GitHub release
         run: .github/workflows/release.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create "${{ inputs.type == 'beta' && 'beta_' || '' }}${{ inputs.version }}" "${{ inputs.commit }}" "${{ inputs.version }}" > .github_release
       - uses: actions/upload-artifact@v3
@@ -39,7 +39,7 @@ jobs:
         architecture: [ amd64, arm64 ]
         cname: [ kvm-gardener_prod, metal-gardener_prod, gcp-gardener_prod, aws-gardener_prod, azure-gardener_prod, ali-gardener_prod, openstack-gardener_prod, openstackbaremetal-gardener_prod, vmware-gardener_prod, metal-gardener_prod_pxe ]
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: actions/download-artifact@v3
         with:
           name: release
@@ -80,7 +80,7 @@ jobs:
           - architecture: arm64
             cname: azure-gardener_prod
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: actions/download-artifact@v3
         with:
           name: release

--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -49,7 +49,7 @@ jobs:
           - arch: arm64
             target: azure
     steps:
-    - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
 
     - name: login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin
@@ -63,7 +63,7 @@ jobs:
     - name: get cname
       run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
 
-    - uses: aws-actions/configure-aws-credentials@v4
+    - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
       with:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
         role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
@@ -82,7 +82,7 @@ jobs:
     - if: ${{ matrix.target == 'gcp' }}
       id: 'auth_gcp'
       name: 'Authenticate to Google Cloud'
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # pin@v1
       with:
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -90,7 +90,7 @@ jobs:
     - if: ${{ matrix.target == 'aws' }}
       id: 'auth_aws'
       name: 'Authenticate to AWS'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
       with:
         role-to-assume: ${{ secrets.AWS_TESTS_IAM_ROLE }}
         role-session-name: ${{ secrets.AWS_TESTS_OIDC_SESSION }}
@@ -99,7 +99,7 @@ jobs:
     - if: ${{ matrix.target == 'azure' }}
       id: 'auth_azure'
       name: 'Authenticate to Azure'
-      uses: azure/login@v1
+      uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # pin@v1
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -49,7 +49,7 @@ jobs:
           - arch: arm64
             target: azure
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - uses: actions/checkout@v4.1.1
 
     - name: login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
           - arch: arm64
             target: ali
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - uses: actions/checkout@v4.1.1
 
     - name: login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
           - arch: arm64
             target: ali
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
 
     - name: login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin
@@ -83,7 +83,7 @@ jobs:
     - name: get cname
       run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
       with:
         name: ${{ env.cname }}
         path: /tmp/gardenlinux-build-artifacts
@@ -93,7 +93,7 @@ jobs:
     - if: ${{ matrix.target == 'gcp' }}
       id: 'auth_gcp'
       name: 'Authenticate to Google Cloud'
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # pin@v1
       with:
         workload_identity_provider: ${{ secrets.gcp_identity_provider }}
         service_account: ${{ secrets.gcp_service_account }}
@@ -104,7 +104,7 @@ jobs:
     - if: ${{ matrix.target == 'aws' }}
       id: 'auth_aws'
       name: 'Authenticate to AWS'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
       with:
         role-to-assume: ${{ secrets.aws_role }}
         role-session-name: ${{ secrets.aws_session }}
@@ -113,7 +113,7 @@ jobs:
     - if: ${{ matrix.target == 'azure' }}
       id: 'auth_azure'
       name: 'Authenticate to Azure'
-      uses: azure/login@v1
+      uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # pin@v1
       with:
         client-id: ${{ secrets.az_client_id }}
         tenant-id: ${{ secrets.az_tenant_id }}
@@ -128,7 +128,7 @@ jobs:
         set -o pipefail
         .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}" 2>&1 | tee "${{ env.cname }}.integration-tests-log"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
       with:
         name: tests-${{ env.cname }}
         path: ${{ env.cname }}.integration-tests-log

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -34,8 +34,8 @@ jobs:
         target: [ kvm, "kvm_secureboot", "kvm_secureboot_readonly", "kvm_secureboot_readonly_persistence", metal, "metal_secureboot", "metal_secureboot_readonly", "metal_secureboot_readonly_persistence", gcp, aws, "aws_secureboot", "aws_secureboot_readonly", "aws_secureboot_readonly_persistence", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: ${{ secrets.session }}
@@ -46,7 +46,7 @@ jobs:
           git update-index --assume-unchanged VERSION
       - name: get cname
         run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: ${{ env.cname }}
       - name: upload to S3 bucket ${{ secrets.bucket }}
@@ -72,8 +72,8 @@ jobs:
           - arch: arm64
             target: azure
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
         with:
           role-to-assume: ${{ secrets.role }}
           role-session-name: ${{ secrets.session }}
@@ -84,7 +84,7 @@ jobs:
           git update-index --assume-unchanged VERSION
       - name: get cname
         run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: tests-${{ env.cname }}
       - name: upload to S3 bucket ${{ secrets.bucket }}

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -34,7 +34,7 @@ jobs:
         target: [ kvm, "kvm_secureboot", "kvm_secureboot_readonly", "kvm_secureboot_readonly_persistence", metal, "metal_secureboot", "metal_secureboot_readonly", "metal_secureboot_readonly_persistence", gcp, aws, "aws_secureboot", "aws_secureboot_readonly", "aws_secureboot_readonly_persistence", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.role }}
@@ -72,7 +72,7 @@ jobs:
           - arch: arm64
             target: azure
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v4.1.1
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.role }}


### PR DESCRIPTION
For consistency it makes sense to just apply actions pinning everywhere.

This was done using mheap/pin-github-action

Dependabot should be clever enough to update the pinned versions.