### PR TITLE
tests: add kernel config tests

### DIFF
--- a/features/base/test/test_kernel_config.py
+++ b/features/base/test/test_kernel_config.py
@@ -3,30 +3,6 @@ from helper.sshclient import RemoteClient
 from helper.tests.file_content import file_content
 
 
-@pytest.mark.parametrize(
-    "args",
-    [
-        (   {
-            # example expected kernel config options:
-            #"CONFIG_INIT_ENV_ARG_LIMIT": "32",
-            #"CONFIG_COMPILE_TEST": "is not set",
-            #"CONFIG_WERROR": "n",
-            #"CONFIG_LOCALVERSION": "",
-            #"CONFIG_LOCALVERSION_AUTO": "is not set",
-            #"CONFIG_HAVE_KERNEL_GZIP": "y"
-            }
-        )
-    ]
-)
-
-def test_kernel_config(client, args, non_container):
-    """compare kernel config options from the parametrize section with the
-    kernel config options in the /boot/config-* file. The values 'is not set'
-    and 'n' are treated as the same."""
-    file = "/boot/config-*"
-    file_content(client, file, args, ignore_comments=True)
-
-
 def test_nvme_kernel_parameter(client, aws):
     """ Test for NVME kernel params """
     (exit_code, output, error) = client.execute_command("grep -c nvme_core.io_timeout=4294967295 /proc/cmdline")

--- a/features/cloud/test/test_kernel_config.py
+++ b/features/cloud/test/test_kernel_config.py
@@ -12,7 +12,7 @@ import helper.utils as utils
 def test_kernel_configs_enabled(client, kernel_config_item):
     kernel_config_paths = utils.get_kernel_config_paths(client)
     for kconf in kernel_config_paths:
