### PR TITLE
fix: add kernel parameter to allow ping for non root users

### DIFF
--- a/features/server/file.include/etc/sysctl.d/90-allow-ping-for-non-root-user.conf
+++ b/features/server/file.include/etc/sysctl.d/90-allow-ping-for-non-root-user.conf
@@ -1,0 +1,9 @@
+# origin: linux-sysctl-default debian package
+#
+# ping(8) without CAP_NET_ADMIN and CAP_NET_RAW
+# The upper limit is set to 2^31-1. Values greater than that get rejected by
+# the kernel because of this definition in linux/include/net/ping.h:
+#   #define GID_T_MAX (((gid_t)~0U) >> 1)
+# That's not so bad because values between 2^31 and 2^32-1 are reserved on
+# systemd-based systems anyway: https://systemd.io/UIDS-GIDS#summary
+-net.ipv4.ping_group_range = 0 2147483647


### PR DESCRIPTION
**What this PR does / why we need it**:
We should allow non root users to use ping.
We need to do this since the needed capabilities are no longer added to _/usr/bin/ping_ via the Debian package post install script.

**Which issue(s) this PR fixes**:
Fixes #
