### PR TITLE
add .`/bin` to `$PATH` to run `upload_to_s3.sh` from everywhere

### DIFF
--- a/.github/workflows/upload_to_s3.sh
+++ b/.github/workflows/upload_to_s3.sh
@@ -2,6 +2,9 @@
 
 set -Eexuo pipefail
 
+ROOT_DIR=$(git rev-parse --show-toplevel)
+PATH="${ROOT_DIR}/bin:${PATH}"
+
 bucket="$1"
 name="$(sed 's/.tar.gz$//g' <<< "$2")"
 platform="$(cut -d - -f 1 <<< "$name")"
@@ -23,7 +26,7 @@ architecture: '$arch'
 base_image: null
 build_committish: '$GARDENLINUX_COMMIT_ID_LONG'
 build_timestamp: '$timestamp'
-gardenlinux_epoch: $(bin/garden-version --major "$GARDENLINUX_VERSION")
+gardenlinux_epoch: $(garden-version --major "$GARDENLINUX_VERSION")
 logs: null
 modifiers: [$GARDENLINUX_FEATURES]
 platform: '$platform'


### PR DESCRIPTION
**What this PR does / why we need it**:

- With https://github.com/gardenlinux/gardenlinux/pull/2308, the `gardenlinux_epoch` field ([ref](https://github.com/gardenlinux/gardenlinux/blob/cab0e41af85cc0812789972d078aaefa8a86d683/.github/workflows/upload_to_s3.sh#L26)) in the release manifests is no longer populated during the `nightly` jobs because the `garden-version` binary cannot be found ([ref](https://github.com/gardenlinux/gardenlinux/actions/runs/11027206393/job/30626455757#step:9:78)). This is probably because of changing the PWD [right here](https://github.com/gardenlinux/gardenlinux/blame/cab0e41af85cc0812789972d078aaefa8a86d683/.github/workflows/upload_to_s3.yml#L70).
- a possible fix is to add .`/bin` to `$PATH` to run `upload_to_s3.sh` from everywhere


**Which issue(s) this PR fixes**:
Fixes #2368 