### PR TITLE
Set GH_TOKEN in workflow to use gh cli

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -85,6 +85,8 @@ jobs:
           version="$(bin/garden-version "${{ inputs.version }}")"
           snapshot="$(gh api "/repos/gardenlinux/repo/contents/.container?ref=$version" | jq -r '.content' | base64 -d)"
           echo -e "base=ghcr.io/${{ github.repository }}:version\nsnapshot=$snapshot" | tee "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: publish gardenlinux kernel module build dev image
         run: |
           version=$(bin/garden-version "${{ inputs.version }}")


### PR DESCRIPTION
Should fix this failed run https://github.com/gardenlinux/gardenlinux/actions/runs/8354499056/job/22868816771#logs