### PR TITLE
define defaults for platform-test-images build/push in nightly

### DIFF
--- a/.github/workflows/platform-test-images.yml
+++ b/.github/workflows/platform-test-images.yml
@@ -13,6 +13,18 @@ on:
       gl_version:
         type: string
         default: nightly
+      build:
+        type: boolean
+        default: false
+        description: 'Build images'
+      push:
+        type: boolean
+        default: false
+        description: 'Push images'
+      push_latest:
+        type: boolean
+        default: false
+        description: 'Push latest tag'
       archs:
         type: string
         default: '["arm64", "amd64"]'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
     uses: ./.github/workflows/platform-test-images.yml
     with:
       gl_version: ${{ inputs.platform_test_tag }}
+      build: ${{ inputs.platform_test_tag == 'nightly' && true || false }}
+      push: ${{ inputs.platform_test_tag == 'nightly' && true || false }}
+      push_latest: ${{ inputs.platform_test_tag == 'nightly' && true || false }}
       platforms: '["tofu"]'
   platform_tests:
     name: platform test


### PR DESCRIPTION
**What this PR does / why we need it**:

This was missed in https://github.com/gardenlinux/gardenlinux/pull/2835.
It enabled the build of platform test images in our nightly workflow.