### PR TITLE
fix: explicitly install dracut for secureboot feature

### DIFF
--- a/features/_secureboot/pkg.include
+++ b/features/_secureboot/pkg.include
@@ -1,2 +1,3 @@
 efitools
+dracut
 systemd-boot-efi


### PR DESCRIPTION
**What this PR does / why we need it**:
* before 6.6 kernel the dracut pkgs were installed as dependency for the linux kernel
* 6.6 debian based garden linux kernel does not have this dependency.
* installing dracut explicitly in a feature where we need it

**Which issue(s) this PR fixes**:
Fixes secureboot targets 

**Special notes for your reviewer**:
- ⚠️ There are more tests failing. These are unrelated to this PR and will be addressed with a new kernel containing: https://gitlab.com/gardenlinux/gardenlinux-package-linux-6.6/-/merge_requests/1  (CONFIG_REMOTEPROC got enabled in 6.6 non-cloud arm64 debian kernel config, and we did not explicitly disable it before)
