### PR TITLE
fix qemu provisioned platform tests

### DIFF
--- a/features/azure/test/test_azure_times.py
+++ b/features/azure/test/test_azure_times.py
@@ -3,7 +3,7 @@ from helper.utils import get_architecture
 from helper.sshclient import RemoteClient
 
 
-def test_startup_time(client, non_chroot, non_kvm):
+def test_startup_time(client, non_provisioner_chroot, non_kvm):
     """ Test for startup time """
     tolerated_kernel_time = 30
     tolerated_userspace_time = 60

--- a/features/base/test/test_basics.py
+++ b/features/base/test/test_basics.py
@@ -64,7 +64,7 @@ def test_startup_time(client, non_provisioner_chroot, non_kvm, non_azure):
     assert tf_userspace < tolerated_userspace_time, f"startup time in user space too long: {tf_userspace}seconds but only {tolerated_userspace_time} tolerated."
 
 
-def test_startup_script(client, gcp):
-    """ Test for validity of startup script on gcp """
+def test_startup_script(client, non_provisioner_chroot, non_provisioner_qemu):
+    """ Test for validity of startup script on tofu provisioned platforms """
     (exit_code, output, error) = client.execute_command("test -f /tmp/startup-script-ok")
     assert exit_code == 0, f"no {error=} expected. Startup script did not run"

--- a/features/base/test/test_basics.py
+++ b/features/base/test/test_basics.py
@@ -38,7 +38,7 @@ def test_ls(client):
     assert "var" in lines
 
 
-def test_startup_time(client, non_chroot, non_kvm, non_azure):
+def test_startup_time(client, non_provisioner_chroot, non_kvm, non_azure):
     """ Test for startup time """
     tolerated_kernel_time = 60
     tolerated_userspace_time = 40

--- a/features/base/test/test_disable_sysrq.py
+++ b/features/base/test/test_disable_sysrq.py
@@ -11,7 +11,7 @@ from helper.utils import execute_remote_command
 )
 
 
-def test_dmesg(client, file, args, non_chroot):
+def test_dmesg(client, file, args, non_provisioner_chroot):
     cmd = "/usr/sbin/sysctl -a > /tmp/sysctl.txt"
     execute_remote_command(client, cmd)
     file_content(client, file, args)

--- a/features/base/test/test_metadata_connection.py
+++ b/features/base/test/test_metadata_connection.py
@@ -1,7 +1,7 @@
 import pytest
 from helper.sshclient import RemoteClient
 
