### PR TITLE
Release note dry run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ make_targets.cache
 /bin/*.permall
 /bin/swtpm-sock
 .DS_Store
+venv


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a simple dry-run flag, so that we can re-generate the release note locally without uploading changes directly to a release in GitHub. 

**Special notes for your reviewer**:
Follow up for #2256 
