### PR TITLE
Bump k8s version to 1.30.7 for `khost`

### DIFF
--- a/features/khost/exec.late
+++ b/features/khost/exec.late
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-K8S_VERSION=v1.28.3
+K8S_VERSION=v1.30.7
 K8S_VERSION_REPO="${K8S_VERSION%.*}"
 
 gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg < /builder/features/khost/release.key


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps k8s deb repository to `1.30` and installs `kubelet`, `kubectl` and `kubeadm` in v1.30.7.

**Which issue(s) this PR fixes**:
Related https://github.com/gardenlinux/gardenlinux-ccloud/pull/14

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)