### PR TITLE
enable arm64 azure platformtests for 1443

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,6 @@ jobs:
         modifier: [ "${{ inputs.default_modifier }}" ]
         exclude:
           - arch: arm64
-            target: azure
-          - arch: arm64
             target: ali
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1


### PR DESCRIPTION
fixes #2721
similar to PR for main branch: #2738
enables platform tests for arm64 on azure
