### PR TITLE
GitHub changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,6 @@ changelog:
   categories:
     - title: Breaking Changes ❗
       labels:
-        - Semver-Major
         - breaking-change
     - title: Bug Fixes :bug:
       labels:
@@ -19,7 +18,6 @@ changelog:
         - security
     - title: New Features :tada:
       labels:
-        - Semver-Minor
         - enhancement
         - features
         - packages

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - github-settings
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes ❗
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Bug Fixes :bug:
+      labels:
+        - bug
+        - bug-fix
+    - title: Security :lock:
+      labels:
+        - security
+    - title: New Features :tada:
+      labels:
+        - Semver-Minor
+        - enhancement
+        - features
+        - packages
+    - title: Build and Test Environment 🏗️
+      labels:
+        - test-env
+        - build-env
+        - github-actions
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
* GitHub supports the generation of automatic release notes based on PRs. 
* PRs can be filtered and sorted into categories via PR labels
* more details: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes