### PR TITLE
test: use architecture in GCP image names

### DIFF
--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -37,6 +37,12 @@ if [[ ! ${gcp_zone:-} ]]; then
     exit 1
 fi
 
+if [ "$TARGET_ARCHITECTURE" == "arm64" ]; then
+    machine_type="t2a-standard-2"
+else
+    machine_type="n1-standard-2"
+fi
+
 # Note: file is located in github runner within checked out repo.
 #        later, we mount the repo folder to /gardenlinux inside the container.
 #        google-githun-actions/auth cleans up credential file. We just take the name,
@@ -54,6 +60,8 @@ gcp:
     region: ${gcp_region}
     zone: ${gcp_zone}
     image: file:///artifacts/$(basename "$image_file")
+    machine_type: ${machine_type}
+    architecture: ${TARGET_ARCHITECTURE}
     ssh:
         user: gardenlinux
     features:

--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -30,6 +30,7 @@ jobs:
       gcp_region: ${{ secrets.GCP_REGION }}
       gcp_zone: ${{ secrets.GCP_ZONE }}
       AZURE_CONFIG_DIR: /tmp/azure_config_dir
+      TARGET_ARCHITECTURE: ${{ matrix.arch }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,8 +45,6 @@ jobs:
         target: [ gcp, aws, azure ]
         modifier: [ "${{ inputs.default_modifier }}" ]
         exclude:
-          - arch: arm64
-            target: gcp
           - arch: arm64
             target: azure
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
       aws_region: ${{ secrets.aws_region }}
       azure_subscription_id: ${{ secrets.az_subscription_id }}
       AZURE_CONFIG_DIR: /tmp/azure_config_dir
+      TARGET_ARCHITECTURE: ${{ matrix.arch }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -55,12 +55,14 @@ class GCP:
     def set_config_defaults(cls, cfg: dict, test_name: str, credentials):
         if 'project' not in cfg:
             cfg['project'] = credentials.project_id
+        if 'architecture' not in cfg:
+            cfg['architecture'] = 'amd64'
         if 'image_project' not in cfg:
             cfg['image_project'] = cfg['project']
         if 'image_region' not in cfg:
             cfg['image_region'] = "eu-central-1"
         if 'image_name' not in cfg:
-            cfg['image_name'] = f"img-{test_name}"
+            cfg['image_name'] = f"img-{test_name}-{cfg['architecture']}"
         if 'bucket' not in cfg:
             cfg['bucket'] = f"gl-upload-{test_name}"
         if 'keep_running' not in cfg:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Supplies the target architecture of the artefact to be tested to the GCP platform test so that image names can be differentiated by architecture. Also selects the proper machine type.

**Which issue(s) this PR fixes**:
Fixes 409 errors on GCP.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Target Architecture of Garden Linux artefacts will be handed into GCP platform tests.
```
