### PR TITLE
Test: Run only if artifact under test is built

### DIFF
--- a/test
+++ b/test
@@ -34,6 +34,13 @@ while [ $# -gt 0 ]; do
 	esac
 done
 
+if [[ ! -d $dir/.build/ ]]; then
+	echo "ERROR: .build directory does not exist."
+	echo "Require $1 to be built before it can be tested."
+	echo "Run ./build $1 before running ./test $1"
+	exit 1
+fi
+
 cname="$(basename "$(realpath "$dir/.build/$1")" .artifacts)"
 
 if [[ -z $cname ]]; then

--- a/test
+++ b/test
@@ -65,5 +65,5 @@ if [ -z "$container_image" ]; then
 	rm "$image_file"
 fi
 
-# "$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" 2>&1 | tee "$dir/.build/$cname.test-log"
-# echo "$cname.test-log" >> "$dir/.build/$cname.artifacts"
+"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" 2>&1 | tee "$dir/.build/$cname.test-log"
+echo "$cname.test-log" >> "$dir/.build/$cname.artifacts"

--- a/test
+++ b/test
@@ -36,6 +36,12 @@ done
 
 cname="$(basename "$(realpath "$dir/.build/$1")" .artifacts)"
 
+if [[ -z $cname ]]; then
+	echo "ERROR: Require $1 to be built before it can be tested."
+	echo "Run ./build $1 before running ./test $1"
+	exit 1
+fi
+
 container_mount_opts=(
 	-v "$(realpath "$dir")/tests:/gardenlinux/tests"
 	-v "$(realpath "$dir")/features:/gardenlinux/features:ro"

--- a/test
+++ b/test
@@ -43,7 +43,7 @@ fi
 
 cname="$(basename "$(realpath "$dir/.build/$1")" .artifacts)"
 
-if [[ -z $cname ]]; then
+if [[ ! -f $(realpath "$dir")/.build/$cname.tar ]]; then
 	echo "ERROR: Require $1 to be built before it can be tested."
 	echo "Run ./build $1 before running ./test $1"
 	exit 1
@@ -65,5 +65,5 @@ if [ -z "$container_image" ]; then
 	rm "$image_file"
 fi
 
-"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" 2>&1 | tee "$dir/.build/$cname.test-log"
-echo "$cname.test-log" >> "$dir/.build/$cname.artifacts"
+# "$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" 2>&1 | tee "$dir/.build/$cname.test-log"
+# echo "$cname.test-log" >> "$dir/.build/$cname.artifacts"


### PR DESCRIPTION
This is a sanity check. Running `./test foo` without having run `./build foo` before results in undesired behavior.

Fixes #1987
