### PR TITLE
Use iso 8601 date format

### DIFF
--- a/docs/02_operators/apt_repo.md
+++ b/docs/02_operators/apt_repo.md
@@ -16,7 +16,7 @@ Packages are built, signed and deployed via the Garden Linux package and repo bu
 
 
 ## Versioning
-`$major` is the number of days since `31.03.2020`.
+`$major` is the number of days since `2020-03-31`.
 
 For each day since we switched to an own package repository, 
 we offer a respective distribution in our repo.gardenlinux.io apt repository.


### PR DESCRIPTION
Tiny nitpick, but the iso 8601 is more appropriate in an English text compared to the former way of using the German standard for noting dates.

More information on the date format:

- https://www.iso.org/iso-8601-date-and-time-format.html
- https://xkcd.com/1179/
