### PR TITLE
fix: release page automation - rm package updates section

### DIFF
--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -210,10 +210,6 @@ def generate_package_update_section(version):
 
 def create_github_release_notes(gardenlinux_version, commitish):
     output = ""
-    if not gardenlinux_version.endswith('.0'):
-        output += "## Package Updates\n"
-        output +=  generate_package_update_section(gardenlinux_version)
-        output += "\n"
   
     manifests = download_all_singles(gardenlinux_version, commitish)
 


### PR DESCRIPTION
* security update annotations are not tracked in package repository, but in security tracker and other internal tooling.
* new package pipeline does not contain annotations for CVEs, thus we need to remove the packages updates section in the release page automation => need to include it manually
