### PR TITLE
better support docker build engine for cert building

### DIFF
--- a/cert/build
+++ b/cert/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eufo pipefail
+set -efo pipefail
 
 dir="$(dirname "${BASH_SOURCE[0]}")"
 
@@ -21,6 +21,9 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 		--container-engine)
 			container_engine="$2"
+			if [ "$container_engine" = "docker" ]; then
+				container_run_opts=()
+			fi
 			shift 2
 			;;
 		--container-run-opts)
@@ -50,7 +53,7 @@ fi
 
 if [ -z "$container_image" ]; then
 	image_file="$(mktemp)"
-	"$container_engine" build --iidfile "$image_file" "$dir"
+	"$container_engine" build --iidfile "$image_file" -f "$dir/Containerfile" "$dir"
 	container_image="$(cat "$image_file")"
 	rm "$image_file"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
`./cert/build --container-engine docker` didn't worked since docker couldn't find the Containerfile

**Which issue(s) this PR fixes**:
Fixes #2385

**Special notes for your reviewer**:
Nope

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
