### PR TITLE
Backport/1443 platform test logs

### DIFF
--- a/.github/workflows/ali_tests.sh
+++ b/.github/workflows/ali_tests.sh
@@ -7,9 +7,6 @@ cname="${@: -1}"
 configFile="ali_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.qcow2"
@@ -47,11 +44,11 @@ EOF
 
 
 echo "### Start Integration Tests for ali"
-podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs" $containerName /bin/bash -s << EOF
+podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 ssh-keygen -t rsa -b 4096 -f /gardenlinux/tmp/id_rsa -N "" -q
 cd /gardenlinux/tests
-pytest --iaas=ali --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-ali_junit.xml || exit 1
+pytest --iaas=ali --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.platform.test.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/aws_tests.sh
+++ b/.github/workflows/aws_tests.sh
@@ -21,9 +21,6 @@ cname=$1
 configFile="aws_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.raw"
@@ -64,10 +61,10 @@ aws:
 EOF
 
 echo "### Start Integration Tests for AWS"
-podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs"  $containerName /bin/bash -s << EOF
+podman run -it --rm -e 'AWS_*' -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
-pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-aws_junit.xml || exit 1
+pytest --iaas=aws --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.platform.test.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/azure_tests.sh
+++ b/.github/workflows/azure_tests.sh
@@ -7,12 +7,9 @@ cname="${@: -1}"
 configFile="azure_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
 
 azure_hyper_v_generation="V1"
 azure_vm_size="Standard_D4_v4"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.vhd"
@@ -47,10 +44,10 @@ azure:
 EOF
 
 echo "### Start Integration Tests for Azure"
-podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts"  -v "$platform_test_log_dir:/platform-test-logs" $containerName /bin/bash -s << EOF
+podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
-pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-azure_junit.xml || exit 1
+pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.platform.test.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,21 +212,30 @@ jobs:
           find .build -exec touch -d "@$t" {} +
       - name: build
         run: ./build ${{ inputs.use_kms && '--kms' || '' }} ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
-      - name: test
-        run: ./test --container-image test ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
-      - uses: pmeier/pytest-results-action@035bda205f160abee0b277db11ac6ca01175ca7d # pin@v0.6.0
-        if: always()
-        with:
-          path: tests/test.xml
       - name: get cname
         run: |
           cname=$(basename "$(realpath ".build/${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}")" .artifacts)
           echo "cname=$cname" | tee -a "$GITHUB_ENV"
+      # ./test writes ${{ env.cname }}.chroot.test.log and puts it into .build/${{ env.cname }}.artifacts
+      - name: test
+        run: |
+          ./test --container-image test ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }}
+      # chroot.test.xml is written in the entrypoint tests/init
+      - name: rename test results
+        if: always()
+        run: |
+          mv tests/chroot.test.xml .build/${{ env.cname }}.chroot.test.xml
+      - uses: pmeier/pytest-results-action@fc6576eced1f411ea48ab10e917d9cfce2960e29 # pin@v0.7.1
+        if: always()
+        with:
+          path: ".build/${{ env.cname }}.chroot.test.xml"
+      - name: add chroot.test.xml to build artifacts
+        run: echo "${{ env.cname }}.chroot.test.xml" >> ".build/${{ env.cname }}.artifacts"
       - name: pack build artifacts for upload
         run: tar -cSzvf "${{ env.cname }}.tar.gz" -C .build -T ".build/${{ env.cname }}.artifacts"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
         with:
-          name: "${{ env.cname }}"
+          name: "build-${{ env.cname }}"
           path: "${{ env.cname }}.tar.gz"
   bare_flavors:
     needs: [ version, base ]
@@ -268,5 +277,5 @@ jobs:
         run: ./build_bare_flavors --arch "${{ matrix.arch }}" "${{ matrix.config }}"
       - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
         with:
-          name: "bare-${{ matrix.config }}-${{ matrix.arch }}"
+          name: "build-bare-${{ matrix.config }}-${{ matrix.arch }}"
           path: ".build/bare_flavors/${{ matrix.config }}-${{ matrix.arch }}.oci"

--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -7,9 +7,6 @@ cname="${@: -1}"
 configFile="gcp_test_config.yaml"
 containerName="ghcr.io/gardenlinux/gardenlinux/integration-test:today"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
