### PR TITLE
base test container: use debian dist

### DIFF
--- a/container/base-test/Dockerfile
+++ b/container/base-test/Dockerfile
@@ -1,4 +1,6 @@
-FROM gardenlinux/slim
+ARG DEBIAN_DIST=bookworm
+FROM debian:${DEBIAN_DIST}-slim
+ARG DEBIAN_DIST
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
@@ -6,11 +8,18 @@ ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinu
 ARG GARDENLINUX_MIRROR_KEY=/etc/apt/trusted.gpg.d/gardenlinux.asc
 ARG VERSION
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 COPY gardenlinux.asc $GARDENLINUX_MIRROR_KEY
 RUN  chown root:root $GARDENLINUX_MIRROR_KEY \
         && chmod 644 $GARDENLINUX_MIRROR_KEY
 
-RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc/apt/sources.list \
+# Install packages from debian dist by default, only install packages from repo.gardenlinux.io if they are specified 
+# with higher pin prio than 900
+RUN echo "Package: onmetal-image\nPin: origin repo.gardenlinux.io\nPin-Priority: 1001" > /etc/apt/preferences.d/onmetal-images \
+    &&  echo "Package: *\nPin: release a=${DEBIAN_DIST}\nPin-Priority: 900" > /etc/apt/preferences.d/default
+
+RUN echo "deb http://deb.debian.org/debian ${DEBIAN_DIST} main contrib non-free" > /etc/apt/sources.list \
      && echo "deb [signed-by=$GARDENLINUX_MIRROR_KEY] https://repo.gardenlinux.io/gardenlinux $VERSION main" >> /etc/apt/sources.list \
      && sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list \
      && if [ -f "/etc/apt/sources.list.d/debian.sources"] ; then sed -i 's/deb.debian.org/cdn-aws.deb.debian.org/g' /etc/apt/sources.list.d/debian.sources ; else echo "file not present" ; fi \
@@ -18,7 +27,6 @@ RUN echo "deb http://deb.debian.org/debian testing main contrib non-free" > /etc
      && apt-get install -y --no-install-recommends \
           curl \
           unzip \
-          ca-certificates \
           less \
           apt-transport-https \
           gnupg \


### PR DESCRIPTION
# changes
* parameterize base-container debian dist
* install packages from debian dist by default
* apt pinning to install pkgs from repo.gardenlinux.io * define it explicitly, avoid unecessary conflicts

# Why?
The integration test container build step fails (for rel-1312 branch), because there is a package conflict with gcc (see [here](https://github.com/gardenlinux/gardenlinux/actions/runs/7254256520/job/19775761030#step:4:60)). 
This is completely unrelated to the use case of the test container. Test container is used for communicating with the target test platforms, we do not need to maintain the CLI tools and CLI tool dependencies in our gardenlinux repo