### PR TITLE
Support generation of 2048 bit RSA keys for TPM PCR value signing

### DIFF
--- a/cert/Makefile
+++ b/cert/Makefile
@@ -11,17 +11,20 @@ GPG_EMAIL=contact@gardenlinux.io
 
 export CERT_C CERT_L CERT_O CERT_OU CERT_E GPG_KEY_TYPE GPG_KEY_LENGTH GPG_NAME GPG_EMAIL
 
+GENCERT_TPM_OPTS=--algorithm-options rsa_keygen_bits:2048
+
 ifdef USE_KMS
 export AWS_DEFAULT_REGION AWS_REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 GENCERT_OPTS=--aws-kms-key-spec RSA_4096
 GENGPG_OPTS=--aws-kms-key-spec RSA_4096
+GENCERT_TPM_OPTS=--aws-kms-key-spec RSA_2048
 endif
 
 .PHONY: default clean distclean
 .PRECIOUS: %.crt
 
 ifndef CA
-default: $(PREFIX)kernel-sign.crt $(PREFIX)secureboot.pk.auth $(PREFIX)secureboot.null.pk.auth $(PREFIX)secureboot.kek.auth $(PREFIX)secureboot.db.auth $(PREFIX)secureboot.aws-efivars $(PREFIX)repo-sign.pub
+default: $(PREFIX)kernel-sign.crt $(PREFIX)secureboot.pk.auth $(PREFIX)secureboot.null.pk.auth $(PREFIX)secureboot.kek.auth $(PREFIX)secureboot.db.auth $(PREFIX)secureboot.aws-efivars $(PREFIX)repo-sign.pub $(PREFIX)tpm-sign.crt
 
 $(PREFIX)intermediate-ca.crt: $(PREFIX)root-ca.crt
 $(PREFIX)kernel-sign.crt: $(PREFIX)intermediate-ca.crt
@@ -45,6 +48,9 @@ endif
 
 GUID.txt:
 	uuidgen --random > '$@'
+
+$(PREFIX)tpm-sign.crt: $(PREFIX)tpm-sign.conf $(PREFIX)intermediate-ca.crt
+	@./gencert --conf '$(word 1,$+)' --ca '$(word 2,$+)' $(GENCERT_TPM_OPTS) '$@'
 
 %.crt: %.conf $(CA)
 	@./gencert --conf '$(word 1,$+)' --ca '$(word 2,$+)' $(GENCERT_OPTS) '$@'

--- a/cert/gardenlinux-tpm-sign.conf
+++ b/cert/gardenlinux-tpm-sign.conf
@@ -1,0 +1,2 @@
+CERT_CN=$CERT_OU tpm sign certificate
+days=365

--- a/cert/tpm-sign.conf
+++ b/cert/tpm-sign.conf
@@ -1,0 +1,2 @@
+CERT_CN=$CERT_OU dev tpm sign certificate
+days=365


### PR DESCRIPTION
As it often cannot be guaranteed that all hardware TPM chips support the standard key size of 4096 bit, this PR allows the generation of specific RSA keypairs for signing TPM PCR values, which only have a size of 2048 bit.

![image](https://github.com/gardenlinux/gardenlinux/assets/121184709/6ff27f46-7017-4e5c-b78b-42bc2e80b9af)