### PR TITLE
Add a gdch feature to Garden Linux rel-1312

### DIFF
--- a/features/gdch/README.md
+++ b/features/gdch/README.md
@@ -1,0 +1,36 @@
+## Feature: gcp
+### Description
+<website-feature>
+This platform feature creates an artifact for the Google Cloud Platform.
+</website-feature>
+
+### Features
+This feature creates a GCP compatible image artifact as an `.raw` file.
+
+To be platform complaint smaller adjustments like defining the platform related clocksource config, networking config etc. are done.
+The artifact includes `cloud-init` and `amazon-ec2-utils` for orchestrating the image.
+
+### Uploading Image to GCP
+
+- create compressed tar image (disk must be called disk.raw)
+
+```tar --format=oldgnu -Sczf compressed-image.tar.gz disk.raw```
+
+- upload tar:
+
+```gsutil cp compressed-image.tar.gz gs://garden-linux-test```
+
+- create image:
+
+```gcloud compute images create garden-linux-gcp-01 --source-uri gs://garden-linux-test/compressed-image.tar.gz```
+
+### Unit testing
+This platform feature supports unit testing and is based on the `gcp` fixture to validate the applied changes according its feature configuration.
+
+### Meta
+|||
+|---|---|
+|type|platform|
+|artifact|`.raw`|
+|included_features|cloud|
+|excluded_features|None|

--- a/features/gdch/convert.gcpimage.tar.gz
+++ b/features/gdch/convert.gcpimage.tar.gz
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+tar --format=oldgnu -cSz --transform "s|$1|disk.raw|" "$1" > "$2"

--- a/features/gdch/exec.config
+++ b/features/gdch/exec.config
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# set default timezone
+ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+
+cat >>/etc/ssh/sshd_conf <<EOF
+
+# Needed for google oslogin
+AuthorizedKeysCommand /usr/libexec/google_authorized_keys
+AuthorizedKeysCommandUser root
+EOF

--- a/features/gdch/file.include/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg
+++ b/features/gdch/file.include/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg
@@ -1,0 +1,13 @@
+apt_preserve_sources_list: true
+manage_etc_hosts: true
+system_info:
+  default_user:
+    name: admin
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: True
+    gecos: Debian
+    groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+

--- a/features/gdch/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
+++ b/features/gdch/file.include/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg
@@ -1,0 +1,1 @@
+network: {config: disabled}

--- a/features/gdch/file.include/etc/kernel/cmdline.d/00-cmdline.cfg
+++ b/features/gdch/file.include/etc/kernel/cmdline.d/00-cmdline.cfg
@@ -1,0 +1,2 @@
+CMDLINE_LINUX_DEFAULT=""
+CMDLINE_LINUX="console=ttyS0,38400n8d earlyprintk=ttyS0,38400n8d consoleblank=0"

--- a/features/gdch/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/gdch/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"

--- a/features/gdch/file.include/etc/modprobe.d/gce-blacklist.conf
+++ b/features/gdch/file.include/etc/modprobe.d/gce-blacklist.conf
@@ -1,0 +1,2 @@
+# nouveau does not work with GCE GPU's.
+blacklist nouveau

--- a/features/gdch/file.include/etc/sysctl.d/60-gce-network-security.conf
+++ b/features/gdch/file.include/etc/sysctl.d/60-gce-network-security.conf
@@ -1,0 +1,53 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Google-recommended kernel parameters
+
+# Turn on SYN-flood protections.  Starting with 2.6.26, there is no loss
+# of TCP functionality/features under normal conditions.  When flood
+# protections kick in under high unanswered-SYN load, the system
+# should remain more stable, with a trade off of some loss of TCP
+# functionality/features (e.g. TCP Window scaling).
+net.ipv4.tcp_syncookies=1
+
+# Ignore source-routed packets
+net.ipv4.conf.all.accept_source_route=0
+net.ipv4.conf.default.accept_source_route=0
+
+# Ignore ICMP redirects from non-GW hosts
+net.ipv4.conf.all.accept_redirects=0
+net.ipv4.conf.default.accept_redirects=0
+net.ipv4.conf.all.secure_redirects=1
+net.ipv4.conf.default.secure_redirects=1
+
+# Don't pass traffic between networks or act as a router
+net.ipv4.ip_forward=0
+net.ipv4.conf.all.send_redirects=0
+net.ipv4.conf.default.send_redirects=0
+
+# Ignore ICMP broadcasts to avoid participating in Smurf attacks
+net.ipv4.icmp_echo_ignore_broadcasts=1
+
+# Ignore bad ICMP errors
+net.ipv4.icmp_ignore_bogus_error_responses=1
+
+# Log spoofed, source-routed, and redirect packets
+net.ipv4.conf.all.log_martians=1
+net.ipv4.conf.default.log_martians=1
+
+# Addresses of mmap base, heap, stack and VDSO page are randomized
+kernel.randomize_va_space=2
+
+# Reboot the machine soon after a kernel panic.
+kernel.panic=10

