### PR TITLE
CI: Publish machine-readable junit-xml logs for platform tests (#2305)

### DIFF
--- a/.github/workflows/ali_tests.sh
+++ b/.github/workflows/ali_tests.sh
@@ -7,9 +7,6 @@ cname="${@: -1}"
 configFile="ali_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.qcow2"
@@ -47,11 +44,11 @@ EOF
 
 
 echo "### Start Integration Tests for ali"
-podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs" $containerName /bin/bash -s << EOF
+podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 ssh-keygen -t rsa -b 4096 -f /gardenlinux/tmp/id_rsa -N "" -q
 cd /gardenlinux/tests
-pytest --iaas=ali --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-ali_junit.xml || exit 1
+pytest --iaas=ali --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.integration-tests-log-junit.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/aws_tests.sh
+++ b/.github/workflows/aws_tests.sh
@@ -21,9 +21,6 @@ cname=$1
 configFile="aws_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.raw"
@@ -64,10 +61,10 @@ aws:
 EOF
 
 echo "### Start Integration Tests for AWS"
-podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs"  $containerName /bin/bash -s << EOF
+podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
-pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-aws_junit.xml || exit 1
+pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.integration-tests-log-junit.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/azure_tests.sh
+++ b/.github/workflows/azure_tests.sh
@@ -7,12 +7,9 @@ cname="${@: -1}"
 configFile="azure_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
 
 azure_hyper_v_generation="V1"
 azure_vm_size="Standard_D4_v4"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.vhd"
@@ -47,10 +44,10 @@ azure:
 EOF
 
 echo "### Start Integration Tests for Azure"
-podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts"  -v "$platform_test_log_dir:/platform-test-logs" $containerName /bin/bash -s << EOF
+podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
-pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-azure_junit.xml || exit 1
+pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.integration-tests-log-junit.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -7,7 +7,6 @@ cname="${@: -1}"
 configFile="gcp_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
 
 mkdir -p "$platform_test_log_dir"
 
@@ -75,13 +74,13 @@ EOF
 
 
 echo "### Start Integration Tests for gcp"
-podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs" $containerName /bin/bash -s << EOF
+podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
 export GOOGLE_APPLICATION_CREDENTIALS="/gardenlinux/$credentials_file_name"
 export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="/gardenlinux/$credentials_file_name"
 export GOOGLE_GHA_CREDS_PATH="/gardenlinux/$credentials_file_name"
-pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-gcp_junit.xml || exit 1
+pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.integration-tests-log-junit.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -103,11 +103,15 @@ jobs:
           commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
           prefix="${{ matrix.cname }}-${{ matrix.architecture }}-${{ inputs.version }}-$commit"
           aws s3 cp "s3://${{ secrets.AWS_S3_BUCKET }}/objects/$prefix/$prefix.test-log" ./
+          aws s3 cp "s3://${{ secrets.AWS_S3_BUCKET }}/objects/$prefix/$prefix.test-log-junit.xml" ./
       - name: upload to release
         run: |
           commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
           release="$(cat .github_release_id)"
           prefix="${{ matrix.cname }}-${{ matrix.architecture }}-${{ inputs.version }}-$commit"
           echo "$release $prefix.test-log"
+          echo "$release $prefix.test-log-junit.xml"
           ls -lah "$prefix.test-log"
+          ls -lah "$prefix.test-log-junit.xml"
           echo "$prefix.test-log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          echo "$prefix.test-log-junit.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
       azure_subscription_id: ${{ secrets.az_subscription_id }}
       AZURE_CONFIG_DIR: /tmp/azure_config_dir
       TARGET_ARCHITECTURE: ${{ matrix.arch }}
+      artifact_dir: /tmp/gardenlinux-build-artifacts
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,9 +89,9 @@ jobs:
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
       with:
         name: ${{ env.cname }}
-        path: /tmp/gardenlinux-build-artifacts
+        path: ${{ env.artifact_dir }}
 
-    - run: ls -lah /tmp/gardenlinux-build-artifacts
+    - run: ls -lah ${{ env.artifact_dir }}
 
     - if: ${{ matrix.target == 'gcp' }}
       id: 'auth_gcp'
@@ -131,9 +132,11 @@ jobs:
     - name: start platform test for ${{ matrix.target }}
       run: |
         set -o pipefail
-        .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}" 2>&1 | tee "${{ env.cname }}.integration-tests-log"
+        .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}" 2>&1 | tee "${{ env.artifact_dir}}/${{ env.cname }}.integration-tests-log"
 
     - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
       with:
         name: tests-${{ env.cname }}
-        path: ${{ env.cname }}.integration-tests-log
+        path: |
+          ${{ env.artifact_dir }}/${{ env.cname }}.integration-tests-log
+          ${{ env.artifact_dir }}/${{ env.cname }}.integration-tests-log-junit.xml

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -95,4 +95,6 @@ jobs:
         with:
           name: tests-${{ env.cname }}
       - name: upload to S3 bucket ${{ secrets.bucket }}
-        run: aws s3 cp "${{ env.cname }}.integration-tests-log" "s3://${{ secrets.bucket }}/objects/${{ env.cname }}/"
+        run: |
+          aws s3 cp "${{ env.cname }}.integration-tests-log" "s3://${{ secrets.bucket }}/objects/${{ env.cname }}/"
+          aws s3 cp "${{ env.cname }}.integration-tests-log-junit.xml" "s3://${{ secrets.bucket }}/objects/${{ env.cname }}/"


### PR DESCRIPTION
**What this PR does / why we need it**:

This publishes the already generated junit-xml reports as artifacts to S3.
The part from #2305 about bundling tests in suites is still missing.

**Which issue(s) this PR fixes**:
Fixes #2305

**Special notes for your reviewer**:
I was not able to test the code changes yet.
