### PR TITLE
Improve docs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Copyright 2017 Tianon Gravi <tianon@debian.org>
-Copyright 2020 SAP SE <gardenlinux@gardenlinux.io>
+Copyright 2024 SAP SE <gardenlinux@gardenlinux.io>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
-[![build](https://github.com/gardenlinux/gardenlinux/actions/workflows/nightly.yml/badge.svg?event=schedule)](https://github.com/gardenlinux/gardenlinux/actions/workflows/nightly.yml)
-[![build](https://github.com/gardenlinux/gardenlinux/actions/workflows/dev.yml/badge.svg?branch=main)](https://github.com/gardenlinux/gardenlinux/actions/workflows/dev.yml)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3925/badge)](https://bestpractices.coreinfrastructure.org/projects/3925)
- [![MIT License](https://img.shields.io/github/license/gardenlinux/gardenlinux)](https://img.shields.io/github/license/gardenlinux/gardenlinux)
-[![Gitter](https://badges.gitter.im/gardenlinux/community.svg)](https://gitter.im/gardenlinux/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![GitHub Open Issues](https://img.shields.io/github/issues-raw/gardenlinux/gardenlinux)](https://img.shields.io/github/issues-raw/gardenlinux/gardenlinux)
-[![GitHub Closed PRs](https://img.shields.io/github/issues-pr-closed-raw/gardenlinux/gardenlinux)](https://img.shields.io/github/issues-pr-closed-raw/gardenlinux/gardenlinux)
-
+<p style="text-align: center;">
+    <img alt="GitHub Release" src="https://img.shields.io/github/v/release/gardenlinux/gardenlinux?label=LTS%20release">
+    <a href="https://github.com/gardenlinux/gardenlinux/actions/workflows/nightly.yml" target="_blank">
+        <img src="https://github.com/gardenlinux/gardenlinux/actions/workflows/nightly.yml/badge.svg?event=schedule" alt="Build">
+    </a>
+    <a href="https://github.com/gardenlinux/gardenlinux/actions/workflows/dev.yml" target="_blank">
+        <img src="https://github.com/gardenlinux/gardenlinux/actions/workflows/dev.yml/badge.svg?branch=main" alt="Build">
+    </a>
+    <a href="https://bestpractices.coreinfrastructure.org/projects/3925" target="_blank">
+        <img src="https://bestpractices.coreinfrastructure.org/projects/3925/badge" alt="CII Best Practices">
+    </a>
+  </p>
+</p>
 
 # Garden Linux
 
@@ -15,24 +20,6 @@
 
 </website-main>
 
-## Table of Contents
-- [Garden Linux](#garden-linux)
-- [Features](#features)
-- [Build](#build)
-  - [Build Requirements](#build-requirements)
-  - [Parallel Builds](#parallel-builds)
-  - [Cross Architecture Builds](#cross-architecture-builds)
-  - [SELinux](#selinux)
-  - [Secureboot](#secureboot)
-  - [Maintained Images](#maintained-images)
-- [Tests](#tests)
-- [Deploying](#deploying)
-- [Release](#release)
-- [Documentation](#documentation)
-  - [Continuous Integration](#continuous-integration)
-  - [Integration Tests](#integration-tests)
-- [Contributing](#contributing)
-- [Community](#community)
 
 ## Features
 - Easy to use build system
@@ -56,10 +43,12 @@
   - Major virtualizer VMware, OpenStack, KVM
   - Bare-metal systems
 
-## Build
+# Build
 
-The build system utilises the [gardenlinux/builder](https://github.com/gardenlinux/builder) to create customized Linux distributions. [gardenlinux/gardenlinux](https://github.com/gardenlinux/gardenlinux) is maintained by the Garden Linux team, highlighting specialized "features" available for other projects.
+The build system utilises the [gardenlinux/builder](https://github.com/gardenlinux/builder) to create customized Linux distributions.
+[gardenlinux/gardenlinux](https://github.com/gardenlinux/gardenlinux) is maintained by the Garden Linux team, highlighting specialized "features" available for other projects.
 
+For further information about the build process, refer to [docs/01_developers/build_images.md](link_to_build_docs).
 
 
 To initiate a build, use the command:
@@ -81,126 +70,38 @@ Example:
 
 The build script fetches the required builder container and manages all internal build steps. By default, it uses rootless podman, but you can switch to another container engine with the `--container-engine` flag.
 
-
-### Build Requirements
-
-- **Memory:** The build process may require up to 8GiB of memory, depending on the selected targets. If your system has insufficient RAM, configure swap space accordingly.
-- **Container Engine:** The Builder has minimal dependencies and only requires a working container engine. You have two options:
-  - **Rootless Podman:** It's recommended to use rootless Podman. Please refer to the [Podman rootless setup guide](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) for instructions on setting it up.
-  - **Sudo Podman:** Alternatively, you can use Podman with sudo for elevated privileges.
-
-To ensure a successful build, please refer to the [Build Requirements section](https://github.com/gardenlinux/builder#requirements) in the `gardenlinux/builder` repository.
-
-### Parallel Builds
-
-For efficient parallel builds of multiple targets, use the `-j ${number_of_threads}` option in the build script. However, note the following:
-
-- Building in parallel significantly increases memory usage.
-- There are no mechanisms in place to handle memory exhaustion gracefully.
-- This feature is only recommended for users with large build machines, ideally with 8GiB of RAM per builder thread. It may work with 4GiB per thread due to spikes in memory usage being only intermittent during the build, but your milage may vary.
-
-### Cross Architecture Builds
-
-By default, the build targets the native architecture of the build system. However, cross-building for other architectures is simple.
-
-Append the target architecture to the target name in the build command, like so: `./build ${target}-${arch}`.
-For example, to build for both amd64 and arm64 architectures:
-
-```
-./build kvm-amd64 kvm-arm64
-```
-
-This requires setting up [binfmt_misc](https://docs.kernel.org/admin-guide/binfmt-misc.html) handlers for the target architecture, allowing the system to execute foreign binaries.
-
-On most distributions, you can install QEMU user static to set up binfmt_misc handlers. For example, on Debian, use the command `apt install qemu-user-static`.
-
-### SELinux
-
-If you intend to build targets with the `_selinux` feature, some additional requirements apply to the build machine.
-
-
-Building the `_selinux` feature will not work on machines running in SELinux enforcing mode. Ideally, you should build on a machine with SELinux disabled. However, if you want to build with SELinux in permissive mode, this can be achieved by running the build as root with the `--privileged` flag.
-
-i.e.: `sudo ./build --privileged ${target}`
-
-**SELinux Workaround for Podman:**
-> :warning: **Note:** [Podman Desktop](https://podman-desktop.io) and [Podman on macOS](https://podman.io) have by default SELinux enabled in their VMs. This may cause issues when building the `_selinux` feature. See [issue #16](https://github.com/gardenlinux/builder/issues/16) for details.
-
-If you're using Podman on macOS, follow these steps to disable SELinux in the podman VM:
-
-1. SSH into the Podman VM: `podman machine ssh`
-2. Run the following command to disable SELinux: `echo SELINUX=disabled | sudo tee /etc/selinux/config`
-3. Exit the SSH connection.
-4. Restart the Podman VM: `podman machine stop && podman machine start`
-
-
-### Secureboot
-
-If you intend to build targets with the `_secureboot` feature, you must first build the secureboot certificates.
-Run the command `./cert/build` to generate the secureboot certificates.
-
-By default, the command uses local files as the private key storage. However, you can configure it to use the AWS KMS key store by using the `--kms` flag. Note that valid AWS credentials need to be configured using the standard AWS environment variables.
-
-### Maintained Images
-
-Garden Linux offers a range of official images tailored for various architectures and platforms. Instead of listing all the specific image variants here, you can find the most up-to-date list of maintained images on the [Garden Linux releases page on GitHub](https://github.com/gardenlinux/gardenlinux/releases).
-
-**Supported Architectures:**
-- arm64
-- amd64
-
-**Supported Platforms:**
-
-
-| Name | Identifier |
-|------|------------|
-| [Ali](https://github.com/gardenlinux/gardenlinux/tree/main/features/ali) | `ali` |
-| [AWS](https://github.com/gardenlinux/gardenlinux/tree/main/features/aws) | `aws` |
-| [Azure](https://github.com/gardenlinux/gardenlinux/tree/main/features/azure) | `azure` |
-| [GCP](https://github.com/gardenlinux/gardenlinux/tree/main/features/gcp) | `gcp` |
-| [KVM](https://github.com/gardenlinux/gardenlinux/tree/main/features/kvm) | `kvm` |
-| [Metal](https://github.com/gardenlinux/gardenlinux/tree/main/features/metal) | `metal` |
-| [OpenStack](https://github.com/gardenlinux/gardenlinux/tree/main/features/openstack) | `openstack` |
-| [VMware](https://github.com/gardenlinux/gardenlinux/tree/main/features/vmware) | `vmware` |
-
-
-To understand the build process for these images, refer to the [build action](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/build.yml). For details on the publishing process, check out the [upload action](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/upload_to_s3.yml) and the [gardenlinux/glci](https://github.com/gardenlinux/glci) repository.
-
-## Tests
+# Test
 
 To run unit tests for a specific target, use the command `./test ${target}`.
+Further documentation about tests is located in [tests/README.md](tests/README.md).
 
-## Deploying
-Deploying on common cloud platforms requires additional packages. The following overview gives a short quick start to run cloud platform deployments. Currently, all modules are based on `Python`. Therefore, please make sure to have Python installed.
 
-| Platform | Module  |
-|---|---|
-| Alicloud | [Aliyun CLI](https://github.com/aliyun/aliyun-cli)
-| AWS | [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-| Azure | [Azure CLI](https://docs.microsoft.com/de-de/cli/azure/install-azure-cli-apt)
-| GCP | [Cloud SDK](https://cloud.google.com/sdk/docs/quickstart?utm_source=youtube&utm_medium=Unpaidsocial&utm_campaign=car-20200311-Quickstart-Mac#linux), [gsutil](https://cloud.google.com/storage/docs/gsutil_install?hl=de#install)
-| OpenStack | [OpenStackCLI](https://github.com/openstack/python-openstackclient)
+# Download Releases 
 
-## Release
-Garden Linux frequently publishes snapshot releases. These are available as machine images in most major cloud providers as well as file-system images for manual import. See the [releases](https://github.com/gardenlinux/gardenlinux/releases) page for more info.
+| Product                        | Release Frequency | Download                                               |
+|--------------------------------|-------------------|--------------------------------------------------------|
+| LTS cloud and baremetal images | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/releases) |
+| LTS base container images      | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux) |
+| LTS bare python container     | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-python) |
+| LTS bare libc container       | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-libc) |
+| LTS bare nodejs container     | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-nodejs) |
 
-## Documentation
-Garden Linux provides a great documentation for build options, customizing, configuration, tests and pipeline integrations. The documentation can be found within the project's `docs/` path or by clicking <a href="https://github.com/gardenlinux/gardenlinux/tree/main/docs">here</a>. Next to this, you may find a corresponding `README.md` in each directory explaining some more details. Below, you may find some important documentations for continuous integration and integration tests.
+**Note:** For each artifact, there also exists a nightly version, which is built daily but is not considered LTS.
 
-### Continuous Integration
-Garden Linux can build in an automated way for continuous integration. See [.github/workflows/README.md](.github/workflows/README.md) for details.
+The LTS cloud and baremetal images provided by Garden Linux are compatible with various cloud platforms, including Alibaba Cloud, AWS, Microsoft Azure and GCP.
 
-### Integration Tests
-While it may be confusing for beginners we highlight this chapter for `integration tests` here. Garden Linux supports integration testing on all major cloud platforms (Alicloud, AWS, Azure, GCP). To allow testing even without access to any cloud platform we created an universal `kvm` platform that may run locally and is accessed in the same way via a `ssh client object` as any other cloud platform. Therefore, you do not need to adjust tests to perform local integration tests. Just to mention here that there is another platform called `chroot`. This platform is used to perform `unit tests` and will run as a local `integration test`. More details can be found within the documentation in  [tests/README.md](tests/README.md).
+# Nvidia Driver Support
+An installer can be found in the [gardenlinux/gardenlinux-nvidia-installer](https://github.com/gardenlinux/gardenlinux-nvidia-installer) repository.
 
-## Contributing
+# Documentation
+Please refer to [docs/README.md](https://github.com/gardenlinux/gardenlinux/tree/main/docs#readme).
 
-Feel free to add further documentation, to adjust already existing one or to contribute with code.
-Please take care about our style guide and naming conventions.
+# Contributing
+
+Contribitions to the Garden Linux open source projects are welcome. 
 More information are available in in <a href="CONTRIBUTING.md">CONTRIBUTING.md</a> and our `docs/`.
-Be aware that this repository leverages the [gardenlinux/builder](https://github.com/gardenlinux/builder) for creating customized Linux distributions. While `gardenlinux/gardenlinux` is a representation of one such distribution.
 
-## Community
-Garden Linux has a large grown community. If you need further assistance, have any issues or just want to get in touch with other Garden Linux users feel free to join our public chat room on Gitter.
+# Community
+If you need further assistance, have any issues or just want to get in touch with other Garden Linux users feel free to join our public chat room on Gitter.
 
 Link: <a href="https://gitter.im/gardenlinux/community">https://gitter.im/gardenlinux/community</a>

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@
 The build system utilises the [gardenlinux/builder](https://github.com/gardenlinux/builder) to create customized Linux distributions.
 [gardenlinux/gardenlinux](https://github.com/gardenlinux/gardenlinux) is maintained by the Garden Linux team, highlighting specialized "features" available for other projects.
 
-For further information about the build process, refer to [docs/01_developers/build_images.md](link_to_build_docs).
-
+> [!TIP]
+> For further information about the build process, and how to set it up on your machine, refer to [the Build Image documentation page](docs/01_developers/build_image.md).
 
 To initiate a build, use the command:
 ```shell
@@ -57,7 +57,7 @@ To initiate a build, use the command:
 ```
 
 Where:
-- `${platform}` denotes the desired platform (e.g., kvm, metal, aws).
+- `${platform}` denotes the desired platform (e.g., `kvm`, `metal`, `aws`).
 - `${feature}` represents a specific feature from the `features/` folder.
 - `${modifier}` is an optional modifier from the `features/` folder, prefixed with an underscore "_".
 
@@ -78,13 +78,13 @@ Further documentation about tests is located in [tests/README.md](tests/README.m
 
 # Download Releases 
 
-| Product                        | Release Frequency | Download                                               |
-|--------------------------------|-------------------|--------------------------------------------------------|
-| LTS cloud and baremetal images | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/releases) |
-| LTS base container images      | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux) |
-| LTS bare python container     | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-python) |
-| LTS bare libc container       | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-libc) |
-| LTS bare nodejs container     | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-nodejs) |
+| Product                        | Release Frequency | Download                                                                                        |
+| ------------------------------ | ----------------- | ----------------------------------------------------------------------------------------------- |
+| LTS cloud and baremetal images | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/releases)                                 |
+| LTS base container images      | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux)               |
+| LTS bare python container      | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-python) |
+| LTS bare libc container        | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-libc)   |
+| LTS bare nodejs container      | Quarterly         | [Download](https://github.com/gardenlinux/gardenlinux/pkgs/container/gardenlinux%2Fbare-nodejs) |
 
 **Note:** For each artifact, there also exists a nightly version, which is built daily but is not considered LTS.
 
@@ -98,7 +98,7 @@ Please refer to [docs/README.md](https://github.com/gardenlinux/gardenlinux/tree
 
 # Contributing
 
-Contribitions to the Garden Linux open source projects are welcome. 
+Contributions to the Garden Linux open source projects are welcome. 
 More information are available in in <a href="CONTRIBUTING.md">CONTRIBUTING.md</a> and our `docs/`.
 
 # Community

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The build system utilises the [gardenlinux/builder](https://github.com/gardenlin
 [gardenlinux/gardenlinux](https://github.com/gardenlinux/gardenlinux) is maintained by the Garden Linux team, highlighting specialized "features" available for other projects.
 
 > [!TIP]
-> For further information about the build process, and how to set it up on your machine, refer to [the Build Image documentation page](docs/01_developers/build_image.md).
+> For further information about the build process, and how to set it up on your machine, refer to [the _Build Image_ documentation page](docs/01_developers/build_image.md).
 
 To initiate a build, use the command:
 ```shell

--- a/docs/01_developers/build_image.md
+++ b/docs/01_developers/build_image.md
@@ -1,38 +1,86 @@
-# Building a Garden Linux Image
+The build system utilises the [gardenlinux/builder](https://github.com/gardenlinux/builder) to create customized Linux distributions. 
+[gardenlinux/gardenlinux](https://github.com/gardenlinux/gardenlinux) is maintained by the Garden Linux team, highlighting specialized "features" available for other projects.
 
-Building a Garden Linux image is a straightforward process, thanks to the Garden Linux builder. This guide will walk you through the steps to create your custom Garden Linux image.
+## Build Requirements
 
-## Prerequisites
+- **Memory:** The build process may require up to 8GiB of memory, depending on the selected targets. If your system has insufficient RAM, configure swap space accordingly.
+- **Container Engine:** The Builder has minimal dependencies and only requires a working container engine. You have two options:
+  - **Rootless Podman:** It's recommended to use rootless Podman. Please refer to the [Podman rootless setup guide](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) for instructions on setting it up.
+  - **Sudo Podman:** Alternatively, you can use Podman with sudo for elevated privileges.
 
-1. Ensure you have the necessary dependencies installed. Refer to the [builder's README](https://github.com/gardenlinux/builder#readme) for a list of required tools and their installation instructions.
-2. Clone the Garden Linux repository:
-   ```bash
-   git clone https://github.com/gardenlinux/gardenlinux.git
-   ```
+To ensure a successful build, please refer to the [Build Requirements section](https://github.com/gardenlinux/builder#requirements) in the `gardenlinux/builder` repository.
 
-## Building the Image
 
-1. Navigate to the Garden Linux directory:
-   ```bash
-   cd gardenlinux
-   ```
+##  Build
 
-2. Use the `build` command to start the image creation process. You can specify the target platform and other configurations as arguments. For a list of available options, refer to the [builder's documentation](https://github.com/gardenlinux/builder#readme).
-   ```bash
-   ./build <target-platform> <other-options>
-   ```
+To initiate a build, use the command:
+```shell
+./build ${platform}-${feature}_${modifier}
+```
 
-3. Once the build process is complete, you'll find the generated image in the `output/` directory.
+Where:
+- `${platform}` denotes the desired platform (e.g., kvm, metal, aws).
+- `${feature}` represents a specific feature from the `features/` folder.
+- `${modifier}` is an optional modifier from the `features/` folder, prefixed with an underscore "_".
 
-## Advanced Configurations
+You can combine multiple platforms, features, and modifiers as needed.
 
-Garden Linux builder offers a range of configurations to tailor the image to specific needs:
+Example:
+```shell
+./build kvm-python_dev
+```
 
-- **Features**: Garden Linux supports a variety of features that can be included or excluded from the build. Refer to the [features documentation](https://github.com/gardenlinux/gardenlinux/tree/main/features) for a comprehensive list and their descriptions.
+The build script fetches the required builder container and manages all internal build steps. By default, it uses rootless podman, but you can switch to another container engine with the `--container-engine` flag.
 
-- **Custom Kernel**: You can specify a custom kernel during the build process. For more details, check the [kernel documentation](https://github.com/gardenlinux/gardenlinux/blob/docs-refactor-docsfolder/docs/00_introduction/kernel.md).
 
-- **Platform-Specific Builds**: Garden Linux can be built for various platforms like AWS, Azure, GCP, and more. The builder allows you to specify the target platform for the image. Refer to the [platforms documentation](https://github.com/gardenlinux/gardenlinux/tree/main/features) for more information.
+### Parallel Builds
+
+For efficient parallel builds of multiple targets, use the `-j ${number_of_threads}` option in the build script. However, note the following:
+
+- Building in parallel significantly increases memory usage.
+- There are no mechanisms in place to handle memory exhaustion gracefully.
+- This feature is only recommended for users with large build machines, ideally with 8GiB of RAM per builder thread. It may work with 4GiB per thread due to spikes in memory usage being only intermittent during the build, but your milage may vary.
+
+### Cross Architecture Builds
+
+By default, the build targets the native architecture of the build system. However, cross-building for other architectures is simple.
+
+Append the target architecture to the target name in the build command, like so: `./build ${target}-${arch}`.
+For example, to build for both amd64 and arm64 architectures:
+
+```
+./build kvm-amd64 kvm-arm64
+```
+
+This requires setting up [binfmt_misc](https://docs.kernel.org/admin-guide/binfmt-misc.html) handlers for the target architecture, allowing the system to execute foreign binaries.
+
+On most distributions, you can install QEMU user static to set up binfmt_misc handlers. For example, on Debian, use the command `apt install qemu-user-static`.
+
+### SELinux
+
+If you intend to build targets with the `_selinux` feature, some additional requirements apply to the build machine.
+
+
+Building the `_selinux` feature will not work on machines running in SELinux enforcing mode. Ideally, you should build on a machine with SELinux disabled. However, if you want to build with SELinux in permissive mode, this can be achieved by running the build as root with the `--privileged` flag.
+
+i.e.: `sudo ./build --privileged ${target}`
+
+**SELinux Workaround for Podman:**
+> :warning: **Note:** [Podman Desktop](https://podman-desktop.io) and [Podman on macOS](https://podman.io) have by default SELinux enabled in their VMs. This may cause issues when building the `_selinux` feature. See [issue #16](https://github.com/gardenlinux/builder/issues/16) for details.
+
+If you're using Podman on macOS, follow these steps to disable SELinux in the podman VM:
+
+1. SSH into the Podman VM: `podman machine ssh`
+2. Run the following command to disable SELinux: `echo SELINUX=disabled | sudo tee /etc/selinux/config`
+3. Exit the SSH connection.
+4. Restart the Podman VM: `podman machine stop && podman machine start`
+
+### Secureboot
+
+If you intend to build targets with the `_secureboot` feature, you must first build the secureboot certificates.
+Run the command `./cert/build` to generate the secureboot certificates.
+
+By default, the command uses local files as the private key storage. However, you can configure it to use the AWS KMS key store by using the `--kms` flag. Note that valid AWS credentials need to be configured using the standard AWS environment variables.
 
 ## Troubleshooting
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request enhances the README.md file to serve as a more comprehensive starting point for individuals unfamiliar with Garden Linux, including non-maintainers and developers. The adjustments aim to streamline the content and provide clear guidance on initiating the build process and accessing releases.


**Which issue(s) this PR fixes**:
* badge showing latest LTS version of Garden Linux
* simple quick start sections: build, test, download
* remove unecessary license badge. we have LICENSE.md file which is commin practise and Github also displays it in UI
* remove toc. README is simple enough.
* add reference to bare container
* add reference to base container
* add reference to nvidia installer
* remove details about integration tests. Details are explained in developer docs. User readind README only needs to know how to test locally and that we test automatically

**Special notes for your reviewer**:
In case you want to read the new README without the diffs: https://github.com/gardenlinux/gardenlinux/blob/3ea7a81fa007f14660f845b3e553d3616002b73f/README.md 

