### PR TITLE
fix: do not exclude copyright files

### DIFF
--- a/features/_slim/exec.late
+++ b/features/_slim/exec.late
@@ -1,0 +1,5 @@
+set -e
+
+# remove everything from /usr/share/doc except the copyrights
+find /usr/share/doc/ -type f -mindepth 1 ! -wholename '/usr/share/doc/*/copyright' -delete
+find /usr/share/doc/ -type d -mindepth 1 -empty -delete

--- a/features/_slim/file.exclude
+++ b/features/_slim/file.exclude
@@ -1,4 +1,3 @@
-/usr/share/doc
 /usr/share/man
 /usr/share/locale
 /usr/share/groff


### PR DESCRIPTION
**What this PR does / why we need it**:
The copyright files from _/usr/share/doc_ should not be excluded.

**Which issue(s) this PR fixes**:
Fixes #2677 