### PR TITLE
use packages.gardenlinux.io for release page generation

### DIFF
--- a/.github/workflows/get_kernelurls.py
+++ b/.github/workflows/get_kernelurls.py
@@ -37,7 +37,7 @@ def get_pkg_attr(package_name, attribute_key, packages_per_repo):
 def get_kernel_urls(gardenlinux_version):
     if not gardenlinux_version:
         print("You need to specify gardenlinux_version")
-    repositories = [f'http://repo.gardenlinux.io/gardenlinux {gardenlinux_version} main']
+    repositories = [f'http://packages.gardenlinux.io/gardenlinux {gardenlinux_version} main']
 
     architecture = ["arm64", "amd64"]
     versions = []


### PR DESCRIPTION
Note: release page action does not need to be run again for 1443.0, I triggered it from the  fix-generate-release-page-for-new-package-pipeline branch