### PR TITLE
platform-test logs are not named with a cname but a combination of $FLAVOR-$ARCH

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
       run: |
         make --directory=tests ${FLAVOR}-${ARCH}-test-platform 2>&1 | tee "${{ env.artifact_dir}}/${{ env.cname }}.platform.test.log"
 
-    - name: copy platform test log for ${{ matrix.flavor }} on ${{ matrix.arch }}
+    - name: copy platform test junit xml file for ${{ matrix.flavor }} on ${{ matrix.arch }}
       if: always()
       run: |
         cp "tests/${FLAVOR}-${ARCH}.platform.test.xml" "${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml" || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,6 +201,11 @@ jobs:
       run: |
         make --directory=tests ${FLAVOR}-${ARCH}-test-platform 2>&1 | tee "${{ env.artifact_dir}}/${{ env.cname }}.platform.test.log"
 
+    - name: copy platform test log for ${{ matrix.flavor }} on ${{ matrix.arch }}
+      if: always()
+      run: |
+        cp "tests/${FLAVOR}-${ARCH}.platform.test.xml" "${{ env.artifact_dir }}/${{ env.cname }}.platform.test.xml" || true
+
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3
       if: always()
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:

platform-test logs are not named with a cname but a combination of $FLAVOR-$ARCH
This PR fixes this in the GithubActions.

This is a change introduced with https://github.com/gardenlinux/gardenlinux/pull/2543

https://github.com/gardenlinux/gardenlinux/blob/e033a4ea8aa4df50123e77960df32f7b049ba418/tests/Makefile#L56C215-L56C216