### PR TITLE
Small fix for start-vm

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -445,8 +445,12 @@ qemu_opt_uefi () {
                 uefi_code="${uefi_code:-$homebrew_prefix/share/qemu/edk2-x86_64-code.fd}"
                 uefi_vars="${uefi_vars:-$homebrew_prefix/share/qemu/edk2-i386-vars.fd}"
             elif [ "$os" = debian ] || [ "$os" = ubuntu ] ; then
-                uefi_code="${uefi_code:-/usr/share/OVMF/OVMF_CODE.fd}"
-                uefi_vars="${uefi_vars:-/usr/share/OVMF/OVMF_VARS.fd}"
+		local usz=""
+		if [ ! -f /usr/share/OVMF/OVMF_CODE.fd ] || [ ! -f /usr/share/OVMF/OVMF_VARS.fd ]; then
+                    usz="_4M"
+                fi
+                uefi_code="${uefi_code:-/usr/share/OVMF/OVMF_CODE${usz}.fd}"
+                uefi_vars="${uefi_vars:-/usr/share/OVMF/OVMF_VARS${usz}.fd}"
             elif [ "$os" = centos ] || [ "$os" = fedora ] ; then
                 uefi_code="${uefi_code:-/usr/share/OVMF/OVMF_CODE.secboot.fd}"
                 uefi_vars="${uefi_vars:-/usr/share/OVMF/OVMF_VARS.secboot.fd}"
@@ -684,7 +688,7 @@ qemu_opt_network () {
 
 # Setup TPM2 emulation support using swtpm
 qemu_opt_tpm () {
-    if [ $tpm2 = 1 ]; then
+    if [ "$tpm2" ]; then
         if [ ! "$(command -v swtpm)" ]; then
             eusage "Error: Could not find swtpm on the system"
         else


### PR DESCRIPTION
**What this PR does / why we need it**:
Small syntax error on line 691 when _--tpm2_ is not used.
On debian, newer versions of OVMF no longer provide the 2M uefi code and vars.

**Which issue(s) this PR fixes**:
Fixes #