### PR TITLE
use nightly as base for platform-test images

### DIFF
--- a/.github/workflows/ali_tests.sh
+++ b/.github/workflows/ali_tests.sh
@@ -5,7 +5,7 @@
 cname="${@: -1}"
 
 configFile="ali_test_config.yaml"
-containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-ali:latest"
+containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-ali:nightly"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
 
 pushd "$artifact_dir" || exit 1

--- a/.github/workflows/aws_tests.sh
+++ b/.github/workflows/aws_tests.sh
@@ -19,7 +19,7 @@ done
 cname=$1
 
 configFile="aws_test_config.yaml"
-containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-aws:latest"
+containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-aws:nightly"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
 
 pushd "$artifact_dir" || exit 1

--- a/.github/workflows/azure_tests.sh
+++ b/.github/workflows/azure_tests.sh
@@ -5,7 +5,7 @@
 cname="${@: -1}"
 
 configFile="azure_test_config.yaml"
-containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-azure:latest"
+containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-azure:nightly"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
 
 azure_hyper_v_generation="V1"

--- a/.github/workflows/gcp_tests.sh
+++ b/.github/workflows/gcp_tests.sh
@@ -5,7 +5,7 @@
 cname="${@: -1}"
 
 configFile="gcp_test_config.yaml"
-containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-gcp:latest"
+containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-gcp:nightly"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
 
 pushd "$artifact_dir" || exit 1

--- a/.github/workflows/gcp_trustedboot_tests.sh
+++ b/.github/workflows/gcp_trustedboot_tests.sh
@@ -5,7 +5,7 @@
 cname="${@: -1}"
 
 configFile="gcp_test_config.yaml"
-containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-gcp:latest"
+containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-gcp:nightly"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
 
 pushd "$artifact_dir" || exit 1

--- a/.github/workflows/gcp_trustedboot_tpm2_tests.sh
+++ b/.github/workflows/gcp_trustedboot_tpm2_tests.sh
@@ -5,7 +5,7 @@
 cname="${@: -1}"
 
 configFile="gcp_test_config.yaml"
-containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-gcp:latest"
+containerName="ghcr.io/gardenlinux/gardenlinux/platform-test-gcp:nightly"
 artifact_dir="/tmp/gardenlinux-build-artifacts"
 
 pushd "$artifact_dir" || exit 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,10 +13,10 @@ on:
         required: false
         default: true
       platform_test_tag:
-        description: "Tag to run platform-test containers. 'latest', Full commitish or GL version. Tag must be available in ghcr.io/gardenlinux/gardenlinux/platform-test-*"
+        description: "Tag to run platform-test containers. 'nightly', Full commitish or GL version. Tag must be available in ghcr.io/gardenlinux/gardenlinux/platform-test-*"
         type: string
         required: true
-        default: "latest"
+        default: "nightly"
 jobs:
   build:
     uses: ./.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       version: ${{ needs.build.outputs.version }}
-      platform_test_tag: ${{ inputs.platform_test_tag || 'latest' }}
+      platform_test_tag: ${{ inputs.platform_test_tag || 'nightly' }}
     secrets:
       gcp_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/platform-test-images.yml
+++ b/.github/workflows/platform-test-images.yml
@@ -19,7 +19,7 @@ on:
     inputs:
       gl_version:
         type: string
-        default: latest
+        default: nightly
       force_build:
         type: boolean
         default: false
@@ -31,7 +31,7 @@ on:
     inputs:
       gl_version:
         type: string
-        default: latest
+        default: nightly
       force_build:
         type: boolean
         default: false
@@ -69,14 +69,11 @@ jobs:
       - name: Set GL_VERSION
         run: |
           if [[ -z "${{ inputs.gl_version }}" ]]; then
-            echo "GL_VERSION=latest" >> ${GITHUB_ENV}
+            echo "GL_VERSION=nightly" >> ${GITHUB_ENV}
           else
             echo "GL_VERSION=${{ inputs.gl_version }}" >> ${GITHUB_ENV}
           fi
       - name: make pull-platform-test-${{ matrix.platform }}
-        env:
-          # needed to use github cli in bin/garden-version-resolver
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "GL_VERSION set to ${GL_VERSION}"
           echo "TAG_EXISTS=false" >> ${GITHUB_ENV}
