### PR TITLE
Disallow loading of nouveau driver on OpenStack baremetal

### DIFF
--- a/features/openstackbaremetal/file.include/etc/modprobe.d/10-disallow-nouveau.conf
+++ b/features/openstackbaremetal/file.include/etc/modprobe.d/10-disallow-nouveau.conf
@@ -1,0 +1,2 @@
+blacklist nouveau
+options nouveau modeset=0


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables the nouveau kernel driver on OpenStack baremetal flavour by adding a corresponding parameter to `/etc/modprobe.d`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
nouveau kernel driver is disallowed on OpenStack baremetal flavour.
```
