### PR TITLE
Add target_commitish parameter to POST release api call

### DIFF
--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -253,6 +253,7 @@ def create_github_release(owner, repo, tag, commitish):
 
     data = {
         'tag_name': tag,
+        'target_commitish': commitish,
         'name': tag,
         'body': body,
         'draft': False,


### PR DESCRIPTION
We were missing the target_commitish parameter which means that github is using main branch instead.

Docs:
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
