### PR TITLE
Add azure-nvme-utils to Azure feature

### DIFF
--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,3 +1,4 @@
 chrony
 cloud-init
 python3-cffi-backend
+azure-nvme-utils


### PR DESCRIPTION
**What this PR does / why we need it**:

The `azure-nvme-utils` package contains udev rules to populate `/dev/disk/azure` with NVMe disks (in addition to traditional SCSI disks) which is required by the Azure CSI driver for Kubernetes to use NVMe disks as persistent volumes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Package azure-nvme-utils is added to the Azure feature.
```
