### PR TITLE
Feat/tofu aws ami

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
         # ssh key generation (if missing)
         test -f ~/.ssh/id_ed25519 || ssh-keygen -t ed25519 -P "" -f ~/.ssh/id_ed25519
         # tf variables generation
-        TEST_PREFIX="gh-actions" CNAME="${{ env.cname }}" make --directory=tests/platformSetup ${FLAVOR}-${ARCH}-tofu-config
+        TEST_PREFIX="gh-actions" IMAGE_NAME="${{ env.cname }}" make --directory=tests/platformSetup ${FLAVOR}-${ARCH}-tofu-config
         # enable S3 backend
         cp "tests/platformSetup/tofu/backend.tf.github" "tests/platformSetup/tofu/backend.tf"
         make --directory="tests/platformSetup" ${FLAVOR}-${ARCH}-tofu-apply 2>&1 | tee "${{ env.artifact_dir}}/${{ env.cname }}.platform.provisioning.log"

--- a/tests/platformSetup/Makefile
+++ b/tests/platformSetup/Makefile
@@ -20,6 +20,11 @@ endif
 ifeq ($(origin TEST_PREFIX), undefined)
 TEST_PREFIX := $(shell echo $(USER) | cut -c1-10)
 endif
+ifeq ($(origin IMAGE_PATH), undefined)
+IMAGE_PATH_CMD :=
+else
+IMAGE_PATH_CMD := --image-path $(IMAGE_PATH)
+endif
 ifeq ($(origin CNAME), undefined)
 CNAME_CMD :=
 else
