### PR TITLE
make sure the `use_kms` input is always set

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,7 @@ name: nightly
 on:
   schedule:
     - cron: '0 6 * * *'
+  # triggered manually
   workflow_dispatch:
     inputs:
       version:
@@ -20,7 +21,7 @@ jobs:
     with:
       version: ${{ inputs.version || 'now' }}
       default_modifier: "-gardener_prod"
-      use_kms: ${{ github.event.inputs.use_kms == 'true' }}
+      use_kms: ${{ inputs.use_kms != null && inputs.use_kms || true }}        
     secrets:
       secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}
       aws_region: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The input `use_kms` is not set on sheduled `nightly` runs (not `workflow_dispatch`).

**Which issue(s) this PR fixes**:
fixes #2356