-platform_test_log_dir="/tmp/gardenlinux-platform-test-logs"
-
-mkdir -p "$platform_test_log_dir"
 
 pushd "$artifact_dir" || exit 1
 tar -xzf "$cname.tar.gz" "$cname.gcpimage.tar.gz"
@@ -75,13 +72,13 @@ EOF
 
 
 echo "### Start Integration Tests for gcp"
-podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" -v "$platform_test_log_dir:/platform-test-logs" $containerName /bin/bash -s << EOF
+podman run -it --rm -v "$(pwd):/gardenlinux" -v "$(dirname "$image_file"):/artifacts" $containerName /bin/bash -s << EOF
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
 export GOOGLE_APPLICATION_CREDENTIALS="/gardenlinux/$credentials_file_name"
 export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="/gardenlinux/$credentials_file_name"
 export GOOGLE_GHA_CREDS_PATH="/gardenlinux/$credentials_file_name"
-pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/platform-test-logs/test-$cname-gcp_junit.xml || exit 1
+pytest --iaas=gcp --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.platform.test.xml || exit 1
 exit 0
 EOF

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,7 @@ name: nightly
 on:
   schedule:
     - cron: '0 6 * * *'
+  # triggered manually
   workflow_dispatch:
     inputs:
       version:
@@ -20,7 +21,7 @@ jobs:
     with:
       version: ${{ inputs.version || 'now' }}
       default_modifier: "-gardener_prod"
-      use_kms: ${{ github.event.inputs.use_kms == 'true' }}
+      use_kms: ${{ inputs.use_kms != null && inputs.use_kms || true }}        
     secrets:
       secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}
       aws_region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,10 @@ on:
       version:
         type: string
         default: now
+      use_kms:
+        type: boolean
+        required: false
+        default: true
 jobs:
   build:
     uses: ./.github/workflows/build.yml
@@ -16,7 +20,7 @@ jobs:
     with:
       version: ${{ inputs.version || 'now' }}
       default_modifier: "-gardener_prod"
-      use_kms: true
+      use_kms: ${{ github.event.inputs.use_kms == 'true' }}
     secrets:
       secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}
       aws_region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -27,10 +27,10 @@ jobs:
           echo "cname_arm64=$cname_arm64" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
         with:
-          name: ${{ env.cname_amd64 }}
-      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
+          name: build-${{ env.cname_amd64 }}
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
         with:
-          name: ${{ env.cname_arm64 }}
+          name: build-${{ env.cname_arm64 }}
       - name: publish gardenlinux container base image
         run: |
           version=$(bin/garden-version "${{ inputs.version }}")
@@ -124,10 +124,10 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
         with:
-          name: bare-${{ matrix.config }}-amd64
-      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
+          name: build-bare-${{ matrix.config }}-amd64
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
         with:
-          name: bare-${{ matrix.config }}-arm64
+          name: build-bare-${{ matrix.config }}-arm64
       - run: ls -lah
       - name: publish bare container image
         run: |

--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -80,5 +80,5 @@ jobs:
           ls -la "$prefix/$prefix.platform.test.xml" || true
           test -f "$prefix/$prefix.chroot.test.log" && echo "$prefix/$prefix.chroot.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
           test -f "$prefix/$prefix.chroot.test.xml" && echo "$prefix/$prefix.chroot.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
-          test -f ls -la "$prefix/$prefix.platform.test.log" && echo "$prefix/$prefix.platform.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
-          test -f ls -la "$prefix/$prefix.platform.test.xml" && echo "$prefix/$prefix.platform.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          test -f "$prefix/$prefix.platform.test.log" && echo "$prefix/$prefix.platform.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          test -f "$prefix/$prefix.platform.test.xml" && echo "$prefix/$prefix.platform.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"

--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -62,6 +62,7 @@ jobs:
           commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
           prefix="${{ matrix.cname }}-${{ matrix.architecture }}-${{ inputs.version }}-$commit"
           .github/workflows/download_from_s3.sh "${{ secrets.AWS_S3_BUCKET }}" "$prefix"
+          # pack tar.xz file for release
           tar -cv "$prefix" | xz -9 > "$prefix.tar.xz"
       - name: upload to release
         run: |
@@ -71,43 +72,13 @@ jobs:
           echo "$release $prefix.tar.xz"
           ls -lah "$prefix.tar.xz"
           echo "$prefix.tar.xz" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
