### PR TITLE
Allow access for group `_chrony` to access symlinked `/dev/ptp_hyperv`

### DIFF
--- a/features/azure/file.include/etc/udev/rules.d/60-hyperv-ptp.rules
+++ b/features/azure/file.include/etc/udev/rules.d/60-hyperv-ptp.rules
@@ -1,1 +1,2 @@
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv", TAG+="systemd"
+# Allow access for group _chrony to access symlinked /dev/ptp_hyperv
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv", MODE="0660", GROUP="_chrony", TAG+="systemd"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tries to fix `Starting chronyd-restricted.service - NTP client (restricted)... Could not open /dev/ptp_hyperv : Permission denied` by granting access to `/dev/ptp_hyperv` to the group `_chrony`. PTP devices usually are accessible by `root` only and use mode `0600`. As stated in the original `chronyd-restricted.service` file it `... cannot use reference clocks, HW timestamping, RTC tracking, and other features.`. As we are interested in allowing access to a device this requires changes to the udev rule as well.