### PR TITLE
fix: only chrony.service should run

### DIFF
--- a/features/azure/file.include/etc/systemd/system-preset/00-chrony-disable.preset
+++ b/features/azure/file.include/etc/systemd/system-preset/00-chrony-disable.preset
@@ -1,0 +1,2 @@
+disable chrony-wait.service
+disable chronyd-restricted.service

--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/05-private-devices-access.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/05-private-devices-access.conf
@@ -1,4 +1,0 @@
-[Service]
-DeviceAllow=/dev/ptp_hyperv rw
-DevicePolicy=closed
-PrivateDevices=no

--- a/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/10-after_dev-ptp_hyperv.device.conf
+++ b/features/azure/file.include/etc/systemd/system/chronyd-restricted.service.d/10-after_dev-ptp_hyperv.device.conf
@@ -1,1 +1,0 @@
-../chronyd.service.d/10-after_dev-ptp_hyperv.device.conf

--- a/features/azure/file.include/etc/udev/rules.d/60-hyperv-ptp.rules
+++ b/features/azure/file.include/etc/udev/rules.d/60-hyperv-ptp.rules
@@ -1,2 +1,2 @@
 # Allow access for group _chrony to access symlinked /dev/ptp_hyperv
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv", MODE="0660", GROUP="_chrony", TAG+="systemd"
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv", TAG+="systemd"


### PR DESCRIPTION
**What this PR does / why we need it**:
Only _chrony.service_ should be enabled.

**Which issue(s) this PR fixes**:
Fixes #2576 