### PR TITLE
fix: set gl_version default to nightly in push step of platform-test-images.yml

### DIFF
--- a/.github/workflows/platform-test-images.yml
+++ b/.github/workflows/platform-test-images.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Set environment variables for ${{ matrix.platform }}
         run: |
-          GL_VERSION="${{ inputs.gl_version }}"
+          GL_VERSION="${{ inputs.gl_version || 'nightly' }}"
           IMAGE_BASE_URL="${IMAGE_REGISTRY}/${IMAGE_BASE}"
           IMAGE_NAME="${IMAGE_BASE}-${{ matrix.platform }}"
           IMAGE_URL="${IMAGE_BASE_URL}-${{ matrix.platform }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the default to nightly if gl_version provided was empty.

**Which issue(s) this PR fixes**:
Fixes currently nightly 
