### PR TITLE
fix: specifically request systemd-networkd for the ignite feature

### DIFF
--- a/features/_ignite/file.include/etc/dracut.conf.d/30-ignition.conf
+++ b/features/_ignite/file.include/etc/dracut.conf.d/30-ignition.conf
@@ -1,1 +1,1 @@
-add_dracutmodules+=" ignition ignition-extra "
+add_dracutmodules+=" ignition ignition-extra systemd-networkd "


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to #1877 and #1879 but IMHO this is the proper fix, the dracut _systemd-networkd_ module needs to be explicitly requested so that all the dependencies are properly generated (url-lib, network, network-legacy).

**Which issue(s) this PR fixes**:
Fixes #