### PR TITLE
Allow `rw` access to `/dev/ptp_hyperv` for `chronyd-restricted`

### DIFF
--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/05-private-devices-access.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/05-private-devices-access.conf
@@ -1,4 +1,4 @@
 [Service]
-DeviceAllow=/dev/ptp_hyperv
+DeviceAllow=/dev/ptp_hyperv rw
 DevicePolicy=closed
 PrivateDevices=no


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow-up of #2570 to ensure `rw` access is configured for `chronyd-restricted`.