### PR TITLE
enable platform-tests for arm64 on azure

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -93,7 +93,7 @@ targets:
         arch: arm64
         build: true
         test: true
-        test-platform: false
+        test-platform: true
         publish: true
       - features:
           - gardener


### PR DESCRIPTION
**What this PR does / why we need it**:
* enables platform tests for arm64 on azure 
* we disabled azure arm64 platform tests a while ago, during Microsoft's back-and-forth with the support of arm64 instances in Azure

**Which issue(s) this PR fixes**:
Fixes #2721 