--- a/features/gdch/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-gcp.conf
+++ b/features/gdch/file.include/etc/systemd/timesyncd.conf.d/00-gardenlinux-gcp.conf
@@ -1,0 +1,3 @@
+[Time]
+# GCP has an own time server
+NTP=metadata.google.internal

--- a/features/gdch/file.include/usr/lib/udev/google_nvme_id
+++ b/features/gdch/file.include/usr/lib/udev/google_nvme_id
@@ -1,0 +1,245 @@
+#!/bin/bash
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to generate symlinks for PD-NVMe devices using the disk names reported by
+# the metadata server
+
+# Locations of the script's dependencies
+readonly nvme_cli_bin=/usr/sbin/nvme
+
+# Bash regex to parse device paths and controller identification
+readonly NAMESPACE_NUMBER_REGEX="/dev/nvme[[:digit:]]+n([[:digit:]]+).*"
+readonly PARTITION_NUMBER_REGEX="/dev/nvme[[:digit:]]+n[[:digit:]]+p([[:digit:]]+)"
+readonly PD_NVME_REGEX="sn[[:space:]]+:[[:space]]+nvme_card-pd"
+
+# Globals used to generate the symlinks for a PD-NVMe disk.  These are populated
+# by the identify_pd_disk function and exported for consumption by udev rules.
+ID_SERIAL=''
+ID_SERIAL_SHORT=''
+
+#######################################
+# Helper function to log an error message to stderr.
+# Globals:
+#   None
+# Arguments:
+#   String to print as the log message
+# Outputs:
+#   Writes error to STDERR
+#######################################
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+}
+
+#######################################
+# Retrieves the device name for an NVMe namespace using nvme-cli.
+# Globals:
+#   Uses nvme_cli_bin
+# Arguments:
+#   The path to the nvme namespace (/dev/nvme0n?)
+# Outputs:
+#   The device name parsed from the JSON in the vendor ext of the ns-id command.
+# Returns:
+#   0 if the device name for the namespace could be retrieved, 1 otherwise
+#######################################
+function get_namespace_device_name() {
+  local nvme_json
+  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
+  if [[ $? -ne 0 ]]; then
+    return 1
+  fi
+
+  if [[ -z "$nvme_json" ]]; then
+    err "NVMe Vendor Extension disk information not present"
+    return 1
+  fi
+
+  local device_name
+  device_name="$(echo "$nvme_json" | grep device_name | sed -e 's/.*"device_name":[  \t]*"\([a-zA-Z0-9_-]\+\)".*/\1/')"
+
+  # Error if our device name is empty
+  if [[ -z "$device_name" ]]; then
+    err "Empty name"
+    return 1
+  fi
+
+  echo "$device_name"
+  return 0
+}
+
+#######################################
+# Retrieves the nsid for an NVMe namespace
+# Globals:
+#   None
+# Arguments:
+#   The path to the nvme namespace (/dev/nvme0n*)
+# Outputs:
+#   The namespace number/id
+# Returns:
+#   0 if the namespace id could be retrieved, 1 otherwise
+#######################################
+function get_namespace_number() {
+  local dev_path="$1"
+  local namespace_number
+  if [[ "$dev_path" =~ $NAMESPACE_NUMBER_REGEX ]]; then
+    namespace_number="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+
+  echo "$namespace_number"
+  return 0
+}
+
+#######################################
+# Retrieves the partition number for a device path if it exists
+# Globals:
+#   None
+# Arguments:
+#   The path to the device partition (/dev/nvme0n*p*)
+# Outputs:
+#   The value after 'p' in the device path, or an empty string if the path has
+#   no partition.
+#######################################
+function get_partition_number() {
+  local dev_path="$1"
+  local partition_number
+  if [[ "$dev_path" =~ $PARTITION_NUMBER_REGEX ]]; then
+    partition_number="${BASH_REMATCH[1]}"
+    echo "$partition_number"
+  else
+    echo ''
+  fi
+  return 0
+}
+
+#######################################
+# Generates a symlink for a PD-NVMe device using the metadata's disk name.
+# Primarily used for testing but can be used if the script is directly invoked.
+# Globals:
+#   Uses ID_SERIAL_SHORT (can be populated by identify_pd_disk)
+# Arguments:
+#   The device path for the disk
+#######################################
+function gen_symlink() {
+  local dev_path="$1"
+  local partition_number="$(get_partition_number "$dev_path")"
+
+  if [[ -n "$partition_number" ]]; then
+    ln -s "$dev_path" /dev/disk/by-id/google-"$ID_SERIAL_SHORT"-part"$partition_number" > /dev/null 2>&1
+  else
+    ln -s "$dev_path" /dev/disk/by-id/google-"$ID_SERIAL_SHORT" > /dev/null 2>&1
+  fi
+
+  return 0
+}
+
+#######################################
+# Populates the ID_* global variables with a disk's device name and namespace
+# Globals:
+#   Populates ID_SERIAL_SHORT, and ID_SERIAL
+# Arguments:
+#   The device path for the disk
+# Returns:
+#   0 on success and 1 if an error occurrs
+#######################################
+function identify_pd_disk() {
+  local dev_path="$1"
+  local dev_name
+  dev_name="$(get_namespace_device_name "$dev_path")"
+  if [[ $? -ne 0 ]]; then
+    return 1
+  fi
+
+  ID_SERIAL_SHORT="$dev_name"
+  ID_SERIAL="Google_PersistentDisk_${ID_SERIAL_SHORT}"
+  return 0
+}
+
+function print_help_message() {
+  echo "Usage: google_nvme_id [-s] [-h] -d device_path"
+  echo "  -d <device_path> (Required): Specifies the path to generate a name"
+  echo "        for.  This needs to be a path to an nvme device or namespace"
+  echo "  -s: Create symbolic link for the disk under /dev/disk/by-id."
+  echo "        Otherwise, the disk name will be printed to STDOUT"
+  echo "  -h: Print this help message"
+}
+
+function main() {
+  local opt_gen_symlink='false'
+  local device_path=''
+
+  while getopts :d:sh flag; do
+    case "$flag" in
+      d) device_path="$OPTARG";;
+      s) opt_gen_symlink='true';;
+      h) print_help_message
+         return 0
+         ;;
+      :) echo "Invalid option: ${OPTARG} requires an argument" 1>&2
+         return 1
+         ;;
+      *) return 1
+    esac
+  done
+
+  if [[ -z "$device_path" ]]; then
+    echo "Device path (-d) argument required. Use -h for full usage." 1>&2
+    exit 1
+  fi
+
+  # Ensure the nvme-cli command is installed
+  command -v "$nvme_cli_bin" > /dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    err "The nvme utility (/usr/sbin/nvme) was not found. You may need to run \
+with sudo or install nvme-cli."
+    return 1
+  fi
+
+  # Ensure the passed device is actually an NVMe device
+  "$nvme_cli_bin" id-ctrl "$device_path" &>/dev/null
+  if [[ $? -ne 0 ]]; then
+    err "Passed device was not an NVMe device.  (You may need to run this \
+script as root/with sudo)."
+    return 1
+  fi
+
+  # Detect the type of attached nvme device
+  local controller_id
+  controller_id=$("$nvme_cli_bin" id-ctrl "$device_path")
+  if [[ ! "$controller_id" =~ nvme_card-pd ]] ; then
+    err "Device is not a PD-NVMe device"
+    return 1
+  fi
+
+  # Fill the global variables for the id command for the given disk type
+  # Error messages will be printed closer to error, no need to reprint here
+  identify_pd_disk "$device_path"
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+
+  # Gen symlinks or print out the globals set by the identify command
+  if [[ "$opt_gen_symlink" == 'true' ]]; then
+    gen_symlink "$device_path"
+  else
+    # These will be consumed by udev
+    echo "ID_SERIAL_SHORT=${ID_SERIAL_SHORT}"
+    echo "ID_SERIAL=${ID_SERIAL}"
+  fi
+
+  return $?
+
+}
+main "$@"

