### PR TITLE
fix release page use long commitish

### DIFF
--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          .github/workflows/release_note.py create --tag ${{ inputs.version }} --commit "$(echo "${{ inputs.commit }}" | cut -c -8)"  
+          .github/workflows/release_note.py create --tag ${{ inputs.version }} --commit "$(echo "${{ inputs.commit }}")"  
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
         with:
           name: release

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -209,6 +209,7 @@ def generate_package_update_section(version):
 
 
 def create_github_release_notes(gardenlinux_version, commitish):
+    commitish=commitish[:8]
     output = ""
   
     manifests = download_all_singles(gardenlinux_version, commitish)

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -209,10 +209,10 @@ def generate_package_update_section(version):
 
 
 def create_github_release_notes(gardenlinux_version, commitish):
-    commitish=commitish[:8]
+    commitish_short=commitish[:8]
     output = ""
   
-    manifests = download_all_singles(gardenlinux_version, commitish)
+    manifests = download_all_singles(gardenlinux_version, commitish_short)
 
     output += generate_release_note_image_ids(manifests)
     
@@ -221,13 +221,17 @@ def create_github_release_notes(gardenlinux_version, commitish):
     output += get_kernel_urls(gardenlinux_version)
     output += "\n"
 
-    output += generate_image_download_section(manifests, gardenlinux_version, commitish )
+    output += generate_image_download_section(manifests, gardenlinux_version, commitish_short )
 
     output += "\n"
-    output += "## Kernel Module Build Container (kmodbuild)"
-    output += "````"
-    output += f"ghcr.io/gardenlinux/kmodbuild:{gardenlinux_version}"
+    output += "## Kernel Module Build Container (kmodbuild) "
+    output += "\n"
     output += "```"
+    output += "\n"
+    output += f"ghcr.io/gardenlinux/kmodbuild:{gardenlinux_version}"
+    output += "\n"
+    output += "```"
+    output += "\n"
     return output
 
 def write_to_release_id_file(release_id):


### PR DESCRIPTION
**What this PR does / why we need it**:

* GitHub API requires the full commitish to create a release page
* To retrieve the correct metadata of Garden Linux published images from S3, we need to use the short commitish (8 characters). 
* Fixes output format of kmodbuild container 
 