### PR TITLE
Create package diff using glvd for release notes

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -20,9 +20,55 @@ on:
         type: string
         description: "Full commitish"
 jobs:
+  # Create new version in GLVD so it has the package list of the new release
+  # This is needed for the automatic changelog generation
+  glvd:
+    if: ${{ inputs.type }} == 'patch'
+    name: Update GLVD distro list
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # This is required for requesting the JWT
+      id-token: write
+    needs:
+      - glrd
+    steps:
+      - name: Get OIDC token
+        id: get-token
+        run: |
+          IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=glvd" | jq -r '.value')
+          echo "idToken=${IDTOKEN}" >> $GITHUB_OUTPUT
+      - uses: azure/k8s-set-context@v4
+        with:
+           method: kubeconfig
+           kubeconfig: "${{ secrets.KUBECONFIG }}"
+      - name: Start a new ingestion job in GLVD to import package list for new version
+        run: |
+          kubectl run ingest-new-gl-version-$RANDOM \
+              --image=ghcr.io/gardenlinux/glvd-data-ingestion:latest \
+              --env=PGDATABASE=glvd \
+              --env=PGUSER=$(kubectl get secret/postgres-credentials --template="{{.data.username}}" | base64 -d) \
+              --env=PGHOST=glvd-database-0.glvd-database \
+              --env=PGPORT=5432 \
+              --env=PGPASSWORD=$(kubectl get secret/postgres-credentials --template="{{.data.password}}" | base64 -d) -- /usr/local/src/ingest-single-gl-release.sh ${{ inputs.version }}
+      - name: Wait for GLVD to ingest the package list of the new version
+        run: |
+          VERSION=${{ inputs.version }}
+          URL="https://glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com/v1/distro/$VERSION"
+          for i in {1..30}; do
+              RESPONSE=$(curl -s $URL)
+              if [[ $RESPONSE != "[]" ]]; then
+                  echo "Non-empty list received: $RESPONSE"
+                  break
+              fi
+              echo "Attempt $i returned an empty list, retrying in 10 seconds..."
+              sleep 10
+          done
+
   create_github_release:
     if: ${{ inputs.type }} == 'patch'
     environment: oidc_aws_s3_upload
+    needs: glvd
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -53,17 +53,8 @@ jobs:
               --env=PGPASSWORD=$(kubectl get secret/postgres-credentials --template="{{.data.password}}" | base64 -d) -- /usr/local/src/ingest-single-gl-release.sh ${{ inputs.version }}
       - name: Wait for GLVD to ingest the package list of the new version
         run: |
-          VERSION=${{ inputs.version }}
-          URL="https://glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com/v1/distro/$VERSION"
-          for i in {1..30}; do
-              RESPONSE=$(curl -s $URL)
-              if [[ $RESPONSE != "[]" ]]; then
-                  echo "Non-empty list received: $RESPONSE"
-                  break
-              fi
-              echo "Attempt $i returned an empty list, retrying in 10 seconds..."
-              sleep 10
-          done
+          echo "Give GLVD some time to ingest the data. It is not clear how long this takes exactly, and there is no single indicator for when it was done."
+          sleep 180
 
   create_github_release:
     if: ${{ inputs.type }} == 'patch'

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -221,12 +221,42 @@ def generate_package_update_section(version):
                     output += _parse_match_section(s['matchBinaries'])
     return output
 
-def release_notes_changes_section():
-    return textwrap.dedent("""
-    ## Changes
-    The following packages have been upgraded, to address the mentioned CVEs:
-    **todo release facilitator: fill this in**
-    """)
+def release_notes_changes_section(gardenlinux_version):
+    """
+        Get list of fixed CVEs, grouped by upgraded package.
+        Note: This result is not perfect, feel free to edit the generated release notes and
+        file issues in glvd for improvement suggestions https://github.com/gardenlinux/glvd/issues
+    """
+    try:
+        url = f"https://glvd.ingress.glvd.gardnlinux.shoot.canary.k8s-hana.ondemand.com/v1/patchReleaseNotes/{gardenlinux_version}"
+        response = requests.get(url)
+        response.raise_for_status()  # Will raise an error for bad responses
+        data = response.json()
+
+        output = [
+            "## Changes",
+            "The following packages have been upgraded, to address the mentioned CVEs:"
+        ]
+        for package in data["packageList"]:
+            upgrade_line = (
+                f"- upgrade '{package['sourcePackageName']}' from `{package['oldVersion']}` "
+                f"to `{package['newVersion']}`"
+            )
+            output.append(upgrade_line)
+
+            if package["fixedCves"]:
+                for fixedCve in package["fixedCves"]:
+                    output.append(f'  - {fixedCve}')
+
+        return "\n".join(output) + "\n"
+    except:
+        # There are expected error cases, for example with versions not supported by glvd (1443.x) or when the api is not available
+        # Fail gracefully by adding the placeholder we previously used, so that the release note generation does not fail.
+        return textwrap.dedent("""
+        ## Changes
+        The following packages have been upgraded, to address the mentioned CVEs:
+        **todo release facilitator: fill this in**
+        """)
 
 def release_notes_software_components_section(package_list):
     output = "\n"
@@ -288,7 +318,7 @@ def create_github_release_notes(gardenlinux_version, commitish, dry_run = False)
 
     output = ""
 
-    output += release_notes_changes_section()
+    output += release_notes_changes_section(gardenlinux_version)
 
     output += release_notes_software_components_section(package_list)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add new Release to glvd before creating release page, and use the glvd api to get a list of upgraded packages and fixed CVE.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/glvd/issues/147


Note to reviewer: This can't be properly tested on a pr branch, we'll have to see how well it works in main