### PR TITLE
feat(capi): use sulogin --force when root is locked

### DIFF
--- a/features/capi/file.include/etc/dracut.conf.d/30-dracut-emergency.conf
+++ b/features/capi/file.include/etc/dracut.conf.d/30-dracut-emergency.conf
@@ -1,0 +1,2 @@
+add_dracutmodules+=" systemd-emergency "
+install_items+=" /etc/systemd/system/emergency.service.d/sulogin.conf " 

--- a/features/capi/file.include/etc/systemd/system/emergency.service.d/sulogin.conf
+++ b/features/capi/file.include/etc/systemd/system/emergency.service.d/sulogin.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=SYSTEMD_SULOGIN_FORCE=1


### PR DESCRIPTION
**What this PR does / why we need it**:
When using _metal-capi_ in CC, any failure that would trigger the emergency service (initrd or regular system) a usable shell won't be started if the root account is locked.
As this is needed for debug purposes, setting SYSTEMD_SULOGIN_FORCE=1 is needed[^1]

[^1]: https://systemd.io/ENVIRONMENT/


**Which issue(s) this PR fixes**: