### PR TITLE
Revert "Feature/test for support disto (#2654)"

### DIFF
--- a/features/base/test/test_basics.py
+++ b/features/base/test/test_basics.py
@@ -1,21 +1,6 @@
 import pytest
-from helper.utils import get_architecture, AptUpdate, install_package_deb, execute_remote_command
+from helper.utils import get_architecture
 from helper.sshclient import RemoteClient
-
-@pytest.mark.security_id(1)
-def test_gl_is_support_distro(client):
-    """
-    This tests ensures that the vendor field is set to 'gardenlinux'.
-    """
-
-    AptUpdate(client)
-    install_package_deb(client, "dpkg-dev")
-    assert '' ==  execute_remote_command(client, "dpkg-vendor --is gardenlinux")
-    assert '' ==  execute_remote_command(client, "dpkg-vendor  --derives-from debian")
-
-    # Negative case:
-    status, output  = execute_remote_command(client, "dpkg-vendor --is debian", skip_error=True)
-    assert status == 1
 
 
 def test_no_man(client):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -7,4 +7,3 @@ log_file_level = INFO
 log_level = INFO
 testpaths = ../features platform local
 addopts = -rA --showlocals --iaas=gcp  --ignore=platform_tests  --ignore=ci  --import-mode=importlib
-markers = security_id


### PR DESCRIPTION
This reverts commit ae4610dafd7e62020bfe820a91928b849a728900.

**What this PR does / why we need it**:

Looks like the added test is broken when run in the platform tests; likely running with different permissions when running platform tests vs chroot tests.

```
=================================== FAILURES ===================================
__________________________ test_gl_is_support_distro ___________________________

client = <helper.sshclient.RemoteClient object at 0x7feef08abe30>

    @pytest.mark.security_id(1)
    def test_gl_is_support_distro(client):
        """
        This tests ensures that the vendor field is set to 'gardenlinux'.
        """
    
>       AptUpdate(client)

client     = <helper.sshclient.RemoteClient object at 0x7feef08abe30>

../features/base/test/test_basics.py:11: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'helper.utils.AptUpdate'>
client = <helper.sshclient.RemoteClient object at 0x7feef08abe30>

    def __new__(cls, client):
        if not hasattr(cls, 'instance'):
            cls.instance = super(AptUpdate, cls).__new__(cls)
    
        (exit_code, output, error) = client.execute_command("apt-get update")
>       assert exit_code == 0, f"no {error=} expected"
E       AssertionError: no error='E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)\nE: Unable to lock directory /var/lib/apt/lists/\n' expected

__class__  = <class 'helper.utils.AptUpdate'>
client     = <helper.sshclient.RemoteClient object at 0x7feef08abe30>
cls        = <class 'helper.utils.AptUpdate'>
error      = 'E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)\nE: Unable to lock directory /var/lib/apt/lists/\n'
exit_code  = 100
output     = 'Reading package lists...\n'
```