-  upload_integration_test_logs_to_release:
-    environment: oidc_aws_s3_upload
-    needs: create_release
-    permissions:
-      contents: write
-      id-token: write
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        architecture: [ amd64, arm64 ]
-        cname: [ gcp-gardener_prod, aws-gardener_prod, azure-gardener_prod ]
-        exclude:
-          - architecture: arm64
-            cname: gcp-gardener_prod
-          - architecture: arm64
-            cname: azure-gardener_prod
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
-      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
-        with:
-          name: release
-      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
-          role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: download build artifacts from S3
-        run: |
-          commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
-          prefix="${{ matrix.cname }}-${{ matrix.architecture }}-${{ inputs.version }}-$commit"
-          aws s3 cp "s3://${{ secrets.AWS_S3_BUCKET }}/objects/$prefix/$prefix.test-log" ./
-      - name: upload to release
-        run: |
-          commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
-          release="$(cat .github_release_id)"
-          prefix="${{ matrix.cname }}-${{ matrix.architecture }}-${{ inputs.version }}-$commit"
-          echo "$release $prefix.test-log"
-          ls -lah "$prefix.test-log"
-          echo "$prefix.test-log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+
+          # upload test logs separately (if they exist)
+          ls -la "$prefix/$prefix.chroot.test.log" || true
+          ls -la "$prefix/$prefix.chroot.test.xml" || true
+          ls -la "$prefix/$prefix.platform.test.log" || true
+          ls -la "$prefix/$prefix.platform.test.xml" || true
+          test -f "$prefix/$prefix.chroot.test.log" && echo "$prefix/$prefix.chroot.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          test -f "$prefix/$prefix.chroot.test.xml" && echo "$prefix/$prefix.chroot.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          test -f ls -la "$prefix/$prefix.platform.test.log" && echo "$prefix/$prefix.platform.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          test -f ls -la "$prefix/$prefix.platform.test.xml" && echo "$prefix/$prefix.platform.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"

--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -113,4 +113,4 @@ jobs:
 
     - name: start platform test for ${{ matrix.target }}
       run: |
-        set -o pipefail && .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}.tar.gz" 2>&1 | tee "${{ env.cname }}.integration-tests-log"
+        set -o pipefail && .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}.tar.gz" 2>&1 | tee "${{ env.cname }}.platform.test.log"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
       azure_subscription_id: ${{ secrets.az_subscription_id }}
       AZURE_CONFIG_DIR: /tmp/azure_config_dir
       TARGET_ARCHITECTURE: ${{ matrix.arch }}
+      artifact_dir: /tmp/gardenlinux-build-artifacts
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,10 +89,10 @@ jobs:
 
     - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
       with:
-        name: ${{ env.cname }}
-        path: /tmp/gardenlinux-build-artifacts
+        name: build-${{ env.cname }}
+        path: ${{ env.artifact_dir }}
 
-    - run: ls -lah /tmp/gardenlinux-build-artifacts
+    - run: ls -lah ${{ env.artifact_dir }}
 
     - if: ${{ matrix.target == 'gcp' }}
       id: 'auth_gcp'
@@ -129,9 +130,11 @@ jobs:
     - name: start platform test for ${{ matrix.target }}
       run: |
         set -o pipefail
-        .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}" 2>&1 | tee "${{ env.cname }}.integration-tests-log"
+        .github/workflows/${{ matrix.target }}_tests.sh --arch "${{ matrix.arch }}" "${{ env.cname }}" 2>&1 | tee "${{ env.artifact_dir}}/${{ env.cname }}.platform.test.log"
 
     - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v3
       with:
-        name: tests-${{ env.cname }}
-        path: ${{ env.cname }}.integration-tests-log
+        name: platform-test-${{ env.cname }}
+        path: |
+          ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.log
+          ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml

--- a/.github/workflows/upload_to_s3.sh
+++ b/.github/workflows/upload_to_s3.sh
@@ -2,6 +2,9 @@
 
 set -Eexuo pipefail
 
+ROOT_DIR=$(git rev-parse --show-toplevel)
+PATH="${ROOT_DIR}/bin:${PATH}"
+
 bucket="$1"
 name="$(sed 's/.tar.gz$//g' <<< "$2")"
 platform="$(cut -d - -f 1 <<< "$name")"
@@ -23,7 +26,7 @@ architecture: '$arch'
 base_image: null
 build_committish: '$GARDENLINUX_COMMIT_ID_LONG'
 build_timestamp: '$timestamp'
