### PR TITLE
change the behavior once more, the step to upload artifacts still gets skipped after a test failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,7 +204,7 @@ jobs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3
       with:
         name: platform-test-${{ env.cname }}
-        if: success() || failure()
+        if: "!cancelled()" 
         path: |
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.log
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml


### PR DESCRIPTION

**What this PR does / why we need it**:

see: https://github.com/gardenlinux/gardenlinux/actions/runs/13265100948/job/37031786164

the test artifact upload step is still skipped

**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
