### PR TITLE
chore: log errors correctly

### DIFF
--- a/bin/.constants.sh
+++ b/bin/.constants.sh
@@ -30,7 +30,7 @@ if [ "Darwin" == $build_os ]; then
 
     # Fail when we can not find any GNU getopt package
     if [ "unset" == $getopt_gnu ]; then
-        echo "No GNU getopt binary for macOS found. Please make sure to install it by Brew or MacPorts."
+        echo "No GNU getopt binary for macOS found. Please make sure to install it by Brew or MacPorts." >&2
         exit 1
     fi
 
@@ -67,13 +67,13 @@ __cgetopt() {
 					shift
 				;;
 			--) break ;;
-			*) echo >&2 "error: unexpected $BASH_SOURCE flag '$flag'"; exit 1 ;;
+			*) echo "error: unexpected $BASH_SOURCE flag '$flag'" >&2; exit 1 ;;
 		esac
 	done
 	local dup=$(sort <<< ${dFlags//,/$'\n'} | uniq -d)
-	[ -n "$dup" ] && { echo "error: duplicate in flags definition \"${dup//$'\n'/\" \"}\""; exit 1; }
+	[ -n "$dup" ] && { echo "error: duplicate in flags definition \"${dup//$'\n'/\" \"}\"" >&2; exit 1; }
 	dup=$(grep -o . <<< ${dFlagsShort} | sort | uniq -d)
-	[ -n "$dup" ] && { echo "error: duplicate in flags-short definition \"${dup//$'\n'/\" \"}\""; exit 1; }
+	[ -n "$dup" ] && { echo "error: duplicate in flags-short definition \"${dup//$'\n'/\" \"}\"" >&2; exit 1; }
 
 	return 0 
 }

--- a/bin/garden-version
+++ b/bin/garden-version
@@ -8,6 +8,13 @@ versionfile="$(readlink -f "${thisDir}/../VERSION")"
 startdate="Mar 31 00:00:00 UTC 2020"
 build_os="$(uname -s)"
 
+function check_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: The binary '$1' could not be found. Please make sure to install it." >&2
+    exit 1
+  fi
+}
+
 # Use "gdate" & sed (GNU) which must be installed by "Homebrew"
 # on macOS systems to have a normalized date interface
 if [ "Darwin" == $build_os ]; then
@@ -17,6 +24,8 @@ else
         date_gnu="date"
         sed_gnu="sed"
 fi
+check_command "$date_gnu"
+check_command "$sed_gnu"
 
 source "${thisDir}/.constants.sh" \
 	--flags 'major,minor,date,datefull,epoch,git' \


### PR DESCRIPTION
This moves some log outputs from stdout to stderr to give users some
information which binaries are missing when running the toolchain
