### PR TITLE
Fix broken nightly by fixing the test shadow password test

### DIFF
--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -21,6 +21,12 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     imply we execute read-only.
     """
     password_shadow(client)
+    outputs = []
+    exit_code, output = execute_remote_command(client, "whoami", skip_error=True)
+    outputs.append(output)
+    exit_code, output = execute_remote_command(client, "ls -la /etc/shadow", skip_error=True)
+    outputs.append(output)
+    assert outputs == []
     exit_code, output = execute_remote_command(client, command, skip_error=True)
     assert output == expected_output
     assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -10,7 +10,7 @@ import pytest
 @pytest.mark.security_id(324)
 @pytest.mark.parametrize(
     "command, expected_exit_code, expected_output",
-    [("sudo -S /usr/sbin/pwck -r", 0, ""), ("sudo -S /usr/sbin/grpck -r", 0, "")],
+    [("pwck -r", 0, ""), ("grpck -r", 0, "")],
 )
 def test_password_shadow(client, command, expected_exit_code, expected_output):
     """This ensure that not only the passwd and shadow is as expected,
@@ -21,6 +21,11 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     imply we execute read-only.
     """
     password_shadow(client)
-    exit_code, output = execute_remote_command(client, command, skip_error=True)
+    exit_code, _ = execute_remote_command(client, "ls /usr/bin/sudo", skip_error=True)
+    if exit_code == 0:
+        exit_code, output = execute_remote_command(client, f"sudo -S {command}", skip_error=True)
+    else:
+        exit_code, output = execute_remote_command(client, command, skip_error=True)
+
     assert output == "" 
     assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -21,11 +21,10 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     imply we execute read-only.
     """
     password_shadow(client)
-    exit_code, _ = execute_remote_command(client, "ls /usr/bin/sudo", skip_error=True)
-    if exit_code == 0:
-        exit_code, output = execute_remote_command(client, f"sudo -S {command}", skip_error=True)
-    else:
-        exit_code, output = execute_remote_command(client, command, skip_error=True)
-
-    assert output == "" 
+    exit_code, output = execute_remote_command(
+        client,
+        f"if [ $(id -u) = 0 ]; then {command}; else sudo -S {command}; fi",
+        skip_error=True,
+    )
+    assert output == ""
     assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -10,7 +10,7 @@ import pytest
 @pytest.mark.security_id(324)
 @pytest.mark.parametrize(
     "command, expected_exit_code, expected_output",
-    [("/usr/sbin/pwck -r", 0, ""), ("/usr/sbin/grpck -r", 0, "")],
+    [("sudo -S /usr/sbin/pwck -r", 0, ""), ("sudo -S /usr/sbin/grpck -r", 0, "")],
 )
 def test_password_shadow(client, command, expected_exit_code, expected_output):
     """This ensure that not only the passwd and shadow is as expected,
@@ -21,12 +21,6 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     imply we execute read-only.
     """
     password_shadow(client)
-    outputs = []
-    exit_code, output = execute_remote_command(client, "whoami", skip_error=True)
-    outputs.append(output)
-    exit_code, output = execute_remote_command(client, "ls -la /etc/shadow", skip_error=True)
-    outputs.append(output)
-    assert outputs == []
     exit_code, output = execute_remote_command(client, command, skip_error=True)
     assert output == expected_output
     assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -23,7 +23,7 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     password_shadow(client)
     exit_code, output = execute_remote_command(
         client,
-        f"if [ $(id -u) = 0 ]; then {command}; else sudo {command}; fi",
+        f"if [ $(id -u) = 0 ]; then {command}; else sudo --stdin {command}; fi",
         skip_error=True,
     )
     assert output == ""

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -22,5 +22,13 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     """
     password_shadow(client)
     exit_code, output = execute_remote_command(client, command, skip_error=True)
-    assert output == expected_output
-    assert exit_code == expected_exit_code
+    assert output == """"user 'games': directory '/nonexistent' does not exist
+user 'man': directory '/nonexistent' does not exist
+user 'lp': directory '/nonexistent' does not exist
+user 'news': directory '/nonexistent' does not exist
+user 'uucp': directory '/nonexistent' does not exist
+user 'www-data': directory '/nonexistent' does not exist
+user 'list': directory '/nonexistent' does not exist
+user 'irc': directory '/nonexistent' does not exist
+pwck: no changes"""
+     assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -22,5 +22,5 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     """
     password_shadow(client)
     exit_code, output = execute_remote_command(client, command, skip_error=True)
-    assert exit_code == expected_exit_code
     assert output == expected_output
+    assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -22,13 +22,5 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     """
     password_shadow(client)
     exit_code, output = execute_remote_command(client, command, skip_error=True)
-    assert output == """"user 'games': directory '/nonexistent' does not exist
-user 'man': directory '/nonexistent' does not exist
-user 'lp': directory '/nonexistent' does not exist
-user 'news': directory '/nonexistent' does not exist
-user 'uucp': directory '/nonexistent' does not exist
-user 'www-data': directory '/nonexistent' does not exist
-user 'list': directory '/nonexistent' does not exist
-user 'irc': directory '/nonexistent' does not exist
-pwck: no changes"""
-     assert exit_code == expected_exit_code
+    assert output == "" 
+    assert exit_code == expected_exit_code

--- a/features/base/test/test_password_shadow.py
+++ b/features/base/test/test_password_shadow.py
@@ -23,7 +23,7 @@ def test_password_shadow(client, command, expected_exit_code, expected_output):
     password_shadow(client)
     exit_code, output = execute_remote_command(
         client,
-        f"if [ $(id -u) = 0 ]; then {command}; else sudo -S {command}; fi",
+        f"if [ $(id -u) = 0 ]; then {command}; else sudo {command}; fi",
         skip_error=True,
     )
     assert output == ""

--- a/tests/helper/tests/capabilities.py
+++ b/tests/helper/tests/capabilities.py
@@ -16,7 +16,9 @@ def capabilities(client, testconfig, non_chroot):
 
     cap_found = []
     cap_notfound = []
+
     for line in output.splitlines():
+        match = None
         line.strip(string.whitespace)
         for cap in capabilities:
             match = re.fullmatch(cap, line)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -6,4 +6,4 @@ log_file = test.log
 log_file_level = INFO
 log_level = INFO
 testpaths = ../features platform local
-addopts = -rA --showlocals --iaas=gcp  --ignore=platform_tests  --ignore=ci  --import-mode=importlib
+addopts = -vvv -rA --showlocals --iaas=gcp  --ignore=platform_tests  --ignore=ci  --import-mode=importlib


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases the tests are being run by an unprivileged user. In those cases we need to run the commands with sudo. In other cases, sudo doesn't exist on the system. In those cases we must run the command with sudo.

Nightly on this branch looks promising: https://github.com/gardenlinux/gardenlinux/actions/runs/13313736886


Minor sneak in changes:
 - the pytest.ini now contains -vvv as additional argument which shouldn't make a huge difference if the tests pass but in case they don't it can help to see the errors more clearly.
 - [tests/helper/tests/capabilities.py](https://github.com/gardenlinux/gardenlinux/pull/2714/files#diff-4c8e94db6da1afedbf8da96c36123aff6d6f8c93275b6c30f9012c614aa7b0d0) now doesn't fail any longer in some cases in which "match" wasn't defined



**Which issue(s) this PR fixes**:
Broken nightly

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
