### PR TITLE
Add script to automatically bump SapMachine version

### DIFF
--- a/features/sapmachine/exec.config
+++ b/features/sapmachine/exec.config
@@ -2,20 +2,26 @@
 
 set -eufo pipefail
 
-CHECKSUM_AAARCH=c9d83b8079cb8a6995b6fe605b88cabe27be2ec8e49a613289187855948f09b6
-CHECKSUM_X64=af9cb50032b709fc46ecb2a8f992c093f16091a3b9959df08180bf2b349ea5ca
-SAPMACHINE_JRE_VERSION=21.0.1
+SAPMACHINE_JRE_VERSION=21.0.2
+CHECKSUM_X64=9b80175e20c846e29ee5c7c02af6b0d3a8d74a8e483f07954168c49d776afbf8
+CHECKSUM_AARCH=396876d56ecc988dd5631ff3f71aa16414ff37695b00bf75df7647a0f0bfea1f
+
 ARCH="$(uname -m | sed 's/x86_64/x64/')"
 
-curl -sSL "https://github.com/SAP/SapMachine/releases/download/sapmachine-${SAPMACHINE_JRE_VERSION}/sapmachine-jre-${SAPMACHINE_JRE_VERSION}_linux-${ARCH}_bin.tar.gz" | gzip -d | tar -C /opt/ -x
-ln -s /opt/sapmachine-jre-${SAPMACHINE_JRE_VERSION}/bin/java /usr/bin/java
+download_dir=$(mktemp -d)
+pushd $download_dir
 
-
+curl -sSL --output jre.tgz "https://github.com/SAP/SapMachine/releases/download/sapmachine-${SAPMACHINE_JRE_VERSION}/sapmachine-jre-${SAPMACHINE_JRE_VERSION}_linux-${ARCH}_bin.tar.gz"
 if [ "$ARCH" = "x64" ]; then
   EXPECTED_CHECKSUM="$CHECKSUM_X64"
 else
-  EXPECTED_CHECKSUM="$CHECKSUM_AAARCH"
+  EXPECTED_CHECKSUM="$CHECKSUM_AARCH"
 fi
+echo "${EXPECTED_CHECKSUM} jre.tgz" | sha256sum --check || exit 1
+tar xf jre.tgz --directory=/opt
 
-echo "${EXPECTED_CHECKSUM} /usr/bin/java" | sha256sum --check || exit 1
+popd
 
+rm -rf $download_dir
+
+ln -s /opt/sapmachine-jre-${SAPMACHINE_JRE_VERSION}/bin/java /usr/bin/java

--- a/features/sapmachine/exec.config
+++ b/features/sapmachine/exec.config
@@ -2,6 +2,7 @@
 
 set -eufo pipefail
 
+# To be updated via `update-sapmachine.py`
 SAPMACHINE_JRE_VERSION=21.0.2
 CHECKSUM_X64=9b80175e20c846e29ee5c7c02af6b0d3a8d74a8e483f07954168c49d776afbf8
 CHECKSUM_AARCH=396876d56ecc988dd5631ff3f71aa16414ff37695b00bf75df7647a0f0bfea1f
@@ -9,7 +10,7 @@ CHECKSUM_AARCH=396876d56ecc988dd5631ff3f71aa16414ff37695b00bf75df7647a0f0bfea1f
 ARCH="$(uname -m | sed 's/x86_64/x64/')"
 
 download_dir=$(mktemp -d)
-pushd $download_dir
+pushd "$download_dir"
 
 curl -sSL --output jre.tgz "https://github.com/SAP/SapMachine/releases/download/sapmachine-${SAPMACHINE_JRE_VERSION}/sapmachine-jre-${SAPMACHINE_JRE_VERSION}_linux-${ARCH}_bin.tar.gz"
 if [ "$ARCH" = "x64" ]; then
@@ -22,6 +23,6 @@ tar xf jre.tgz --directory=/opt
 
 popd
 
-rm -rf $download_dir
+rm -rf "$download_dir"
 
 ln -s /opt/sapmachine-jre-${SAPMACHINE_JRE_VERSION}/bin/java /usr/bin/java

--- a/features/sapmachine/update-sapmachine.py
+++ b/features/sapmachine/update-sapmachine.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import json
+import argparse
+
+from urllib.request import urlopen
+
+sapmachine_releases_json_url = 'https://sap.github.io/SapMachine/assets/data/sapmachine-releases-website.json'
+
+
+def loadReleases():
+    with urlopen(sapmachine_releases_json_url) as response:
+        releases = json.loads(response.read().decode())
+        return releases
+
+
+def loadChecksum(url):
+    with urlopen(url) as checksum:
+        checksum_file_content: str = checksum.read().decode()
+        # Need to split because the file contains the checksum and the file name
+        # We only want the checksum which is the first element in the line
+        checksum = checksum_file_content.split(' ')[0]
+        return checksum
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--majorJreVersion', type=str)
+    args = parser.parse_args()
+    major_jre_version = args.majorJreVersion
+    releases = loadReleases()
+    tag: str = releases['assets'][major_jre_version]['releases'][0]['tag']
+    version = tag.split('-')[1]
+    downloadUrlSapMachineBinary_amd64: str = releases['assets'][major_jre_version]['releases'][0]['jre']['linux-x64']
+    downloadUrlSapMachineBinary_aarch64: str = releases['assets'][major_jre_version]['releases'][0]['jre']['linux-aarch64']
+    downloadUrlSapMachineChecksum_amd64 = downloadUrlSapMachineBinary_amd64.replace('.tar.gz', '.sha256.txt')
+    downloadUrlSapMachineChecksum_aarch64 = downloadUrlSapMachineBinary_aarch64.replace('.tar.gz', '.sha256.txt')
+    checksumAmd = loadChecksum(downloadUrlSapMachineChecksum_amd64)
+    checksumArm = loadChecksum(downloadUrlSapMachineChecksum_aarch64)
+    print(f'SAPMACHINE_JRE_VERSION={version}')
+    print(f'CHECKSUM_X64={checksumAmd}')
+    print(f'CHECKSUM_AARCH={checksumArm}')
+
+
+if __name__ == '__main__':
+    main()

--- a/features/sapmachine/update-sapmachine.py
+++ b/features/sapmachine/update-sapmachine.py
@@ -24,7 +24,7 @@ def loadChecksum(url):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--majorJreVersion', type=str)
+    parser.add_argument('--majorJreVersion', required=True, type=str)
     args = parser.parse_args()
     major_jre_version = args.majorJreVersion
     releases = loadReleases()


### PR DESCRIPTION
So far the SapMachine version we include needs to be updated manually.

This PR adds a script to help with that, but the update is still a manual process.

The script finds the latest minor/patch version of a given major version along with the checksums of the tarballs.

Running `update-sapmachine.py` will print out the variables to be used in `exec.config`.
A potential improvement is to edit the `exec.config` script automatically via `update-sapmachine.py`.

We still want the checksum and the exact SapMachine version to be stored in the git repo, so we don't want to hide this by automatically running `update-sapmachine.py` during the build for reproducibility reasons.
