### PR TITLE
Upload build artefacts to AWS S3 in China during nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,20 @@ jobs:
       region: ${{ secrets.AWS_REGION }}
       role: ${{ secrets.AWS_IAM_ROLE }}
       session: ${{ secrets.AWS_OIDC_SESSION }}
+  upload_to_s3_cn:
+    name: upload to S3 china
+    needs: [ build, tests ]
+    permissions:
+      id-token: write
+    uses: ./.github/workflows/upload_to_s3.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      default_modifier: "-gardener_prod"
+    secrets:
+      bucket: ${{ secrets.AWS_CN_S3_BUCKET }}
+      region: ${{ secrets.AWS_CN_REGION }}
+      role: ${{ secrets.AWS_CN_IAM_ROLE }}
+      session: ${{ secrets.AWS_CN_OIDC_SESSION }}
   publish_container:
     name: publish gardenlinux container base image
     needs: [ build, tests ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatically uploads build artefacts to S3 in AWS CN as well to have better distribution of build artefacts to Chinese cloud platforms.

**Which issue(s) this PR fixes**:
Fixes #2121 and fixes #2130

**Special notes for your reviewer**:

Tested in https://github.com/gardenlinux/gardenlinux/actions/runs/9398491888 and verified that artefacts are indeed present in S3 bucket of Garden Linux' AWS China subscription.

Must be cherry-picked to relevant release branches (rel-1312 and rel-1443) as well.