@@ -87,9 +84,6 @@ jobs:
 
       # build if tag does not exist, force_build or force_release is set
       - name: make build-platform-test-${{ matrix.platform }}
-        env:
-          # needed to use github cli in bin/garden-version-resolver
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${TAG_EXISTS}" == false ]] || [[ "${{ inputs.force_build }}" == true ]] || [[ "${{ inputs.force_release }}" == true ]]; then
             make -j $(nproc) --directory=tests/images GARDENLINUX_BUILD_CRE=podman build-platform-test-${{ matrix.platform }}
@@ -99,16 +93,10 @@ jobs:
       # after merge to main, run push-release-platform-test
       - name: make push-release-platform-test-${{ matrix.platform }} (after merge to main)
         if: github.event.pull_request.merged == true && github.ref_name == 'main'
-        env:
-          # needed to use github cli in bin/garden-version-resolver
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make -j $(nproc) --directory=tests/images GARDENLINUX_BUILD_CRE=podman push-release-platform-test-${{ matrix.platform }}
       # when forced, run push-release-platform-test
       - name: make push-release-platform-test-${{ matrix.platform }} (when force_release is set)
         if: inputs.force_release
-        env:
-          # needed to use github cli in bin/garden-version-resolver
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make -j $(nproc) --directory=tests/images GARDENLINUX_BUILD_CRE=podman push-release-platform-test-${{ matrix.platform }}  

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/platform-test-images.yml
     with:
       gl_version: ${{ inputs.platform_test_tag }}
+      force_release: ${{ inputs.platform_test_tag == 'nightly' || false }}
   platform_tests:
     name: platform test
     needs: [ generate_matrix_test_platform, platform_test_images ]

--- a/tests/images/Makefile
+++ b/tests/images/Makefile
@@ -5,7 +5,7 @@ ROOT_DIR := $(shell git rev-parse --show-toplevel)
 GIT_SHA:= $(shell git rev-parse HEAD)
 GIT_SHA_SHORT := $(shell git rev-parse --short HEAD)
 ifeq ($(strip $(GL_VERSION)),)
-GL_VERSION := $(shell $(ROOT_DIR)/bin/glrd --no-header --type patch --latest --fields Version)
+GL_VERSION := nightly
 endif
 ifeq ($(strip $(GL_REGISTRY)),)
 GL_REGISTRY := ghcr.io/gardenlinux

--- a/tests/images/platform-test-base/Containerfile
+++ b/tests/images/platform-test-base/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 ARG GL_BASE=ghcr.io/gardenlinux/gardenlinux:${GL_VERSION}
 
 FROM ${GL_BASE}

--- a/tests/images/platform-test/ali/Containerfile
+++ b/tests/images/platform-test/ali/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 

--- a/tests/images/platform-test/aws/Containerfile
+++ b/tests/images/platform-test/aws/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 

--- a/tests/images/platform-test/azure/Containerfile
+++ b/tests/images/platform-test/azure/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 

--- a/tests/images/platform-test/firecracker/Containerfile
+++ b/tests/images/platform-test/firecracker/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 

--- a/tests/images/platform-test/gcp/Containerfile
+++ b/tests/images/platform-test/gcp/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 

--- a/tests/images/platform-test/kvm/Containerfile
+++ b/tests/images/platform-test/kvm/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 

--- a/tests/images/platform-test/openstack/Containerfile
+++ b/tests/images/platform-test/openstack/Containerfile
@@ -1,5 +1,5 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+# use latest nightly by default
+ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM gardenlinux/platform-test-base:${GL_VERSION}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the latest release stable patch version of gardenlinux, e.g. `1592.4` is used as base for building platform-test images. This is not very flexible if we need to add new dependencies. From a security perspective @gehoern also made the point that it makes more sense to test with the latest code.

This PR changes the build input for the platform-test images to be the latest successful nightly (`ghcr.io/gardenlinux/gardenlinux:nightly`). It also publishes the platform-test images with the `nightly` tag (in the nightly run).

**Which issue(s) this PR fixes**:
Fixes #2433

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:
- successfull nightly run with changes: https://github.com/gardenlinux/gardenlinux/actions/runs/12278779208
- Needs not backporting as only nightly is touched anyways.