### PR TITLE
fix: _usi: explicitly include systemd-cryptsetup dracut module

### DIFF
--- a/features/_usi/image.esp.tar
+++ b/features/_usi/image.esp.tar
@@ -61,7 +61,7 @@ chroot "$rootfs" dracut \
 	--force \
 	--tmpdir /tmp \
 	--kver "${kernel#*-}" \
-	--modules "bash dash systemd systemd-initrd systemd-repart kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt" \
+	--modules "bash dash systemd systemd-initrd systemd-repart systemd-cryptsetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt" \
 	--reproducible \
 	--install 'find findmnt grep lsblk tail head realpath basename sfdisk mkfs.ext4 resizefat32 dd cryptsetup' \
 	--include '/tmp/initrd.include' / \


### PR DESCRIPTION
**What this PR does / why we need it**:

Since https://github.com/dracut-ng/dracut-ng/pull/921 this is no longer automatically included

**Which issue(s) this PR fixes**:
Fixes #2824

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
  - => would only be needed if we plan to backport new dracut