### PR TITLE
Correctly read the git ref for branches as well as for `main`

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -49,7 +49,9 @@ jobs:
         with:
           script: |
             const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
-            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, "${{ github.head_ref }}", 3);
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 3);
   test:
     needs: build
     name: Test
@@ -88,7 +90,9 @@ jobs:
         with:
           script: |
             const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
-            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, "${{ github.head_ref }}", 5);
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 5);
   upload_workflow_data:
     needs: [ build, test ]
     name: Store workflow data

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           script: |
             const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
-            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, "${{ github.head_ref }}", 5);
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 5);
   test:
     needs: build
     name: Test
@@ -69,7 +71,9 @@ jobs:
         with:
           script: |
             const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
-            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, "${{ github.head_ref }}", 8);
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 8);
   upload_workflow_data:
     needs: [ build, test ]
     name: Store workflow data

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
     types: [ 'completed' ]
 jobs:
   workflow_data:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.conclusion == "success" }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.conclusion == 'success' }}
     name: Download workflow JSON data from trigger
     uses: ./.github/workflows/download_workflow_data.yml
     with:
@@ -56,4 +56,6 @@ jobs:
         with:
           script: |
             const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
-            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, "${{ github.head_ref }}", 3);
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 3);

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -11,7 +11,7 @@ on:
     types: [ 'completed' ]
 jobs:
   workflow_data:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.conclusion == "success" }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.conclusion == 'success' }}
     name: Download workflow JSON data from trigger
     uses: ./.github/workflows/download_workflow_data.yml
     with:
@@ -130,4 +130,6 @@ jobs:
         with:
           script: |
             const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
-            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, "${{ github.head_ref }}", 5);
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 5);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the use of GitHub workflow variables to identify the branch to use for `main` as well.