### PR TITLE
ci: release-page - fix platform test upload error code

### DIFF
--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -82,14 +82,14 @@ jobs:
           echo "$prefix.tar.xz" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
 
           # upload test logs separately (if they exist)
-          ls -la "$prefix/$prefix.chroot.test.log" || true
-          ls -la "$prefix/$prefix.chroot.test.xml" || true
-          ls -la "$prefix/$prefix.platform.test.log" || true
-          ls -la "$prefix/$prefix.platform.test.xml" || true
-          test -f "$prefix/$prefix.chroot.test.log" && echo "$prefix/$prefix.chroot.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
-          test -f "$prefix/$prefix.chroot.test.xml" && echo "$prefix/$prefix.chroot.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
-          test -f "$prefix/$prefix.platform.test.log" && echo "$prefix/$prefix.platform.test.log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
-          test -f "$prefix/$prefix.platform.test.xml" && echo "$prefix/$prefix.platform.test.xml" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+          log_suffixes="chroot.test.log chroot.test.xml platform.test.log platform.test.xml"
+          for suffix in $log_suffixes; do
+            log="$prefix/$prefix.$suffix"
+            if [ -f "$log" ]; then
+              echo "$log" | .github/workflows/release-page.sh ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} upload "$release"
+            fi
+          done
+
   tag_container_as_latest:
     if: ${{ inputs.type }} == 'patch'
     uses: ./.github/workflows/tag_latest_container.yml


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently an `exit 1` is thrown when a non existing platform test log file is uploaded in the release-page workflow.
This tries to fix it.

**Which issue(s) this PR fixes**:
* https://github.com/gardenlinux/gardenlinux/actions/runs/11930076105/job/33250190914#step:6:121

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

* Could not test this. Test release will be done after merge.
* needs not backporting