### PR TITLE
feat: improved os-release file

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -6,6 +6,8 @@ cat > /etc/os-release << EOF
 ID=gardenlinux
 NAME="Garden Linux"
 PRETTY_NAME="Garden Linux $BUILDER_VERSION"
+IMAGE_VERSION=${BUILDER_VERSION}
+VARIANT_ID=${BUILDER_CNAME%-*}
 HOME_URL="https://gardenlinux.io"
 SUPPORT_URL="https://github.com/gardenlinux/gardenlinux"
 BUG_REPORT_URL="https://github.com/gardenlinux/gardenlinux/issues"


### PR DESCRIPTION
This improves general information displayed by systemd about the OS by
adding `VARIANT` and `VARIANT_ID` to the os-release file.

Details about the variables can be found in https://www.freedesktop.org/software/systemd/man/latest/os-release.html#VARIANT=
