### PR TITLE
Disable rp_filter in Gardener feature on GCP

### DIFF
--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -14,3 +14,12 @@ update-alternatives --set iptables "/usr/sbin/iptables-legacy" > /dev/null
 update-alternatives --set ip6tables "/usr/sbin/ip6tables-legacy" > /dev/null
 update-alternatives --set arptables "/usr/sbin/arptables-legacy" > /dev/null
 update-alternatives --set ebtables "/usr/sbin/ebtables-legacy" > /dev/null
+
+# remove rp_filter settings from 60-gce-network-security.conf
+gce_network_sysctl_file="/etc/sysctl.d/60-gce-network-security.conf"
+if [ -e "$gce_network_sysctl_file" ]; then
+    sed -i "/^# Turn on Source Address Verification.*/d" "$gce_network_sysctl_file"
+    sed -i "/^# prevent some spoofing attacks.*/d" "$gce_network_sysctl_file"
+    sed -i "/^net\.ipv4\.conf\.all\.rp_filter.*/d" "$gce_network_sysctl_file"
+    sed -i "/^net\.ipv4\.conf\.default\.rp_filter.*/d" "$gce_network_sysctl_file"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

As the package google-compute-engine contains sysctls that turn on rp_filter on all interfaces which can interfere with CNI plugins, these lines have to be removed again in the Gardener feature.

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
