### PR TITLE
(main branch) fix gdch: exclude systemd-timesyncd in favour of chrony

### DIFF
--- a/features/gdch/pkg.exclude
+++ b/features/gdch/pkg.exclude
@@ -1,0 +1,1 @@
+systemd-timesyncd

--- a/features/gdch/pkg.exclude
+++ b/features/gdch/pkg.exclude
@@ -1,1 +1,2 @@
+irqbalance
 systemd-timesyncd


### PR DESCRIPTION
**What this PR does / why we need it**:
gdch requires chrony
**Which issue(s) this PR fixes**:
Fixes the nightly platform build for new gdch feature 
