### PR TITLE
feat: add skip_upload option to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,9 @@ on:
         type: string
         required: true
         default: "nightly"
+      skip_upload:
+        type: boolean
+        default: false
 jobs:
   build:
     uses: ./.github/workflows/build.yml
@@ -57,6 +60,7 @@ jobs:
       tf_encryption: ${{ secrets.TF_ENCRYPTION }}
   upload_to_s3:
     name: upload to S3
+    if: ${{ ! inputs.skip_upload }}
     needs: [ build, tests ]
     permissions:
       id-token: write
@@ -70,6 +74,7 @@ jobs:
       session: ${{ secrets.AWS_OIDC_SESSION }}
   upload_to_s3_cn:
     name: upload to S3 china
+    if: ${{ ! inputs.skip_upload }}
     needs: [ build, tests ]
     permissions:
       id-token: write
@@ -83,12 +88,14 @@ jobs:
       session: ${{ secrets.AWS_CN_OIDC_SESSION }}
   publish_container:
     name: publish gardenlinux container base image
+    if: ${{ ! inputs.skip_upload }}
     needs: [ build, tests ]
     uses: ./.github/workflows/publish_container.yml
     with:
       version: ${{ needs.build.outputs.version }}
   upload_oci:
     name: Run glcli to publish to OCI
+    if: ${{ ! inputs.skip_upload }}
     needs: [ build, publish_container ]
     uses: ./.github/workflows/upload_oci.yml
     with:
@@ -100,12 +107,12 @@ jobs:
       oci-kms-arn: ${{ secrets.OCI_KMS_ARN }}
   glrd:
     name: create GLRD release
+    # only create release on main branch
+    if: ${{ ! inputs.skip_upload && github.ref == 'refs/heads/main'}}
     needs: [ upload_to_s3 ]
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    # only create release on main branch
-    if: ${{ github.ref }} == 'refs/heads/main'
     steps:
       - uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # pin@v4
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add option to skip upload. Useful to test only platform tests from branches without permissions to write to S3.