### PR TITLE
feat: enable in-place updates

### DIFF
--- a/features/_usi/exec.post
+++ b/features/_usi/exec.post
@@ -6,6 +6,7 @@ rootfs="$1"
 
 mkdir -p "$rootfs/etc/gardenlinux"
 
+openssl x509 -in /builder/cert/gardenlinux-oci-sign.crt -pubkey -noout > "$rootfs/etc/gardenlinux/oci_signing_key.pem"
 for key in pk null.pk kek db; do
 	cp "/builder/cert/secureboot.$key.auth" "$rootfs/etc/gardenlinux/gardenlinux-secureboot.$key.auth"
 done

--- a/features/_usi/pkg.include
+++ b/features/_usi/pkg.include
@@ -1,5 +1,6 @@
 cryptsetup
 dracut
 efitools
+gardenlinux-update
 resizefat32
 systemd-boot-efi


### PR DESCRIPTION
**What this PR does / why we need it**:

install gardenlinux-update in _usi feature and write OCI public key to location expected by it

**Which issue(s) this PR fixes**:
Fixes #2458
