### PR TITLE
Increase retry wait time for azure platform tests

### DIFF
--- a/.github/workflows/azure_tests.sh
+++ b/.github/workflows/azure_tests.sh
@@ -48,6 +48,7 @@ podman run -it --rm -v "${AZURE_CONFIG_DIR}:/root/.azure" -v "$(pwd):/gardenlinu
 mkdir /gardenlinux/tmp
 TMPDIR=/gardenlinux/tmp/
 cd /gardenlinux/tests
+GL_REMOTE_CLIENT_SSH_RETRY_WAIT_SECONDS=30
 pytest --iaas=azure --configfile=/gardenlinux/$configFile --junit-xml=/artifacts/$cname.platform.test.xml || exit 1
 exit 0
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the (currently default) 15 seconds retry wait time to 30 seconds for azure platform tests.

**Which issue(s) this PR fixes**:
Fixes: #2552