### PR TITLE
fix: use short commitish also for generation of release note script

### DIFF
--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -27,7 +27,9 @@ jobs:
       - name: install dependencies for generate_release_note.py script
         run: sudo apt-get update && sudo apt-get install -qy --no-install-recommends python3-boto3
       - name: create GitHub release
-        run: .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create "${{ inputs.type == 'beta' && 'beta_' || '' }}${{ inputs.version }}" "${{ inputs.commit }}" "${{ inputs.version }}" > .github_release
+        run: |
+          commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
+          .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} create "${{ inputs.type == 'beta' && 'beta_' || '' }}${{ inputs.version }}" "$commit" "${{ inputs.version }}" > .github_release
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
         with:
           name: release


### PR DESCRIPTION
- Use 8 character long commit hash instead of full commit hash

- the `generate_release_notes.py` script requires the commit hash. The commit hash is used to retrieve the artifact. Therefore it must be the same length as in the artifact
