### PR TITLE
ci: update actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
         run: echo "${{ env.cname }}.chroot.test.xml" >> ".build/${{ env.cname }}.artifacts"
       - name: pack build artifacts for upload
         run: tar -cSzvf "${{ env.cname }}.tar.gz" -C .build -T ".build/${{ env.cname }}.artifacts"
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
         with:
           name: "build-${{ env.cname }}"
           path: "${{ env.cname }}.tar.gz"
@@ -281,7 +281,7 @@ jobs:
           cd bare_flavors/${{ matrix.config }}/test
           podman build -t test --build-arg image="$image" .
           podman run --rm test
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
         with:
           name: "build-bare-${{ matrix.config }}-${{ matrix.arch }}"
           path: ".build/bare_flavors/${{ matrix.config }}-${{ matrix.arch }}.oci"

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -25,10 +25,10 @@ jobs:
           cname_arm64="$(./build --resolve-cname container-arm64)"
           echo "cname_amd64=$cname_amd64" | tee -a "$GITHUB_ENV"
           echo "cname_arm64=$cname_arm64" | tee -a "$GITHUB_ENV"
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: build-${{ env.cname_amd64 }}
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: build-${{ env.cname_arm64 }}
       - name: publish gardenlinux container base image
@@ -122,10 +122,10 @@ jobs:
         config: [ libc, python, nodejs, sapmachine ]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: build-bare-${{ matrix.config }}-amd64
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: build-bare-${{ matrix.config }}-arm64
       - run: ls -lah

--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           .github/workflows/release_note.py create --tag ${{ inputs.version }} --commit "$(echo "${{ inputs.commit }}")"  
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
         with:
           name: release
           path: .github_release_id
@@ -49,7 +49,7 @@ jobs:
         cname: [ kvm-gardener_prod, metal-gardener_prod, gcp-gardener_prod, gdch-gardener_prod, aws-gardener_prod, azure-gardener_prod, ali-gardener_prod, openstack-gardener_prod, openstackbaremetal-gardener_prod, vmware-gardener_prod, metal-gardener_prod_pxe ]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: release
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4

--- a/.github/workflows/stig.yaml
+++ b/.github/workflows/stig.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build the image
         run: ./build ${{ matrix.platform}}-stig
       - name: Upload build logs
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
         with:
           name: STIG-${{ matrix.platform}}-logs
           path: .build/*log

--- a/.github/workflows/stig.yaml
+++ b/.github/workflows/stig.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build the image
         run: ./build ${{ matrix.platform}}-stig
       - name: Upload build logs
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
         with:
           name: STIG-${{ matrix.platform}}-logs
           path: .build/*log

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
         cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
         echo "cname=$cname" | tee -a "$GITHUB_ENV"
 
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
       with:
         name: build-${{ env.cname }}
         path: ${{ env.artifact_dir }}
@@ -134,7 +134,7 @@ jobs:
         set -o pipefail
         .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}" 2>&1 | tee "${{ env.artifact_dir}}/${{ env.cname }}.platform.test.log"
 
-    - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
+    - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # pin@v4.4.0
       with:
         name: platform-test-${{ env.cname }}
         path: |

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -49,11 +49,11 @@ jobs:
         run: |
           cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
           echo "cname=$cname" | tee -a "$GITHUB_ENV"
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: build-${{ env.cname }}
           path: build-${{ env.cname }}
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v4.1.8
         with:
           name: platform-test-${{ env.cname }}
           path: platform-test-${{ env.cname }}


### PR DESCRIPTION
**What this PR does / why we need it**:

v3 is scheduled for deprecation on November 30, 2024

**Special notes for your reviewer**:

There are breaking changes:
- https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
- https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes

checked:
- We are not uploading to the same named Artifact multiple times.
- I think we do not have the use case of downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.