### PR TITLE
Remove mark manual for packages not in the repo

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -39,16 +39,3 @@ chmod u-s /bin/umount /bin/mount
 # Mark package as manual installed to pass the orphaned test
 # The package is installed and required by debootstrap 1.0.127
 apt-mark manual usr-is-merged
-
-# Issue 1305
-# Mark some packages as manual installed so that the orphaned test
-# is not complaining. These packages are installed due to a bug
-# in debootstrap 1.0.127+nmu1 which installs the dependencies of
-# 'usrmerge' but leaves the package itself behind.
-# garden-repo-manager gets installed during the debootstarp process
-apt-mark manual \
-  libfile-find-rule-perl \
-  libgdbm-compat4 \
-  libnumber-compare-perl \
-  "libperl5.*" \
-  libtext-glob-perl


### PR DESCRIPTION
**What this PR does / why we need it**:
The removed code marks some packages as 'manually installed' as described in #1305.
This now breaks the build as some of those packages are not in the repo anymore.
This code was a workaround for an issue with debootstrap in 2022, I don't think we need this anymore, so we can remove it to make the build work again.

**Which issue(s) this PR fixes**:
Fixes #2579
