### PR TITLE
Take care of community gallery images for azure in release notes

### DIFF
--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -60,7 +60,7 @@ def _azure_release_note(published_image_metadata):
     output = ""
     for pset in published_image_metadata:
         if pset == 'published_gallery_images':
-            if (len(published_image_metadata[pset]) > 1):
+            if (len(published_image_metadata[pset]) > 0):
                 output += "# all regions (community gallery image):\n"
             for gallery_image in published_image_metadata[pset]:
                 output += f"Hyper V: {gallery_image['hyper_v_generation']}, "
@@ -68,7 +68,7 @@ def _azure_release_note(published_image_metadata):
                 output += f"Image Id: {gallery_image['community_gallery_image_id']}\n"
 
         if pset == 'published_marketplace_images':
-            if (len(published_image_metadata[pset]) > 1):
+            if (len(published_image_metadata[pset]) > 0):
                 output += "# all regions (marketplace image):\n"
             for market_image in published_image_metadata[pset]:
                 output += f"Hyper V: {market_image['hyper_v_generation']}, "
@@ -302,8 +302,6 @@ def create_github_release_notes(gardenlinux_version, commitish, dry_run = False)
     output += "## Kernel Package direct download links\n"
     output += get_kernel_urls(gardenlinux_version)
     output += "\n"
-
-
 
     output += generate_image_download_section(manifests, gardenlinux_version, commitish_short )
 

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -59,8 +59,17 @@ def _gcp_release_note(published_image_metadata):
 def _azure_release_note(published_image_metadata):
     output = ""
     for pset in published_image_metadata:
+        if pset == 'published_gallery_images':
+            if (len(published_image_metadata[pset]) > 1):
+                output += "# all regions (community gallery image):\n"
+            for gallery_image in published_image_metadata[pset]:
+                output += f"Hyper V: {gallery_image['hyper_v_generation']}, "
+                output += f"Azure Cloud: {gallery_image['azure_cloud']}, "
+                output += f"Image Id: {gallery_image['community_gallery_image_id']}\n"
+
         if pset == 'published_marketplace_images':
-            output += "# all regions:\n"
+            if (len(published_image_metadata[pset]) > 1):
+                output += "# all regions (marketplace image):\n"
             for market_image in published_image_metadata[pset]:
                 output += f"Hyper V: {market_image['hyper_v_generation']}, "
                 output += f"urn: {market_image['urn']}\n"
@@ -285,22 +294,18 @@ def create_github_release_notes(gardenlinux_version, commitish, dry_run = False)
 
     output += release_notes_compare_package_versions_section(gardenlinux_version, package_list)
 
-    # Ignore in dry run because this fails when called locally
-    # Run as usual in CI
-    if not dry_run:
-        manifests = download_all_singles(gardenlinux_version, commitish_short)
+    manifests = download_all_singles(gardenlinux_version, commitish_short)
 
-        output += generate_release_note_image_ids(manifests)
+    output += generate_release_note_image_ids(manifests)
 
     output += "\n"
     output += "## Kernel Package direct download links\n"
     output += get_kernel_urls(gardenlinux_version)
     output += "\n"
 
-    # Ignore in dry run because this fails when called locally
-    # Run as usual in CI
-    if not dry_run:
-        output += generate_image_download_section(manifests, gardenlinux_version, commitish_short )
+
+
+    output += generate_image_download_section(manifests, gardenlinux_version, commitish_short )
 
     output += "\n"
     output += "## Kernel Module Build Container (kmodbuild) "

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ make_targets.cache
 venv
 config
 shell.nix
+s3_downloads/


### PR DESCRIPTION
**What this PR does / why we need it**: Adds azure community gallery images to the release notes automation

Should look like this in the release page:
<img width="1150" alt="Screenshot 2024-11-26 at 11 00 38" src="https://github.com/user-attachments/assets/001e8344-4c3e-475a-b924-53ea73ab37bb">
<img width="974" alt="Screenshot 2024-11-26 at 11 00 44" src="https://github.com/user-attachments/assets/5e29a636-c605-45f9-bbb1-b9524c810642">

**Which issue(s) this PR fixes**:
Relates to [#2488](https://github.com/gardenlinux/gardenlinux/issues/2488)
