### PR TITLE
github: add labeler action 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,7 @@ features:
 
 tools:
 - 'hack/**'
+- 'tools/**'
 
 logo:
 - 'logo/*'
@@ -48,7 +49,6 @@ checksums:
 
 packages:
 - 'features/**/pkg.*'
-
 
 bare-container:
 - 'bare_flavors/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -53,3 +53,34 @@ packages:
 bare-container:
 - 'bare_flavors/**'
 - 'unbase_oci'
+
+gcp-platform:
+- 'features/gcp/**'
+- 'tests/integration/gcp.py'
+
+azure-platform:
+- 'features/azure/**'
+- 'tests/integration/azure.py'
+
+aws-platform:
+- 'features/aws/**'
+- 'tests/integration/aws.py'
+
+ali-platform:
+- 'features/ali/**'
+- 'tests/integration/ali.py'
+
+firecracker-platform:
+- 'features/firecracker/**'
+- 'tests/integration/firecracker.py'
+
+firecracker-platform:
+- 'features/firecracker/**'
+- 'tests/integration/firecracker.py'
+
+kvm-platform:
+- 'features/kvm/**'
+- 'tests/integration/kvm.py'
+
+metal-platform:
+- 'features/metal/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,3 +49,7 @@ checksums:
 packages:
 - 'features/**/pkg.*'
 
+
+bare-container:
+- 'bare_flavors/**'
+- 'unbase_oci'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,46 @@
+# GitHub Actions
+github-actions:
+- '.github/workflows/**'
+
+# Non workflow related changes
+github-settings:
+- any: ['.github/**']
+  all: ['!.github/workflows/**']
+
+test-env:
+- any: ['container/integration-test/*', 'tests/**', 'test']
+
+test:
+- 'features/*/test/**'
+
+build-env:
+- 'build'
+- 'get_repo'
+- 'get_timestamp'
+- 'get_version'
+- 'get_commit'
+- 'bin/**'
+
+docs:
+- '*.md'
+- 'docs/**'
+- 'CODEOWNERS'
+
+features:
+- 'features/**'
+
+tools:
+- 'hack/**'
+
+logo:
+- 'logo/*'
+
+certificates:
+- 'cert/**'
+
+# Explicit label to show changes on gardenlinux public repo key
+repo-key:
+- 'gardenlinux.asc'
+
+checksums:
+- 'checksums.sha256'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,6 +25,7 @@ docs:
 - '*.md'
 - 'docs/**'
 - 'CODEOWNERS'
+- 'examples/**'
 
 features:
 - 'features/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,3 +44,7 @@ repo-key:
 
 checksums:
 - 'checksums.sha256'
+
+packages:
+- 'features/**/pkg.*'
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,11 @@
-**How to categorize this PR?**
 <!--
-Please select area, kind, and priority for this pull request. This helps the community categorizing it.
-Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
-If multiple identifiers make sense you can also state the commands multiple times, e.g.
-  /area control-plane
-  /area auto-scaling
-  ...
-
-"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-
+Garden Linux PR Labels: 
+* breaking-change: breaking change for a Garden Linux image
+* enhancement: improvement for a Garden Linux image
+* build-env: build environment 
+* test-env: test environement
+* bug-fix: fixes a bug
 -->
-/kind TODO
-/area os
-/os garden-linux
 
 **What this PR does / why we need it**:
 
@@ -20,17 +13,3 @@ If multiple identifiers make sense you can also state the commands multiple time
 Fixes #
 
 **Special notes for your reviewer**:
-
-**Release note**:
-<!--  Write your release note:
-1. Enter your release note in the below block.
-2. If no release note is required, just write "NONE" within the block.
-
-Format of block header: <category> <target_group>
-Possible values:
-- category:       breaking|feature|bugfix|doc|other
-- target_group:   user|operator|developer|dependency
--->
-```feature user
-
-```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,8 @@ Garden Linux PR Labels:
 -->
 
 **What this PR does / why we need it**:
-
-**Which issue(s) this PR fixes**:
+<!-- 
 Fixes #
+-->
 
 **Special notes for your reviewer**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-**What this PR does / why we need it**:
-<!-- 
-Fixes #
--->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,5 +2,3 @@
 <!-- 
 Fixes #
 -->
-
-**Special notes for your reviewer**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,3 @@
-<!--
-Garden Linux PR Labels: 
-* breaking-change: breaking change for a Garden Linux image
-* enhancement: improvement for a Garden Linux image
-* build-env: build environment 
-* test-env: test environement
-* bug-fix: fixes a bug
--->
-
 **What this PR does / why we need it**:
 <!-- 
 Fixes #

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   triage:
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # pin@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # pin@v4
+        with:
+          dot: true


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add github labeler action
    * must be merged to main before the new labeler action can assign labels to PRs 
    * test repo: https://github.com/Vincinator/test-labeler/pull/1 
* use PR template from gardenlinux/.github org repo 