### PR TITLE
fix: disable ssh.socket

### DIFF
--- a/features/ssh/file.include/etc/systemd/system-preset/00-sshsocket-disable.preset
+++ b/features/ssh/file.include/etc/systemd/system-preset/00-sshsocket-disable.preset
@@ -1,0 +1,1 @@
+disable ssh.socket


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable the socket activation mechanism for SSH.

**Which issue(s) this PR fixes**:
Fixes #2507 