### PR TITLE
enable arm64 azure platform tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,6 @@ jobs:
         modifier: [ "${{ inputs.default_modifier }}" ]
         exclude:
           - arch: arm64
-            target: azure
-          - arch: arm64
             target: ali
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1


### PR DESCRIPTION
**What this PR does / why we need it**:

enable arm64 platform tests on azure 

for main branch: https://github.com/gardenlinux/gardenlinux/pull/2738
for rel-1443 branch: https://github.com/gardenlinux/gardenlinux/pull/2739


**Which issue(s) this PR fixes**:
Fixes #2721 