-        assert utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is not set, but expected it to be set to y or m"
+        assert utils.check_kernel_config_exact(client, kconf, f"{kernel_config_item}=(y|m)"), f"Kernel Config: {kernel_config_item} is not set, but expected it to be set"
 
 @pytest.mark.parametrize(
     "kernel_config_item",
@@ -24,4 +24,16 @@ def test_kernel_configs_enabled(client, kernel_config_item):
 def test_kernel_configs_disabled(client, kernel_config_item):
     kernel_config_paths = utils.get_kernel_config_paths(client)
     for kconf in kernel_config_paths:
-        assert not utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is set, but expected it to be disabled or not set"
+        assert not utils.check_kernel_config_exact(client, kconf, f"{kernel_config_item}=(y|m)"), f"Kernel Config: {kernel_config_item} is set, but expected it to be disabled or not set"
+
+
+@pytest.mark.parametrize(
+    "kernel_config_item",
+    [
+    #    "CONFIG_BLK_DEV_RAM_COUNT=16",
+    ]
+)
+def test_kernel_config_exact(client, kernel_config_item):
+    kernel_config_paths = utils.get_kernel_config_paths(client)
+    for kconf in kernel_config_paths:
+        assert utils.check_kernel_config_exact(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} not found "

--- a/features/cloud/test/test_kernel_config.py
+++ b/features/cloud/test/test_kernel_config.py
@@ -1,39 +1,32 @@
 import pytest
 import helper.utils as utils
+import sys
 
 
 @pytest.mark.parametrize(
-    "kernel_config_item",
+    "test_kernel_config_tuple",
     [
-        "CONFIG_X86_SGX",
-        "CONFIG_X86_SGX_KVM",
+        ("CONFIG_X86_SGX", "y", "enable SGX","amd64"),
+        ("CONFIG_X86_SGX_KVM", "y", "enable SGX", "amd64"),
+        ("CONFIG_MAGIC_SYSRQ", "n", "Security: an attacker with physical access could use this magic sysrq key to reboot, shutdown or remount", "all"),
+       # ("CONFIG_BLK_DEV_RAM_COUNT", "16", "Example how to test for other values than y,m,n", "all"),
     ]
 )
-def test_kernel_configs_enabled(client, kernel_config_item):
+def test_kernel_configs(client, test_kernel_config_tuple):
     kernel_config_paths = utils.get_kernel_config_paths(client)
-    for kconf in kernel_config_paths:
-        assert utils.check_kernel_config_exact(client, kconf, f"{kernel_config_item}=(y|m)"), f"Kernel Config: {kernel_config_item} is not set, but expected it to be set"
+    kernel_conf_key = test_kernel_config_tuple[0]
+    kernel_conf_value = test_kernel_config_tuple[1]
+    kernel_conf_test_rational = test_kernel_config_tuple[2]
+    arch = test_kernel_config_tuple[3]
 
-@pytest.mark.parametrize(
-    "kernel_config_item",
-    [
-        "CONFIG_REMOTEPROC",
-        "CONFIG_MAGIC_SYSRQ",
-    ]
-)
-def test_kernel_configs_disabled(client, kernel_config_item):
-    kernel_config_paths = utils.get_kernel_config_paths(client)
     for kconf in kernel_config_paths:
-        assert not utils.check_kernel_config_exact(client, kconf, f"{kernel_config_item}=(y|m)"), f"Kernel Config: {kernel_config_item} is set, but expected it to be disabled or not set"
+        if arch in kconf or arch == "all": 
+            if kernel_conf_value == "n":
+                print(f"Check if {kernel_conf_key} is disabled for {arch}")
+                assert not utils.check_kernel_config_exact(client, kconf, f"{kernel_conf_key}=(y|m)"), f"Kernel Config: {kernel_conf_key} is set, but expected it to be disabled or not set"
+            else:
+                print(f"Check if {kernel_conf_key} is enabled for {arch}")
+                assert utils.check_kernel_config_exact(client, kconf, f"{kernel_conf_key}={kernel_conf_value}"), f"Kernel Config: {kernel_config_item} is not set to {kernel_conf_value}"
+        else:
+            print(f"Skipping config test of {kernel_conf_key} for architecture {arch}")
 
-
-@pytest.mark.parametrize(
-    "kernel_config_item",
-    [
-    #    "CONFIG_BLK_DEV_RAM_COUNT=16",
-    ]
-)
-def test_kernel_config_exact(client, kernel_config_item):
-    kernel_config_paths = utils.get_kernel_config_paths(client)
-    for kconf in kernel_config_paths:
-        assert utils.check_kernel_config_exact(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} not found "

--- a/features/cloud/test/test_kernel_config.py
+++ b/features/cloud/test/test_kernel_config.py
@@ -1,0 +1,27 @@
+import pytest
+import helper.utils as utils
+
+
+@pytest.mark.parametrize(
+    "kernel_config_item",
+    [
+        "CONFIG_X86_SGX",
+        "CONFIG_X86_SGX_KVM",
+    ]
+)
+def test_kernel_configs_enabled(client, kernel_config_item):
+    kernel_config_paths = utils.get_kernel_config_paths(client)
+    for kconf in kernel_config_paths:
+        assert utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is not set, but expected it to be set to y or m"
+
+@pytest.mark.parametrize(
+    "kernel_config_item",
+    [
+        "CONFIG_REMOTEPROC",
+        "CONFIG_MAGIC_SYSRQ",
+    ]
+)
+def test_kernel_configs_disabled(client, kernel_config_item):
+    kernel_config_paths = utils.get_kernel_config_paths(client)
+    for kconf in kernel_config_paths:
+        assert not utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is set, but expected it to be disabled or not set"

--- a/features/metal/test/test_kernel_config.py
+++ b/features/metal/test/test_kernel_config.py
@@ -1,27 +1,32 @@
 import pytest
 import helper.utils as utils
+import sys
 
 
 @pytest.mark.parametrize(
-    "kernel_config_item",
+    "test_kernel_config_tuple",
     [
-        "CONFIG_X86_SGX",
-        "CONFIG_X86_SGX_KVM",
+        ("CONFIG_X86_SGX", "y", "enable SGX","amd64"),
+        ("CONFIG_X86_SGX_KVM", "y", "enable SGX", "amd64"),
+        ("CONFIG_MAGIC_SYSRQ", "n", "Security: an attacker with physical access could use this magic sysrq key to reboot, shutdown or remount", "all"),
+       # ("CONFIG_BLK_DEV_RAM_COUNT", "16", "Example how to test for other values than y,m,n", "all"),
     ]
 )
-def test_kernel_configs_enabled(client, kernel_config_item):
+def test_kernel_configs(client, test_kernel_config_tuple):
     kernel_config_paths = utils.get_kernel_config_paths(client)
-    for kconf in kernel_config_paths:
-        assert utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is not set, but expected it to be set to y or m"
+    kernel_conf_key = test_kernel_config_tuple[0]
+    kernel_conf_value = test_kernel_config_tuple[1]
+    kernel_conf_test_rational = test_kernel_config_tuple[2]
+    arch = test_kernel_config_tuple[3]
 
-@pytest.mark.parametrize(
-    "kernel_config_item",
-    [
-        "CONFIG_REMOTEPROC",
-        "CONFIG_MAGIC_SYSRQ",
-    ]
-)
-def test_kernel_configs_disabled(client, kernel_config_item):
-    kernel_config_paths = utils.get_kernel_config_paths(client)
     for kconf in kernel_config_paths:
-        assert not utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is set, but expected it to be disabled or not set"
+        if arch in kconf or arch == "all": 
+            if kernel_conf_value == "n":
+                print(f"Check if {kernel_conf_key} is disabled for {arch}")
+                assert not utils.check_kernel_config_exact(client, kconf, f"{kernel_conf_key}=(y|m)"), f"Kernel Config: {kernel_conf_key} is set, but expected it to be disabled or not set"
+            else:
+                print(f"Check if {kernel_conf_key} is enabled for {arch}")
+                assert utils.check_kernel_config_exact(client, kconf, f"{kernel_conf_key}={kernel_conf_value}"), f"Kernel Config: {kernel_config_item} is not set to {kernel_conf_value}"
+        else:
+            print(f"Skipping config test of {kernel_conf_key} for architecture {arch}")
+

--- a/features/metal/test/test_kernel_config.py
+++ b/features/metal/test/test_kernel_config.py
@@ -1,0 +1,27 @@
+import pytest
+import helper.utils as utils
+
+
+@pytest.mark.parametrize(
+    "kernel_config_item",
+    [
+        "CONFIG_X86_SGX",
+        "CONFIG_X86_SGX_KVM",
+    ]
+)
+def test_kernel_configs_enabled(client, kernel_config_item):
+    kernel_config_paths = utils.get_kernel_config_paths(client)
+    for kconf in kernel_config_paths:
+        assert utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is not set, but expected it to be set to y or m"
+
+@pytest.mark.parametrize(
+    "kernel_config_item",
+    [
+        "CONFIG_REMOTEPROC",
+        "CONFIG_MAGIC_SYSRQ",
+    ]
+)
+def test_kernel_configs_disabled(client, kernel_config_item):
+    kernel_config_paths = utils.get_kernel_config_paths(client)
+    for kconf in kernel_config_paths:
+        assert not utils.check_kernel_config_enabled(client, kconf, kernel_config_item), f"Kernel Config: {kernel_config_item} is set, but expected it to be disabled or not set"

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -238,13 +238,12 @@ def install_package_deb(client, pkg):
         f"apt-get install -y --no-install-recommends {pkg}", quiet=True)
     assert exit_code == 0, f"Could not install Debian Package: {error}"
 
