### PR TITLE
Add ipxe files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ __pycache__
 /tests/*.xml
 make_targets.cache
 /bin/*.vars
+/bin/*.ipxe
 .DS_Store


### PR DESCRIPTION
Similar to efi vars files, those might be created when running `start-vm`. There is no plausible reason why one would want to commit this, so adding it to gitignore.