### PR TITLE
feat: prepare gl-live dracut module for the new installer

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/module-setup.sh
@@ -6,12 +6,11 @@ check() {
 }
 
 depends() {
-    echo "fs-lib dracut-systemd systemd-networkd systemd-resolved"
+    echo "fs-lib dracut-systemd systemd-networkd systemd-resolved systemd-repart"
 }
 
 install() {
-    #inst_multiple grep sfdisk growpart udevadm awk mawk sed rm readlink
-    inst_multiple curl grep sfdisk awk mawk sha256sum
+    inst_multiple curl grep sfdisk awk mawk sha256sum efibootmgr mkfs.ext4 mkfs.vfat chroot
 
     inst_simple "$moddir/gl-end.service" ${systemdsystemunitdir}/gl-end.service
     inst_script "$moddir/live-get-squashfs.sh" /sbin/live-get-squashfs

--- a/features/_pxe/pkg.include
+++ b/features/_pxe/pkg.include
@@ -4,3 +4,4 @@ btrfs-progs
 xfsprogs
 dracut-network
 ca-certificates
+gdisk


### PR DESCRIPTION
**What this PR does / why we need it**:
We'd like to add systemd-repart to the _gardenlinux-live_ dracut module. 
_efibootmgr_ and _chroot_ also needed for the new installer we're preparing.