### PR TITLE
fix(pxe): cdc_ether should be omitted from the initrd

### DIFF
--- a/features/_pxe/file.include/etc/dracut.conf.d/30-omit-cdc-ether.conf
+++ b/features/_pxe/file.include/etc/dracut.conf.d/30-omit-cdc-ether.conf
@@ -1,0 +1,1 @@
+omit_drivers+=" cdc_ether "


### PR DESCRIPTION
**What this PR does / why we need it**:
This is related to some ironcore issues.
When net booting, certain servers that don't have the Ethernet Over USB interface (used for in-band communication between the server and the BMC) disabled, this interface is going to get configured and it is going to make systemd consider the network as being online and certain services that require network will of course malfunction - e.q. fetching of the ignition config.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**: