### PR TITLE
Use guestfish instead of libguestfs-tools in test containers

### DIFF
--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc
           inetutils-ping \
           wget \
           iproute2 \
-          libguestfs-tools \
+          guestfish \
           qemu-system-x86 \
           qemu-system-arm \
           qemu-efi-aarch64 \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

The only binary from the guestfs universe that is used in Garden Linux test containers is `virt-copy-in` which is actually part of `guestfish`. Therefore, all the other dependencies (especially Perl) of `libguestfs-tools` can be omitted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Guestfish is used instead of libguestfs-tools in test containers
```
