### PR TITLE
feat: include certs in build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ inputs.use_kms }}
         run: |
           touch cert/gardenlinux-secureboot.db.arn
-          for f in secureboot.{{pk,null.pk,kek,db}.auth,db.{crt,arn}}; do
+          for f in secureboot.{{pk,null.pk,kek,db}.{crt,der,auth},db.arn,aws-efivars}; do
             ln -sr "cert/gardenlinux-$f" "cert/$f"
           done
       - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v3
@@ -249,6 +249,12 @@ jobs:
           path: ".build/${{ env.cname }}.chroot.test.xml"
       - name: add chroot.test.xml to build artifacts
         run: echo "${{ env.cname }}.chroot.test.xml" >> ".build/${{ env.cname }}.artifacts"
+      - name: add certs to build artifacts
+        run: |
+          for f in secureboot.{{pk,kek,db}.{crt,der,auth},aws-efivars}; do
+            cp "cert/$f" ".build/${{ env.cname }}.$f"
+            echo "${{ env.cname }}.$f" >> ".build/${{ env.cname }}.artifacts"
+          done
       - name: pack build artifacts for upload
         run: tar -cSzvf "${{ env.cname }}.tar.gz" -C .build -T ".build/${{ env.cname }}.artifacts"
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # pin@v4.4.3

--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.12"
       - name: Install glcli util
         run: |
-          git clone --depth 1 --branch 0.6.2 https://github.com/gardenlinux/python-gardenlinux-cli.git
+          git clone --depth 1 --branch 0.6.3 https://github.com/gardenlinux/python-gardenlinux-cli.git
           mv python-gardenlinux-cli /opt/glcli
           pip install -r /opt/glcli/requirements.txt
       - name: Install cosign


### PR DESCRIPTION
**What this PR does / why we need it**:

Include certs in build artifacts uploaded to S3 => GLCI can fetch from there rather then having to lookup corresponding git commit.

**Which issue(s) this PR fixes**:
Resolves #2692 

Requires https://github.com/gardenlinux/python-gardenlinux-cli/pull/49
