### PR TITLE
native and parallel build of kmodbuild_container

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -69,16 +69,22 @@ jobs:
           podman manifest add ghcr.io/${{ github.repository }}:${version} ghcr.io/${{ github.repository }}:arm64-${version}
           podman push ghcr.io/${{ github.repository }}:${version}
 
-  publish_kmodbuild_container:
-    name: publish gardenlinux kernel module build dev image
-    runs-on: ubuntu-latest
-    needs: publish_container
+  build_kmodbuild_container:
+    name: build gardenlinux kernel module build dev image
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-latest-arm' || 'ubuntu-latest' }}
     defaults:
       run:
         shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ amd64, arm64 ]
+    needs: publish_container
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: ./.github/actions/setup
+        with:
+          arch: "${{ matrix.arch }}"
       - name: get container versions
         id: versions
         run: |
@@ -87,7 +93,7 @@ jobs:
           echo -e "base=ghcr.io/${{ github.repository }}:$version\nsnapshot=$snapshot" | tee "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: publish gardenlinux kernel module build dev image
+      - name: build gardenlinux kernel module build dev image
         run: |
           version=$(bin/garden-version "${{ inputs.version }}")
           podman login -u token -p ${{ github.token }} ghcr.io
@@ -95,16 +101,26 @@ jobs:
           base='${{ steps.versions.outputs.base }}'
           snapshot='${{ steps.versions.outputs.snapshot }}'
 
-          podman pull --arch amd64 "$base"
-          podman pull --arch amd64 "$snapshot"
-          podman build --arch amd64 --build-arg base="$base" --build-arg snapshot="$snapshot" -t ghcr.io/${{ github.repository }}/kmodbuild:amd64-${version} images/kmodbuild
-          podman push ghcr.io/${{ github.repository }}/kmodbuild:amd64-${version}
+          podman pull --arch ${{ matrix.arch }} "$base"
+          podman pull --arch ${{ matrix.arch }} "$snapshot"
+          podman build --arch ${{ matrix.arch }} --build-arg base="$base" --build-arg snapshot="$snapshot" -t ghcr.io/${{ github.repository }}/kmodbuild:${{ matrix.arch }}-${version} images/kmodbuild
+          podman push ghcr.io/${{ github.repository }}/kmodbuild:${{ matrix.arch }}-${version}
 
-          podman pull --arch arm64 "$base"
-          podman pull --arch arm64 "$snapshot"
-          podman build --arch arm64 --build-arg base="$base" --build-arg snapshot="$snapshot" -t ghcr.io/${{ github.repository }}/kmodbuild:arm64-${version} images/kmodbuild
-          podman push ghcr.io/${{ github.repository }}/kmodbuild:arm64-${version}
-
+  publish_kmodbuild_container:
+    name: publish gardenlinux kernel module build dev image
+    runs-on: ubuntu-latest
+    needs: build_kmodbuild_container
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - uses: ./.github/actions/setup
+      - name: publish gardenlinux kernel module build dev image
+        run: |
+          version=$(bin/garden-version "${{ inputs.version }}")
+          podman login -u token -p ${{ github.token }} ghcr.io
+          
           podman manifest create ghcr.io/${{ github.repository }}/kmodbuild:${version}
           podman manifest add ghcr.io/${{ github.repository }}/kmodbuild:${version} ghcr.io/${{ github.repository }}/kmodbuild:amd64-${version}
           podman manifest add ghcr.io/${{ github.repository }}/kmodbuild:${version} ghcr.io/${{ github.repository }}/kmodbuild:arm64-${version}


### PR DESCRIPTION
**What this PR does / why we need it**:

Building `kmodbuild_container` takes very long as it is not parallelized per architecture and does not use native builders.

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

https://github.com/gardenlinux/gardenlinux/actions/runs/13950195229 is a nightly run where this was tested successfully.
