### PR TITLE
Ensure `/dev/ptp_hyperv` systemd unit is in active state for chrony

### DIFF
--- a/features/azure/file.include/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf
@@ -1,3 +1,3 @@
 [Unit]
-Requires=dev-ptp_hyperv.device
+BindsTo=dev-ptp_hyperv.device
 After=dev-ptp_hyperv.device

--- a/features/azure/file.include/etc/udev/rules.d/60-hyperv-ptp.rules
+++ b/features/azure/file.include/etc/udev/rules.d/60-hyperv-ptp.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv", TAG+="systemd"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses systemd's `BindTo` directive for `chronyd.service` as well as `chronyd-restricted.service`. Based on systemd that means:
> Configures requirement dependencies, very similar in style to Requires=. However, this dependency type is stronger: in addition to the effect of Requires= it declares that if the unit bound to is stopped, this unit will be stopped too. This means a unit bound to another unit that suddenly enters inactive state will be stopped too. Units can suddenly, unexpectedly enter inactive state for different reasons: the main process of a service unit might terminate on its own choice, the backing device of a device unit might be unplugged or the mount point of a mount unit might be unmounted without involvement of the system and service manager.

This way chronyd / chronyd-restricted only gets active if and only if `/dev/ptp_hyperv` is active too. If the device is (virtually) unplugged this service will get inactive as well.

**Which issue(s) this PR fixes**:
Fixes #2562