### PR TITLE
remove vim-tiny from server feature

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -28,5 +28,4 @@ systemd-cron
 systemd-timesyncd
 tcpdump
 traceroute
-vim-tiny
 wget


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
* less potential security vulnerabilities

**Special notes for your reviewer**:
* as an alternative; vim can open files via scp

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Remove vim-tiny from Garden Linux. 
* less potential security vulnerabilities
* as an alternative; vim can open files remotely via scp
```