-def test_metadata_connection(client, non_aws, non_azure, non_ali, non_chroot, non_kvm):
+def test_metadata_connection(client, non_aws, non_azure, non_ali, non_kvm, non_provisioner_chroot, non_provisioner_qemu):
     metadata_host = "169.254.169.254"
     (exit_code, output, error) = client.execute_command(
         f"wget --timeout 5  'http://{metadata_host}/'"
@@ -10,7 +10,7 @@ def test_metadata_connection(client, non_aws, non_azure, non_ali, non_chroot, no
     assert f"Connecting to {metadata_host}:80... connected." in error
     assert "200 OK" in error
 
-def test_metadata_connection_aws(client, aws):
+def test_metadata_connection_aws(client, aws, non_provisioner_chroot, non_provisioner_qemu):
     metadata_host = "169.254.169.254"
     # request the IMDSv2 token to allow access to the metadata_host on AWS.
     (exit_code, token, error) = client.execute_command(
@@ -27,7 +27,7 @@ def test_metadata_connection_aws(client, aws):
     assert "200 OK" in error
 
 
-def test_metadata_connection_azure(client, azure):
+def test_metadata_connection_azure(client, azure, non_provisioner_chroot, non_provisioner_qemu):
     metadata_url = "http://169.254.169.254/metadata/instance/compute?api-version=2021-01-01&format=json"
     (exit_code, output, error) = client.execute_command(
         f"curl --connect-timeout 5 '{metadata_url}' -H 'Metadata: true'"
@@ -35,7 +35,7 @@ def test_metadata_connection_azure(client, azure):
     assert exit_code == 0, f"no {error=} expected"
 
 
-def test_metadate_connection_aliyun(client, ali):
+def test_metadate_connection_aliyun(client, ali, non_provisioner_chroot, non_provisioner_qemu):
     metadata_url = "http://100.100.100.200/2016-01-01"
     (exit_code, output, error) = client.execute_command(
         f"curl --connect-timeout 5 '{metadata_url}' -H 'Metadata: true'"

--- a/features/base/test/test_network.py
+++ b/features/base/test/test_network.py
@@ -3,7 +3,7 @@ import datetime
 from helper.sshclient import RemoteClient
 
 
-def test_hostname_azure(client, azure):
+def test_hostname_azure(client, azure, non_provisioner_chroot, non_provisioner_qemu):
     """ Test for valid hostname on azure platform. 
     The OS is responsible to register its hostname to Azure DNS.
     This test checks if hostname registration was successfull. 
@@ -23,7 +23,7 @@ def test_hostname_azure(client, azure):
 def ping4_host(request):
     return request.param
 
-def test_ping4(client, ping4_host, non_chroot, non_kvm):
+def test_ping4(client, ping4_host, non_provisioner_chroot, non_provisioner_qemu):
     """ Test if destination by fixture in pingable (IPv4) """
     command = f"ping -c 5 -W 5 {ping4_host}"
     (exit_code, output, error) = client.execute_command(command)
@@ -36,7 +36,7 @@ def ping6_host(request):
     return request.param
 
 @pytest.mark.skip(reason="ipv6 not available in all vpcs")
-def test_ping6(client, ping6_host):
+def test_ping6(client, ping6_host, non_provisioner_chroot, non_provisioner_qemu):
     """ Test if destination by fixture in pingable (IPv6) """
     command = f"ping6 -c 5 -W 5 {ping6_host}"
     (exit_code, output, error) = client.execute_command(command)

--- a/features/base/test/test_orphaned.py
+++ b/features/base/test/test_orphaned.py
@@ -3,5 +3,5 @@ from helper.tests.orphaned import orphaned
 # Execute the orphaned check only on chroot
 # since it must install some packages that
 # may not be possible on running machines.
-def test_orphaned(client, chroot, non_container):
+def test_orphaned(client, provisioner_chroot, non_container):
     orphaned(client)

--- a/features/base/test/test_platform_driver.py
+++ b/features/base/test/test_platform_driver.py
@@ -1,7 +1,7 @@
 import pytest
 from helper.sshclient import RemoteClient
 
-def test_aws_ena_driver(client, aws):
+def test_aws_ena_driver(client, aws, non_provisioner_chroot, non_provisioner_qemu):
     """ Test for network driver on aws platform """
     (exit_code, output, error) = client.execute_command("/sbin/ethtool -i $(ip -j link show  | jq -r '.[] | if .ifname != \"lo\" and .ifname != \"docker0\" then .ifname else empty end') | grep \"^driver\" | awk '{print $2}'")
     assert exit_code == 0, f"no {error=} expected"

--- a/features/base/test/test_systemd.py
+++ b/features/base/test/test_systemd.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from helper.sshclient import RemoteClient
 
-def test_systemctl_no_failed_units(client, non_chroot, non_kvm):
+def test_systemctl_no_failed_units(client, non_provisioner_chroot, non_kvm):
     """this test always fails on kvm therefore kvm has it's own, chroot does not use systemd"""
     (exit_code, output, error) = client.execute_command("systemctl list-units --output=json --state=failed")
     assert exit_code == 0, f"no {error=} expected"

--- a/features/base/test/test_time_config.py
+++ b/features/base/test/test_time_config.py
@@ -18,7 +18,7 @@ def test_correct_ntp(client, gcp):
     assert output.rstrip() == "1", "Expected NTP server to be configured to metadata.google.internal"
 
 
-def test_timesync(client, azure):
+def test_timesync(client, azure, non_provisioner_chroot, non_provisioner_qemu):
     """ Ensure symbolic link has been created """
     (exit_code, output, error) = client.execute_command("test -L /dev/ptp_hyperv")
     assert exit_code == 0, f"Expected /dev/ptp_hyperv to be a symbolic link"

--- a/features/base/test/test_usr_ro.py
+++ b/features/base/test/test_usr_ro.py
@@ -1,5 +1,5 @@
 
-def test_usr_read_only(client, non_chroot):
+def test_usr_read_only(client, non_provisioner_chroot):
     (exit_code, output, error) = client.execute_command("/usr/bin/touch /usr/fail-test")
     assert exit_code == 1, "Read-only file system error expected"
     assert error.rstrip() == "/usr/bin/touch: cannot touch '/usr/fail-test': Read-only file system"

--- a/features/chost/test/test_systemd_unit.py
+++ b/features/chost/test/test_systemd_unit.py
@@ -11,6 +11,6 @@ from helper.utils import validate_systemd_unit
 )
 
 
-def test_systemd_unit(client, systemd_unit, non_chroot):
+def test_systemd_unit(client, systemd_unit, non_provisioner_chroot):
     execute_remote_command(client, f"systemctl start {systemd_unit}")
     validate_systemd_unit(client, f"{systemd_unit}")

--- a/features/cis/test/test_debian_cis.py
+++ b/features/cis/test/test_debian_cis.py
@@ -16,5 +16,5 @@ from helper.tests.debian_cis import DebianCIS
     ]
 )
 
-def test_debian_cis(client, args, non_chroot):
+def test_debian_cis(client, args, non_provisioner_chroot):
     DebianCIS(client, args)

--- a/features/firecracker/test/test_systemd_unit.py
+++ b/features/firecracker/test/test_systemd_unit.py
@@ -12,7 +12,7 @@ from helper.utils import get_architecture
 )
 
 
-def test_systemd_unit(client, systemd_unit, non_chroot):
+def test_systemd_unit(client, systemd_unit, non_provisioner_chroot):
     arch = get_architecture(client)
     active = True
 

--- a/features/firewall/test/test_nft_config.py
+++ b/features/firewall/test/test_nft_config.py
@@ -1,7 +1,7 @@
 from helper.utils import execute_remote_command
 
 
-def test_nft_config(client, non_chroot):
+def test_nft_config(client, non_provisioner_chroot):
     # This will already fail if table "inet" is missing
     out = execute_remote_command(client, "nft list table inet filter")
     # Validate that input has policy drop as default

--- a/features/firewall/test/test_systemd_units.py
+++ b/features/firewall/test/test_systemd_units.py
@@ -11,6 +11,6 @@ from helper.utils import validate_systemd_unit
 )
 
 
