### PR TITLE
Add isc dhcp client to kvm and metal

### DIFF
--- a/features/kvm/pkg.include
+++ b/features/kvm/pkg.include
@@ -1,2 +1,3 @@
 dosfstools
+isc-dhcp-client
 qemu-guest-agent

--- a/features/metal/pkg.include
+++ b/features/metal/pkg.include
@@ -5,6 +5,7 @@ dosfstools
 efibootmgr
 efitools
 ipmitool
+isc-dhcp-client
 pciutils
 usbutils
 numactl


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes build of Garden Linux `kvm` and `metal` based flavours
- only effects flavours using `_boot`, flavours using `_secureboot` were not affected 
- `dracut[I]: Module 'network-legacy' will not be installed, because command 'dhclient' could not be found!`
  
**Special notes for your reviewer**:
- might be related https://github.com/dracutdevs/dracut/commit/e863807
