### PR TITLE
azure: wait for /dev/ptp_hyperv before starting chronyd-restricted

### DIFF
--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d
@@ -1,0 +1,1 @@
+chronyd.service.d


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up for https://github.com/gardenlinux/gardenlinux/pull/2542 that also makes sure the `chronyd-restricted.service` waits for the PTP clocksource.

**Which issue(s) this PR fixes**:
Fixes #2538
