### PR TITLE
test: Require azure-cli >= 2.44.0 for tests

### DIFF
--- a/container/Makefile
+++ b/container/Makefile
@@ -21,6 +21,7 @@ build: needslim
 build-base-test: needslim
 	cp -p ../gardenlinux.asc base-test/gardenlinux.asc
 	cp ../tests/Pipfile base-test/
+	cp ../tests/Pipfile.lock base-test/
 	@$(GARDENLINUX_BUILD_CRE) build --build-arg VERSION=$(VERSION) -t gardenlinux/base-test:$(VERSION) base-test
 	rm base-test/gardenlinux.asc
 	rm base-test/Pipfile

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -49,7 +49,7 @@ ENV VIRTUAL_ENV="$VIRTUAL_ENV_PARENT/.venv"
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY Pipfile* "$VIRTUAL_ENV_PARENT/"
+COPY Pipfile Pipfile.lock "$VIRTUAL_ENV_PARENT/"
 # Do not use --system, we want the pip from the virtual env
 RUN cd "$VIRTUAL_ENV_PARENT" && pipenv install --dev 
 WORKDIR /gardenlinux/tests

--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -49,7 +49,7 @@ ENV VIRTUAL_ENV="$VIRTUAL_ENV_PARENT/.venv"
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY Pipfile "$VIRTUAL_ENV_PARENT"
+COPY Pipfile* "$VIRTUAL_ENV_PARENT/"
 # Do not use --system, we want the pip from the virtual env
 RUN cd "$VIRTUAL_ENV_PARENT" && pipenv install --dev 
 WORKDIR /gardenlinux/tests

--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -23,7 +23,7 @@ aliyun-python-sdk-ecs = "*"
 # OpenStack client packages
 python-openstackclient = "*"
 # Azure SDK/CLI packages
-azure-cli = "*"
+azure-cli = ">=2.44.0"   # https://github.com/Azure/azure-cli/issues/23015
 azure-core = "*"
 azure-identity = "*"
 azure-mgmt-subscription = "*"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind test
/area os
/os garden-linux

**What this PR does / why we need it**:

Require azure-cli >= 2.44.0 for Azure platform tests. Also make sure that the `Pipfile.lock` is actually used in building the integration test containers so that we have tighter control over which versions of the packages are used.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
test: Require azure-cli >= 2.44.0 for tests
```
