### PR TITLE
get git root - if running as git submodule, return parent project root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -euo pipefail -c
 
-ROOT_DIR := $(shell git rev-parse --show-toplevel)
+# get git root - if running as git submodule, return parent project root
+ROOT_DIR := $(shell git rev-parse --show-toplevel --show-superproject-working-tree | tail -n1)
 
 # Generate FLAVORS variable by running the flavor parser
 FLAVORS := $(shell $(ROOT_DIR)/bin/flavors_parse.py --exclude "bare-*" --build --test)

--- a/bin/flavors_parse.py
+++ b/bin/flavors_parse.py
@@ -48,9 +48,15 @@ SCHEMA = {
 
 
 def find_repo_root():
-    """Finds the root directory of the Git repository."""
+    """
+    Finds the root directory of the Git repository
+    If running in submodule, return root of parent project.
+    """
     try:
-        root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
+        root = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel", "--show-superproject-working-tree"],
+            text=True
+        ).strip().split('\n')[-1]
         return root
     except subprocess.CalledProcessError:
         sys.exit("Error: Unable to determine Git repository root.")

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,8 @@
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -euo pipefail -c
 
-ROOT_DIR := $(shell git rev-parse --show-toplevel)
+# get git root - if running as git submodule, return parent project root
+ROOT_DIR := $(shell git rev-parse --show-toplevel --show-superproject-working-tree | tail -n1)
 
 ifeq ($(origin GL_VERSION), undefined)
 GL_VERSION := latest

--- a/tests/platformSetup/Makefile
+++ b/tests/platformSetup/Makefile
@@ -1,7 +1,8 @@
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -euo pipefail -c
 
-ROOT_DIR := $(shell git rev-parse --show-toplevel)
+# get git root - if running as git submodule, return parent project root
+ROOT_DIR := $(shell git rev-parse --show-toplevel --show-superproject-working-tree | tail -n1)
 UUID_FILE := $(ROOT_DIR)/tests/platformSetup/.uuid
 # Check if the .uuid file exists. If it does, read from it, otherwise generate a new uuid/seed
 ifeq ($(wildcard $(UUID_FILE)),)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed in https://github.com/gardenlinux/gardenlinux-ccloud/pull/57 to fix https://github.com/gardenlinux/gardenlinux-ccloud/issues/42.

This enabled cloning https://github.com/gardenlinux/gardenlinux as a git submodule and return parent project root. This allows constructs like https://github.com/gardenlinux/gardenlinux-ccloud to overwrite files, e.g. features and flavors.

**Which issue(s) this PR fixes**:
Fixes #42

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
  - needs not backport