### PR TITLE
fix: use https for gardenlinux repo

### DIFF
--- a/.github/workflows/gl-kernelurls.py
+++ b/.github/workflows/gl-kernelurls.py
@@ -19,7 +19,7 @@ def main(args=None):
                         help='Get Linux kernel package urls for a specific Gardenlinux version.')
     parser.add_argument('-o', '--output', choices=['yaml', 'json'], default='yaml', help='Select output format.')
 
-    repositories = [f'http://repo.gardenlinux.io/gardenlinux {args.gardenlinux} main']
+    repositories = [f'https://repo.gardenlinux.io/gardenlinux {args.gardenlinux} main']
 
     if not args:
         args = parser.parse_args()

--- a/bin/check-pkgs-availability.py
+++ b/bin/check-pkgs-availability.py
@@ -53,7 +53,7 @@ def get_unavailable_packages(available_packages, required_packages):
 
 
 def check_packages(arch, dist) -> list():
-    available_packages = get_available_pkgs_from_repo(f"http://repo.gardenlinux.io/gardenlinux/dists/{dist}/main/binary-{arch}/Packages")
+    available_packages = get_available_pkgs_from_repo(f"https://repo.gardenlinux.io/gardenlinux/dists/{dist}/main/binary-{arch}/Packages")
     required_packages = read_pkg_files(arch)
     missing_packages = get_unavailable_packages(available_packages, required_packages)
     return missing_packages

--- a/bin/garden-version
+++ b/bin/garden-version
@@ -53,7 +53,7 @@ function get_minor_from_repo {
   minor=0   # running index
   limit=100 # hard limit the search in case of unexpected curl results
   major=$1  # major to check the latest minor for
-  repo_url="http://repo.gardenlinux.io/gardenlinux/dists/$major.__MINOR__/Release"
+  repo_url="https://repo.gardenlinux.io/gardenlinux/dists/$major.__MINOR__/Release"
   while [ $minor -le $limit ]
   do
     check_url=${repo_url//__MINOR__/$minor}

--- a/bin/pkg2deps
+++ b/bin/pkg2deps
@@ -60,7 +60,7 @@ def parse_arguments():
 
 def fetch_repositories_metadata(arguments):
     """ Fetch repository metadata """
-    repositories = [arguments.repository, 'http://repo.gardenlinux.io/gardenlinux']
+    repositories = [arguments.repository, 'https://repo.gardenlinux.io/gardenlinux']
     repository_metadata = {}
     repository_metadata['foreign'] = {}
     repository_metadata['gardenlinux'] = {}
@@ -71,7 +71,7 @@ def fetch_repositories_metadata(arguments):
         for repository in repositories:
 
             # Overload vars to create a common base of remote url
-            if repository == 'http://repo.gardenlinux.io/gardenlinux':
+            if repository == 'https://repo.gardenlinux.io/gardenlinux':
                 dist = arguments.gardenlinux_version
                 metadata_key = 'gardenlinux'
             # Use cli defaults for foreign destination

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -11,7 +11,7 @@ RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
         && chmod 644 $GARDENLINUX_MIRROR_KEY
 
 RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
-     && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] http://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
+     && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
      && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
      && if [ -f "/etc/apt/sources.list.d/debian.sources"] ; then sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources ; else echo "file not present" ; fi \
      && apt-get update \

--- a/docs/02_operators/apt_repo.md
+++ b/docs/02_operators/apt_repo.md
@@ -10,8 +10,8 @@ Packages are built, signed and deployed via the Garden Linux gitlab pipelines.
 
 | Release  | Line for `/etc/apt/sources.list`  | Description  |
 |---|---|---|
-| dev  | `deb http://repo.gardenlinux.io/gardenlinux dev main`  | New package versions are publishes here first. |
-| `$major.$minor` | `deb http://repo.gardenlinux.io/gardenlinux major.minor main` | Packages for the the Garden Linux version `major.minor`  |
+| dev  | `deb https://repo.gardenlinux.io/gardenlinux dev main`  | New package versions are publishes here first. |
+| `$major.$minor` | `deb https://repo.gardenlinux.io/gardenlinux major.minor main` | Packages for the the Garden Linux version `major.minor`  |
 
 
 ## Versioning
@@ -43,7 +43,7 @@ Try running [bin/garden-version](../../bin/garden-version), to get the $days_sin
 
 The Source Line for this example should look like:
 
-    deb http://repo.gardenlinux.io/gardenlinux 730.0 main
+    deb https://repo.gardenlinux.io/gardenlinux 730.0 main
 	
 
 </details>

--- a/hack/gl-pkg-url.sh
+++ b/hack/gl-pkg-url.sh
@@ -11,10 +11,10 @@ GL_VERSION=${1:-today}
 GL_ARCH=${2:-"amd64"}
 GL_PKG_NAME=${3:-"linux*"}
 
-packages_url="http://repo.gardenlinux.io/gardenlinux/dists/${GL_VERSION}/main/binary-${GL_ARCH}/Packages"
+packages_url="https://repo.gardenlinux.io/gardenlinux/dists/${GL_VERSION}/main/binary-${GL_ARCH}/Packages"
 
 packages=$(curl -s "$packages_url" | grep "Filename: pool/main/.*/$GL_PKG_NAME" | cut -d':' -f 2)
 
 for p in $packages; do
-    echo "http://repo.gardenlinux.io/gardenlinux/$p"
+    echo "https://repo.gardenlinux.io/gardenlinux/$p"
 done


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
https is offered and configured for repo.gardenlinux.io, thus this should be the default in documentation, scripts and other. 

**Special notes for your reviewer**:
search and replace all http://repo.gardenlinux.io references with https://repo.gardenlinux.io
