### PR TITLE
secureboot enablement

### DIFF
--- a/.github/workflows/aws_secureboot_tests.sh
+++ b/.github/workflows/aws_secureboot_tests.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#set -Eeuo pipefail
+
+arch=amd64
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --arch)
+      arch="$2"
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# Name of Image to test
+cname=$1
+
+configFile="aws_test_config.yaml"
+containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
+artifact_dir="/tmp/gardenlinux-build-artifacts"
+platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
+
+mkdir -p "$platform_test_log_dir"
+
+pushd "$artifact_dir" || exit 1
+tar -xzf "$cname.tar.gz" "$cname.raw"
+popd || exit 1
+
+image_file=$(realpath "$artifact_dir/$cname.raw")
+echo "Image file that will be used for the tests is $image_file"
+if [[ ! -e $image_file ]]; then
+    echo "Image file $image_file does not exist."
+    exit 1
+fi
+
+case "$arch" in
+  amd64) instance_type=m5.large ;;
+  arm64) instance_type=m6g.large ;;
+  *)
+    echo "unsupported architecture $arch" >&2
+    exit 1
+    ;;
+esac
+
+cat << EOF > "$configFile"
+aws:
+    region: ${aws_region}
+    instance_type: $instance_type
+    architecture: $arch
+    image: file:///artifacts/$(basename "$image_file")
+    ssh:
+      user: admin
+    boot_mode: uefi
+    uefi_data: '$(cat cert/secureboot.aws-efivars)'
+    keep_running: false
+    features:
+      - aws
+      - gardener
+      - cloud
+      - server
+      - base
+      - _slim
+      - _secureboot
+EOF
+
+echo "### Start Integration Tests for AWS"
+podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs"  $containerName /bin/bash -s << EOF
+mkdir /gardenlinux/tmp
+TMPDIR=/gardenlinux/tmp/
+cd /gardenlinux/tests
+pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-aws_junit.xml || exit 1
+exit 0
+EOF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ amd64, arm64 ]
-        target: [ gcp, aws, azure, ali ]
+        target: [ gcp, aws, aws_secureboot, azure, ali ]
         modifier: [ "${{ inputs.default_modifier }}" ]
         exclude:
           - arch: arm64
@@ -104,7 +104,7 @@ jobs:
         cleanup_credentials: true
         export_environment_variables: true
 
-    - if: ${{ matrix.target == 'aws' }}
+    - if: ${{ matrix.target == 'aws' || matrix.target == 'aws_secureboot' }}
       id: 'auth_aws'
       name: 'Authenticate to AWS'
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,3 +1,3 @@
 # Dependency management via Dependabot
 
-FROM ghcr.io/gardenlinux/builder:191279b0a54c227851413077283c69df29ce7335
+FROM ghcr.io/gardenlinux/builder:4fef0f35db4923702c9cb639b51f63dee1baac97

--- a/features/_secureboot/file.exclude
+++ b/features/_secureboot/file.exclude
@@ -1,4 +1,3 @@
 /etc/kernel/cmdline.d/50-ignition.cfg
 /etc/dracut.conf.d/30-ignition.conf
 /etc/systemd/system/ignition-disable.service
-/etc/repart.d/root.conf


### PR DESCRIPTION
- fix `_secureboot` feature to not exclude the repart.d definition for the root disk (this should only be done in the `_readonly` feature)
- add secureboot mode to the aws platform tests