### PR TITLE
Revert "enable ssh-rsa as HostKeyAlgorithm"

### DIFF
--- a/features/ssh/file.include/etc/ssh/sshd_config
+++ b/features/ssh/file.include/etc/ssh/sshd_config
@@ -41,6 +41,3 @@ AuthenticationMethods publickey
 # Supported HostKey algorithms by order of preference.
 HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
-
-# Add ssh-rsa to allowed HostKeyAlgorithms
-HostKeyAlgorithms=+ssh-rsa


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #1500 was introduced because some limitations with Azures Marketplace certification required `ssh-rsa` to be available as cipher algorithm for SSH host keys.

As Garden Linux is now published through Azure community image galleries and no longer via the Azure Marketplace, deviating from the recommended defaults for sshd is no longer required and thus, PR #1500 (commit 71e5a67f458506327b99755e5682d6f6b6ccaa7d) should be reverted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
ssh-rsa is no longer available as cipher algorithm for SSH host keys.
```
