### PR TITLE
fix: bump kernel time to work with _usi

### DIFF
--- a/features/base/test/test_basics.py
+++ b/features/base/test/test_basics.py
@@ -55,7 +55,7 @@ def test_ls(client):
 
 def test_startup_time(client, non_chroot, non_kvm, non_azure):
     """ Test for startup time """
-    tolerated_kernel_time = 30
+    tolerated_kernel_time = 60
     tolerated_userspace_time = 40
     (exit_code, output, error) = client.execute_command("systemd-analyze")
     assert exit_code == 0, f"no {error=} expected"


### PR DESCRIPTION
The `tolerated_kernel_time` in this test is actually the sum of kernel time + initrd time. Since #2591 the initrd is doing a lot more work on first boot, so this needs to be bumped up

#2661 