### PR TITLE
test rp_filter in Gardener feature not set to 1

### DIFF
--- a/features/gardener/test/test_sysctls.py
+++ b/features/gardener/test/test_sysctls.py
@@ -1,0 +1,13 @@
+import pytest
+from helper.tests.sysctl import check_sysctl
+
+
+@pytest.mark.parametrize(
+    "key,operator,value",
+    [
+        ("net.ipv4.conf.all.rp_filter", "isnotornotset", "1"),
+        ("net.ipv4.conf.default.rp_filter", "isnotornotset", "1"),
+    ],
+)
+def test_sysctls(client, key, operator, value, non_provisioner_chroot):
+    check_sysctl(client, key, operator, value)

--- a/tests/helper/tests/sysctl.py
+++ b/tests/helper/tests/sysctl.py
@@ -1,0 +1,39 @@
+import logging
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def check_sysctl(client, key, operator, value):
+    (exit_code, output, error) = client.execute_command(
+        "sudo -u root /usr/sbin/sysctl -a", quiet=True
+    )
+    assert exit_code == 0, f"no {error=} expected"
+
+    sysctls = {}
+    for line in output:
+        if len(line) < 1 or line.startswith("#"):
+            continue
+        s = line.split("=", 1)
+        if len(s) < 2:
+            continue
+        sysctls[s[0].strip()] = s[1].strip()
+
+    match operator:
+        case "is":
+            assert key in sysctls
+            assert sysctls[key] == value, f"{key} is not {value} but {sysctls[key]}"
+        case "isnot":
+            assert key in sysctls
+            assert sysctls[key] != value, f"{key} should not be {value}"
+        case "isnotornotset":
+            if key in sysctls:
+                assert (
+                    sysctls[key] != value
+                ), f"as {key} is set, it should not be {value}"
+        case "isset":
+            assert key in sysctls, f"{key} should be set"
+        case "isnotset":
+            assert key not in sysctls, f"{key} should not be set"
+        case _:
+            pytest.fail(f"unsupported operator {operator}")


### PR DESCRIPTION
**What this PR does / why we need it**:

For the Gardener feature, the sysctls `net.ipv4.conf.all.rp_filter` and `net.ipv4.conf.default.rp_filter` must not be set to `1` as it will interfere with CNI plugins like Calico or Cilium.

This test tests if those sysctls are set to 1 and will fail if so.

For this test to work, I created an new test helper `check_sysctl()`. Even though we already had a test helper `test_kernel_parameter()` (this name is utterly misleading btw), it is too inflexible as it only allows to test for a certain sysctl to be set to a certain value. With `check_sysctl()`, I introduced an operator with which it is possible to test wether a sysctl `is` a certain value, `isnot` a certain value, `isnotorisnotset` a certain value, `isset` but the value does not matter, `isnotset` at all.

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

Should be backported to `rel-1592` as 1592.7 introduced a regression that makes this test necessary.