### PR TITLE
Resize metal /efi to 300MiB

### DIFF
--- a/features/metal/fstab.mod
+++ b/features/metal/fstab.mod
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+while read -r line; do
+	read -r source target fs options args <<< "$line"
+	if [ "$target" = "/efi" ]; then
+		args="$args,size=300MiB"
+		echo "$source $target $fs $options $args"
+	else
+		echo "$line"
+	fi
+done


### PR DESCRIPTION
**What this PR does / why we need it**:

Garden Linux images have a default /efi size of `64MiB`. This is not sufficient for more than one kernel, which often prevents Kernel Updates from working. We experienced this with our images and customers also experienced it. I propose to enlarge the /efi partition to `300MiB` have no issues if the need for two (or even three) images arises. 

**Which issue(s) this PR fixes**:
Fixes #1893

**Special notes for your reviewer**:
Although this is against the "create a small/minimal immutable image" rule, but i think practically this would help many users in the future.
