### PR TITLE
feat: better serial console output

### DIFF
--- a/features/_dev/file.include/etc/kernel/cmdline.d/42-forward-journal.cfg
+++ b/features/_dev/file.include/etc/kernel/cmdline.d/42-forward-journal.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX systemd.journald.forward_to_console=1"

--- a/features/kvm/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/kvm/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,1 +1,13 @@
-CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"
+serial_dev=ttyS0
+earlycon="earlycon=ttyS0"
+
+if [ "$BUILDER_ARCH" = amd64 ]; then
+	earlycon="earlyprintk=$serial_dev,115200n8"
+fi
+
+if [ "$BUILDER_ARCH" = arm64 ]; then
+	serial_dev=ttyAMA0
+	earlycon="earlycon=pl011,mmio,0x09000000"
+fi
+
+CMDLINE_LINUX="$earlycon console=tty0 console=$serial_dev $CMDLINE_LINUX"


### PR DESCRIPTION
- setup console correctly for qemu virt machine type in arm64 kvm build
- add earlycon/earlyprintk entries working with qemu to kvm feature
- add systemd.journald.forward_to_console=1 to _dev feature
