### PR TITLE
Rename uefivars.py to uefivars

### DIFF
--- a/cert/Makefile
+++ b/cert/Makefile
@@ -62,7 +62,7 @@ $(PREFIX)tpm-sign.crt: $(PREFIX)tpm-sign.conf $(PREFIX)intermediate-ca.crt
 	@./genefiauth --guid-file '$(word 1,$+)' --ca '$(word 2,$+)' --null '$@'
 
 %.aws-efivars: %.pk.auth %.kek.auth %.db.auth
-	@uefivars.py -i none -o aws -O '$@' -P '$*.pk.esl' -K '$*.kek.esl' -b '$*.db.esl'
+	@uefivars -i none -o aws -O '$@' -P '$*.pk.esl' -K '$*.kek.esl' -b '$*.db.esl'
 
 %.pub: gpg.conf
 	@./gengpg --conf '$<' $(GENGPG_OPTS) '$@'


### PR DESCRIPTION
Needed because of this commit: https://github.com/awslabs/python-uefivars/commit/ec1eab1717c65ea36ca7160c96fe0e10e071fb66

Fixes this error `make: uefivars.py: No such file or directory` in our ci pipeline in the `certificates` job.