### PR TITLE
Update builder to include gardenlinux/builder#57

### DIFF
--- a/build
+++ b/build
@@ -3,6 +3,9 @@
 set -euo pipefail
 shopt -s nullglob
 
+exec 3>&1
+exec 1>&2
+
 container_image=localhost/builder
 container_engine=podman
 target_dir=.build
@@ -43,7 +46,7 @@ while [ $# -gt 0 ]; do
 			shift
 			;;
 		--print-container-image)
-			printf '%s\n' "$container_image"
+			printf '%s\n' "$container_image" >&3
 			exit 0
 			;;
 		--resolve-cname)
@@ -80,7 +83,7 @@ if [ "$container_image" = localhost/builder ]; then
 	# That file might only contain a single line 'FROM ghcr.io/gardenlinux/builder:...' which can be updated via dependabot.
 	if [[ -f builder.dockerfile ]]; then
 		"$container_engine" build -t "$container_image" -f builder.dockerfile "$dir"
-	else
+	else 
 		"$container_engine" build -t "$container_image" "$dir"
 	fi
 fi
@@ -95,7 +98,7 @@ if [ "$resolve_cname" = 1 ]; then
 	arch="$("$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" dpkg --print-architecture)"
 	cname="$("$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" /builder/parse_features --feature-dir /builder/features --default-arch "$arch" --default-version "$default_version" --cname "$1")"
 	short_commit="$(head -c 8 <<< "$commit")"
-	echo "$cname-$short_commit"
+	echo "$cname-$short_commit" >&3
 	exit 0
 fi
 
@@ -114,8 +117,17 @@ if [ "$use_kms" = 1 ]; then
 	done
 fi
 
+# Default values which can be overriden via 'build.config' file
+tempfs_size=2G
+
+if [[ -f "$PWD"/build.config ]]; then
+	. "$PWD"/build.config
+fi
+
+make_opts+=("TEMPFS_SIZE=$tempfs_size")
+
 if [ -d cert ]; then
 	container_mount_opts+=(-v "$PWD/cert:/builder/cert:ro")
 fi
 
-"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" ${container_cmd[@]+"${container_cmd[@]}"} make --no-print-directory -C /builder "${make_opts[@]}" "$@"
+"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" ${container_cmd[@]+"${container_cmd[@]}"} make --no-print-directory -C /builder "${make_opts[@]}" "$@" >&3

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,3 +1,3 @@
 # Dependency management via Dependabot
 
-FROM ghcr.io/gardenlinux/builder:e8eecd6246bd78c81708696e5eb6a7e22ef4edfe
+FROM ghcr.io/gardenlinux/builder:3ab2bb52bc46bb200c761369c087e9413d1ce0ac

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,3 +1,3 @@
 # Dependency management via Dependabot
 
-FROM ghcr.io/gardenlinux/builder:002a2ff4d1dc6a39d04543b6a6e92a1465d9e226
+FROM ghcr.io/gardenlinux/builder:488dac49dcd698ac63dc1a2581bbcde5b200c024

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,3 +1,3 @@
 # Dependency management via Dependabot
 
-FROM ghcr.io/gardenlinux/builder:488dac49dcd698ac63dc1a2581bbcde5b200c024
+FROM ghcr.io/gardenlinux/builder:e8eecd6246bd78c81708696e5eb6a7e22ef4edfe


### PR DESCRIPTION
This should fix the failed nightly builds because they make assumptions about what is written to stdout.