### PR TITLE
feat: add driver-build container to nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,12 @@ jobs:
           - target: container
             arch: arm64
             modifier: ""
+          - target: driverbuild
+            arch: amd64
+            modifier: ""
+          - target: driverbuild
+            arch: arm64
+            modifier: ""
     steps:
       # - uses: gardenlinux/workflow-telemetry-action@c75b594f552d305ffd5f9074637137bc343ba35e # pin@v2
       #   with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,3 +67,9 @@ jobs:
     uses: ./.github/workflows/publish_container.yml
     with:
       version: ${{ needs.build.outputs.version }}
+  publish_driverbuild_container:
+    name: publish gardenlinux driverbuild container image
+    needs: [ publish_container ]
+    uses: ./.github/workflows/publish_driverbuild_container.yml
+    with:
+      version: ${{ needs.build.outputs.version }}

--- a/.github/workflows/publish_driverbuild_container.yml
+++ b/.github/workflows/publish_driverbuild_container.yml
@@ -1,0 +1,70 @@
+name: publish gardenlinux driverbuild container
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        default: now
+jobs:
+  publish_container:
+    name: publish gardenlinux driverbuild container
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: ./.github/actions/setup
+      - name: set VERSION=${{ inputs.version }}
+        run: |
+          bin/garden-version "${{ inputs.version }}" | tee VERSION
+          git update-index --assume-unchanged VERSION
+      - name: get cname
+        run: |
+          cname_amd64="$(./build --resolve-cname driverbuild-amd64)"
+          cname_arm64="$(./build --resolve-cname driverbuild-arm64)"
+          echo "cname_amd64=$cname_amd64" | tee -a "$GITHUB_ENV"
+          echo "cname_arm64=$cname_arm64" | tee -a "$GITHUB_ENV"
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
+        with:
+          name: ${{ env.cname_amd64 }}
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
+        with:
+          name: ${{ env.cname_arm64 }}
+      - name: publish gardenlinux container base image
+        run: |
+          version=$(bin/garden-version "${{ inputs.version }}")
+          podman login -u token -p ${{ github.token }} ghcr.io
+          tar xzv < "${{ env.cname_amd64 }}.tar.gz"
+          image="$(podman load < ${{ env.cname_amd64 }}.oci | awk '{ print $NF }')"
+
+          # Tagging for amd64 nightly
+          podman tag "$image" ghcr.io/${{ github.repository }}}/driver-build:amd64-nightly
+          podman push ghcr.io/${{ github.repository }}}/driver-build:amd64-nightly
+
+          # Tagging for amd64 with version
+          podman tag "$image" ghcr.io/${{ github.repository }}}/driver-build:amd64-${version}
+          podman push ghcr.io/${{ github.repository }}}/driver-build:amd64-${version}
+
+          tar xzv < "${{ env.cname_arm64 }}.tar.gz"
+          image="$(podman load < ${{ env.cname_arm64 }}.oci | awk '{ print $NF }')"
+
+          # Tagging for arm64 nightly
+          podman tag "$image" ghcr.io/${{ github.repository }}}/driver-build:arm64-nightly
+          podman push ghcr.io/${{ github.repository }}}/driver-build:arm64-nightly
+
+          # Tagging for arm64 with version
+          podman tag "$image" ghcr.io/${{ github.repository }}}/driver-build:arm64-${version}
+          podman push ghcr.io/${{ github.repository }}}/driver-build:arm64-${version}
+
+          # Creating and pushing manifest for nightly
+          podman manifest create ghcr.io/${{ github.repository }}/driver-build:nightly
+          podman manifest add ghcr.io/${{ github.repository }}/driver-build:nightly ghcr.io/${{ github.repository }}/driver-build:amd64-nightly
+          podman manifest add ghcr.io/${{ github.repository }}/driver-build:nightly ghcr.io/${{ github.repository }}/driver-build:arm64-nightly
+          podman push ghcr.io/${{ github.repository }}/driver-build:nightly
+
+          # Creating and pushing manifest for version tag
+          podman manifest create ghcr.io/${{ github.repository }}}/driver-build:${version}
+          podman manifest add ghcr.io/${{ github.repository }}}/driver-build:${version} ghcr.io/${{ github.repository }}}/driver-build:amd64-${version}
+          podman manifest add ghcr.io/${{ github.repository }}}/driver-build:${version} ghcr.io/${{ github.repository }}}/driver-build:arm64-${version}
+          podman push ghcr.io/${{ github.repository }}}/driver-build:${version}

--- a/features/driverbuild/README.md
+++ b/features/driverbuild/README.md
@@ -1,0 +1,10 @@
+## Feature: driverbuild
+The driver-build container has pre-installed kernel headers and typicall driver build dependencies.
+
+### Meta
+|||
+|---|---|
+|type|element|
+|artifact|`.tar.gz`|
+|included_features|container|
+|excluded_features|None|

--- a/features/driverbuild/info.yaml
+++ b/features/driverbuild/info.yaml
@@ -1,0 +1,5 @@
+description: "Driver Build Container"
+type: element
+features:
+  include: 
+    - container 

--- a/features/driverbuild/pkg.include
+++ b/features/driverbuild/pkg.include
@@ -1,0 +1,1 @@
+../base/pkg.include


### PR DESCRIPTION
**What this PR does / why we need it**:

* Use feature-system to construct driver-build container

**Special notes for your reviewer**:
* still testing 


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add driver-build as a Garden Linux feature and include it in nightly build and publish pipelines 

```
