### PR TITLE
Bump glcli version

### DIFF
--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.12"
       - name: Install glcli util
         run: |
-          git clone --depth 1 --branch 0.6.1 https://github.com/gardenlinux/python-gardenlinux-cli.git
+          git clone --depth 1 --branch 0.6.2 https://github.com/gardenlinux/python-gardenlinux-cli.git
           mv python-gardenlinux-cli /opt/glcli
           pip install -r /opt/glcli/requirements.txt
       - name: Install cosign
@@ -107,7 +107,7 @@ jobs:
           python-version: "3.12"
       - name: Install glcli util
         run: |
-          git clone --depth 1 --branch 0.6.1 https://github.com/gardenlinux/python-gardenlinux-cli.git
+          git clone --depth 1 --branch 0.6.2 https://github.com/gardenlinux/python-gardenlinux-cli.git
           mv python-gardenlinux-cli /opt/glcli
           pip install -r /opt/glcli/requirements.txt
       - name: Download OCI manifest artifacts


### PR DESCRIPTION
Closes https://github.com/gardenlinux/gardenlinux/issues/2551

The previous version of glcli was only able to apply the `mediaType` to new indexes, not update existing ones, which we need as [workflows/publish_container.yml](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/publish_container.yml) is actually writing to the OCI registry first before glcli uploads the rest.
