### PR TITLE
Include checksums and additional tags to S3 artefact uploads

### DIFF
--- a/.github/workflows/upload_to_s3.sh
+++ b/.github/workflows/upload_to_s3.sh
@@ -37,8 +37,8 @@ EOF
 
 for file in "$name/$name"*; do
 suffix="$(basename "$file" | sed "s/^$name//")"
-md5sum=$(md5sum -b "$file" | cut -d " " -f 1)
-md5bin=$(openssl md5 -binary "$file" | base64 -w0)
+md5sum=$(md5sum -b "$file" | cut -d " " -f 1)         # human readable (hexlified) digest for tags
+md5bin=$(openssl md5 -binary "$file" | base64 -w0)    # base64 encoded binary digest for S3 api
 sha256sum=$(sha256sum -b "$file" | cut -d " " -f 1)
 sha256bin=$(openssl sha256 -binary "$file" | base64 -w0)
 cat << EOF >> "$meta_yml"


### PR DESCRIPTION
**What this PR does / why we need it**:

During the upload to S3 job of the `nightly` Action:
- md5sums and sha256sums will be calculated for every artefact
- both values will be supplied to S3 to verify proper upload ([ref](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html))
- md5sum and sha256sum will be added to the release manifest
- md5sum and sha256sum will be added as tags to every uploaded artefact (along with Garden Linux version, platform, architecture and comittish)

All this to have the possibility to track and check integrity of image artefacts right from the moment they come out of the build pipeline.

**Special notes for your reviewer**:

Tested in https://github.com/gardenlinux/gardenlinux/actions/runs/9465059139

Do not cherry-pick to `rel-*` branches as this will require changes to glci as well.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Checksums (md5 and sha256) are now calculated for and added to each release artefact.
```
