### PR TITLE
bump glrd version to be compatible with v2 syntax

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,11 +113,11 @@ jobs:
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Create GLRD nightly release
-        uses: gardenlinux/glrd@v1
+        uses: gardenlinux/glrd@v2
         with:
           cmd: glrd-manage --s3-update --create nightly
       - name: Get latest GL nightly
         id: gl_version_nightly
-        uses: gardenlinux/glrd@v1
+        uses: gardenlinux/glrd@v2
         with:
           cmd: glrd --type nightly --latest

--- a/.github/workflows/release-page.yml
+++ b/.github/workflows/release-page.yml
@@ -111,7 +111,7 @@ jobs:
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Create GLRD release
-        uses: gardenlinux/glrd@v1
+        uses: gardenlinux/glrd@v2
         with:
           cmd: |
             type=${{ inputs.type }}
@@ -129,7 +129,7 @@ jobs:
               glrd-manage --s3-update --create dev --version ${version} --commit ${commit}
             fi
       - name: Get created GLRD release
-        uses: gardenlinux/glrd@v1
+        uses: gardenlinux/glrd@v2
         with:
           cmd: |
             version=${{ inputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,10 +100,10 @@ jobs:
         if [[ "${{ inputs.download_s3 }}" == "true" ]]; then
           if [[ "${{ inputs.version }}" == "latest" ]]; then
             VERSION="$(bin/glrd --latest --fields 'Version' --no-header --type patch)"
-            SHA="$(bin/glrd --latest --fields 'Git\ Commit' --no-header --type patch)"
+            SHA="$(bin/glrd --latest --fields 'GitCommitShort' --no-header --type patch)"
           else
             VERSION="$(bin/glrd --fields 'Version' --no-header --type patch,nightly,dev --version ${{ inputs.version }} | tail -1)"
-            SHA="$(bin/glrd --fields 'Git\ Commit' --no-header --type patch,nightly,dev --version ${{ inputs.version }} | tail -1)"
+            SHA="$(bin/glrd --fields 'GitCommitShort' --no-header --type patch,nightly,dev --version ${{ inputs.version }} | tail -1)"
           fi
           echo "${VERSION}" >VERSION
           echo "${SHA}" >COMMIT


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/gardenlinux/glrd/pull/2 renamed some fields that need updating in our workflows.