### PR TITLE
Automate package upgrade release notes using glvd

### DIFF
--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -221,12 +221,42 @@ def generate_package_update_section(version):
                     output += _parse_match_section(s['matchBinaries'])
     return output
 
-def release_notes_changes_section():
-    return textwrap.dedent("""
-    ## Changes
-    The following packages have been upgraded, to address the mentioned CVEs:
-    **todo release facilitator: fill this in**
-    """)
+def release_notes_changes_section(gardenlinux_version):
+    """
+        Get list of fixed CVEs, grouped by upgraded package.
+        Note: This result is not perfect, feel free to edit the generated release notes and
+        file issues in glvd for improvement suggestions https://github.com/gardenlinux/glvd/issues
+    """
+    try:
+        url = f"https://glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com/v1/patchReleaseNotes/{gardenlinux_version}"
+        response = requests.get(url)
+        response.raise_for_status()  # Will raise an error for bad responses
+        data = response.json()
+
+        output = [
+            "## Changes",
+            "The following packages have been upgraded, to address the mentioned CVEs:"
+        ]
+        for package in data["packageList"]:
+            upgrade_line = (
+                f"- upgrade '{package['sourcePackageName']}' from `{package['oldVersion']}` "
+                f"to `{package['newVersion']}`"
+            )
+            output.append(upgrade_line)
+
+            if package["fixedCves"]:
+                cve_line = "  - " + ", ".join(package["fixedCves"])
+                output.append(cve_line)
+
+        return "\n".join(output) + "\n"
+    except:
+        # There are expected error cases, for example with versions not supported by glvd (1443.x) or when the api is not available
+        # Fail gracefully by adding the placeholder we previously used, so that the release note generation does not fail.
+        return textwrap.dedent("""
+        ## Changes
+        The following packages have been upgraded, to address the mentioned CVEs:
+        **todo release facilitator: fill this in**
+        """)
 
 def release_notes_software_components_section(package_list):
     output = "\n"
@@ -288,7 +318,7 @@ def create_github_release_notes(gardenlinux_version, commitish, dry_run = False)
 
     output = ""
 
-    output += release_notes_changes_section()
+    output += release_notes_changes_section(gardenlinux_version)
 
     output += release_notes_software_components_section(package_list)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Get list of fixed CVEs, grouped by upgraded package.
This automates some of the work needed when a new release is done.

Note that the output is known to be not perfect, it depends on the data available in glvd. Manual editing of the output is anticipated, but it should still reduce the manual effort needed on creating a new release.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/2653

Example output:

## Changes
The following packages have been upgraded, to address the mentioned CVEs:
- upgrade 'jinja2' from `3.1.3-1` to `3.1.5-1gl0`
  - CVE-2024-34064, CVE-2024-56201, CVE-2024-56326
- upgrade 'rsync' from `3.3.0-1` to `3.3.0+ds1-4gl0~bp1592`
  - CVE-2024-12084, CVE-2024-12085, CVE-2024-12086, CVE-2024-12087, CVE-2024-12088, CVE-2024-12747
- upgrade 'curl' from `8.11.0-1gl0` to `8.11.1-1gl0`
  - CVE-2024-11053
- upgrade 'python3.12' from `3.12.7-1gl1~bp1592` to `3.12.8-5gl0~bp1592`
  - CVE-2024-12254, CVE-2024-9287
- upgrade 'linux' from `6.6.63-0gl0~bp1592` to `6.6.71-0gl0~bp1592`
  - CVE-2024-50106, CVE-2024-53141, CVE-2024-53142, CVE-2024-57937, CVE-2025-21630
- upgrade 'runc' from `1.1.12+ds1-2gardenlinux0` to `1.1.15+ds1-1gl0`
  - CVE-2024-45310
