### PR TITLE
Make GitHub workflow `tests.yml` input `bare_flavors_matrix` optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ on:
       bare_flavors_matrix:
         description: 'Generated GitHub workflow flavors matrix for bare flavors'
         type: string
-        required: true
+        default: '{"include": []}'
       bare_flavors_test:
         description: 'Execute bare flavors container tests'
         type: boolean


### PR DESCRIPTION
**What this PR does / why we need it**:
Another issue has been found with the alternative support in GitHub workflow `manual_tests.yml` with downloading S3 flavors. `tests.yml` was expecting input `bare_flavors_matrix`. It will be optional after merge.