### PR TITLE
Initial releases.json file

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,16 @@
+{
+    "releases": [
+        {
+            "version": "1592.1",
+            "iseol": false,
+        },
+        {
+            "version": "1592.0",
+            "iseol": true,
+        },
+        {
+            "version": "1443.10",
+            "iseol": false,
+        }
+  ]
+}


### PR DESCRIPTION
This file is supposed to be updated automatically when a new release is performed. It should always contain up-to-date information on maintained Garden Linux releases. This is relevant for glvd and it might also be useful for other tooling.

There are ways to find out about existing releases (for example git tags, github releases, ..) but they don't provide life-cycle information (for example if a version is eol or not).

This file should have more fields indicating the exact status of a release, and that needs to be updated automatically (for example by the 'create release notes' workflow).

see https://github.com/gardenlinux/gardenlinux/issues/2296
