### PR TITLE
Dracutnetworkfix

### DIFF
--- a/features/_boot/exec.late
+++ b/features/_boot/exec.late
@@ -6,11 +6,14 @@ update-kernel-cmdline
 
 mkdir -p /efi/Default
 
+sed -i "s/    echo network/    echo systemd-networkd network/" /usr/lib/dracut/modules.d/45url-lib/module-setup.sh
+
+
 for kernel in /boot/vmlinuz-*; do
 	unshare --mount bash -c 'mount -t tmpfs none /sys && mount --bind /usr/bin/false /usr/bin/systemd-detect-virt && "$@"' \
 	DRACUT_COMPRESS_XZ="$(command -v xz)" dracut \
 	--no-hostonly \
-	--force \
+	--force -v \
 	--kver "${kernel#*-}" \
 	--modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown" \
 	--reproducible \


### PR DESCRIPTION
there was a build error that url-lib could not be installed in dracut because of missing dhcpsupport.

Preferring systemd-networkd fixed the problem.