-def test_systemd_unit(client, systemd_unit, non_chroot):
+def test_systemd_unit(client, systemd_unit, non_provisioner_chroot):
     execute_remote_command(client, f"systemctl start {systemd_unit}")
     validate_systemd_unit(client, f"{systemd_unit}")

--- a/features/gardener/test/test_dmesg.py
+++ b/features/gardener/test/test_dmesg.py
@@ -12,7 +12,7 @@ from helper.utils import execute_remote_command
 )
 
 
-def test_dmesg(client, file, args, non_chroot):
+def test_dmesg(client, file, args, non_provisioner_chroot):
     cmd = "/usr/sbin/sysctl -a > /tmp/sysctl.txt"
     execute_remote_command(client, cmd)
     file_content(client, file, args)

--- a/features/gardener/test/test_lsm.py
+++ b/features/gardener/test/test_lsm.py
@@ -11,7 +11,7 @@ from helper.utils import execute_remote_command
 )
 
 
-def test_lsm(client, lsm, active, non_chroot):
+def test_lsm(client, lsm, active, non_provisioner_chroot):
     out = execute_remote_command(client, "cat /sys/kernel/security/lsm")
 
     if active:

--- a/features/gardener/test/test_systemd_units.py
+++ b/features/gardener/test/test_systemd_units.py
@@ -11,6 +11,6 @@ from helper.utils import validate_systemd_unit
 )
 
 
-def test_systemd_unit(client, systemd_unit, non_chroot):
+def test_systemd_unit(client, systemd_unit, non_provisioner_chroot):
     execute_remote_command(client, f"sudo -u root systemctl start {systemd_unit}")
     validate_systemd_unit(client, f"{systemd_unit}")

--- a/features/khost/test/test_systemd_unit.py
+++ b/features/khost/test/test_systemd_unit.py
@@ -11,6 +11,6 @@ from helper.utils import validate_systemd_unit
 )
 
 
-def test_systemd_unit(client, systemd_unit, non_chroot):
+def test_systemd_unit(client, systemd_unit, non_provisioner_chroot):
     execute_remote_command(client, f"systemctl start {systemd_unit}")
     validate_systemd_unit(client, f"{systemd_unit}")

--- a/features/server/test/test_dmesg.py
+++ b/features/server/test/test_dmesg.py
@@ -12,7 +12,7 @@ from helper.utils import execute_remote_command
 )
 
 
