### PR TITLE
revert changes from #1874

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,3 @@ updates:
     versioning-strategy: "increase-if-necessary"
     reviewers:
       - "gardenlinux/garden-linux-maintainers"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - "gardenlinux/garden-linux-maintainers"

--- a/build
+++ b/build
@@ -6,7 +6,7 @@ shopt -s nullglob
 exec 3>&1
 exec 1>&2
 
-container_image=localhost/builder
+container_image=ghcr.io/gardenlinux/builder:191279b0a54c227851413077283c69df29ce7335
 container_engine=podman
 target_dir=.build
 
@@ -78,14 +78,7 @@ done
 
 if [ "$container_image" = localhost/builder ]; then
 	dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
-	# Build from 'builder.dockerfile' if that exists, otherwise the default file name will be 'Dockerfile' or 'Containerfile'.
-	# It is recommended to call the file 'builder.dockerfile' to make it's intention clear.
-	# That file might only contain a single line 'FROM ghcr.io/gardenlinux/builder:...' which can be updated via dependabot.
-	if [[ -f "${dir}"/builder.dockerfile ]]; then
-		"$container_engine" build -t "$container_image" -f "${dir}"/builder.dockerfile "$dir"
-	else 
-		"$container_engine" build -t "$container_image" "$dir"
-	fi
+	"$container_engine" build -t "$container_image" "$dir"
 fi
 
 repo="$(./get_repo)"

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,3 +1,0 @@
-# Dependency management via Dependabot
-
-FROM ghcr.io/gardenlinux/builder:191279b0a54c227851413077283c69df29ce7335


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplify the build by removing the dockerfile indirection.
This was intended to be used with dependabot but never really worked with how the builder image is published, so we can just remove it to simplify.