### PR TITLE
set nightly/now version in tests-only

### DIFF
--- a/.github/workflows/tests-only.yml
+++ b/.github/workflows/tests-only.yml
@@ -7,7 +7,7 @@ on:
       version:
         description: "Garden Linux Version: version passed to glrd"
         type: string
-        default: latest
+        default: now
       build:
         description: "Build for version 'today' instead of downloading version from S3"
         type: boolean
@@ -30,7 +30,7 @@ jobs:
       id-token: write
       packages: write
     with:
-      version: 'today'
+      version: '${{ inputs.version }}'
       use_kms: false
       flavors_parse_params_images: '${{ inputs.flavors_parse_params }}'
       flavors_parse_params_bare: '--exclude "*" --no-arch --json-by-arch'


### PR DESCRIPTION
**What this PR does / why we need it**:

The version to build/tests images in the `tests-only.yml` workflow is set inconstantly.
This PR sets it to the nightly version by setting `version: now`.

https://github.com/gardenlinux/gardenlinux/actions/runs/13493390858 is a successful run started with:
```
gh workflow run "platform tests only" -f build=true --ref fix/2759 -f flavors_parse_params='--no-arch --json-by-arch --test-platform --include-only gcp-gardener_prod-amd64'
```

**Which issue(s) this PR fixes**:
Fixes #2756