### PR TITLE
doc: remove 934 reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
   - [SELinux](#selinux)
   - [Secureboot](#secureboot)
   - [Maintained Images](#maintained-images)
-- [Building 934](#building-934)
 - [Tests](#tests)
 - [Deploying](#deploying)
 - [Release](#release)
@@ -167,20 +166,6 @@ Garden Linux offers a range of official images tailored for various architecture
 
 
 To understand the build process for these images, refer to the [build action](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/build.yml). For details on the publishing process, check out the [upload action](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/upload_to_s3.yml) and the [gardenlinux/glci](https://github.com/gardenlinux/glci) repository.
-
-## Building 934
-
-For the sake of reproducibility, the earlier versions like 934 use the old Garden Linux builder.
-
-Here's a quick guide on building the 934 image:
-```shell
-git checkout rel-934
-# Ensure you're working in a clean environment (optional but recommended)
-make clean
-make aws-prod
-```
-
-If you encounter any issues specifically with the 934 build, please [open an issue](https://github.com/gardenlinux/gardenlinux/issues) on our GitHub repository. Make sure to mention that your issue pertains to the 934 build for clarity.
 
 ## Tests
 


### PR DESCRIPTION
README.md of main should only describe how main branch is build. Branches containing legacy code contain also a legacy readme. 