### PR TITLE
feat: _tpm2

### DIFF
--- a/features/_tpm2/exec.config
+++ b/features/_tpm2/exec.config
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+systemctl enable check-tpm.service

--- a/features/_tpm2/file.include/etc/repart.d/10-var.conf
+++ b/features/_tpm2/file.include/etc/repart.d/10-var.conf
@@ -1,0 +1,6 @@
+[Partition]
+Type=var
+Weight=15
+Label=VAR
+Format=ext4
+Encrypt=tpm2

--- a/features/_tpm2/file.include/etc/systemd/system-generators/detect-tpm
+++ b/features/_tpm2/file.include/etc/systemd/system-generators/detect-tpm
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ -e /sys/firmware/acpi/tables/TPM2 ]; then
+	mkdir "$1/reload.target.wants"
+	ln -s ../tpm2.target "$1/reload.target.wants/tpm2.target"
+	ln -s ../systemd-tpm2-setup.service "$1/reload.target.wants/systemd-tpm2-setup.service"
+	ln -s ../systemd-tpm2-setup-early.service "$1/reload.target.wants/systemd-tpm2-setup-early.service"
+fi

--- a/features/_tpm2/file.include/etc/systemd/system/check-tpm.service
+++ b/features/_tpm2/file.include/etc/systemd/system/check-tpm.service
@@ -1,0 +1,13 @@
+[Unit]
+DefaultDependencies=no
+After=tpm2.target
+Before=local-fs-pre.target
+Before=systemd-repart.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/check-tpm
+RemainAfterExit=yes
+
+[Install]
+WantedBy=local-fs.target

--- a/features/_tpm2/file.include/etc/systemd/system/systemd-cryptsetup@var.service
+++ b/features/_tpm2/file.include/etc/systemd/system/systemd-cryptsetup@var.service
@@ -1,0 +1,20 @@
+[Unit]
+DefaultDependencies=no
+After=cryptsetup-pre.target systemd-udevd-kernel.socket systemd-tpm2-setup-early.service
+Before=blockdev@dev-mapper-var.target
+Wants=blockdev@dev-mapper-var.target
+IgnoreOnIsolate=true
+Conflicts=umount.target
+Before=umount.target
+Before=cryptsetup.target
+After=systemd-repart.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutSec=infinity
+KeyringMode=shared
+OOMScoreAdjust=500
+ImportCredential=cryptsetup.*
+ExecStart=/usr/bin/systemd-cryptsetup attach var /dev/disk/by-partlabel/VAR
+ExecStop=/usr/bin/systemd-cryptsetup detach var

--- a/features/_tpm2/file.include/etc/systemd/system/var.mount
+++ b/features/_tpm2/file.include/etc/systemd/system/var.mount
@@ -1,0 +1,11 @@
+[Unit]
+Requires=systemd-cryptsetup@var.service
+After=systemd-cryptsetup@var.service
+
+[Mount]
+What=/dev/mapper/var
+Where=/var
+Type=ext4
+
+[Install]
+WantedBy=local-fs.target

--- a/features/_tpm2/file.include/usr/bin/check-tpm
+++ b/features/_tpm2/file.include/usr/bin/check-tpm
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+if [ ! -c /dev/tpmrm0 ]; then
+	printf '\e[1;31mNo TPM2.0 device found!\e[0m\n' > /dev/kmsg
+	halt -f
+fi
+
+secureboot_state=0
+efivars_path=/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c
+
+if [ -f "$efivars_path" ]; then
+	secureboot_state="$(od -An -j4 -N1 -t u1 "$efivars_path" | tr -d ' ')"
+fi
+
+if [ "$secureboot_state" != 1 ]; then
+	printf '\e[1;31mSecureboot not enabled!\e[0m\n' > /dev/kmsg
+	halt -f
+fi

--- a/features/_tpm2/info.yaml
+++ b/features/_tpm2/info.yaml
@@ -1,0 +1,5 @@
+description: "TPM2.0 backed encrypted var partition"
+type: flag
+features:
+  exclude:
+    - _ephemeral

--- a/features/_tpm2/pkg.include
+++ b/features/_tpm2/pkg.include
@@ -1,0 +1,2 @@
+systemd-cryptsetup
+tpm2-tools


### PR DESCRIPTION
provide an alternative implementation of mutable data handling for _trustedboot this uses a TPM 2.0 device to store the disk encryption secrets instead of using boot time random gen keys this allows for data to persist across reboots