### PR TITLE
publish gcp_trustedboot_tpm2 on S3

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ amd64, arm64 ]
-        target: [ kvm, "kvm_trustedboot_tpm2", metal, "metal_trustedboot_tpm2", gcp, gdch, aws, "aws_trustedboot_tpm2", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
+        target: [ kvm, "kvm_trustedboot_tpm2", metal, "metal_trustedboot_tpm2", gcp, "gcp_trustedboot_tpm2", gdch, aws, "aws_trustedboot_tpm2", azure, ali, openstack, openstackbaremetal, vmware, "metal_pxe" ]
         modifier: [ "${{ inputs.default_modifier }}" ]
         include:
           - target: container


### PR DESCRIPTION
**What this PR does / why we need it**:

After testing the gcp_trustedboot_tpm2 images there is no upload. Seems that this slipped through.

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

`rel-1592` seems not to have trustedboot at all, so I will not backport this.
