### PR TITLE
Use pipenv sync instead of install

### DIFF
--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -10,7 +10,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install pipenv
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
-RUN pipenv install --system --dev --verbose
+RUN pipenv sync --system --dev --verbose
 
 COPY init /init
 CMD /init


### PR DESCRIPTION
**What this PR does / why we need it**:

replaces pipenv install with pipenv sync, it is needed to only use lock file to install dependencies during tests, otherwise building testing container image might often fail, please see https://stackoverflow.com/a/53489664

**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [x] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer

```
