### PR TITLE
test: add test to check if containerd+runc can pull and spawn an image

### DIFF
--- a/features/gardener/test/test_containerd.py
+++ b/features/gardener/test/test_containerd.py
@@ -14,6 +14,6 @@ def test_containerd(client, non_chroot):
     (exit_code, output, error) = client.execute_command("sudo ctr image pull ghcr.io/gardenlinux/gardenlinux:nightly")
     assert exit_code == 0, f"no {error=} expected"
 
-    (exit_code, output, error) = client.execute_command("sudo ctr run --rm -t ghcr.io/gardenlinux/gardenlinux:nightly gardenlinux echo 'hello from container'")
+    (exit_code, output, error) = client.execute_command("sudo ctr run --rm -ti ghcr.io/gardenlinux/gardenlinux:nightly gardenlinux echo 'hello from container'")
     assert exit_code == 0, f"no {error=} expected"
     assert output == "hello from container", f"unexpected output: {output}"

--- a/features/gardener/test/test_containerd.py
+++ b/features/gardener/test/test_containerd.py
@@ -1,0 +1,19 @@
+
+import pytest
+from helper.sshclient import RemoteClient
+
+
+def test_containerd(client, non_chroot):
+    """ Test if containerd capability """
+    (exit_code, output, error) = client.execute_command("sudo systemctl enable containerd")
+    assert exit_code == 0, f"no {error=} expected"
+
+    (exit_code, output, error) = client.execute_command("sudo systemctl start containerd")
+    assert exit_code == 0, f"no {error=} expected"
+
+    (exit_code, output, error) = client.execute_command("sudo ctr image pull ghcr.io/gardenlinux/gardenlinux:nightly")
+    assert exit_code == 0, f"no {error=} expected"
+
+    (exit_code, output, error) = client.execute_command("sudo ctr run --rm -t ghcr.io/gardenlinux/gardenlinux:nightly gardenlinux echo 'hello from container'")
+    assert exit_code == 0, f"no {error=} expected"
+    assert output == "hello from container", f"unexpected output: {output}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a test to gardener feature, that checks if containerd can pull and spawn a container successfully. 

**Which issue(s) this PR fixes**:
No issue reported yet. 

In 1312 we have docker.io included and a test using docker to spawn a container. See [test_docker](https://github.com/gardenlinux/gardenlinux/blob/rel-1312/features/base/test/test_docker.py).

However, we can utilise `ctr` which is the cli for containerd to test it in version that do not have a user friendly overlay like podman or docker. 