-
-def check_kernel_config_enabled(client, kernel_config_path, kernel_config_item ):
+def check_kernel_config_exact(client, kernel_config_path, kernel_config_item ):
     """ Checks if the given kernel_config_item is set in kernel_config_path """
 
     assert check_file(client, kernel_config_path), f"Kernel config does not exist - {kernel_config_path}"
 
-    command = f"grep -qE '^{kernel_config_item}=(y|m)$' '{kernel_config_path}'"
+    command = f"grep -qE '^{kernel_config_item}$' '{kernel_config_path}'"
     (exit_code, output, error) = client.execute_command(command, quiet=True)
     return exit_code == 0
 

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -238,7 +238,7 @@ def install_package_deb(client, pkg):
         f"apt-get install -y --no-install-recommends {pkg}", quiet=True)
     assert exit_code == 0, f"Could not install Debian Package: {error}"
 
-def check_kernel_config_exact(client, kernel_config_path, kernel_config_item ):
+def check_kernel_config_exact(client, kernel_config_path, kernel_config_item):
     """ Checks if the given kernel_config_item is set in kernel_config_path """
 
     assert check_file(client, kernel_config_path), f"Kernel config does not exist - {kernel_config_path}"

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -201,6 +201,26 @@ def execute_remote_command(client, cmd, skip_error=False):
         return exit_code, output
 
 
+def get_installed_kernel_versions(client):
+    """Get a list of installed kernel versions using 'linux-version list'."""
+    command = "linux-version list"
+    (exit_code, output, error) = client.execute_command(command, quiet=True)
+    if exit_code == 0 and output:
+        kernel_versions = output.strip().split('\n')
+        return kernel_versions
+    else:
+        return []
+
+def get_kernel_config_paths(client):
+    kernel_versions = get_installed_kernel_versions(client)
+    paths = []
+    for k in kernel_versions:
+        config_path = f"/boot/config-{k}"
+        if check_file(client, config_path):
+            paths.append(config_path)
+    return paths
+
+
 def install_package_deb(client, pkg):
     """ Installs (a) Debian packagei(s) on a target platform """
     # Packages for testing may not be included within the Garden Linux
@@ -217,3 +237,16 @@ def install_package_deb(client, pkg):
     (exit_code, output, error) = client.execute_command(
         f"apt-get install -y --no-install-recommends {pkg}", quiet=True)
     assert exit_code == 0, f"Could not install Debian Package: {error}"
+
+
+def check_kernel_config_enabled(client, kernel_config_path, kernel_config_item ):
+    """ Checks if the given kernel_config_item is set in kernel_config_path """
+
+    assert check_file(client, kernel_config_path), f"Kernel config does not exist - {kernel_config_path}"
+
+    command = f"grep -qE '^{kernel_config_item}=(y|m)$' '{kernel_config_path}'"
+    (exit_code, output, error) = client.execute_command(command, quiet=True)
+    return exit_code == 0
+
+
+


### PR DESCRIPTION
Refactors the kernel config tests
* Checks all configurations of all installed kernels
    * in theory, only one kernel is installed during build time. But if we include two different kernels in the image (intentionally or unintentionally), then we will have multiple /boot/config-* files, and the result of the kernel config test is useless- can not be trusted. Therefore this test does not assume anything about the number of installed kernels, and just verifies that all included configs are correct.  
* Check each config individually to identify wrong config directly
* Three test types:
    * is enabled: either `y` or `m`
    * is disabled: either not set or `n`
    * is exact: check if exactly this line is contained in the config

**What this PR does / why we need it**:
Add another layer of verification that our kernel configuration is correct.

**Which issue(s) this PR fixes**:
Fixes #1981 
  
