### PR TITLE
feat: remove rootlesskit from chost

### DIFF
--- a/features/chost/pkg.include
+++ b/features/chost/pkg.include
@@ -1,5 +1,4 @@
 apparmor
 containerd
 ethtool
-rootlesskit
 dbus-user-session


### PR DESCRIPTION
**What this PR does / why we need it**:
After discussing with @gehoern it was decided to remove _rootlesskit_ from the _chost_ feature.
At the moment nobody using this feature really needs the functionality provided by _rootlesskit_.