### PR TITLE
Add auto rerun on GHCR upload

### DIFF
--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -80,6 +80,7 @@ jobs:
             exit_code=$?
             if echo "$output" | grep -q "Bad Gateway"; then
               retry_count=$((retry_count+1))
+              exit_code=1
               echo "Bad Gateway detected, retry $retry_count/$max_retries"
               sleep 10
             elif [ $exit_code -eq 0 ]; then

--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -72,7 +72,28 @@ jobs:
       - name: push using the glcli util
         run: |
           mkdir -p manifests
-          GLOCI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }} GLOCI_REGISTRY_USERNAME=${{ github.repository_owner }} python /opt/glcli/src/glcli.py push-manifest --dir ${{ env.cname }} --container ghcr.io/${{ github.repository }} --arch ${{ matrix.arch }} --version ${{ inputs.version }} --cname ${{ env.cname }} --cosign_file digest --manifest_file manifests/oci_manifest_entry_${{ env.cname }}.json
+          max_retries=3
+          retry_count=0
+          exit_code=0
+          until [ $retry_count -ge $max_retries ]; do
+            output=$(GLOCI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }} GLOCI_REGISTRY_USERNAME=${{ github.repository_owner }} python /opt/glcli/src/glcli.py push-manifest --dir ${{ env.cname }} --container ghcr.io/${{ github.repository }} --arch ${{ matrix.arch }} --version ${{ inputs.version }} --cname ${{ env.cname }} --cosign_file digest --manifest_file manifests/oci_manifest_entry_${{ env.cname }}.json 2>&1)
+            exit_code=$?
+            if echo "$output" | grep -q "Bad Gateway"; then
+              retry_count=$((retry_count+1))
+              echo "Bad Gateway detected, retry $retry_count/$max_retries"
+              sleep 10
+            elif [ $exit_code -eq 0 ]; then
+              echo $output
+              break
+            else
+              echo "Fatal error: $output"
+              exit $exit_code
+            fi
+          done
+          if [ $exit_code -ne 0 ]; then
+            echo "Failed after $max_retries retries"
+            exit 1
+          fi
       - name: Upload oci manifest artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Implements retry logic for **502 Bad Gateway** errors on GHCR upload. After 3 unsuccessful retries the action should then terminate.