### PR TITLE
Always upload test artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3
       with:
         name: platform-test-${{ env.cname }}
-        if: {{ success() || failure() }} 
+        if: success() || failure()
         path: |
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.log
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,7 @@ jobs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3
       with:
         name: platform-test-${{ env.cname }}
+        if: always()
         path: |
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.log
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3
       with:
         name: platform-test-${{ env.cname }}
-        if: always()
+        if: {{ success() || failure() }} 
         path: |
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.log
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now if some of the tests have the result "failure" the job fails (which is ok) but the artifacts as in the pytest test log is not being uploaded. For the compliance reporting it would be good to keep those artifacts to then do reporting on them.

This PR is supposed to upload the test result log files independently of the test results themselves.

**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
