### PR TITLE
switch ali region to eu-west-1

### DIFF
--- a/tests/platformSetup/tofu/variables.tf
+++ b/tests/platformSetup/tofu/variables.tf
@@ -62,7 +62,8 @@ variable "ali_ssh_user" {
 
 variable "ali_region" {
   description = "AWS region"
-  default     = "eu-central-1"
+  # default     = "eu-central-1" # Frankfurt
+  default     = "eu-west-1" # London
 }
 
 variable "ali_instance_type" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently our Alibaba Cloud related platform tests are failing.
Switching the region from Frankfurt `eu-central-1` to London `eu-west-1` as this regions seems more stable at the moment.