### PR TITLE
Only skip tagging as `nightly` on `main` in GitHub workflow `publish_s3.yml`

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -98,7 +98,6 @@ jobs:
       aws_s3_bucket: ${{ secrets.AWS_CN_S3_BUCKET }}
   glrd:
     needs: [ workflow_data, upload_to_s3 ]
-    if: ${{ github.ref_name == "main" }}
     name: create GLRD release
     permissions:
       id-token: write
@@ -109,7 +108,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Create GLRD nightly release
+      - if: ${{ github.ref_name == 'main' }}
+        name: Create GLRD nightly release
         uses: gardenlinux/glrd@v2
         with:
           cmd: glrd-manage --s3-update --create nightly


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows GitHub workflow `publish_s3.yml` to create releases in GLRD without tagging it as `nightly` if not executed on `main`.