### PR TITLE
build only tofu platform-test-images in nightly

### DIFF
--- a/.github/workflows/platform-test-images.yml
+++ b/.github/workflows/platform-test-images.yml
@@ -26,6 +26,10 @@ on:
       force_release:
         type: boolean
         default: false
+      platforms:
+        type: string
+        default: '["firecracker", "kvm", "openstack", "tofu"]'
+        description: 'JSON array of platforms to build'
   # triggered manually
   workflow_dispatch:
     inputs:
@@ -38,6 +42,10 @@ on:
       force_release:
         type: boolean
         default: false
+      platforms:
+        type: string
+        default: '["firecracker", "kvm", "openstack", "tofu"]'
+        description: 'JSON array of platforms to build'
 jobs:
   images:
     runs-on: ubuntu-latest
@@ -47,11 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: 
-          - firecracker
-          - kvm
-          - openstack
-          - tofu
+        platform: ${{ fromJSON(inputs.platforms) }}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
     with:
       gl_version: ${{ inputs.platform_test_tag }}
       force_release: ${{ inputs.platform_test_tag == 'nightly' || false }}
+      platforms: '["tofu"]'
   platform_tests:
     name: platform test
     needs: [ generate_matrix_test_platform, platform_test_images ]


### PR DESCRIPTION
**What this PR does / why we need it**:

After the OpenTofu merge in https://github.com/gardenlinux/gardenlinux/pull/2543/ our nightly still builds platform-test-images for other platforms than tofu. This is not needed anymore and will be disabled by default by this PR.