### PR TITLE
Add utility script to find the correct build container for Garden Linux releases

### DIFF
--- a/bin/find-build-container-for
+++ b/bin/find-build-container-for
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import requests
+import sys
+
+def download_file(version):
+    # Ensure the version follows the format "1234.5"
+    if '.' not in version:
+        version = f"{version}.0"
+
+    url = f"https://raw.githubusercontent.com/gardenlinux/repo/refs/tags/{version}/.container"
+
+    try:
+        response = requests.get(url)
+        
+        if response.status_code == 200:
+            print(response.text)
+        else:
+            print(f"Failed to download file. HTTP Status Code: {response.status_code}")
+            print("Please check if the version number is correct.")
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred while trying to download the file: {e}")
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python find-build-container-for <version>")
+        return
+
+    version = sys.argv[1]
+    download_file(version)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # Note: You should always prefer your local package manager.
 PyYAML
 networkx
+requests


### PR DESCRIPTION
This script might make it a bit more easy to maintain backports of packages, when needed.