### PR TITLE
Fix/disable IMDSv1

### DIFF
--- a/features/base/test/test_metadata_connection.py
+++ b/features/base/test/test_metadata_connection.py
@@ -4,9 +4,15 @@ from helper.sshclient import RemoteClient
 
 def test_metadata_connection(client, non_azure, non_ali, non_chroot, non_kvm):
     metadata_host = "169.254.169.254"
+    # request the IMDSv2 token to allow access to the metadata_host on AWS.
+    (exit_code, token, error) = client.execute_command(
+            f"curl -sqX PUT 'http://{metadata_host}/latest/api/token'\
+                    -H 'X-aws-ec2-metadata-token-ttl-seconds:60'"
+    )
     (exit_code, output, error) = client.execute_command(
         f"wget --timeout 5 \
-               --header=\"X-aws-ec2-metadata-token: $(curl -sqX PUT 'http://{metadata_host}/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')\" \
+               --header='X-aws-ec2-metadata-token: {token}' \
+               -H 'X-aws-ec2-metadata-token-ttl-seconds:60' \
                'http://{metadata_host}/'"
     )
     assert exit_code == 0, f"no {error=} expected"

--- a/features/base/test/test_metadata_connection.py
+++ b/features/base/test/test_metadata_connection.py
@@ -12,7 +12,6 @@ def test_metadata_connection(client, non_azure, non_ali, non_chroot, non_kvm):
     (exit_code, output, error) = client.execute_command(
         f"wget --timeout 5 \
                --header='X-aws-ec2-metadata-token: {token}' \
-               -H 'X-aws-ec2-metadata-token-ttl-seconds:60' \
                'http://{metadata_host}/'"
     )
     assert exit_code == 0, f"no {error=} expected"

--- a/features/base/test/test_metadata_connection.py
+++ b/features/base/test/test_metadata_connection.py
@@ -5,7 +5,9 @@ from helper.sshclient import RemoteClient
 def test_metadata_connection(client, non_azure, non_ali, non_chroot, non_kvm):
     metadata_host = "169.254.169.254"
     (exit_code, output, error) = client.execute_command(
-        f"wget --header=\"X-aws-ec2-metadata-token: $(curl -sqX PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')\" 'http://169.254.169.254/'"
+        f"wget --timeout 5 \
+               --header=\"X-aws-ec2-metadata-token: $(curl -sqX PUT 'http://{metadata_host}/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')\" \
+               'http://{metadata_host}/'"
     )
     assert exit_code == 0, f"no {error=} expected"
     assert f"Connecting to {metadata_host}:80... connected." in error

--- a/features/base/test/test_metadata_connection.py
+++ b/features/base/test/test_metadata_connection.py
@@ -5,7 +5,7 @@ from helper.sshclient import RemoteClient
 def test_metadata_connection(client, non_azure, non_ali, non_chroot, non_kvm):
     metadata_host = "169.254.169.254"
     (exit_code, output, error) = client.execute_command(
-        f"wget --timeout 5 http://{metadata_host}"
+        f"wget --header=\"X-aws-ec2-metadata-token: $(curl -sqX PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')\" 'http://169.254.169.254/'"
     )
     assert exit_code == 0, f"no {error=} expected"
     assert f"Connecting to {metadata_host}:80... connected." in error


### PR DESCRIPTION
**What this PR does / why we need it**:

We have to disable the IMDSv1. The test will fail without a token. So we request a token from IMDSv2 and provide it for our current test case. 


