### PR TITLE
vmware: Fix ova vmdk size

### DIFF
--- a/features/vmware/make-ova
+++ b/features/vmware/make-ova
@@ -48,7 +48,7 @@ class OVAImageBuild:
             sys.exit("Error getting image info for " + filename + ": " + result.stdout)
 
         doc = json.loads(result.stdout)
-        fileSize = doc["actual-size"]
+        fileSize = os.stat(filename).st_size
         virtualSize = doc["format-specific"]["data"]["extents"][0]["virtual-size"]
         return (fileSize, virtualSize)
 


### PR DESCRIPTION
The actual-size is not the actual file size.
Not sure what it is, but differs from st_size and vsphere aborts loading files with the value qemu, 
but accepts them with the st_size value, which matches also what tar reports, when it is in the ova.

**What this PR does / why we need it**:

Fixes #2322

**Special notes for your reviewer**:

**Release note**:
```
bugfix operator Fixes the import of OVA by correcting the `ovf:size` attribute
```
