### PR TITLE
pass correct latest GL_VERSION to container build and run

### DIFF
--- a/.github/workflows/platform-test-images.yml
+++ b/.github/workflows/platform-test-images.yml
@@ -96,9 +96,9 @@ jobs:
           else
             echo "Tag for ${GL_VERSION} already exists in ghcr.io/gardenlinux/platform-test-${{ matrix.platform }} and FORCE_BUILD=false"
           fi
-      # after merge to main, run push-release-platform-test
-      - name: make push-release-platform-test-${{ matrix.platform }} (after merge to main)
-        if: github.event.pull_request.merged == true && github.ref_name == 'main'
+      # on main, run push-release-platform-test
+      - name: make push-release-platform-test-${{ matrix.platform }} (on main)
+        if: github.ref_name == 'main'
         env:
           # needed to use github cli in bin/garden-version-resolver
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/images/Makefile
+++ b/tests/images/Makefile
@@ -4,7 +4,8 @@ SHELL := /usr/bin/env bash
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 GIT_SHA:= $(shell git rev-parse HEAD)
 GIT_SHA_SHORT := $(shell git rev-parse --short HEAD)
-ifeq ($(strip $(GL_VERSION)),)
+# if GL_VERSION is empty or latest
+ifeq ($(or $(strip $(GL_VERSION)), $(GL_VERSION)), latest)
 GL_VERSION := $(shell $(ROOT_DIR)/bin/glrd --no-header --type patch --latest --fields Version)
 endif
 ifeq ($(strip $(GL_REGISTRY)),)


### PR DESCRIPTION
**What this PR does / why we need it**:

Platform test images are not pushed with correct version tag and latest tag after merge to main.

**Which issue(s) this PR fixes**:
Fixes #2433

**Special notes to reviewer**:
This will not build unless our latest stable patch release (1592.2) will have certain packages backported (https://github.com/gardenlinux/gardenlinux/issues/2445).