### PR TITLE
platform-tests: convert UUIDs to lowercase on macos

### DIFF
--- a/tests/platformSetup/Makefile
+++ b/tests/platformSetup/Makefile
@@ -5,7 +5,7 @@ ROOT_DIR := $(shell git rev-parse --show-toplevel)
 UUID_FILE := $(ROOT_DIR)/tests/platformSetup/.uuid
 # Check if the .uuid file exists. If it does, read from it, otherwise generate a new uuid/seed
 ifeq ($(wildcard $(UUID_FILE)),)
-	UUID := $(shell uuidgen)
+	UUID := $(shell uuidgen | tr A-F a-f)
     $(shell echo $(UUID) > $(UUID_FILE))
 else
     UUID := $(shell cat $(UUID_FILE))


### PR DESCRIPTION
**What this PR does / why we need it**:

convert UUIDs to lowercase
`uuidgen` creates uppercase UUIDs on MacOs

**Which issue(s) this PR fixes**:
Fixes #2622