### PR TITLE
Change format of CVEs in release notes to long-list style

### DIFF
--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -245,8 +245,8 @@ def release_notes_changes_section(gardenlinux_version):
             output.append(upgrade_line)
 
             if package["fixedCves"]:
-                cve_line = "  - " + ", ".join(package["fixedCves"])
-                output.append(cve_line)
+                for fixedCve in package["fixedCves"]:
+                    output.append(f'  - {fixedCve}')
 
         return "\n".join(output) + "\n"
     except:


### PR DESCRIPTION
Output this style of markdown for the release notes:

Fixes https://github.com/gardenlinux/gardenlinux/issues/2777

```
The following packages have been upgraded, to address the mentioned CVEs:
- upgrade 'jinja2' from `3.1.3-1` to `3.1.5-1gl0`
  - CVE-2024-34064
  - CVE-2024-56201
  - CVE-2024-56326
- upgrade 'rsync' from `3.3.0-1` to `3.3.0+ds1-4gl0~bp1592`
  - CVE-2024-12084
  - CVE-2024-12085
  - CVE-2024-12086
  - CVE-2024-12087
  - CVE-2024-12088
  - CVE-2024-12747
- upgrade 'curl' from `8.11.0-1gl0` to `8.11.1-1gl0`
  - CVE-2024-11053
- upgrade 'python3.12' from `3.12.7-1gl1~bp1592` to `3.12.8-5gl0~bp1592`
  - CVE-2024-12254
  - CVE-2024-9287
```