### PR TITLE
Revert disable openstack arm64 for rel-1592

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,13 +159,6 @@ jobs:
           - target: container
             arch: arm64
             modifier: ""
-        exclude:
-          - target: openstack
-            arch: arm64
-            modifier: "${{ inputs.default_modifier }}"
-          - target: vmware
-            arch: arm64
-            modifier: "${{ inputs.default_modifier }}"
     steps:
       # - uses: gardenlinux/workflow-telemetry-action@c75b594f552d305ffd5f9074637137bc343ba35e # pin@v2
       #   with:

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -33,13 +33,6 @@ jobs:
         arch: [ amd64, arm64 ]
         target: [ kvm, "kvm_secureboot", "kvm_secureboot_readonly", "kvm_secureboot_readonly_persistence", metal, "metal_secureboot", "metal_secureboot_readonly", "metal_secureboot_readonly_persistence", gcp, gdch, aws, "aws_secureboot", "aws_secureboot_readonly", "aws_secureboot_readonly_persistence", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
         modifier: [ "${{ inputs.default_modifier }}" ]
-        exclude:
-          - target: openstack
-            arch: arm64
-            modifier: "${{ inputs.default_modifier }}"
-          - target: vmware
-            arch: arm64
-            modifier: "${{ inputs.default_modifier }}"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup


### PR DESCRIPTION
This reverts commit f43dbbf49784e4a74183cb86bd2ceecf809e4aca.

**What this PR does / why we need it**:
Enable openstack arm64 targets in build.yml action and upload_to_s3.yml action. 
 
**Which issue(s) this PR fixes**:
Fixes #2265

**Special notes for your reviewer**:
open-vm-tools is available in 1592.0 repo in general (see https://github.com/gardenlinux/repo/blob/41d727a2e85314cd4fc772d33e8d15e7bbe8876b/package-imports#L97) and also for arm64 specifically (checked with hack/gl-search.sh). 

As documented in the commit message of the reverted  f43dbbf commit, `open-vm-tools` was missing. It is back in debian testing. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
enable arm64 openstack images
```
