### PR TITLE
fix: rewrite test_proc.py to check if proc/ is empty in image artifact

### DIFF
--- a/features/base/test/test_proc.py
+++ b/features/base/test/test_proc.py
@@ -16,10 +16,10 @@ def test_proc(client, container, testconfig):
     # Only proceed if local command was sucessfull
     assert rc == 0, f"Could not unpack {image_path}."
 
-    # Validate for captures of any "proc/" content
+    # Validate for captures of any lines starting with "proc/"
     matches = []
     for line in out.split('\n'):
-        if "proc/" in line:
+        if line.startswith("proc/"):
             matches.append(line)
 
     # Only "/proc/" as an empty directory should be found


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes test_proc.py, so that it checks for files **starting with** "proc/" instead of containing "proc/" in the file name. 

The previous implementation of test_proc.py checked for any files in the image artifact containing the string "proc/". 

**Which issue(s) this PR fixes**:
Fixes nightly builds ([see](https://github.com/gardenlinux/gardenlinux/actions/runs/8000143319/job/21866538698#step:14:352)) 

```
        # Only "/proc/" as an empty directory should be found
>       assert len(matches) == 1, f"/proc is not empty. Found: {matches}"
E       AssertionError: /proc is not empty. Found: ['proc/', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/mtk_scp.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/mtk_scp_ipi.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_common.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_pil_info.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_q6v5.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_q6v5_adsp.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_q6v5_mss.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_q6v5_pas.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_q6v5_wcss.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/qcom_sysmon.ko.xz', 'usr/lib/modules/6.6.17-arm64/kernel/drivers/remoteproc/ti_k3_r5_remoteproc.ko.xz']
E       assert 13 == 1
```

A file in the artifact containing "remoteproc/" in the file path caused the tests to fail. The failing tests were actually a false alert, because proc/ was in fact still empty. 

**Special notes for your reviewer**:
* linux version `6.6.17-0gardenlinux3` is released and available in 1424.0 (tomorrow). This new version will disable the `CONFIG_REMOTEPROC`, so that even without this PR, the nightlies would be green again. 
* Thanks @MrBatschner for identifying the issue with the test!
