### PR TITLE
fix container flavor

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -195,17 +195,13 @@ targets:
   - name: container
     category: container
     flavors:
-      - features:
-          - gardener
-          - _prod
+      - features: []
         arch: amd64
         build: true
         test: true
         test-platform: false
         publish: true
-      - features:
-          - gardener
-          - _prod
+      - features: []
         arch: arm64
         build: true
         test: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Since merging #2514 the container flavor has some false features enabled and it cannot be published anymore:
https://github.com/gardenlinux/gardenlinux/actions/runs/12157353271/job/33910257296

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
