### PR TITLE
Revert "tests: add GVNIC and VIRTIO_SCSI_MULTIQUEUE to GCP tests"

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -411,10 +411,8 @@ class GCP:
             'labels': self._tags,
         }
 
-        guest_os_features = "GVNIC,VIRTIO_SCSI_MULTIQUEUE"
         if self.config['uefi'] or self.config['secureboot']:
-            guest_os_features += ",UEFI_COMPATIBLE"
-        config['guest_os_features'] = [{'type': guest_os_features}]
+            config['guest_os_features'] = [{'type_': "UEFI_COMPATIBLE"}]
 
         if self.config['secureboot']:
             cert_file_type = self.config['secureboot_parameters']['cert_file_type']


### PR DESCRIPTION
Reverts gardenlinux/gardenlinux#2002 because of errors that appeared with GCP platform tests after this PR got merged. Needs more investigation.