### PR TITLE
fix(gardener): keep LimitNOFILE same as old GL versions

### DIFF
--- a/features/gardener/file.include/etc/systemd/system/containerd.service.d/override.conf
+++ b/features/gardener/file.include/etc/systemd/system/containerd.service.d/override.conf
@@ -1,2 +1,3 @@
 [Service]
 LimitMEMLOCK=67108864
+LimitNOFILE=1048576


### PR DESCRIPTION
**What this PR does / why we need it**:
With systemd version 256 the hard limits have been bumped to the kernel max allowed value.
Because containerd is using _LimitNOFILE=inifinity_ this is having a lot unforeseen effects and we'd like to keep the value to the value that has been used in Gardener so far - 2^20 - this has been agreed upon with @MrBatschner 

More info : [here](https://lists.debian.org/debian-devel/2024/06/msg00041.html) and https://github.com/containerd/containerd/commit/3ca39ef01608fdd44245c0173bf071682b3bfe3c

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

