### PR TITLE
Limit concurrent jobs uploading to OCI to prevent rate limiting

### DIFF
--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -31,6 +31,7 @@ jobs:
       packages: write
     environment: oidc_aws_s3_upload
     strategy:
+      max-parallel: 5
       fail-fast: false
       matrix: ${{ fromJson(needs.generate_matrix_publish.outputs.matrix) }}
     steps:


### PR DESCRIPTION
Addresses https://github.com/gardenlinux/gardenlinux/issues/2868

Limiting the amount of concurrent jobs to 5 in order to prevent rate limiting.
If this issue still persists after that we could also try adding sleep statements either in the [upload_oci.yml](https://github.com/gardenlinux/gardenlinux/blob/main/.github/workflows/upload_oci.yml) or directly to [python-gardenlinux-cli](https://github.com/gardenlinux/python-gardenlinux-cli/blob/main/src/registry.py )