@@ -80,7 +85,7 @@ $(foreach flavor,$(FLAVORS_PUBLIC_CLOUD), \
 		mkdir -p $(MKDIRS) && \
 		$(CRE_CMD_tofu) bash -c "\
 			cd platformSetup/tofu && \
-			../platformSetup.py --provisioner tofu --flavor $(flavor) $(CNAME_CMD) --test-prefix $(TEST_PREFIX) --create-tfvars" \
+			../platformSetup.py --provisioner tofu --flavor $(flavor) $(IMAGE_PATH_CMD) $(CNAME_CMD) --test-prefix $(TEST_PREFIX) --create-tfvars" \
 	) \
 	$(eval \
 		$(flavor)-tofu-plan: ; \

--- a/tests/platformSetup/Makefile
+++ b/tests/platformSetup/Makefile
@@ -25,10 +25,10 @@ IMAGE_PATH_CMD :=
 else
 IMAGE_PATH_CMD := --image-path $(IMAGE_PATH)
 endif
-ifeq ($(origin CNAME), undefined)
-CNAME_CMD :=
+ifeq ($(origin IMAGE_NAME), undefined)
+IMAGE_NAME_CMD :=
 else
-CNAME_CMD := --cname $(CNAME)
+IMAGE_NAME_CMD := --image-name $(IMAGE_NAME)
 endif
 
 GARDENLINUX_BUILD_CRE ?= podman
@@ -85,7 +85,7 @@ $(foreach flavor,$(FLAVORS_PUBLIC_CLOUD), \
 		mkdir -p $(MKDIRS) && \
 		$(CRE_CMD_tofu) bash -c "\
 			cd platformSetup/tofu && \
-			../platformSetup.py --provisioner tofu --flavor $(flavor) $(IMAGE_PATH_CMD) $(CNAME_CMD) --test-prefix $(TEST_PREFIX) --create-tfvars" \
+			../platformSetup.py --provisioner tofu --flavor $(flavor) $(IMAGE_PATH_CMD) $(IMAGE_NAME_CMD) --test-prefix $(TEST_PREFIX) --create-tfvars" \
 	) \
 	$(eval \
 		$(flavor)-tofu-plan: ; \
@@ -148,7 +148,7 @@ $(foreach flavor,$(FLAVORS_IMAGE), \
 		$(flavor)-qemu-apply: ; \
 		mkdir -p $(MKDIRS) && \
 		$(CRE_CMD_kvm) --name qemu-$(flavor) -d --replace $(CRE_CMD_kvm_image) bash -c "\
-			/gardenlinux/tests/platformSetup/platformSetup.py --provisioner qemu --flavor $(flavor) $(CNAME_CMD) && \
+			/gardenlinux/tests/platformSetup/platformSetup.py --provisioner qemu --flavor $(flavor) $(IMAGE_NAME_CMD) && \
 			/gardenlinux/tests/pytest.qemu.$(flavor).apply.sh && \
 			sleep 86400 \
 		" && \

--- a/tests/platformSetup/platformSetup.py
+++ b/tests/platformSetup/platformSetup.py
@@ -77,7 +77,7 @@ class Flavors:
         self.paths = paths
         self.flavor = args.flavor
         self.provisioner = args.provisioner
-        self.platform, self.feature_list, self.cname_features, self.arch = self.parse_features()
+        self.platform, self.feature_list, self.image_features, self.arch = self.parse_features()
 
     def parse_features(self):
         """Parse features from the flavor name."""
@@ -88,14 +88,14 @@ class Flavors:
             sys.exit(1)
 
         platform = parts[0]
-        features_cname = "-".join(parts[1:-1])
+        features_image_name = "-".join(parts[1:-1])
         arch = parts[-1]
         
         if arch not in {"amd64", "arm64"}:
             logger.error(f"Unsupported architecture '{arch}'. Valid options are 'amd64' or 'arm64'.")
             sys.exit(1)
 
-        print(f"features_cname: {features_cname}")
+        print(f"features_image_name: {features_image_name}")
         
         # Create flavor string without architecture
         flavor_without_arch = "-".join(parts[:-1])
@@ -113,7 +113,7 @@ class Flavors:
         logger.info(f"Features: {feature_list}")
         logger.info(f"Architecture: {arch}")
         
-        return platform, feature_list, features_cname, arch
+        return platform, feature_list, features_image_name, arch
 
 class PytestConfig:
     """Generates pytest configuration files."""
@@ -123,15 +123,15 @@ class PytestConfig:
         self.flavors = flavors
         self.script = script
 
-    def generate_pytest_configfile(self, config_data, image_path=None, cname=None):
+    def generate_pytest_configfile(self, config_data, image_path=None, image_name=None):
         """Generate a pytest configuration file."""
         flavor = self.flavors.flavor
         platform = config_data["platform"]
         provisioner = self.args.provisioner
         provisioner_pytest = PROVISIONER_PYTEST_MAP[provisioner]
         
-        if cname is None:
-            cname = self.script.get_cname()
+        if image_name is None:
+            image_name = self.script.get_image_name()
             
         if provisioner == "qemu":
             config_file = self.paths.config_dir / f"pytest.{provisioner_pytest}.{flavor}.yaml"
@@ -178,16 +178,16 @@ class Scripts:
         self.flavors = flavors
         self.version = Version(self.paths.git_root)
 
-    def get_cname(self):
-        """Get cname if not provided."""
-        if self.args.cname:
-            return self.args.cname
+    def get_image_name(self):
+        """Get image_name if not provided."""
+        if self.args.image_name:
+            return self.args.image_name
             
         platform = self.flavors.platform
-        features = self.flavors.cname_features
+        features = self.flavors.tures
         arch = self.flavors.arch
 
-        return self.version.get_cname(platform, features, arch)
+        return self.version.get_image_name(platform, features, arch)
 
     def generate_config_data(self, tofu_out=None):
         """Generate config data for pytest and login script."""
@@ -317,7 +317,7 @@ class Tofu:
             # Always return to original directory
             os.chdir(original_dir)
 
-    def create_tfvars_file(self, test_prefix, image_path=None, cname=None):
+    def create_tfvars_file(self, test_prefix, image_path=None, image_name=None):
         """Create .tfvars files for OpenTofu configuration."""
         flavor = self.flavor_parser.flavor
         platform = self.flavor_parser.platform
@@ -342,15 +342,15 @@ class Tofu:
             "gcp": "gcpimage.tar.gz",
         }
 
-        # Generate cname if not provided
-        if not cname:
-            cname = self.scripts.get_cname()
+        # Generate image_name if not provided
+        if not image_name:
+            image_name = self.scripts.get_image_name()
 
         # Determine if we should add extension based on image_path
         image_source_type = image_path.split("://")[0] if image_path else "file"
         image_file = (
-            cname if image_source_type == "cloud"
-            else f"{cname}.{image_files.get(platform, 'raw')}"
+            image_name if image_source_type == "cloud"
+            else f"{image_name}.{image_files.get(platform, 'raw')}"
         )
 
         # Create flavor configuration
@@ -396,13 +396,20 @@ def parse_arguments():
     parser.add_argument(
         '--image-path', 
         type=str, 
-        help="Base path for image files.",
+        help="Uri and base path for image files (e.g., 'file:///gardenlinux/.build' or 'cloud://').",
         default='file:///gardenlinux/.build'
     )
     parser.add_argument(
-        '--cname', 
+        '--image-name', 
         type=str, 
-        help="Basename of image file (e.g., 'kvm-gardener_prod-amd64-1312.0-80ffcc87')."
+        help="""
+                Image name or image_name style image reference:
+                (e.g., image_name: 'kvm-gardener_prod-amd64-1312.0-80ffcc87',
+                ali image: 'm-01234567890123456',
+                aws ami: 'ami-01234567890123456',
+                azure community gallery version: '/communityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/images/gardenlinux-gen2/versions/1443.18.0',
+                gcp image: 'projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-gardener-prod-arm64-1443-18-97fd20ac'.
+            """
     )
     parser.add_argument(
         '--test-prefix',
@@ -433,7 +440,7 @@ def main():
         pytest.generate_pytest_configfile(
             config_data,
             image_path=args.image_path,
-            cname=args.cname
+            image_name=args.image_name,
         )
         scripts.generate_pytest_scripts()
     
@@ -446,7 +453,7 @@ def main():
                 tofu.create_tfvars_file(
                     args.test_prefix,
                     image_path=args.image_path,
-                    cname=args.cname
+                    image_name=args.image_name,
                 )
             else:
                 tofu_data = tofu.get_tofu_output(args.flavor)

--- a/tests/platformSetup/platformSetup.py
+++ b/tests/platformSetup/platformSetup.py
@@ -346,6 +346,13 @@ class Tofu:
         if not cname:
             cname = self.scripts.get_cname()
 
+        # Determine if we should add extension based on image_path
+        image_source_type = image_path.split("://")[0] if image_path else "file"
+        image_file = (
+            cname if image_source_type == "cloud"
+            else f"{cname}.{image_files.get(platform, 'raw')}"
+        )
+
         # Create flavor configuration
         flavor_item = {
             "name": flavor,
@@ -353,7 +360,7 @@ class Tofu:
             "features": self.flavor_parser.feature_list,
             "arch": arch,
             "instance_type": instance_types.get(platform, {}).get(arch),
-            "image_file": f"{cname}.{image_files.get(platform, 'raw')}"
+            "image_file": image_file
         }
 
         # Write the tfvars file

--- a/tests/platformSetup/tofu/README.md
+++ b/tests/platformSetup/tofu/README.md
@@ -384,8 +384,8 @@ It is called by the "-tofu-config" make targets but can also be called manually.
 # use default settings
 make --directory=tests/platformSetup gcp-gardener_prod-amd64-tofu-config
 
-# write a custom test prefix and image via cname
-TEST_PREFIX=myprefix CNAME=gcp-gardener_prod_tpm2_trustedboot-amd64-1695.0-30903f3a \
+# write a custom test prefix and image via IMAGE_NAME (cname)
+TEST_PREFIX=myprefix IMAGE_NAME=gcp-gardener_prod_tpm2_trustedboot-amd64-1695.0-30903f3a \
   make --directory=tests/platformSetup \
   gcp-gardener_prod_tpm2_trustedboot-amd64-tofu-config
 ```
@@ -401,10 +401,10 @@ or
     --test-prefix myprefix \
     --create-tfvars
 
-# Generate for a specific image version
+# Generate for a specific image version via providing the image cname
 ./tests/platformSetup/platformSetup.py \
     --flavors gcp-gardener_prod_trustedboot_tpm2-amd64 \
-    --cname gcp-gardener_prod_tpm2_trustedboot-amd64-1695.0-30903f3a \
+    --image-name gcp-gardener_prod_tpm2_trustedboot-amd64-1695.0-30903f3a \
     --provisioner tofu \
     --test-prefix myprefix \
     --create-tfvars
@@ -417,7 +417,7 @@ The script supports these options:
 
 ```bash
 tests/platformSetup/platformSetup.py --help
-usage: platformSetup.py [-h] --flavor FLAVOR --provisioner {qemu,tofu} [--image-path IMAGE_PATH] [--cname CNAME] [--test-prefix TEST_PREFIX] [--create-tfvars]
+usage: platformSetup.py [-h] --flavor FLAVOR --provisioner {qemu,tofu} [--image-path IMAGE_PATH] [--image_name IMAGE_NAME] [--test-prefix TEST_PREFIX] [--create-tfvars]
 
 Generate pytest config files and SSH login scripts for platform tests.
 
@@ -428,7 +428,13 @@ options:
                         Provisioner to use: 'qemu' for local testing or 'tofu' for Cloud Provider testing.
   --image-path IMAGE_PATH
                         Base path for image files.
-  --cname CNAME         Basename of image file (e.g., 'kvm-gardener_prod-amd64-1312.0-80ffcc87').
+  --image-name IMAGE_NAME
+                        Image name or cname style image reference: (e.g.,
+                        cname: 'kvm-gardener_prod-amd64-1312.0-80ffcc87',
+                        ali image: 'm-01234567890123456',
+                        aws ami: 'ami-01234567890123456',
+                        azure community gallery version: '/communityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/images/gardenlinux-gen2/versions/1443.18.0',
+                        gcp image: 'projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-gardener-prod-arm64-1443-18-97fd20ac'.  
   --test-prefix TEST_PREFIX
                         Test prefix for OpenTofu variable files.
   --create-tfvars       Create OpenTofu variables file.
@@ -438,6 +444,34 @@ options:
 
 > [!WARNING]
 > Before running tests, ensure the variables file exists with the correct name, matching your test flavor (e.g., `variables.gcp-gardener_prod_trustedboot_tpm2-amd64.tfvars`)
+
+#### Use existing published cloud images from the official gardenlinux releases
+
+You can boot published cloud images from the official gardenlinux releases like e.g. [Release 1592.6](https://github.com/gardenlinux/gardenlinux/releases/tag/1592.6) by referencing the image path and image name in the `IMAGE_PATH` and `IMAGE_NAME` variables.
+
+```bash
+# use an existing image for ali
+IMAGE_PATH=cloud:// IMAGE_NAME=m-d7oaobmhtxwjsw07e3as \
+  make --directory=tests/platformSetup \
+  ali-gardener_prod-amd64-tofu-config
+
+# use an existing image for aws
+IMAGE_PATH=cloud:// IMAGE_NAME=ami-073c0d4753f70877d \
+  make --directory=tests/platformSetup \
+  aws-gardener_prod-amd64-tofu-config
+
+# use an existing image for azure
+IMAGE_PATH=cloud:// IMAGE_NAME=/communityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/images/gardenlinux-gen2/versions/1592.6.0 \
+  make --directory=tests/platformSetup \
+  azure-gardener_prod-amd64-tofu-config
+
+# use an existing image for gcp
+IMAGE_PATH=cloud:// IMAGE_NAME=projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-gardener-prod-amd64-1592-6-cb05e11f \
+  make --directory=tests/platformSetup \
+  gcp-gardener_prod-amd64-tofu-config
+```
+
+After creating the OpenTofu variables file, you can create the cloud resources with the `tofu-apply` make targets as usual.
 
 ### Creating Cloud Resources with OpenTofu
 

--- a/tests/platformSetup/tofu/modules/aws/main.tf
+++ b/tests/platformSetup/tofu/modules/aws/main.tf
@@ -35,10 +35,16 @@ locals {
   }
 
   image_source_type = split("://", var.image_path)[0]
-  image             = local.image_source_type == "file" ? "${split("file://", var.image_path)[1]}/${var.image_file}" : null
+  image = (
+    local.image_source_type == "file" ? "${split("file://", var.image_path)[1]}/${var.image_file}" :
+    local.image_source_type == "cloud" ? var.image_file :
+    null
+  )
 }
 
 resource "aws_s3_bucket" "images" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   bucket = local.bucket_name
 
   tags = merge(
@@ -48,20 +54,26 @@ resource "aws_s3_bucket" "images" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "images_owner" {
-  bucket = aws_s3_bucket.images.id
+  count = local.image_source_type == "file" ? 1 : 0
+
+  bucket = aws_s3_bucket.images.0.id
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
 }
 
 resource "aws_s3_bucket_acl" "images_acl" {
-  depends_on = [aws_s3_bucket_ownership_controls.images_owner]
+  count = local.image_source_type == "file" ? 1 : 0
 
-  bucket = aws_s3_bucket.images.id
+  depends_on = [aws_s3_bucket_ownership_controls.images_owner.0]
+
+  bucket = aws_s3_bucket.images.0.id
   acl    = "private"
 }
 
 data "aws_iam_policy_document" "policy_document" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   statement {
     # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#principals-and-not_principals
     # principal = "*"
@@ -74,8 +86,8 @@ data "aws_iam_policy_document" "policy_document" {
       "s3:*"
     ]
     resources = [
-      aws_s3_bucket.images.arn,
-      "${aws_s3_bucket.images.arn}/*"
+      aws_s3_bucket.images.0.arn,
+      "${aws_s3_bucket.images.0.arn}/*"
     ]
     condition {
       test     = "Bool"
@@ -91,12 +103,16 @@ data "aws_iam_policy_document" "policy_document" {
 }
 
 resource "aws_s3_bucket_policy" "images_policy" {
-  bucket = aws_s3_bucket.images.id
-  policy = data.aws_iam_policy_document.policy_document.json
+  count = local.image_source_type == "file" ? 1 : 0
+
+  bucket = aws_s3_bucket.images.0.id
+  policy = data.aws_iam_policy_document.policy_document.0.json
 }
 
 resource "aws_s3_bucket_public_access_block" "no_public_access" {
-  bucket = aws_s3_bucket.images.id
+  count = local.image_source_type == "file" ? 1 : 0
+
+  bucket = aws_s3_bucket.images.0.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -105,7 +121,9 @@ resource "aws_s3_bucket_public_access_block" "no_public_access" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "images_encryption" {
-  bucket = aws_s3_bucket.images.id
+  count = local.image_source_type == "file" ? 1 : 0
+
+  bucket = aws_s3_bucket.images.0.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -202,9 +220,10 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_s3_object" "image" {
-  bucket = aws_s3_bucket.images.id
+  count = local.image_source_type == "file" ? 1 : 0
+
+  bucket = aws_s3_bucket.images.0.id
   key    = local.image_name
-  source = local.image
 
   tags = merge(
     local.labels,
@@ -213,12 +232,14 @@ resource "aws_s3_object" "image" {
 }
 
 resource "aws_ebs_snapshot_import" "snapshot_import" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   disk_container {
     # format = "VHD"
     format = "RAW"
     user_bucket {
-      s3_bucket = aws_s3_bucket.images.bucket
-      s3_key    = aws_s3_object.image.key
+      s3_bucket = aws_s3_bucket.images.0.bucket
+      s3_key    = aws_s3_object.image.0.key
     }
   }
 
@@ -232,6 +253,8 @@ resource "aws_ebs_snapshot_import" "snapshot_import" {
 }
 
 resource "aws_ami" "ami" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name                = local.image_name
   description         = "gardenlinux"
   ena_support         = true
@@ -243,7 +266,7 @@ resource "aws_ami" "ami" {
   root_device_name = "/dev/xvda"
   ebs_block_device {
     device_name = "/dev/xvda"
-    snapshot_id = aws_ebs_snapshot_import.snapshot_import.id
+    snapshot_id = aws_ebs_snapshot_import.snapshot_import.0.id
   }
 
   tpm_support = local.feature_trustedboot ? "v2.0" : null
@@ -266,7 +289,11 @@ resource "aws_key_pair" "ssh_key" {
 }
 
 resource "aws_instance" "instance" {
-  ami           = aws_ami.ami.id
+  ami = (
+    local.image_source_type == "file" ? aws_ami.ami.0.id :
+    local.image_source_type == "cloud" ? var.image_file :
+    null
+  )
   instance_type = var.instance_type
   subnet_id     = aws_subnet.subnet.id
 

--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -26,7 +26,11 @@ locals {
   public_ip = azurerm_public_ip.pip.ip_address
 
   image_source_type = split("://", var.image_path)[0]
-  image             = local.image_source_type == "file" ? "${split("file://", var.image_path)[1]}/${var.image_file}" : null
+  image = (
+    local.image_source_type == "file" ? "${split("file://", var.image_path)[1]}/${var.image_file}" :
+    local.image_source_type == "cloud" ? replace(lower(var.image_file), "communitygalleries", "communityGalleries") :
+    null
+  )
 
   labels = {
     component = "gardenlinux"
@@ -76,15 +80,19 @@ resource "azurerm_storage_account" "storage_account" {
 }
 
 resource "azurerm_storage_container" "blob" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name                  = local.vhds_name
   storage_account_id    = azurerm_storage_account.storage_account.id
   container_access_type = "private"
 }
 
 resource "azurerm_storage_blob" "image" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name                   = local.image_name
   storage_account_name   = azurerm_storage_account.storage_account.name
-  storage_container_name = azurerm_storage_container.blob.name
+  storage_container_name = azurerm_storage_container.blob.0.name
   type                   = "Page"
   source                 = local.image
 
@@ -95,6 +103,8 @@ resource "azurerm_storage_blob" "image" {
 }
 
 resource "azurerm_shared_image_gallery" "gallery" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name                = local.image_gallery_name
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
@@ -103,8 +113,10 @@ resource "azurerm_shared_image_gallery" "gallery" {
 }
 
 resource "azurerm_shared_image" "shared_image" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name                = "gardenlinux"
-  gallery_name        = azurerm_shared_image_gallery.gallery.name
+  gallery_name        = azurerm_shared_image_gallery.gallery.0.name
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   os_type             = "Linux"
@@ -123,13 +135,15 @@ resource "azurerm_shared_image" "shared_image" {
 }
 
 resource "azurerm_shared_image_version" "shared_image_version" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name                = "0.0.0"
-  gallery_name        = azurerm_shared_image_gallery.gallery.name
+  gallery_name        = azurerm_shared_image_gallery.gallery.0.name
   resource_group_name = azurerm_resource_group.rg.name
-  image_name          = azurerm_shared_image.shared_image.name
+  image_name          = azurerm_shared_image.shared_image.0.name
   location            = azurerm_resource_group.rg.location
   storage_account_id  = azurerm_storage_account.storage_account.id
-  blob_uri            = azurerm_storage_blob.image.url
+  blob_uri            = azurerm_storage_blob.image.0.url
   replication_mode    = "Shallow"
 
   target_region {
@@ -252,7 +266,11 @@ resource "azurerm_linux_virtual_machine" "instance" {
   network_interface_ids = [azurerm_network_interface.nic.id]
   size                  = var.instance_type
 
-  source_image_id = azurerm_shared_image_version.shared_image_version.id
+  source_image_id = (
+    local.image_source_type == "file" ? azurerm_shared_image_version.shared_image_version.0.id :
+    local.image_source_type == "cloud" ? local.image :
+    null
+  )
 
   os_disk {
     caching              = "ReadWrite"
@@ -280,13 +298,13 @@ resource "azurerm_linux_virtual_machine" "instance" {
 
   # wait until image version is available
   depends_on = [
-    azurerm_shared_image_version.shared_image_version
+    azurerm_shared_image_version.shared_image_version.0
   ]
 
   # replace if image source changes
   lifecycle {
     replace_triggered_by = [
-      azurerm_storage_blob.image.metadata
+      # azurerm_storage_blob.image.0.metadata
     ]
   }
 }

--- a/tests/platformSetup/tofu/modules/gcp/main.tf
+++ b/tests/platformSetup/tofu/modules/gcp/main.tf
@@ -21,7 +21,11 @@ locals {
   public_ip = google_compute_instance.instance.network_interface.0.access_config.0.nat_ip
 
   image_source_type = split("://", var.image_path)[0]
-  image             = local.image_source_type == "file" ? "${split("file://", var.image_path)[1]}/${var.image_file}" : null
+  image = (
+    local.image_source_type == "file" ? "${split("file://", var.image_path)[1]}/${var.image_file}" :
+    local.image_source_type == "cloud" ? var.image_file :
+    null
+  )
 
   labels = {
     component = "gardenlinux"
@@ -31,6 +35,8 @@ locals {
 }
 
 resource "google_storage_bucket" "images" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name          = local.bucket_name
   location      = var.region_storage
   force_destroy = true
@@ -42,9 +48,11 @@ resource "google_storage_bucket" "images" {
 }
 
 resource "google_storage_bucket_object" "image" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name   = local.tar_name
   source = local.image
-  bucket = google_storage_bucket.images.name
+  bucket = google_storage_bucket.images.0.name
 
   content_type = "application/x-tar"
 }
@@ -55,10 +63,12 @@ resource "google_storage_bucket_object" "image" {
 # }
 
 resource "google_compute_image" "image" {
+  count = local.image_source_type == "file" ? 1 : 0
+
   name = local.image_name
 
   raw_disk {
-    source = "https://storage.cloud.google.com/${google_storage_bucket.images.name}/${google_storage_bucket_object.image.name}"
+    source = "https://storage.cloud.google.com/${google_storage_bucket.images.0.name}/${google_storage_bucket_object.image.0.name}"
   }
 
   guest_os_features {
@@ -93,7 +103,7 @@ resource "google_compute_image" "image" {
 
   lifecycle {
     replace_triggered_by = [
-      google_storage_bucket_object.image.crc32c
+      google_storage_bucket_object.image.0.crc32c
     ]
   }
 }
@@ -140,7 +150,11 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = google_compute_image.image.name
+      image = (
+        local.image_source_type == "file" ? google_compute_image.image.0.name :
+        local.image_source_type == "cloud" ? "projects/sap-se-gcp-gardenlinux/global/images/${local.image}" :
+        null
+      )
       type  = "pd-ssd"
       size  = 7
     }
@@ -184,7 +198,7 @@ resource "google_compute_instance" "instance" {
 
   lifecycle {
     replace_triggered_by = [
-      google_compute_image.image.creation_timestamp
+      # google_compute_image.image.0.creation_timestamp
     ]
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This scope of this feature is spinning up test instances of existing and released gardenlinux versions quickly on cloud providers.

#### Use existing published cloud images from the official gardenlinux releases
You can boot published cloud images from the official gardenlinux releases like e.g. [Release 1592.6](https://github.com/gardenlinux/gardenlinux/releases/tag/1592.6) by referencing the image path and image name in the `IMAGE_PATH` and `IMAGE_NAME` variables.
```bash
# use an existing image for ali
IMAGE_PATH=cloud:// IMAGE_NAME=m-d7oaobmhtxwjsw07e3as \
  make --directory=tests/platformSetup \
  ali-gardener_prod-amd64-tofu-config

# use an existing image for aws
IMAGE_PATH=cloud:// IMAGE_NAME=ami-073c0d4753f70877d \
  make --directory=tests/platformSetup \
  aws-gardener_prod-amd64-tofu-config

# use an existing image for azure
IMAGE_PATH=cloud:// IMAGE_NAME=/communityGalleries/gardenlinux-13e998fe-534d-4b0a-8a27-f16a73aef620/images/gardenlinux-gen2/versions/1592.6.0 \
  make --directory=tests/platformSetup \
  azure-gardener_prod-amd64-tofu-config

# use an existing image for gcp
IMAGE_PATH=cloud:// IMAGE_NAME=projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-gardener-prod-amd64-1592-6-cb05e11f \
  make --directory=tests/platformSetup \
  gcp-gardener_prod-amd64-tofu-config
```
After creating the OpenTofu variables file, you can create the cloud resources with the `tofu-apply` make targets as usual.



**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

This scope of this feature is spinning up test instances of existing and released gardenlinux versions quickly on cloud providers.
This feature is not yet usable in github actions. There we have the possibility to boot/test images that are stored on s3 already (https://github.com/gardenlinux/gardenlinux/blob/15c9622539f1e5b6d88f4a6ed3db94e95bbe2053/tests/platformSetup/tofu/README.md#tests-onlyyml---on-demand-testing).