### PR TITLE
Ensure systemd detects drop-in files in `chronyd-restricted` for azure

### DIFF
--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d
@@ -1,1 +1,0 @@
-chronyd.service.d

--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/10-after_dev-ptp_hyperv.device.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/10-after_dev-ptp_hyperv.device.conf
@@ -1,0 +1,1 @@
+../chronyd.service.d/10-after_dev-ptp_hyperv.device.conf


### PR DESCRIPTION
**What this PR does / why we need it**:
After another appearance of the error `Starting chronyd-restricted.service - NTP client (restricted)... Could not open /dev/ptp_hyperv : No such file or directory` it was found that `chronyd-restricted.service.d` was never applied because it is a symlink. systemd expect drop-in files to be placed in directories. Linking individual drop-in files is supported while analysis shows that symlinking directories does not (for systemd 257).

If directories are symlinked `systemctl cat chronyd-restricted` only outputs the original unit. Symlinking the drop-in file results in the expected output of the drop-in file as well.

**Which issue(s) this PR fixes**:
Fixes #2562
Fixes #2565