### PR TITLE
Allow access to `ptp_hyperv` for `chronyd-restricted.service`

### DIFF
--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/05-private-devices-access.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/05-private-devices-access.conf
@@ -1,0 +1,4 @@
+[Service]
+DeviceAllow=/dev/ptp_hyperv
+DevicePolicy=closed
+PrivateDevices=no


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an additional attempt to fix the issue `Starting chronyd-restricted.service - NTP client (restricted)... Could not open /dev/ptp_hyperv : No such file or directory`. Beside the fixes introduced in #2563 and #2566 the following setting is used in the default systemd unit: `PrivateDevices=yes`

`PrivateDevices=yes` means:
```
If true, sets up a new /dev/ mount for the executed processes and only adds API pseudo devices such as /dev/null, /dev/zero or /dev/random (as well as the pseudo TTY subsystem) to it, but no physical devices such as /dev/sda, system memory /dev/mem, system ports /dev/port and others. This is useful to turn off physical device access by the executed process.
```

Instead we would like to restrict access to pseudo devices and add `/dev/ptp_hyperv` to the devices allowed to be accessed by `chronyd-restricted.service`.

**Which issue(s) this PR fixes**:
Fixes: #2562
Fixes: #2565
Fixes: #2567