### PR TITLE
fix: server should include systemd-repart

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -26,6 +26,7 @@ systemd-boot
 systemd-boot-efi
 systemd-coredump
 systemd-cron
+systemd-repart
 systemd-timesyncd
 tcpdump
 traceroute


### PR DESCRIPTION
**What this PR does / why we need it**:
@damyan made us aware that systemd-repart is no longer part of the image. With systemd 256, systemd-repart is now a separate package and should be included by the server feature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
