### PR TITLE
fix: set umask value even if /etc/login.defs did not set it before

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -21,9 +21,13 @@ if [ -f /etc/update-motd.d/05-logo ]; then
 fi
 
 # set default umask to a more conservative value
-# inplace sed would change file access permissions
-login_defs="$(sed 's/UMASK\t\t022/UMASK\t\t027/' /etc/login.defs)"
-cat > /etc/login.defs <<< "$login_defs"
+if grep -q "^UMASK" /etc/login.defs; then
+    # inplace sed would change file access permissions
+    login_defs="$(sed 's/UMASK.*/UMASK\t\t027/' /etc/login.defs)"
+    cat > /etc/login.defs <<< "$login_defs"
+else
+    echo -e "UMASK\t\t027" >> /etc/login.defs
+fi
 
 # set Garden Linux as default for dpkg
 ln -sf /etc/dpkg/origins/gardenlinux /etc/dpkg/origins/default

--- a/features/stig/exec.config
+++ b/features/stig/exec.config
@@ -67,8 +67,13 @@ ensure_stig_compliance() {
     fi
 
     # https://www.stigviewer.com/stig/canonical_ubuntu_20.04_lts/2023-09-08/finding/V-238209
-    # ensure_line /etc/login.defs "UMASK        " 077
-    sed -i 's/UMASK\t\t[[:digit:]][[:digit:]][[:digit:]]/UMASK 077/' /etc/login.defs
+    if grep -q "^UMASK" /etc/login.defs; then
+        # inplace sed would change file access permissions
+        login_defs="$(sed 's/UMASK.*/UMASK\t\t077/' /etc/login.defs)"
+        cat > /etc/login.defs <<< "$login_defs"
+    else
+        echo -e "UMASK\t\t077" >> /etc/login.defs
+    fi
     grep ^UMASK /etc/login.defs
 
     # https://www.stigviewer.com/stig/canonical_ubuntu_20.04_lts/2023-09-08/finding/V-238205


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the case when `/etc/login.defs`  does not contain a UMASK value by adding a check, and appending the desired configuration in this case.  

**Which issue(s) this PR fixes**:
Fixes #2191 