--- a/features/gdch/file.include/usr/lib/udev/rules.d/64-gce-disk-removal.rules
+++ b/features/gdch/file.include/usr/lib/udev/rules.d/64-gce-disk-removal.rules
@@ -1,0 +1,17 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# When a disk is removed, unmount any remaining attached volumes.
+
+ACTION=="remove", SUBSYSTEM=="block", KERNEL=="sd*|vd*|nvme*", RUN+="/bin/sh -c '/bin/umount -fl /dev/$name && /usr/bin/logger -p daemon.warn -s WARNING: hot-removed /dev/$name that was still mounted, data may have been corrupted'"

--- a/features/gdch/file.include/usr/lib/udev/rules.d/65-gce-disk-naming.rules
+++ b/features/gdch/file.include/usr/lib/udev/rules.d/65-gce-disk-naming.rules
@@ -1,0 +1,34 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Name the attached disks as the specified by deviceName.
+
+ACTION!="add|change", GOTO="gce_disk_naming_end"
+SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
+
+# SCSI naming
+KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
+
+# NVME Local SSD naming
+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'nsid=$$(echo %k|sed -re s/nvme[0-9]+n\([0-9]+\).\*/\\1/); echo $$((nsid-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
+KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
+
+# NVME Persistent Disk Naming
+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card-pd", IMPORT{program}="google_nvme_id -d $tempnode"
+
+# Symlinks
+KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
+KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"
+
+LABEL="gce_disk_naming_end"

