### PR TITLE
Fix handling of `inputs` as `outputs` in GitHub reusable workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       commit_id: ${{ needs.requirements.outputs.commit_id }}
       version: ${{ needs.requirements.outputs.version }}
       # GitHub workflow workaround for bool
-      use_kms: ${{ needs.requirements.outputs.use_kms == true }}
+      use_kms: ${{ needs.requirements.outputs.use_kms == 'true' }}
     uses: ./.github/workflows/build_flavor.yml
     secrets: inherit
   kmodbuild_container:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes how `outputs.use_kms` are used as `inputs.use_kms` later on to fix the evaluation of boolean.