-gardenlinux_epoch: $(bin/garden-version --major "$GARDENLINUX_VERSION")
+gardenlinux_epoch: $(garden-version --major "$GARDENLINUX_VERSION")
 logs: null
 modifiers: [$GARDENLINUX_FEATURES]
 platform: '$platform'

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -51,48 +51,27 @@ jobs:
           echo "cname=$cname" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
         with:
-          name: ${{ env.cname }}
-      - name: upload to S3 bucket ${{ secrets.bucket }}
-        run: .github/workflows/upload_to_s3.sh ${{ secrets.bucket }} ${{ env.cname }}.tar.gz
-  upload_test_logs_to_s3:
-    name: upload test logs to S3
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    permissions:
-      id-token: write
-    environment: oidc_aws_s3_upload
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ amd64, arm64 ]
-        target: [ gcp, aws, azure ]
-        modifier: [ "${{ inputs.default_modifier }}" ]
-        exclude:
-          - arch: arm64
-            target: gcp
-          - arch: arm64
-            target: azure
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
-      - uses: ./.github/actions/setup
-      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4
+          name: build-${{ env.cname }}
+          path: build-${{ env.cname }}
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # pin@v3
         with:
-          role-to-assume: ${{ secrets.role }}
-          role-session-name: ${{ secrets.session }}
-          aws-region: ${{ secrets.region }}
-      - name: set VERSION=${{ inputs.version }}
+          name: platform-test-${{ env.cname }}
+          path: platform-test-${{ env.cname }}
+        # artifacts might not exist if no platform-test ran (e.g. excluded)
+        continue-on-error: true
+      # repack tar.gz from build workflow to contain platform-test logs (if they exist)
+      - name: add platform-test logs to tar.gz
         run: |
-          bin/garden-version "${{ inputs.version }}" | tee VERSION
-          git update-index --assume-unchanged VERSION
-      - name: get cname
-        run: |
-          cname="$(./build --resolve-cname ${{ matrix.target }}${{ matrix.modifier }}-${{ matrix.arch }})"
-          echo "cname=$cname" | tee -a "$GITHUB_ENV"
-
-      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v3
-        with:
-          name: tests-${{ env.cname }}
+          ls -l platform-test-${{ env.cname }}/${{ env.cname }}.platform.test.log || true
+          ls -l platform-test-${{ env.cname }}/${{ env.cname }}.platform.test.xml || true
+          if [ -f platform-test-${{ env.cname }}/${{ env.cname }}.platform.test.log ]; then
+            gunzip build-${{ env.cname }}/${{ env.cname }}.tar.gz
+            tar -rvf build-${{ env.cname }}/${{ env.cname }}.tar -C platform-test-${{ env.cname }} ${{ env.cname }}.platform.test.log ${{ env.cname }}.platform.test.xml
+            gzip build-${{ env.cname }}/${{ env.cname }}.tar
+          else
+            echo "no platform-test log files found"
+          fi
       - name: upload to S3 bucket ${{ secrets.bucket }}
-        run: aws s3 cp "${{ env.cname }}.integration-tests-log" "s3://${{ secrets.bucket }}/objects/${{ env.cname }}/"
+        run: |
+          cd build-${{ env.cname }}
+          ${{ github.workspace }}/.github/workflows/upload_to_s3.sh ${{ secrets.bucket }} ${{ env.cname }}.tar.gz

--- a/test
+++ b/test
@@ -65,5 +65,5 @@ if [ -z "$container_image" ]; then
 	rm "$image_file"
 fi
 
-"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" 2>&1 | tee "$dir/.build/$cname.test-log"
-echo "$cname.test-log" >> "$dir/.build/$cname.artifacts"
+"$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" 2>&1 | tee "$dir/.build/$cname.chroot.test.log"
+echo "$cname.chroot.test.log" >> "$dir/.build/$cname.artifacts"

--- a/tests/init
+++ b/tests/init
@@ -19,4 +19,4 @@ $(for feature in "${features[@]}"; do echo "    - $feature"; done)
 EOF
 
 cd /gardenlinux/tests
-python3 -m pytest --iaas=chroot --configfile=/tmp/test_config.yaml --junit-xml=test.xml
+python3 -m pytest --iaas=chroot --configfile=/tmp/test_config.yaml --junit-xml=chroot.test.xml


### PR DESCRIPTION
**What this PR does / why we need it**:

`rel-1443` needs to also publish platform test logs. These are backports from `main` to enable this.