### PR TITLE
Upload container builds to S3 too

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -33,6 +33,13 @@ jobs:
         arch: [ amd64, arm64 ]
         target: [ kvm, "kvm_trustedboot_tpm2", metal, "metal_trustedboot_tpm2", gcp, gdch, aws, "aws_trustedboot_tpm2", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
         modifier: [ "${{ inputs.default_modifier }}" ]
+        include:
+          - target: container
+            arch: amd64
+            modifier: ""
+          - target: container
+            arch: arm64
+            modifier: ""
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup


### PR DESCRIPTION
This PR is needed for the publication of container images to OCI.

The OCI upload workflow reads its artifacts from S3. I want to keep the workflow for container images and non-container images as similar as possible. If you ask yourself "Why are the artifacts not read directly from the workflow runs?", the answer is: this is only easily possible if your job is executed in the same workflow (like build and upload S3 are). When the upload OCI workflow is triggered nightly the intermediate step with S3 can be removed, but currently it is a good intermediate step because it makes artifacts "addressable". They can be downloaded with version number and commit.

Signed-off-by: Malte Münch <muench@b1-systems.de>
