### PR TITLE
ci: use special upload runner instead of 64 core

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -22,7 +22,7 @@ jobs:
   upload_to_s3:
     name: upload to S3
     needs: [ generate_matrix_publish ]
-    runs-on: ubuntu-latest-64core
+    runs-on: upload
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
no need to use 64 core, just need some runner not using the default runner ip addr range to avoid issues with upload to S3 china.