### PR TITLE
Upgrade python to 3.13 in platform tests

### DIFF
--- a/tests/images/platform-test-base/Containerfile
+++ b/tests/images/platform-test-base/Containerfile
@@ -4,7 +4,7 @@ ARG GL_BASE=ghcr.io/gardenlinux/gardenlinux:${GL_VERSION}
 
 FROM ${GL_BASE}
 
-ENV PYTHON=python3.12
+ENV PYTHON=python3.13
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash


### PR DESCRIPTION
Python 3.13 is the current version in debian trixie and the maintained version of python in Garden Linux today.