### PR TITLE
Fix platform tests apply crun workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,7 +219,9 @@ jobs:
         with:
           path: tests/test.xml
       - name: get cname
-        run: echo "cname=$(basename "$(realpath ".build/${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}")" .artifacts)" | tee -a "$GITHUB_ENV"
+        run: |
+          cname='$(basename "$(realpath ".build/${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}")" .artifacts)'
+          echo "cname=$cname" | tee -a "$GITHUB_ENV"
       - name: pack build artifacts for upload
         run: tar -cSzvf "${{ env.cname }}.tar.gz" -C .build -T ".build/${{ env.cname }}.artifacts"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -20,8 +20,10 @@ jobs:
           git update-index --assume-unchanged VERSION
       - name: get cname
         run: |
-          echo "cname_amd64=$(./build --resolve-cname container-amd64)" | tee -a "$GITHUB_ENV"
-          echo "cname_arm64=$(./build --resolve-cname container-arm64)" | tee -a "$GITHUB_ENV"
+          cname_amd64="$(./build --resolve-cname container-amd64)"
+          cname_arm64="$(./build --resolve-cname container-arm64)"
+          echo "cname_amd64=$cname_amd64" | tee -a "$GITHUB_ENV"
+          echo "cname_arm64=$cname_arm64" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
         with:
           name: ${{ env.cname_amd64 }}

--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -60,7 +60,9 @@ jobs:
         git update-index --assume-unchanged VERSION
 
     - name: get cname
-      run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+      run: |
+        cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
+        echo "cname=$cname" | tee -a "$GITHUB_ENV"
 
     - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,8 @@ jobs:
             target: ali
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      # Use crun workaround
+    - uses: ./.github/actions/setup
 
     - name: login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u $ --password-stdin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,9 @@ jobs:
         git update-index --assume-unchanged VERSION
 
     - name: get cname
-      run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+      run: |
+        cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
+        echo "cname=$cname" | tee -a "$GITHUB_ENV"
 
     - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
       with:

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -46,7 +46,9 @@ jobs:
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - name: get cname
-        run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+        run: |
+          cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
+          echo "cname=$cname" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
         with:
           name: ${{ env.cname }}
@@ -85,7 +87,10 @@ jobs:
           bin/garden-version "${{ inputs.version }}" | tee VERSION
           git update-index --assume-unchanged VERSION
       - name: get cname
-        run: echo "cname=$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})" | tee -a "$GITHUB_ENV"
+        run: |
+          cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
+          echo "cname=$cname" | tee -a "$GITHUB_ENV"
+
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
         with:
           name: tests-${{ env.cname }}


### PR DESCRIPTION
Platform tests fail because of empty cname, and download-artifacts step tries to download all because no input was provided due to empty cname

```
Error: OCI runtime error: chmod `run/shm`: Operation not supported
cname=
```


Therefore this PR does two things:
1. Include fix, so that cname can be resolved with `./build --resolve-cname` in pipeline (crun workaround)
2. Make `get cname` steps fail in github actions bash environment that has **not** set `pipefail`