-def test_dmesg(client, file, args, non_chroot, non_feature_gardener):
+def test_dmesg(client, file, args, non_provisioner_chroot, non_feature_gardener):
     cmd = "sysctl -a > /tmp/sysctl.txt"
     execute_remote_command(client, cmd)
     file_content(client, file, args)

--- a/features/server/test/test_kernel_parameter.py
+++ b/features/server/test/test_kernel_parameter.py
@@ -9,5 +9,5 @@ import pytest
         ("kernel.randomize_va_space", 2)
     ]
 )
-def test_kernel_parameter(client, parameter, value, non_chroot):
+def test_kernel_parameter(client, parameter, value, non_provisioner_chroot):
     kernel_parameter(client, parameter, value)

--- a/features/server/test/test_machine_id.py
+++ b/features/server/test/test_machine_id.py
@@ -1,8 +1,8 @@
 from helper.tests.machine_id import machine_id
 from helper.tests.machine_id import machine_id_powered_on
 
-def test_machine_id(client, chroot):
+def test_machine_id(client, provisioner_chroot):
      machine_id(client)
 
-def test_machine_id_powered_on(client, non_chroot):
+def test_machine_id_powered_on(client, non_provisioner_chroot):
      machine_id_powered_on(client)

--- a/features/vhost/test/test_systemd_unit.py
+++ b/features/vhost/test/test_systemd_unit.py
@@ -11,6 +11,6 @@ from helper.utils import validate_systemd_unit
 )
 
 
-def test_systemd_unit(client, systemd_unit, non_chroot):
+def test_systemd_unit(client, systemd_unit, non_provisioner_chroot):
     execute_remote_command(client, f"systemctl start {systemd_unit}")
     validate_systemd_unit(client, f"{systemd_unit}")

--- a/tests/conftests/provisioner.py
+++ b/tests/conftests/provisioner.py
@@ -16,50 +16,50 @@ import pytest
 
 
 @pytest.fixture
-def chroot(iaas):
+def provisioner_chroot(iaas):
     """This is the target infrastructure process we consume"""
     if iaas != 'chroot':
         pytest.skip('test only supported on chroot')
 
 
 @pytest.fixture
-def local(iaas):
+def provisioner_local(iaas):
     if iaas != 'local':
         pytest.skip('test only supported on local')
 
 
 @pytest.fixture
-def manual(iaas):
+def provisioner_manual(iaas):
     if iaas != 'local':
         pytest.skip('test only supported on local')
 
 
 @pytest.fixture
-def qemu(iaas):
+def provisioner_qemu(iaas):
     """This is the target infrastructure process we consume"""
     if iaas != 'qemu':
         pytest.skip('test only supported on qemu')
 
 
 @pytest.fixture
-def non_chroot(iaas):
+def non_provisioner_chroot(iaas):
     if iaas == 'chroot':
         pytest.skip('test not supported on chroot')
 
 
 @pytest.fixture
-def non_local(iaas):
+def non_provisioner_local(iaas):
     if iaas == 'local':
         pytest.skip('test not supported on local')
 
 
 @pytest.fixture
-def non_manual(iaas):
+def non_provisioner_manual(iaas):
     if iaas == 'manual':
         pytest.skip('test not supported on manual')
 
 
 @pytest.fixture
-def non_qemu(iaas):
+def non_provisioner_qemu(iaas):
     if iaas == 'qemu':
         pytest.skip('test not supported on qemu')

--- a/tests/helper/tests/capabilities.py
+++ b/tests/helper/tests/capabilities.py
@@ -2,7 +2,7 @@ from helper.utils import read_test_config
 import string
 import re
 
-def capabilities(client, testconfig, non_chroot):
+def capabilities(client, testconfig, non_provisioner_chroot):
     """ Test if only the defined capabilities are set"""
     (exit_code, output, error) = client.execute_command(
         "sudo -u root find /boot /etc /usr /var -type f -exec /usr/sbin/getcap {} \\;", quiet=True)

--- a/tests/helper/tests/rkhunter.py
+++ b/tests/helper/tests/rkhunter.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 # Execute the rkhunter test only on chroot
 # since it must install some packages that
 # may not be possible on running machines.
-def rkhunter(client, testconfig, chroot, non_container, non_chroot):
+def rkhunter(client, testconfig, provisioner_chroot, non_container, non_provisioner_chroot):
     """Run rkhunter to test for rootkits"""
     utils.AptUpdate(client)
     utils.install_package_deb(client, "rkhunter")

