### PR TITLE
fix: pxe module should include systemd-resolved and ca-certificates

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
@@ -6,7 +6,7 @@ check() {
 }
 
 depends() {
-    echo "fs-lib dracut-systemd systemd-networkd"
+    echo "fs-lib dracut-systemd systemd-networkd systemd-resolved"
 }
 
 install() {
@@ -34,4 +34,10 @@ install() {
 
     # clean up
     inst_hook cleanup 00 "$moddir/cleanup.sh"
+
+    # ca-certificates
+    if ! inst_simple /etc/ssl/certs/ca-certificates.crt; then
+	    dwarn "GL PXE module, can't install ca-certificates"
+	    exit 1
+    fi
 }

--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -3,3 +3,4 @@ dosfstools
 btrfs-progs
 xfsprogs
 dracut-network
+ca-certificates


### PR DESCRIPTION
**What this PR does / why we need it**:
The PXE GL module should include systemd-resolved as dependency and also add the ca-certificates into the initrd.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

