### PR TITLE
Add dpkg-dev package to _dev feature

### DIFF
--- a/features/_dev/pkg.include
+++ b/features/_dev/pkg.include
@@ -1,2 +1,3 @@
 vim
 neofetch
+dpkg-dev


### PR DESCRIPTION
dpkg-dev is needed for downloading the sources via `apt-get source` (at least for some packages), thus it should be available in dev images.