### PR TITLE
rename azure-nvme-utils to azure-vm-utils

### DIFF
--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,4 +1,4 @@
 chrony
 cloud-init
 python3-cffi-backend
-azure-nvme-utils
+azure-vm-utils


### PR DESCRIPTION
**What this PR does / why we need it**:

Renames `azure-nvme-utils` to `azure-vm-utils` following https://github.com/gardenlinux/repo/pull/28.
