### PR TITLE
Various pxe fixes

### DIFF
--- a/features/_ignite/file.include/usr/lib/dracut/modules.d/30ignition-extra/after-net-online.conf
+++ b/features/_ignite/file.include/usr/lib/dracut/modules.d/30ignition-extra/after-net-online.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=network-online.target
+Wants=network-online.target

--- a/features/_ignite/file.include/usr/lib/dracut/modules.d/30ignition-extra/module-setup.sh
+++ b/features/_ignite/file.include/usr/lib/dracut/modules.d/30ignition-extra/module-setup.sh
@@ -8,4 +8,5 @@ install() {
     # ignition environment
     inst_script "$moddir/ignition-env-generator.sh" $systemdutildir/system-generators/ignition-env-generator
     inst_simple "$moddir/ignition-files.env" /etc/ignition-files.env
+    inst_simple "$moddir/after-net-online.conf" "/etc/systemd/system/ignition-fetch.service.d/after-net-online.conf"
 }

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/99-any.conf
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/99-any.conf
@@ -1,3 +1,5 @@
 [Service]
 ExecStart=
 ExecStart=/lib/systemd/systemd-networkd-wait-online --any
+[Unit]
+ConditionPathExists=

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-get-squashfs.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/live-get-squashfs.sh
@@ -16,7 +16,7 @@ if [ -z "${url#gl.url=}" ]; then
 	exit 0
 fi
 
-if ! curl --globoff --location --retry 3 --fail --show-error "${url}" --output "${squashFile}"; then
+if ! curl --globoff --location --retry 10 --retry-delay 3 --retry-max-time 30 --fail --show-error "${url}" --output "${squashFile}"; then
        warn "can't fetch the squashfs from ${url#gl.url=}"
        exit 1
 fi       

--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
@@ -26,7 +26,7 @@ install() {
     #inst_simple "/usr/lib/file/magic.mgc" "/usr/lib/file/magic.mgc"
 
     mkdir -m 0755 -p ${initdir}/etc/systemd/system/systemd-networkd-wait-online.service.d
-    inst_simple "$moddir/any.conf" "/etc/systemd/system/systemd-networkd-wait-online.service.d/any.conf"
+    inst_simple "$moddir/99-any.conf" "/etc/systemd/system/systemd-networkd-wait-online.service.d/99-zany.conf"
 
     # ignition-fetch after resolved
     mkdir -m 0755 -p "${initdir}/etc/systemd/system/ignition-fetch.service.d"


### PR DESCRIPTION
**What this PR does / why we need it**:
ignition-fetch.service is starting too soon with the default configuration, it should start after _network-online.target_
_systemd-networkd-wait-online.service_ should not start only if _/run/networkd/initrd/neednet_ exists[^1]
when fetching the squashfs, retry multiple times and retry on all errors

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

[^1]: https://github.com/dracut-ng/dracut-ng/blob/103/modules.d/01systemd-networkd/99-wait-online-dracut.conf#L3
