### PR TITLE
fixing git1.2 availability issue

### DIFF
--- a/features/vhost/pkg.include
+++ b/features/vhost/pkg.include
@@ -3,9 +3,13 @@ dnsmasq-base
 $(if [ $arch = amd64 ]; then echo qemu-system-x86; fi)
 $(if [ $arch = arm64 ]; then echo qemu-system-arm; fi)
 qemu-utils
+qemu-block-extra
 libvirt-daemon-system
 libvirt-clients
-virtinst
+libgoogle-perftools4
+libtcmalloc-minimal4
+libvirt0
+#virtinst
 $(if [ $arch = amd64 ]; then echo ovmf; fi)
 $(if [ $arch = arm64 ]; then echo qemu-efi-aarch64; fi)
 swtpm


### PR DESCRIPTION
fixes the 
gir1.2-libosinfo-1.0 : Depends: gir1.2-libxml2-2.0 but it is not installable

since virtinst is anyhow not needed.