--- a/features/gdch/info.yaml
+++ b/features/gdch/info.yaml
@@ -1,0 +1,5 @@
+description: "Google Distributed Cloud Hosted platform (cloud-init based guest environment)"
+type: platform
+features:
+  include:
+    - cloud

--- a/features/gdch/pkg.exclude
+++ b/features/gdch/pkg.exclude
@@ -1,0 +1,2 @@
+irqbalance
+systemd-timesyncd

--- a/features/gdch/pkg.include
+++ b/features/gdch/pkg.include
@@ -1,0 +1,5 @@
+#google-compute-engine-oslogin
+#google-guest-agent
+nvme-cli
+chrony
+cloud-init

--- a/features/gdch/test/test_blacklisted_packages.py
+++ b/features/gdch/test/test_blacklisted_packages.py
@@ -1,0 +1,11 @@
+from helper.tests.blacklisted_packages import blacklisted_packages
+import pytest
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        "irqbalance"
+    ]
+)
+def test_blacklisted_packages(client, package):
+    blacklisted_packages(client, package)

--- a/features/gdch/test/test_packages_musthave.py
+++ b/features/gdch/test/test_packages_musthave.py
@@ -1,0 +1,1 @@
+from helper.tests.packages_musthave import packages_musthave as test_packages_musthave

--- a/features/gdch/test/test_users.py
+++ b/features/gdch/test/test_users.py
@@ -1,0 +1,6 @@
+from helper.tests.users import users
+
+additional_user="gardenlinux"
+
+def test_users(client, gcp):
+     users(client=client, additional_user=additional_user, additional_sudo_users=[additional_user])


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a GDCH feature to Garden Linux release 1312 for testing purposes.

**Which issue(s) this PR fixes**:

Might need to be cherry-picked/ported to `main`.

