### PR TITLE
Block project wide SSH keys in GCP platform tests

### DIFF
--- a/tests/integration/gcp.py
+++ b/tests/integration/gcp.py
@@ -518,6 +518,10 @@ class GCP:
                     {
                         "key": "startup-script",
                         "value" : startup_script
+                    },
+                    {
+                        "key": "block-project-ssh-keys",
+                        "value": "true"
                     }
                 ]
             },


### PR DESCRIPTION
**What this PR does / why we need it**:

Virtual machines used in GCP platform tests must not import/include project wide SSH keys but only those that are explicitly specified in the test code.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Project wide SSH keys are now blocked on virtual machines for GCP platform tests.
```
