### PR TITLE
fix: temporarily disable /lib64 audit rule

### DIFF
--- a/features/sap/file.include/etc/audit/rules.d/70-system-integrity.rules
+++ b/features/sap/file.include/etc/audit/rules.d/70-system-integrity.rules
@@ -6,4 +6,4 @@
 -a exit,always -F dir=/opt -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/root -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/lib -F perm=wa -F key=system_integrity
--a exit,always -F dir=/lib64 -F perm=wa -F key=system_integrity
+#-a exit,always -F dir=/lib64 -F perm=wa -F key=system_integrity


### PR DESCRIPTION
**What this PR does / why we need it**:
In certain scenarios /lib64 symlink is missing, so till we have this fully figured out, we need to disable this rule.

**Which issue(s) this PR fixes**: