### PR TITLE
Umask test use umask cmd

### DIFF
--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -1,4 +1,5 @@
 import pytest
+from helper.tests.file_content import file_content
 
 # Parametrize the test unit with further
 # options.

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -5,4 +5,4 @@ def test_umask(client):
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)
     assert exit_code == 0, f"Could not execute umask cmd: {error}"
-    assert output == "0027", "umask is not set to 0027 "
+    assert output == "0027\n", "umask is not set to 0027 "

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -1,8 +1,29 @@
 import pytest
 
-def test_umask(client):
+# Parametrize the test unit with further
+# options.
+# First: File to process
+# Second: Key to search
+# Third: Value of Key
+@pytest.mark.parametrize(
+    "file,dict",
+    [
+        ("/etc/login.defs", {"UMASK": "027"})
+    ]
+)
+
+
+# Run the test unit to perform the
+# final tests by the given artifact.
+def test_umask(client, file, dict):
+    # Check /etc/login.defs
+    file_content(client, file, dict)
+
+def test_umask_cmd(client, non_container):
+    # Additionally check umask via cmd
     cmd = f"sudo su root -c umask"
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)
+
     assert exit_code == 0, f"Could not execute umask cmd: {error}"
     assert output == "0027\n", "umask is not set to 0027 "

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -14,14 +14,15 @@ from helper.tests.file_content import file_content
 )
 
 
-# Run the test unit to perform the
-# final tests by the given artifact.
+# pam_umask reads the umask value from /etc/login.defs,
+# therefore we need to test the UMASK default value set via /etc/login.defs
 def test_umask(client, file, dict, non_gcp):
     # Check /etc/login.defs
     file_content(client, file, dict)
 
+# `/root/.bashrc`, `/root/.profile`, ... can overwrite default value from /etc/login.defs
+# therefore we need to check via the umask cmd in root bash environment
 def test_umask_cmd(client, non_container):
-    # Additionally check umask via cmd
     cmd = f"sudo su root -c umask"
     (exit_code, output, error) = client.execute_command(
         cmd, quiet=True)

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -15,7 +15,7 @@ import pytest
 
 # Run the test unit to perform the
 # final tests by the given artifact.
-def test_umask(client, file, dict):
+def test_umask(client, file, dict, non_gcp):
     # Check /etc/login.defs
     file_content(client, file, dict)
 

--- a/features/base/test/test_umask.py
+++ b/features/base/test/test_umask.py
@@ -1,20 +1,8 @@
-from helper.tests.file_content import file_content
 import pytest
 
-# Parametrize the test unit with further
-# options.
-# First: File to process
-# Second: Key to search
-# Third: Value of Key
-@pytest.mark.parametrize(
-    "file,dict",
-    [
-        ("/etc/login.defs", {"UMASK": "027"})
-    ]
-)
-
-
-# Run the test unit to perform the
-# final tests by the given artifact.
-def test_umask(client, file, dict):
-    file_content(client, file, dict)
+def test_umask(client):
+    cmd = f"sudo su root -c umask"
+    (exit_code, output, error) = client.execute_command(
+        cmd, quiet=True)
+    assert exit_code == 0, f"Could not execute umask cmd: {error}"
+    assert output == "0027", "umask is not set to 0027 "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,8 +316,8 @@ def aws(iaas):
 
 @pytest.fixture
 def non_gcp(iaas):
-    if iaas != 'gcp':
-        pytest.skip('test only supported on gcp')
+    if iaas == 'gcp':
+        pytest.skip('test not supported on gcp')
 
 @pytest.fixture
 def gcp(iaas):


### PR DESCRIPTION
**What this PR does**
- repair `non_gcp` flag for python platform tests
- add a second umask test `test_umask_cmd` (check via `umask`) 
- disable `test_umask` for platform gcp tests (check by reading UMASK value from /etc/login.defs) 


**Why we need it?**
- pam_umask reads the umask value from /etc/login.defs: we need to test /etc/login.defs
- `/root/.bashrc`, `/root/.profile`, ... can overwrite default value from /etc/login.defs
    - ➡️  we need to check via umask cmd in root bash environment

Conclusion: we need both tests. Disabling `/etc/login.defs` for gcp only is only acceptable, because we additionally have chroot tests that still check the file content.

|               | platform test (gcp) | chroot tests (gcp) |
|---------------|---------------|--------------|
| login.defs    |        ❌       |         ✅       |
| umask cmd     |         ✅        |        ✅        |


**Which issue(s) this PR fixes**:
Fixes #2112 


**Special notes for your reviewer**:
We still need to find out why test_umask only fails on gcp platform tests (could not find /etc/login.defs).  

Tested gcp-gardener_prod image:
- ✅  Tested locally (all green)
- ✅  Tested manually in gcp by creating a custom image and spawning a vm (all green)
- ❌  Tested automatically via nightly platform tests (test_umask fails)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
