### PR TITLE
change "!cancelled()" to always() to get the test artifacts to upload…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,7 +204,7 @@ jobs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3
       with:
         name: platform-test-${{ env.cname }}
-        if: "!cancelled()" 
+        if: always() 
         path: |
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.log
           ${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml


### PR DESCRIPTION
… in case tests fail

upload the artifacts anyways!

**What this PR does / why we need it**:

We need it for compliance mapping / reporting


**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/gardenlinux/compliance-reporting/issues/1 

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
