### PR TITLE
Add feature to support basic Debian packages generation

### DIFF
--- a/features/buildDep/exec.config
+++ b/features/buildDep/exec.config
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+mkdir -p /usr/local/src/debbuild

--- a/features/buildDep/exec.late
+++ b/features/buildDep/exec.late
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [[ -d /usr/local/src/debbuild && $(ls -A /usr/local/src/debbuild) ]]; then
+    cd /usr/local/src/debbuild
+    dpkg-buildpackage
+
+    rm -fR /usr/local/src/debbuild
+fi

--- a/features/buildDep/info.yaml
+++ b/features/buildDep/info.yaml
@@ -1,0 +1,2 @@
+description: 'Install basic support to generate Debian packages'
+type: element

--- a/features/buildDep/pkg.include
+++ b/features/buildDep/pkg.include
@@ -1,0 +1,2 @@
+build-essential
+debhelper


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add's a feature to:
- add `build-essential` and `debhelper`
- run `dpkg-buildpackage` in `/usr/local/src/debbuild`

This allows the generation of any Debian package in `/usr/local/src` from sources provided in `/usr/local/src/debbuild` e.g. as a separate feature.

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)