### PR TITLE
bump builder version

### DIFF
--- a/build
+++ b/build
@@ -6,7 +6,7 @@ shopt -s nullglob
 exec 3>&1
 exec 1>&2
 
-container_image=ghcr.io/gardenlinux/builder:357fbe01a5a95854ccb5065c28fc6eca13466a46
+container_image=ghcr.io/gardenlinux/builder:4f276755fda93d7716c34087ceef2b054b818db1
 container_engine=podman
 target_dir=.build
 


### PR DESCRIPTION
includes fix for https://github.com/gardenlinux/seccomp_fake_xattr/issues/1