### PR TITLE
features/base/test/test_sgid_suid_files: add mount.nfs

### DIFF
--- a/features/base/test/test_sgid_suid_files.py
+++ b/features/base/test/test_sgid_suid_files.py
@@ -27,7 +27,8 @@ import pytest
                  "/usr/bin/sudo,root,root",
                  "/usr/bin/passwd,root,root",
                  "/usr/lib/polkit-1/polkit-agent-helper-1,root,root",
-                 "/usr/bin/pkexec,root,root"
+                 "/usr/bin/pkexec,root,root",
+                 "/usr/sbin/mount.nfs,root,root"
                  ]
         )
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

`mount.nfs` is available on certain flavors/features and is another suid binary.
It is not yet allow-listed in `features/base/test/test_sgid_suid_files.py`.

**Which issue(s) this PR fixes**:
Fixes #2375 