### PR TITLE
Cloud-init should configure the network on OpenStack Baremetal

### DIFF
--- a/features/openstackbaremetal/file.include/etc/cloud/cloud.cfg.d/65-network-config.cfg
+++ b/features/openstackbaremetal/file.include/etc/cloud/cloud.cfg.d/65-network-config.cfg
@@ -1,0 +1,4 @@
+# enable/force netplan renderer for network config
+system_info:
+  network:
+    renderers: ['netplan', 'networkd']

--- a/features/openstackbaremetal/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
+++ b/features/openstackbaremetal/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
@@ -1,1 +1,0 @@
-network: {config: disabled}

--- a/features/openstackbaremetal/file.include/etc/dracut.conf.d/49-include-bnxt-drivers.conf
+++ b/features/openstackbaremetal/file.include/etc/dracut.conf.d/49-include-bnxt-drivers.conf
@@ -1,0 +1,2 @@
+# include BroadCom network drivers into initrd to initialize them early on
+add_drivers+=" bnxt_en "

--- a/features/openstackbaremetal/pkg.include
+++ b/features/openstackbaremetal/pkg.include
@@ -3,3 +3,4 @@ python3-boto
 cloud-init
 dmidecode
 rng-tools5
+netplan.io

--- a/features/openstackbaremetal/test/test_check_files.py
+++ b/features/openstackbaremetal/test/test_check_files.py
@@ -8,7 +8,8 @@ import pytest
         "/etc/cloud/ds-identify.cfg",
         "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg",
         "/etc/cloud/cloud.cfg.d/50-datasource.cfg",
-        "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
+        "/etc/cloud/cloud.cfg.d/65-network-config.cfg",
+        "/etc/dracut.conf.d/49-include-bnxt-drivers.conf"
     ]
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To configure network bonds/trunks/LACP on OpenStack baremetal machines, cloud-init must be allowed to configure the network and hand over the network config to netplan so that it can take care of initialising the bond* interface before any
dhcp request is made.

Also, since some network interfaces take a little longer to initialise, this can introduce a race between them and
cloud-init-local which will fail if the network interfaces listed in a `network_config.json` are not present yet. The `bnxt_en` network driver is placed into initrd so that it loads and initialises at a very early stage to circumvent the race.

We need to resort to `netplan.io` because cloud-inits [network renderer for systemd-networkd](https://github.com/canonical/cloud-init/blob/3582dbebc7bc1a933ae378f8ca7bbd1480a188c8/cloudinit/net/networkd.py) is "currently experimental and doesn't support all the use cases supported by the other renderers yet" ([ref](https://github.com/canonical/cloud-init/blob/3582dbebc7bc1a933ae378f8ca7bbd1480a188c8/cloudinit/net/networkd.py#L88-L89)) - and one of the unsupported uses cases is configuring LACP bonds.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The OpenStack baremetal feature will now be able to configure lacp bonds through cloud-init and config-drive.
```
