### PR TITLE
docs: use new builder in oras and oci feature README

### DIFF
--- a/features/_oci/README.md
+++ b/features/_oci/README.md
@@ -15,7 +15,7 @@ This feature creates an archive containing the artifacts for an upload to an OCI
 Build a kernel, an initrd and the rootfs by generating the build for your target platform and add the *_oci* feature:
 
 ``` shell
-$ ./build.sh --features server,cloud,gardener,gcp,_oci .build/
+$ ./build gcp_oci
 ```
 
 After the build process has finished you*ll find an compressed archive in the destination directory of your build:

--- a/features/_oras/README.md
+++ b/features/_oras/README.md
@@ -9,7 +9,7 @@ This flag feature shows how to push to an OCI compatible registry image using [o
 ### Usage
 
 ``` shell
-$ ./build.sh --features kvm,_oras .build/
+$ ./build kvm_oras
 ```
 
 The output of the build process shows the oras command to push the artifacts in the way they can be consumed by a `onmetal` image.


### PR DESCRIPTION
Updates remaining references to old build.sh.  fixes #1689 