### PR TITLE
hack: add script to list package releases

### DIFF
--- a/hack/list-package-releases.sh
+++ b/hack/list-package-releases.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+org=gardenlinux
+
+gh api --paginate "/orgs/$org/repos" | jq -r '.[] | .name' | grep '^package-' | grep --invert-match package-build | while read -r repo; do
+        TAG_NAME=$(GH_PAGER= gh release view --repo="$org/$repo" --json=tagName --jq='.tagName')
+	echo "https://github.com/$org/$repo" $TAG_NAME
+done

--- a/hack/list-package-releases.sh
+++ b/hack/list-package-releases.sh
@@ -5,6 +5,6 @@ set -eufo pipefail
 org=gardenlinux
 
 gh api --paginate "/orgs/$org/repos" | jq -r '.[] | .name' | grep '^package-' | grep --invert-match package-build | while read -r repo; do
-        TAG_NAME=$(GH_PAGER= gh release view --repo="$org/$repo" --json=tagName --jq='.tagName')
-	echo "https://github.com/$org/$repo" $TAG_NAME
+        TAG_NAME=$(GH_PAGER='' gh release view --repo="$org/$repo" --json=tagName --jq='.tagName')
+	echo "https://github.com/$org/$repo   $TAG_NAME"
 done


### PR DESCRIPTION
This is useful for finding outdated pinned versions in our package repo.