### PR TITLE
fix azure chronyd start and gcp ssh timeouts

### DIFF
--- a/features/azure/file.include/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=dev-ptp_hyperv.device
+After=dev-ptp_hyperv.device

--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -170,13 +170,17 @@ class RemoteClient:
                     logger.warning(f"Unable to connect")
                     self._increase_retry_count_and_wait()
                 except AuthenticationException as e:
-                    auth_banner = self.client.get_transport().get_banner().decode()
-                    logger.warning(f"Failed to login - {auth_banner=}")
-                    if "pam_nologin(8)" in auth_banner:
-                        # SSH is already accepting connections but PAM refuses to let anyone in ("System is booting up"), have to retry
+                    try:
+                        auth_banner = self.client.get_transport().get_banner().decode()
+                        logger.warning(f"Failed to login - {auth_banner=}")
+                        if "pam_nologin(8)" in auth_banner:
+                            # SSH is already accepting connections but PAM refuses to let anyone in ("System is booting up"), have to retry
+                            self._increase_retry_count_and_wait()
+                        else:
+                            raise e
+                    # increase counter if banner is not yet decodable
+                    except:
                         self._increase_retry_count_and_wait()
-                    else:
-                        raise e
         except AuthenticationException as error:
             logger.exception("Authentication failed")
             raise error

--- a/tests/helper/utils.py
+++ b/tests/helper/utils.py
@@ -153,13 +153,33 @@ def get_kernel_version(client):
 
 
 def wait_systemd_boot(client):
-    """ Wait for systemd to finish booting """
+    """Wait for systemd to finish booting."""
+    """If there are failed units, show their Logs."""
+    systemd_status_cmd = "systemctl is-system-running --wait"
+    systemd_failed_cmd = (
+        "systemctl --failed --no-legend --no-pager | awk '{print $2}' | "
+        "xargs -rn1 journalctl --no-pager --lines 100 -u"
+    )
 
-    cmd = "systemctl is-system-running --wait"
+    # Check if systemd has finished booting
+    exit_code, output, error = client.execute_command(systemd_status_cmd, quiet=False)
 
-    (exit_code, output, error) = client.execute_command(cmd, quiet=False)
-
-    assert exit_code == 0, f"Failed to wait for systemd"
+    if exit_code != 0:
+        # Fetch logs of failed units
+        failed_exit_code, failed_output, failed_error = client.execute_command(
+            systemd_failed_cmd, quiet=False
+        )
+        logs = (
+            failed_output if failed_exit_code == 0
+            else f"Failed to fetch logs: {failed_error}"
+        )
+        # Append logs to debug message
+        debug_message = (
+            f"Systemd did not finish booting.\nError: {error}\nOutput: {output}\n"
+            f"Failed unit logs:\n{logs}"
+        )
+        # Assert with detailed debug message
+        assert exit_code == 0, debug_message
 
 
 def validate_systemd_unit(client, systemd_unit, active=True):

--- a/tests/platformSetup/gcp.py
+++ b/tests/platformSetup/gcp.py
@@ -459,13 +459,14 @@ class GCP:
     def _wait_until_reachable(self, hostname):
         self.logger.info(f"Waiting for {hostname} to respond...")
         i = 0
-        while i < 40:
+        # wait for 10 minutes
+        while i < 60:
             response = os.system("timeout 1 bash -c \"</dev/tcp/" + hostname + "/22\"")
             if response == 0:
                 self.logger.info(f"Instance {hostname} is reachable...")
                 return
             self.logger.info(f"Waiting for {hostname} to respond...")
-            time.sleep(2)
+            time.sleep(10)
             i += 1
         raise Exception("Remote host unreachable")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- adds [tests/helper/utils.py: debugging in wait_systemd_boot](https://github.com/gardenlinux/gardenlinux/commit/93f177452afde9533ed779dc52a02206d2f91274)
- azure: adds systemd dependency to make sure PTP clocksource is available on azure (https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#check-for-ptp-clock-source)
- gcp: increases wait for vm timeout to 10m
- general: if ssh banner cannot be decoded, retry

**Which issue(s) this PR fixes**:
Fixes #2538

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:
- successful nightly run: https://github.com/gardenlinux/gardenlinux/actions/runs/12279315300
- Needs no backports so far.
