### PR TITLE
do not always push platform test images

### DIFF
--- a/.github/workflows/platform-test-images.yml
+++ b/.github/workflows/platform-test-images.yml
@@ -96,13 +96,6 @@ jobs:
           else
             echo "Tag for ${GL_VERSION} already exists in ghcr.io/gardenlinux/platform-test-${{ matrix.platform }} and FORCE_BUILD=false"
           fi
-      # always run push-platform-test
-      - name: make push-platform-test-${{ matrix.platform }}
-        env:
-          # needed to use github cli in bin/garden-version-resolver
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          make -j $(nproc) --directory=tests/images GARDENLINUX_BUILD_CRE=podman push-platform-test-${{ matrix.platform }}
       # after merge to main, run push-release-platform-test
       - name: make push-release-platform-test-${{ matrix.platform }} (after merge to main)
         if: github.event.pull_request.merged == true && github.ref_name == 'main'


### PR DESCRIPTION
**What this PR does / why we need it**:
This tries do address an issue where dependabot cannot write to the image registry.
Also we do not want to push to the registry on every push/pull_request, only after a successful merge to main.

**Which issue(s) this PR fixes**:
This could fix #2431