### PR TITLE
Fix build after breaking it in #1874

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -20,8 +20,8 @@ jobs:
           git update-index --assume-unchanged VERSION
       - name: get cname
         run: |
-          echo "cname_amd64=$(./build --resolve-cname container-amd64)" | tee -a "$GITHUB_ENV"
-          echo "cname_arm64=$(./build --resolve-cname container-arm64)" | tee -a "$GITHUB_ENV"
+          echo "cname_amd64=$(./build --resolve-cname container-amd64 | grep ^container-amd64)" | tee -a "$GITHUB_ENV"
+          echo "cname_arm64=$(./build --resolve-cname container-arm64 | grep ^container-arm64)" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: ${{ env.cname_amd64 }}

--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -60,7 +60,7 @@ jobs:
         git update-index --assume-unchanged VERSION
 
     - name: get cname
-      run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+      run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }} | grep ^${{ matrix.target }})" | tee -a "$GITHUB_ENV"
 
     - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # pin@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
         git update-index --assume-unchanged VERSION
 
     - name: get cname
-      run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+      run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }} | grep ^${{ matrix.target }})" | tee -a "$GITHUB_ENV"
 
     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
       with:

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -45,7 +45,7 @@ jobs:
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - name: get cname
-        run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+        run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }} | grep ^${{ matrix.target }})" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: ${{ env.cname }}
@@ -83,7 +83,7 @@ jobs:
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - name: get cname
-        run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+        run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }} | grep ^${{ matrix.target }})" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # pin@v3
         with:
           name: tests-${{ env.cname }}


### PR DESCRIPTION
Additional output created by building the image breaks assumptions about what ./build --resolve-cname does. Fix by grepping for the cname.