### PR TITLE
tests: add GVNIC and VIRTIO_SCSI_MULTIQUEUE to GCP tests

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -411,8 +411,10 @@ class GCP:
             'labels': self._tags,
         }
 
+        guest_os_features = "GVNIC,VIRTIO_SCSI_MULTIQUEUE"
         if self.config['uefi'] or self.config['secureboot']:
-            config['guest_os_features'] = [{'type_': "UEFI_COMPATIBLE"}]
+            guest_os_features += ",UEFI_COMPATIBLE"
+        config['guest_os_features'] = [{'type': guest_os_features}]
 
         if self.config['secureboot']:
             cert_file_type = self.config['secureboot_parameters']['cert_file_type']

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -409,12 +409,12 @@ class GCP:
                 'source': blob_url,
             },
             'labels': self._tags,
+            'guest_os_features': [
+                {'type_': 'VIRTIO_SCSI_MULTIQUEUE'},
+                {'type_': 'UEFI_COMPATIBLE'},
+                {'type_': 'GVNIC'},
+            ]
         }
-
-        guest_os_features = "GVNIC,VIRTIO_SCSI_MULTIQUEUE"
-        if self.config['uefi'] or self.config['secureboot']:
-            guest_os_features += ",UEFI_COMPATIBLE"
-        config['guest_os_features'] = [{'type_': guest_os_features}]
 
         if self.config['secureboot']:
             cert_file_type = self.config['secureboot_parameters']['cert_file_type']

--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -414,7 +414,7 @@ class GCP:
         guest_os_features = "GVNIC,VIRTIO_SCSI_MULTIQUEUE"
         if self.config['uefi'] or self.config['secureboot']:
             guest_os_features += ",UEFI_COMPATIBLE"
-        config['guest_os_features'] = [{'type': guest_os_features}]
+        config['guest_os_features'] = [{'type_': guest_os_features}]
 
         if self.config['secureboot']:
             cert_file_type = self.config['secureboot_parameters']['cert_file_type']


### PR DESCRIPTION
**What this PR does / why we need it**:
Add GVNIC and SCSI_MULTIQUEUE guestOS features to platform tests. 

see #2002 + fixed typo `type` should be `type_`, see https://cloud.google.com/python/docs/reference/compute/latest/google.cloud.compute_v1.types.GuestOsFeature

**Special notes for your reviewer**:
Once this is merged and had a successful run, consider merging https://github.com/gardenlinux/glci/pull/50.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Adds `GVNIC` and `VIRTIO_SCSI_MULTIQUEUE` guestOsFeatures to images for GCP platform tests.
```
