### PR TITLE
fix: console settings should be applied only via platform feature

### DIFF
--- a/features/gardener/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/gardener/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,1 +1,0 @@
-CMDLINE_LINUX="console=tty0 console=ttyS0 $CMDLINE_LINUX"


### PR DESCRIPTION
**What this PR does / why we need it**:
Console settings should be applied only via the platform features.

**Which issue(s) this PR fixes**: