### PR TITLE
test: test ARM64 images on GCP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,6 @@ jobs:
         modifier: [ "${{ inputs.default_modifier }}" ]
         exclude:
           - arch: arm64
-            target: gcp
-          - arch: arm64
             target: azure
           - arch: arm64
             target: ali

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -307,6 +307,12 @@ class GCP:
         return self._gcp_create_firewall_rules(rules)
 
 
+    def _gcp_delete_firewall_rules(self, firewall_rule_name):
+        self.logger.info(f"Deleting firewall rule {firewall_rule_name}...")
+        operation = self._compute_firewalls.delete(project=self.project, firewall=firewall_rule_name)
+        self._gcp_wait_for_operation(operation)
+
+
     def _ensure_bucket(self, name):
         bucket = self._storage.bucket(bucket_name=name)
         if bucket.exists():


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Enables nightly tests for ARM64 images on GCP. Also fixes an embarrassing bug (missing function definition) in the GCP test cleanup code.

**Special notes for your reviewer**:

Before merging, the GCP test region and zone must be set to `europe-west4` and `europe-west4-c` respectively in GitHub Actions secrets.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Nightly build artefacts for ARM64 are platform tested on GCP.
```
