### PR TITLE
Include sbom information in release notes

### DIFF
--- a/.github/workflows/parse_aptsource.py
+++ b/.github/workflows/parse_aptsource.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+
+# Based on code from glvd https://github.com/gardenlinux/glvd/blob/main/src/glvd/data/debsrc.py
+
+from __future__ import annotations
+
+import re
+from typing import TextIO
+
+class Debsrc():
+    def __init__(self, deb_source, deb_version):
+        self.deb_source = deb_source
+        self.deb_version = deb_version
+
+    deb_source: str
+    deb_version: str
+
+    def __repr__(self) -> str:
+        return f"{self.deb_source} {self.deb_version}"
+
+
+class DebsrcFile(dict[str, Debsrc]):
+    __re = re.compile(r'''
+        ^(?:
+            Package:\s*(?P<source>[a-z0-9.-]+)
+            |
+            Version:\s*(?P<version>[A-Za-z0-9.+~:-]+)
+            |
+            Extra-Source-Only:\s*(?P<eso>yes)
+            |
+            (?P<eoe>)
+            |
+            # All other fields
+            [A-Za-z0-9-]+:.*
+            |
+            # Continuation field
+            \s+.*
+        )$
+    ''', re.VERBOSE)
+
+    def _read_source(self, source: str, version: str) -> None:
+        self[source] = Debsrc(
+            deb_source=source,
+            deb_version=version,
+        )
+
+    def read(self, f: TextIO) -> None:
+        current_source = current_version = None
+
+        def finish():
+            if current_source and current_version:
+                self._read_source(current_source, current_version)
+
+        for line in f.readlines():
+            if match := self.__re.match(line):
+                if i := match['source']:
+                    current_source = i
+                elif i := match['version']:
+                    current_version = i
+                elif match['eso']:
+                    current_source = current_version = None
+                elif match['eoe'] is not None:
+                    finish()
+                    current_source = current_version = None
+            else:
+                raise RuntimeError(f'Unable to read line: {line}')
+
+        finish()
+
+
+if __name__ == '__main__':
+    import sys
+
+    d = DebsrcFile()
+    with open(sys.argv[1]) as f:
+        d.read(f)
+
+    for entry in d.values():
+        print(f'{entry!r}')

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -228,7 +228,7 @@ def create_github_release_notes(gardenlinux_version, commitish):
         d.read(f)
         packages_regex = re.compile(r'^linux-image-amd64$|^systemd$|^containerd$|^runc$|^curl$|^openssl$|^openssh-server$|^libc-bin$')
         for entry in d.values():
-            if re.match(packages_regex, entry.deb_source):
+            if packages_regex.match(entry.deb_source):
                 output += f'{entry!r}\n'
     output += "```"
     output += "\n"

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -11,8 +11,11 @@ import urllib.request
 from botocore import UNSIGNED
 from botocore.client import Config
 import argparse
+import gzip
+import re
 
 from get_kernelurls import get_kernel_urls
+from parse_aptsource import DebsrcFile
 
 GARDENLINUX_GITHUB_RELEASE_BUCKET_NAME="gardenlinux-github-releases"
 
@@ -215,7 +218,21 @@ def create_github_release_notes(gardenlinux_version, commitish):
     manifests = download_all_singles(gardenlinux_version, commitish_short)
 
     output += generate_release_note_image_ids(manifests)
-    
+
+    output += "\n"
+    output += "## Software Component Versions\n"
+    output += "```"
+    (path, headers) = urllib.request.urlretrieve(f'https://packages.gardenlinux.io/gardenlinux/dists/{gardenlinux_version}/main/binary-amd64/Packages.gz')
+    with gzip.open(path, 'rt') as f:
+        d = DebsrcFile()
+        d.read(f)
+        packages_regex = re.compile(r'^linux-image-amd64$|^systemd$|^containerd$|^runc$|^curl$|^openssl$|^openssh-server$|^libc-bin$')
+        for entry in d.values():
+            if re.match(packages_regex, entry.deb_source):
+                output += f'{entry!r}\n'
+    output += "```"
+    output += "\n"
+
     output += "\n"
     output += "## Kernel Package direct download links\n"
     output += get_kernel_urls(gardenlinux_version)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a list of selected packages with their respective versions to the release notes workflow.
This should give Garden Linux developers and users a way to quickly identify the versions of relevant components in a specific Garden Linux version.
