### PR TITLE
fix  platform-tests: paramiko.ssh_exception.SSHException: Error reading SSH protocol banner

### DIFF
--- a/tests/helper/sshclient.py
+++ b/tests/helper/sshclient.py
@@ -181,6 +181,9 @@ class RemoteClient:
                     # increase counter if banner is not yet decodable
                     except:
                         self._increase_retry_count_and_wait()
+                except SSHException as e:
+                    logger.warning(f"SSH exception: {e}")
+                    self._increase_retry_count_and_wait()
         except AuthenticationException as error:
             logger.exception("Authentication failed")
             raise error


### PR DESCRIPTION
**What this PR does / why we need it**:

We have connection issues in our platform tests. These come up at random which indicated that the VM might sometimes take longer to boot, define autorized_keys, ..., be available for connect.

This changes the behavior to retry in this cases.

**Which issue(s) this PR fixes**:
Fixes #2547

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
