### PR TITLE
Add script to compare apt repo versions

### DIFF
--- a/hack/compare-apt-repo-versions.sh
+++ b/hack/compare-apt-repo-versions.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -o nounset
 set -o errexit
-set -o pipefail
 
 SCRIPT_NAME="${0##*/}"
 readonly SCRIPT_NAME
@@ -27,14 +26,8 @@ main() {
 
     trap 'rm -rf $TEMP_DIR' EXIT
 
-    if [[ -z "${GARDENLINUX_DEBUG}" ]]; then
-        trap 'rm -rf $TEMP_DIR' EXIT
-    else
-        trap 'echo find the package files in: $TEMP_DIR' EXIT
-    fi
-
-    curl --silent --fail https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_A"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_A"
-    curl --silent --fail https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_B"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_B"
+    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_A"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_A"
+    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_B"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_B"
 
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_A" > "$TEMP_DIR"/a
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_B" > "$TEMP_DIR"/b

--- a/hack/compare-apt-repo-versions.sh
+++ b/hack/compare-apt-repo-versions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -o nounset
 set -o errexit
+set -o pipefail
 
 SCRIPT_NAME="${0##*/}"
 readonly SCRIPT_NAME
@@ -26,8 +27,14 @@ main() {
 
     trap 'rm -rf $TEMP_DIR' EXIT
 
-    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_A"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_A"
-    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_B"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_B"
+    if [[ -z "${GARDENLINUX_DEBUG}" ]]; then
+        trap 'rm -rf $TEMP_DIR' EXIT
+    else
+        trap 'echo find the package files in: $TEMP_DIR' EXIT
+    fi
+
+    curl --silent --fail https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_A"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_A"
+    curl --silent --fail https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_B"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_B"
 
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_A" > "$TEMP_DIR"/a
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_B" > "$TEMP_DIR"/b

--- a/hack/compare-apt-repo-versions.sh
+++ b/hack/compare-apt-repo-versions.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+
+SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_NAME
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+readonly SCRIPT_DIR
+
+usage() {
+    echo "Script to compare the apt repo version of two Garden Linux releases."
+    echo "Usage: $SCRIPT_NAME VERSION_A VERSION_B"
+    echo "Example: $SCRIPT_NAME 1443.10 1587.0"
+    exit 1
+}
+
+main() {
+    [[ $# -ge 2 ]] || usage
+    [[ -n "$1" ]] || usage
+    [[ -n "$2" ]] || usage
+    local VERSION_A="${1}"; shift
+    local VERSION_B="${1}"; shift
+
+    TEMP_DIR=$(mktemp -d)
+
+    trap 'rm -rf $TEMP_DIR' EXIT
+
+    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_A"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_A"
+    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION_B"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION_B"
+
+    python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_A" > "$TEMP_DIR"/a
+    python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_B" > "$TEMP_DIR"/b
+
+    diff "$TEMP_DIR"/a "$TEMP_DIR"/b
+}
+
+main "${@}"
+

--- a/hack/compare-apt-repo-versions.sh
+++ b/hack/compare-apt-repo-versions.sh
@@ -31,7 +31,7 @@ main() {
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_A" > "$TEMP_DIR"/a
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION_B" > "$TEMP_DIR"/b
 
-    diff "$TEMP_DIR"/a "$TEMP_DIR"/b
+    diff -U 0 --minimal  "$TEMP_DIR"/a "$TEMP_DIR"/b | grep -v '^@'
 }
 
 main "${@}"

--- a/hack/compare-apt-repo-versions.sh
+++ b/hack/compare-apt-repo-versions.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -o nounset
 set -o errexit
 
 SCRIPT_NAME="${0##*/}"

--- a/hack/get-selected-gl-bom.sh
+++ b/hack/get-selected-gl-bom.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -o errexit
+
+SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_NAME
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+readonly SCRIPT_DIR
+
+usage() {
+    echo "Get a list of important packages and their versions for a specific Garden Linux version."
+    echo "Usage: $SCRIPT_NAME VERSION"
+    echo "Example: $SCRIPT_NAME 1443.10"
+    exit 1
+}
+
+main() {
+    [[ $# -ge 1 ]] || usage
+    [[ -n "$1" ]] || usage
+    local VERSION="${1}"; shift
+
+    TEMP_DIR=$(mktemp -d)
+
+    trap 'rm -rf $TEMP_DIR' EXIT
+
+    curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION"
+    python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION" > "$TEMP_DIR"/packages
+    grep -E '^linux-image-amd64 |^systemd |^containerd |^runc |^curl |^openssl |^libc-bin ' "$TEMP_DIR"/packages
+}
+
+main "${@}"

--- a/hack/get-selected-gl-bom.sh
+++ b/hack/get-selected-gl-bom.sh
@@ -25,7 +25,7 @@ main() {
 
     curl -s https://packages.gardenlinux.io/gardenlinux/dists/"$VERSION"/main/binary-amd64/Packages.gz | gunzip > "$TEMP_DIR"/"$VERSION"
     python3 "$SCRIPT_DIR"/parse-aptsource.py "$TEMP_DIR"/"$VERSION" > "$TEMP_DIR"/packages
-    grep -E '^linux-image-amd64 |^systemd |^containerd |^runc |^curl |^openssl |^libc-bin ' "$TEMP_DIR"/packages
+    grep -E '^linux-image-amd64 |^systemd |^containerd |^runc |^curl |^openssl |^openssh-server |^libc-bin ' "$TEMP_DIR"/packages
 }
 
 main "${@}"

--- a/hack/parse-aptsource.py
+++ b/hack/parse-aptsource.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+
+# Based on code from glvd https://github.com/gardenlinux/glvd/blob/main/src/glvd/data/debsrc.py
+# To be used by compare-apt-repo-versions.sh, but can also be used alone to parse apt source files
+
+from __future__ import annotations
+
+import re
+from typing import TextIO
+
+class Debsrc():
+    def __init__(self, deb_source, deb_version):
+        self.deb_source = deb_source
+        self.deb_version = deb_version
+
+    deb_source: str
+    deb_version: str
+
+    def __repr__(self) -> str:
+        return f"{self.deb_source} {self.deb_version}"
+
+
+class DebsrcFile(dict[str, Debsrc]):
+    __re = re.compile(r'''
+        ^(?:
+            Package:\s*(?P<source>[a-z0-9.-]+)
+            |
+            Version:\s*(?P<version>[A-Za-z0-9.+~:-]+)
+            |
+            Extra-Source-Only:\s*(?P<eso>yes)
+            |
+            (?P<eoe>)
+            |
+            # All other fields
+            [A-Za-z0-9-]+:.*
+            |
+            # Continuation field
+            \s+.*
+        )$
+    ''', re.VERBOSE)
+
+    def _read_source(self, source: str, version: str) -> None:
+        self[source] = Debsrc(
+            deb_source=source,
+            deb_version=version,
+        )
+
+    def read(self, f: TextIO) -> None:
+        current_source = current_version = None
+
+        def finish():
+            if current_source and current_version:
+                self._read_source(current_source, current_version)
+
+        for line in f.readlines():
+            if match := self.__re.match(line):
+                if i := match['source']:
+                    current_source = i
+                elif i := match['version']:
+                    current_version = i
+                elif match['eso']:
+                    current_source = current_version = None
+                elif match['eoe'] is not None:
+                    finish()
+                    current_source = current_version = None
+            else:
+                raise RuntimeError(f'Unable to read line: {line}')
+
+        finish()
+
+
+if __name__ == '__main__':
+    import sys
+
+    d = DebsrcFile()
+    with open(sys.argv[1]) as f:
+        d.read(f)
+
+    for entry in d.values():
+        print(f'{entry!r}')


### PR DESCRIPTION
Helpful script to investigate differences in repo versions between different Garden Linux versions.

This script will download the apt source file of two given versions, unpack and compare them. Example output:
<img width="350" alt="Screenshot 2024-08-05 at 13 32 35" src="https://github.com/user-attachments/assets/4e31f73d-d4c8-4348-af03-cd468d694e31">