--- a/tests/helper/tests/ssh_authorized.py
+++ b/tests/helper/tests/ssh_authorized.py
@@ -1,6 +1,6 @@
 import hashlib
 
-def ssh_authorized(client, testconfig, chroot):
+def ssh_authorized(client, testconfig, provisioner_chroot):
     """Test to that not user has an authorized_keys file and also check
     that the test_authorized_keys file injected for testing wasn't modified"""
     # get passwd

--- a/tests/helper/tests/tiger.py
+++ b/tests/helper/tests/tiger.py
@@ -4,7 +4,7 @@ from helper import utils
 # Execute the tiger test only on chroot
 # since it must install some packages that
 # may not be possible on running machines.
-def tiger(client, testconfig, chroot, non_chroot):
+def tiger(client, testconfig, provisioner_chroot, non_provisioner_chroot):
     """Run tiger to test for system security vulnerabilities"""
     utils.AptUpdate(client)
     utils.install_package_deb(client, "tiger")

--- a/tests/local/test_oci.py
+++ b/tests/local/test_oci.py
@@ -10,7 +10,7 @@ import pytest
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-def test_oci_feat(local, testconfig):
+def test_oci_feat(provisioner_local, testconfig):
     """ This test does several steps using the results of a build with _oci feature:
     - verify neccessary testconfig options are present (image, kernel)
     - install the docker-registry into the container, provide a config, start the registry

--- a/tests/platformSetup/platformSetup.py
+++ b/tests/platformSetup/platformSetup.py
@@ -137,6 +137,7 @@ class PytestConfig:
             config_file = self.paths.config_dir / f"pytest.{provisioner_pytest}.{flavor}.yaml"
             yaml_data = {
                 "qemu": {
+                    "platform": platform,
                     "image": f"{image_path}/{cname}.raw" if image_path else None,
                     "ip": "127.0.0.1",
                     "port": 2223,

--- a/tests/platformSetup/qemu.py
+++ b/tests/platformSetup/qemu.py
@@ -228,7 +228,11 @@ class QEMU:
             f"write-append /etc/hosts.allow 'ALL: 10.\n' : "
             f"ln-s "
             f"  {systemd_dir}/{sshd_systemd_file} "
-            f"  {systemd_dir}/multi-user.target.wants/{sshd_systemd_file}")
+            f"  {systemd_dir}/multi-user.target.wants/{sshd_systemd_file} : "
+            # Remove google services as they cannot reach their APIs
+            f"rm-f /usr/lib/systemd/system/google-guest-agent.service : "
+            f"rm-f /usr/lib/systemd/system/gce-workload-cert-refresh.service : "
+            f"rm-f /usr/lib/systemd/system/google-startup-scripts.service")
 
         cmds.append(guestfish_cmd)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Several fixes to make qemu provisioned platform tests work.

- [rename provisioner fixtures to distinguish them from platform fixtures](https://github.com/gardenlinux/gardenlinux/commit/1dcb001dd23600a5d7eaa74b45974920d1bd3b47)
- [/tmp/startup-script-ok is created for all tofu provisioned platforms](https://github.com/gardenlinux/gardenlinux/commit/cb2c5f751e579bf63c651939f4bf90b16877fd85)
- [fix ntp tests to work on qemu provisioner](https://github.com/gardenlinux/gardenlinux/commit/d7282d2157628b5033ae1c22b20c9ce43840054d)
- [pass platform to qemu provisioner](https://github.com/gardenlinux/gardenlinux/commit/fb8390987b884a78a97e4202eaf58fad4143a739)
- [remove google services in qemu provisioned tests as they cannot reach their APIs](https://github.com/gardenlinux/gardenlinux/commit/e7af7fc2f9b791cd8a5c8db98f4ca0cdecb8259f)

Can be tested with:

```
for i in ali aws azure gcp kvm; do make ${i}-gardener_prod-amd64-build; done

for i in ali aws azure gcp kvm; do make --directory=tests/platformSetup ${i}-gardener_prod-amd64-qemu-apply; done   

for i in ali aws azure gcp kvm; do make --directory=tests ${i}-gardener_prod-amd64-qemu-test-platform 2>&1; done
```



**Which issue(s) this PR fixes**:
Fixes #2861

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)