### PR TITLE
Stop building openstack and vmware for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,13 @@ jobs:
           - target: container
             arch: arm64
             modifier: ""
+        exclude:
+          - target: openstack
+            arch: arm64
+            modifier: "${{ inputs.default_modifier }}"
+          - target: vmware
+            arch: arm64
+            modifier: "${{ inputs.default_modifier }}"
     steps:
       # - uses: gardenlinux/workflow-telemetry-action@c75b594f552d305ffd5f9074637137bc343ba35e # pin@v2
       #   with:

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -33,6 +33,13 @@ jobs:
         arch: [ amd64, arm64 ]
         target: [ kvm, "kvm_secureboot", "kvm_secureboot_readonly", "kvm_secureboot_readonly_persistence", metal, "metal_secureboot", "metal_secureboot_readonly", "metal_secureboot_readonly_persistence", gcp, aws, "aws_secureboot", "aws_secureboot_readonly", "aws_secureboot_readonly_persistence", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
         modifier: [ "${{ inputs.default_modifier }}" ]
+        exclude:
+          - target: openstack
+            arch: arm64
+            modifier: "${{ inputs.default_modifier }}"
+          - target: vmware
+            arch: arm64
+            modifier: "${{ inputs.default_modifier }}"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove failing image config due to missing arm64 build of `open-vm-tools`

Those images are not consumed by anyone.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/process/issues/50

**Special notes for your reviewer**:

Nightly job using this pr branch: https://github.com/gardenlinux/gardenlinux/actions/runs/8601644058

