### PR TITLE
feat: usi: use bind mounts for /opt /root /home instead of symlinks

### DIFF
--- a/features/_usi/exec.config
+++ b/features/_usi/exec.config
@@ -8,6 +8,9 @@ mv /etc/systemd/system/default.target.wants /etc/systemd/system/post-reload.targ
 
 systemctl enable systemd-bless-boot.service
 systemctl enable var.mount
+systemctl enable opt.mount
+systemctl enable root.mount
+systemctl enable home.mount
 systemctl enable etc-overlay.service
 
 update-kernel-cmdline

--- a/features/_usi/exec.post
+++ b/features/_usi/exec.post
@@ -6,13 +6,6 @@ rootfs="$1"
 
 mkdir -p "$rootfs/etc/gardenlinux"
 
-rm -rf "$rootfs/opt"
-ln -sT /var/opt "$rootfs/opt"
-
-# shellcheck disable=SC2115
-rm -rf "$rootfs/home"
-ln -sT /var/home "$rootfs/home"
-
 for key in pk null.pk kek db; do
 	cp "/builder/cert/secureboot.$key.auth" "$rootfs/etc/gardenlinux/gardenlinux-secureboot.$key.auth"
 done

--- a/features/_usi/file.exclude
+++ b/features/_usi/file.exclude
@@ -3,3 +3,6 @@
 /etc/systemd/system/ignition-disable.service
 /etc/repart.d/root.conf
 /usr/lib/tmpfiles.d/home.conf
+/opt/{,.}*
+/home/{,.}*
+/root/{,.}*

--- a/features/_usi/file.include/etc/systemd/system/home.mount
+++ b/features/_usi/file.include/etc/systemd/system/home.mount
@@ -1,0 +1,12 @@
+[Unit]
+Requires=systemd-tmpfiles-setup.service
+After=systemd-tmpfiles-setup.service
+
+[Mount]
+What=/var/home
+Where=/home
+Type=none
+Options=bind
+
+[Install]
+WantedBy=local-fs.target

--- a/features/_usi/file.include/etc/systemd/system/opt.mount
+++ b/features/_usi/file.include/etc/systemd/system/opt.mount
@@ -1,0 +1,12 @@
+[Unit]
+Requires=systemd-tmpfiles-setup.service
+After=systemd-tmpfiles-setup.service
+
+[Mount]
+What=/var/opt
+Where=/opt
+Type=none
+Options=bind
+
+[Install]
+WantedBy=local-fs.target

--- a/features/_usi/file.include/etc/systemd/system/root.mount
+++ b/features/_usi/file.include/etc/systemd/system/root.mount
@@ -1,0 +1,12 @@
+[Unit]
+Requires=systemd-tmpfiles-setup.service
+After=systemd-tmpfiles-setup.service
+
+[Mount]
+What=/var/root
+Where=/root
+Type=none
+Options=bind
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
**What this PR does / why we need it**:

Using bind mounts instead of symlinks allows changing them dynamically without having to modify the immutable EROFS.
This will also allow making the set of persistent locations run-time configurable in the future.

With this the new mounts look like:

```
/efi /dev/vda1 vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro
/var /dev/mapper/var ext4 rw,relatime,seclabel
/etc overlay overlay rw,relatime,seclabel,lowerdir=/etc,upperdir=/var/etc.overlay,workdir=/var/etc.overlay.workdir,uuid=on
/opt /dev/mapper/var[/opt] ext4 rw,relatime,seclabel
/root /dev/mapper/var[/root] ext4 rw,relatime,seclabel
/home /dev/mapper/var[/home] ext4 rw,relatime,seclabel
```

**Which issue(s) this PR fixes**:
Fixes #2508 

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
