### PR TITLE
ci: read version from VERSION file

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   set_version:
     runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,7 +9,17 @@ on:
       - 'docs/**'
       - '**/README.md'
 jobs:
+  set_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: use VERSION file to support dev build on rel-branch
+        id: version
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
   build:
+    needs: [ set_version ]
     uses: ./.github/workflows/build.yml
     with:
-      version: today
+      version: ${{ needs.set_version.outputs.VERSION }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, a `dev` build does not retrieve the correct version if it is executed for a rel-* branch. 

This PR enables dev actions to run on rel-* branches. 

**Which issue(s) this PR fixes**:
Pushes to a `rel-` branch will trigger a dev build with the correct version set. 


**Notes for Reviewer**
If this is merged, we will also backport it to rel-1443 branch

