### PR TITLE
Support NixOS in bin/start-vm

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -51,7 +51,7 @@ get_os () {
         if [ $init_system != "systemd" ]; then
             host_dist="debian"
         else
-            host_dist="$(hostnamectl | grep "Operating System:" | awk {'print tolower($3)}')"
+            host_dist="$(hostnamectl | grep "Operating System:" | awk '{print tolower($3)}')"
         fi
 
         # Evaluate Distribution

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -65,6 +65,8 @@ get_os () {
             os="ubuntu"
         elif [ $host_dist = "arch" ] || [ "$host_dist" = "manjaro" ]; then
             os="arch"
+        elif [ $host_dist = "nixos" ]; then
+            os="nixos"
         else
             echo "Error: Unsupported Linux distribution."
             exit 1
@@ -457,6 +459,11 @@ qemu_opt_uefi () {
             elif [ "$os" = arch ]; then
                 uefi_code="${uefi_code:-/usr/share/OVMF/x64/OVMF_CODE.fd}"
                 uefi_vars="${uefi_vars:-/usr/share/OVMF/x64/OVMF_VARS.fd}"
+            elif [ "$os" = nixos ]; then
+                # Requires the following NixOS configuration:
+                # virtualisation.libvirtd.enable = true;
+                uefi_code="${uefi_code:-/run/libvirt/nix-ovmf/OVMF_CODE.fd}"
+                uefi_vars="${uefi_vars:-/run/libvirt/nix-ovmf/OVMF_VARS.fd}"
             else
                 echo "Error: Could not find UEFI code and vars file."
                 exit 1
@@ -490,6 +497,15 @@ qemu_opt_uefi () {
             # package which is *present* in official repositories
             uefi_code="${uefi_code:-/usr/share/AAVMF/AAVMF_CODE.fd}"
             uefi_vars="${uefi_vars:-/usr/share/AAVMF/AAVMF_VARS.fd}"
+        elif [ "$os" = nixos ]; then
+            # Requires the following NixOS configuration to have AArch64 UEFI firmware on x86 hosts:
+            #
+            # virtualisation.libvirtd.qemu.ovmf.packages = [
+            #   pkgs.OVMFFull.fd
+            #   pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd
+            # ];
+            uefi_code="${uefi_code:-/run/libvirt/nix-ovmf/AAVMF_CODE.fd}"
+            uefi_vars="${uefi_vars:-/run/libvirt/nix-ovmf/AAVMF_VARS.fd}"
         else
             echo "Error: Could not find UEFI code and vars file."
             exit 1
@@ -503,7 +519,8 @@ qemu_opt_uefi () {
         [ -r $uefi_code ] || eusage "Missing uefi code at $uefi_code.\n Run: apt-get install ovmf qemu-efi-aarch64"
         [ -r $uefi_vars ] || eusage "Missing uefi vars at $uefi_vars.\n Run: apt-get install ovmf qemu-efi-aarch64"
 
-        [ -e $CURR_DIR/$mac.vars ] || cp $uefi_vars $CURR_DIR/$mac.vars
+        # The source file might be read-only.
+        [ -e $CURR_DIR/$mac.vars ] || cp --no-preserve=mode,ownership $uefi_vars $CURR_DIR/$mac.vars
 
         # Add support for amd64 architecture
         if [ "$arch" = amd64 ]; then

--- a/bin/start-vm
+++ b/bin/start-vm
@@ -55,17 +55,17 @@ get_os () {
         fi
 
         # Evaluate Distribution
-        if [ $host_dist = "centos" ]; then
+        if [ "$host_dist" = "centos" ]; then
             os="centos"
-        elif [ $host_dist = "fedora" ]; then
+        elif [ "$host_dist" = "fedora" ]; then
             os="fedora"
-        elif [ $host_dist = "debian" ] || [ $host_dist = "garden" ]; then
+        elif [ "$host_dist" = "debian" ] || [ "$host_dist" = "garden" ]; then
             os="debian"
-        elif [ $host_dist = "ubuntu" ]; then
+        elif [ "$host_dist" = "ubuntu" ]; then
             os="ubuntu"
-        elif [ $host_dist = "arch" ] || [ "$host_dist" = "manjaro" ]; then
+        elif [ "$host_dist" = "arch" ] || [ "$host_dist" = "manjaro" ]; then
             os="arch"
-        elif [ $host_dist = "nixos" ]; then
+        elif [ "$host_dist" = "nixos" ]; then
             os="nixos"
         else
             echo "Error: Unsupported Linux distribution."


### PR DESCRIPTION
**What this PR does / why we need it**:

With these changes, NixOS users can build and start Garden Linux VMs without fiddling with the script.

For all features, you need the following NixOS configuration on x86_64:

```nix
 environment.systemPackages = with pkgs; [
   qemu
 ];

 virtualisation.libvirtd = {
   enable = true;

   qemu.ovmf.packages = with pkgs; [
     OVMFFull.fd

     # Only for AArch64 support.
     pkgsCross.aarch64-multiplatform.OVMF.fd
   ];
 };
```

Ping @parthy @notandy 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I've successfully tested this on NixOS 24.05 to boot the `x86_64` `kvm-python_dev` target. I haven't tested the aarch64 image, because I don't know yet how to cross-compile an aarch64 image. I've manually validated the paths, though.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
