### PR TITLE
Delete links to deleted file groups.chroot, follow up for #985

### DIFF
--- a/features/_dev/test/groups.chroot
+++ b/features/_dev/test/groups.chroot
@@ -1,1 +1,0 @@
-../../base/test/groups.chroot

--- a/features/gardener/test/groups.chroot
+++ b/features/gardener/test/groups.chroot
@@ -1,1 +1,0 @@
-../../base/test/groups.chroot


### PR DESCRIPTION
The file those links point to don't exist anymore.

Follow up for #985