### PR TITLE
Call setup workflow in upload to s3 pipelines

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -35,6 +35,7 @@ jobs:
         modifier: [ "${{ inputs.default_modifier }}" ]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: ./.github/actions/setup
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4
         with:
           role-to-assume: ${{ secrets.role }}
@@ -73,6 +74,7 @@ jobs:
             target: azure
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: ./.github/actions/setup
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4
         with:
           role-to-assume: ${{ secrets.role }}


### PR DESCRIPTION
cname is empty in upload to s3 pipeline because of issue #1980

```
Error: OCI runtime error: chmod `run/shm`: Operation not supported
```

https://github.com/gardenlinux/gardenlinux/actions/runs/8110254782/job/22168856733#step:7:26

Apply workaround from #1982 also for `.github/workflows/upload_to_s3.yml`


**Which issue(s) this PR fixes**:
Fixes #1994

**Special notes for your reviewer**:

