### PR TITLE
Fixes the _readonly build

### DIFF
--- a/features/_readonly/exec.config
+++ b/features/_readonly/exec.config
@@ -2,6 +2,6 @@
 
 set -eufo pipefail
 
-
-ln -s systemd-pcrextend /usr/lib/systemd/systemd-pcrphase
+# Test for the systemd-pcrphase in case dracut changes it mind. #2108
+[ -e /usr/lib/systemd/systemd-pcrphase ] || ln -s systemd-pcrextend /usr/lib/systemd/systemd-pcrphase
 

--- a/features/_readonly/exec.config
+++ b/features/_readonly/exec.config
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+
+ln -s systemd-pcrextend /usr/lib/systemd/systemd-pcrphase
+

--- a/features/_readonly/pkg.include
+++ b/features/_readonly/pkg.include
@@ -1,1 +1,2 @@
 cryptsetup
+tpm2-tools

--- a/features/_secureboot/exec.config
+++ b/features/_secureboot/exec.config
@@ -6,4 +6,5 @@ update-kernel-cmdline
 
 mkdir -p /efi
 
-ln -s systemd-pcrextend /usr/lib/systemd/systemd-pcrphase
+# Test for the systemd-pcrphase in case dracut changes it mind. #2108
+[ -e /usr/lib/systemd/systemd-pcrphase ] || ln -s systemd-pcrextend /usr/lib/systemd/systemd-pcrphase


### PR DESCRIPTION
In this commit we imitation the fix\[0\] for `_secureboot`. Since systemd 255 has renamed the  naming from pcrextend to pcrphase. Without the build fails:

    building raw image kvm-python_dev_readonly-amd64-today
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] using base fstab: /builder/features/base/fstab
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] modifying fstab with /builder/features/_readonly/fstab.mod
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] ---- fstab ----
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] LABEL=EFI    /efi    vfat    ro,umask=0077    type=uefi,size=128MiB
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] LABEL=USR    /usr         ext4    ro               verity
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] REPART=00    /            ext4    rw               ephemeral
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:22] ---------------
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] mke2fs 1.47.1-rc2 (01-May-2024)
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Discarding device blocks: done
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Creating filesystem with 123648 4k blocks and 123648 inodes
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Filesystem UUID: 574aaca1-0e64-d36a-f743-e943b6bbca85
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Superblock backups stored on blocks:
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47]      32768, 98304
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47]
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Allocating group tables: done
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Writing inode tables: done
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:47] Creating journal (4096 blocks): done
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] Copying files into the device: done
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] Writing superblocks and filesystem accounting information: done
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55]
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] tune2fs 1.47.1-rc2 (01-May-2024)
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] resize2fs 1.47.1-rc2 (01-May-2024)
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] The filesystem is already 123648 (4k) blocks long.  Nothing to do!
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55]
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] resize2fs 1.47.1-rc2 (01-May-2024)
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] Resizing the filesystem on /tmp/tmp.NQarjGu1rf to 128000 (4k) blocks.
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55] The filesystem on /tmp/tmp.NQarjGu1rf is now 128000 (4k) blocks long.
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:00:55]
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:03] /usr 5c3c3ad846e38b5b137e5483134ef1518b67eb4cdee901a2ad80556efc1ffcec  /tmp/tmp.NQarjGu1rf
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] VERITY header information for /tmp/tmp.NQarjGu1rf.verity
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] UUID:                b22d938d-1a08-3803-f9fe-e56a1f5bf88b
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Hash type:           1
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Data blocks:         128000
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Data block size:     4096
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Hash blocks:         1009
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Hash block size:     4096
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Hash algorithm:      sha256
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Salt:                59cdd7476f7045846a89fb0743b0508cc366b6dfa40a4fc6e3e6e6df095f6ad5
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Root hash:           cf485e037bd039c77ebe06c196f11ca553c49408f8e8d5e461f2f40c7255e392
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] Hash device size:    4136960 [bytes]
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] ERROR: ld.so: object 'datefudge.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:04] /efi ce715d6156ecbde3caf8b52818a27515ae678c1fc3da7167905c7b5c39ae7bdc  /tmp/tmp.FpyBisxA15
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:09] /usr/bin/dracut: line 1067: /sys/module/firmware_class/parameters/path: No such file or directory
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:09] dracut[I]: Executing: /usr/bin/dracut --no-hostonly --force --kver 6.6.30-cloud-amd64 --modules "bash dash systemd systemd-initrd systemd-veritysetup systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt systemd-pcrphase " --install "/etc/veritytab cryptsetup head mkfs.ext4 systemd-escape lsblk" --include /tmp/tmp.uQc9lA1NcJ / --reproducible /tmp/tmp.xSSK9wE6VQ
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:09] dracut[I]: Module 'systemd-pcrphase' will not be installed, because command '/usr/lib/systemd/systemd-pcrphase' could not be found!
    [.build/kvm-python_dev_readonly-amd64-today-local.raw 2024-05-08 11:02:09] dracut[E]: Module 'systemd-pcrphase' cannot be installed.
    completed in 107 seconds

He also exepcts tpm2 to be preseted now. Hence adding it to the packages. As of now this fixes the build. I'm unsure if the build will work correctly. Since it will fail as follows:

    [  OK  ] Reached target initrd-root-device.target - Initrd Root Device.
    [    3.877478] systemd-repart[383]: Automatically determined minimal disk image size as 599.0M, current image size is 584.0M.
    [    3.878989] systemd[1]: systemd-repart.service: Main process exited, code=exited, status=1/FAILURE
    [    3.880320] systemd[1]: systemd-repart.service: Failed with result 'exit-code'.
    [    3.881512] systemd[1]: Failed to start systemd-repart.service - Repartition Root Disk.
    [    3.882701] systemd[1]: Reached target initrd-root-device.target - Initrd Root Device.

But this might be a different issue.

[0]: https://github.com/gardenlinux/gardenlinux/commit/b96dee22b47eea01ec961fd105f2f40dd84841ab#diff-a3b49b4e0d4692bdba91c7b6cf3c645271fca310499bac80cf4737da4dcc3094
