### PR TITLE
fix: remove test for  "/etc/cloud/cloud.cfg.d/99_disable-network-conf…

### DIFF
--- a/features/openstack/test/test_check_files.py
+++ b/features/openstack/test/test_check_files.py
@@ -8,7 +8,6 @@ import pytest
         "/etc/cloud/ds-identify.cfg",
         "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg",
         "/etc/cloud/cloud.cfg.d/50-datasource.cfg",
-        "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
     ]
 )
 


### PR DESCRIPTION
openstack feature requires network config to be enabled. See #2017 