### PR TITLE
Enable cloud-init network config for OpenStack Baremetal

### DIFF
--- a/features/openstack/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
+++ b/features/openstack/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
@@ -1,1 +1,0 @@
-network: {config: disabled}


### PR DESCRIPTION
**What this PR does / why we need it**:

Garden Linux images running on OpenStack baremetal need to be able to use cloud-init to set up potential network bonds
that get configured through a config-drive.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
cloud-init may configure the network ion OpenStack Baremetal
```
