### PR TITLE
ci: use pattern to download build and platform-test artifacts

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -51,14 +51,8 @@ jobs:
           echo "cname=$cname" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
         with:
-          name: build-${{ env.cname }}
-          path: build-${{ env.cname }}
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
-        with:
-          name: platform-test-${{ env.cname }}
-          path: platform-test-${{ env.cname }}
-        # artifacts might not exist if no platform-test ran (e.g. excluded)
-        continue-on-error: true
+          # match build-${{ env.cname }} and  platform-test-${{ env.cname }}
+          pattern: "*-${{ env.cname }}"
       # repack tar.gz from build workflow to contain platform-test logs (if they exist)
       - name: add platform-test logs to tar.gz
         run: |


### PR DESCRIPTION
This way, we only need one download step and the second step does not fail in case there are no platform-test logs uploaded by a previous workflow.

**What this PR does / why we need it**:

This PR is related to the error messages we see in https://github.com/gardenlinux/gardenlinux/issues/2328#issuecomment-2342921558.
These errors are actually expected as there are no platform-test logs for certain platforms. Currently a `continue-on-error: true` is build in for downloading the platform-test logs. This is working out but is a bit noisy.

This PR tries to get rid of those error messages by downloading all available artifacts for `*-${{ env.name}}`.

**Which issue(s) this PR fixes**:
Fixes #2328

**Special notes for your reviewer**:

This pattern should work according to https://github.com/actions/download-artifact?tab=readme-ov-file#inputs.
