### PR TITLE
Fix missing import of `path` in GitHub workflow to login to GCP

### DIFF
--- a/.github/workflows/platform_test_cleanup.yml
+++ b/.github/workflows/platform_test_cleanup.yml
@@ -71,6 +71,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const path = await import("path");
+
             const basePath = "/gardenlinux/";
             const credentialsFileName = path.basename(process.env.GOOGLE_APPLICATION_CREDENTIALS);
 

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -129,6 +129,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const path = await import("path");
+
             const basePath = "/gardenlinux/";
             const credentialsFileName = path.basename(process.env.GOOGLE_APPLICATION_CREDENTIALS);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This one-liner imports `path` missing in `platform_test_cleanup.yml` and `test_platform_flavor.yml` GitHub workflows.