### PR TITLE
Document architecture decision on vendoring go dependencies

### DIFF
--- a/docs/architecture/decisions/0004-vendoring-go-dependencies.md
+++ b/docs/architecture/decisions/0004-vendoring-go-dependencies.md
@@ -8,12 +8,12 @@ Accepted
 
 ## Context
 
-This document discusses the options and tradeoffs for packaging go applications in Garden Linux.
+This document discusses the options and tradeoffs for packaging Go applications in Garden Linux.
 
 ### Build time vs run time dependencies
 
 When speaking of software dependencies, it is important to keep build time and run time dependencies apart.
-This document is concerned with build time dependencies in go applications.
+This document is concerned with build time dependencies in Go applications.
 
 Build dependencies can be specified in the Garden Linux package build like in [this example](https://github.com/gardenlinux/package-ignition/blob/a5403d0e5473b63cf19a4fb2d4ac42f8ed979000/.github/workflows/build.yml#L11).
 
@@ -23,14 +23,14 @@ Linux distributions historically assume compiled languages work similar to C or 
 Build time dependencies are packaged as part of the distribution.
 If an application needs the `foo` library to build, installing a package named `libfoo-dev` or similar is the recommended solution.
 
-### The go ecosystem
+### The Go ecosystem
 
-Like many modern programming language ecosystems, go has a dependency management system that works independent of linux package managers.
+Like many modern programming language ecosystems, Go has a dependency management system that works independent of linux package managers.
 Go is a compiled language, and it's known for producing large binary files with little to no run time dependencies.
 
-[go mod](https://go.dev/doc/modules/gomod-ref) is a tool to declare and manage build time dependencies for go applications.
+[go mod](https://go.dev/doc/modules/gomod-ref) is a tool to declare and manage build time dependencies for Go applications.
 
-It's also common in go to manually copy dependencies in source code form in the repository.
+It's also common in Go to manually copy dependencies in source code form in the repository.
 
 This process is described as 'vendoring'.
 `go mod` also supports the `go mod vendor` command to automate this process.
@@ -39,7 +39,7 @@ This process is described as 'vendoring'.
 
 Vendoring goes against the general idea of traditional linux distributions where dependencies are packaged on their own as described above.
 
-The following articles provide context on how vendoring of go code is viewed in Debian:
+The following articles provide context on how vendoring of Go code is viewed in Debian:
 
 - [LWN.net (January 13, 2021): Debian discusses vendoring—again](https://lwn.net/Articles/842319/)
 - [LWN.net (January 20, 2021): The Debian tech committee allows Kubernetes vendoring](https://lwn.net/Articles/843313/)
@@ -47,18 +47,19 @@ The following articles provide context on how vendoring of go code is viewed in 
 ### Qualities ensured by Garden Linux
 
 For Garden Linux, being able to reproduce disk images of previous releases is a crucial quality.
-In the past, one way to achieve this was to have all dependencies packages in the Garden Linux APT repository, and to de-vendor go applications when needed.
+In the past, one way to achieve this was to have all dependencies packages in the Garden Linux APT repository, and to de-vendor Go applications when needed.
 
 ### The downsides of de-vendoring
 
-To be able to build go applications without vendoring can mean quite a lot of effort as most likely Garden Linux does not package all the needed dependencies.
-Adding multiple new packages for dependencies of a new go package might be a lot of maintenance effort.
+To be able to build Go applications without vendoring can mean quite a lot of effort as most likely Garden Linux does not package all the needed dependencies.
+Adding multiple new packages for dependencies of a new Go package might be a lot of maintenance effort.
 
 ## Decision
 
-We allow vendoring dependencies for go applications in Garden Linux.
+We allow vendoring dependencies for Go applications in Garden Linux.
 
 ## Consequences
 
-- We are able to follow upstream projects of applications written in go (like containerd) more closely
-- To keep the promise of being able to reproduce releases bit-for-bit, (FIXME: how exactly does this work?)
+- We are able to follow upstream projects of applications written in Go (like containerd) more closely
+- To keep the promise of being able to reproduce releases, we require the full source code of vendored dependencies in the project's SCM repository
+  - If dependencies are downloaded at build time, even with proper version locks and checksums, we depend on external repositories which defeat the purpose of our [debian snapshot](https://github.com/gardenlinux/repo?tab=readme-ov-file#gardenlinux-repo-infrastructure)

--- a/docs/architecture/decisions/0004-vendoring-go-dependencies.md
+++ b/docs/architecture/decisions/0004-vendoring-go-dependencies.md
@@ -57,9 +57,9 @@ Adding multiple new packages for dependencies of a new Go package might be a lot
 ## Decision
 
 We allow vendoring dependencies for Go applications in Garden Linux.
+We require vendored dependencies to be commited to version control to allow reproduce releases.
 
 ## Consequences
 
 - We are able to follow upstream projects of applications written in Go (like containerd) more closely
-- To keep the promise of being able to reproduce releases, we require the full source code of vendored dependencies in the project's SCM repository
-  - If dependencies are downloaded at build time, even with proper version locks and checksums, we depend on external repositories which defeat the purpose of our [debian snapshot](https://github.com/gardenlinux/repo?tab=readme-ov-file#gardenlinux-repo-infrastructure)
+- If dependencies are downloaded at build time, even with proper version locks and checksums, we depend on external repositories which defeats the purpose of our [debian snapshot](https://github.com/gardenlinux/repo?tab=readme-ov-file#gardenlinux-repo-infrastructure)

--- a/docs/architecture/decisions/0004-vendoring-go-dependencies.md
+++ b/docs/architecture/decisions/0004-vendoring-go-dependencies.md
@@ -1,0 +1,64 @@
+# 4. Vendoring dependencies in Go Applications
+
+**Date:** 2024-08-01
+
+## Status
+
+Accepted
+
+## Context
+
+This document discusses the options and tradeoffs for packaging go applications in Garden Linux.
+
+### Build time vs run time dependencies
+
+When speaking of software dependencies, it is important to keep build time and run time dependencies apart.
+This document is concerned with build time dependencies in go applications.
+
+Build dependencies can be specified in the Garden Linux package build like in [this example](https://github.com/gardenlinux/package-ignition/blob/a5403d0e5473b63cf19a4fb2d4ac42f8ed979000/.github/workflows/build.yml#L11).
+
+### Traditional Linux distributions
+
+Linux distributions historically assume compiled languages work similar to C or C++.
+Build time dependencies are packaged as part of the distribution.
+If an application needs the `foo` library to build, installing a package named `libfoo-dev` or similar is the recommended solution.
+
+### The go ecosystem
+
+Like many modern programming language ecosystems, go has a dependency management system that works independent of linux package managers.
+Go is a compiled language, and it's known for producing large binary files with little to no run time dependencies.
+
+[go mod](https://go.dev/doc/modules/gomod-ref) is a tool to declare and manage build time dependencies for go applications.
+
+It's also common in go to manually copy dependencies in source code form in the repository.
+
+This process is described as 'vendoring'.
+`go mod` also supports the `go mod vendor` command to automate this process.
+
+### Debian's position
+
+Vendoring goes against the general idea of traditional linux distributions where dependencies are packaged on their own as described above.
+
+The following articles provide context on how vendoring of go code is viewed in Debian:
+
+- [LWN.net (January 13, 2021): Debian discusses vendoring—again](https://lwn.net/Articles/842319/)
+- [LWN.net (January 20, 2021): The Debian tech committee allows Kubernetes vendoring](https://lwn.net/Articles/843313/)
+
+### Qualities ensured by Garden Linux
+
+For Garden Linux, being able to reproduce disk images of previous releases is a crucial quality.
+In the past, one way to achieve this was to have all dependencies packages in the Garden Linux APT repository, and to de-vendor go applications when needed.
+
+### The downsides of de-vendoring
+
+To be able to build go applications without vendoring can mean quite a lot of effort as most likely Garden Linux does not package all the needed dependencies.
+Adding multiple new packages for dependencies of a new go package might be a lot of maintenance effort.
+
+## Decision
+
+We allow vendoring dependencies for go applications in Garden Linux.
+
+## Consequences
+
+- We are able to follow upstream projects of applications written in go (like containerd) more closely
+- To keep the promise of being able to reproduce releases bit-for-bit, (FIXME: how exactly does this work?)


### PR DESCRIPTION
Motivated by https://github.com/gardenlinux/package-containerd/pull/2
