### PR TITLE
use DER cert and KEK on azure platform tests

### DIFF
--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -149,18 +149,12 @@ resource "azurerm_shared_image_version" "shared_image_version" {
       additional_signatures {
         db {
           key_type = "x509"
-          certificate_data = replace(
-            replace(
-              replace(
-                join("", split("\n", file("cert/secureboot.db.crt"))),
-                "-----BEGIN CERTIFICATE-----",
-                ""
-              ),
-              "-----END CERTIFICATE-----",
-              ""
-            ),
-            "\n",
-            ""
+          certificate_data = filebase64("cert/secureboot.db.der")
+          )
+        }
+        kek {
+          key_type = "x509"
+          certificate_data = filebase64("cert/secureboot.kek.der")
           )
         }
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use DER cert and KEK on azure platform tests. The current implementation is doing unneeded magic. Currently we're not passing the KEK.

[use secureboot PK on azure platform tests](https://github.com/gardenlinux/gardenlinux/issues/2857) is related but a different feature.