### PR TITLE
Fix GitHub workflow trying to access non-existent `archs` matrix

### DIFF
--- a/.github/workflows/build_platform_test_images.yml
+++ b/.github/workflows/build_platform_test_images.yml
@@ -211,7 +211,7 @@ jobs:
         run: |
           # Get architectures from matrix
           # convert to space separated string
-          ARCH_LIST='${{ needs.generate_matrix.outputs.archs }}'
+          ARCH_LIST='${{ needs.generate_matrix.outputs.arch_matrix }}'
           ARCHS=$(echo $ARCH_LIST | tr -d '[]"' | tr ',' ' ')
 
           # Create manifest list


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue with GitHub workflow `build_platform_test_images.yml` trying to use the non-existent `archs` matrix.