### PR TITLE
Cleanup various GitHub workflow statements

### DIFF
--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -31,7 +31,6 @@ jobs:
             COMMIT
             VERSION
           key: build-container-${{ matrix.arch }}-${{ github.run_id }}
-          fail-on-cache-miss: true
       - if: ${{ steps.build_container_cache.outputs.cache-hit }}}}
         name: Set CNAME
         run: |

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -39,7 +39,7 @@ jobs:
       secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}
   build_retry:
     needs: build
-    if: ${{ always() && needs.build.result == 'failure' }}
+    if: ${{ needs.build.result == 'failure' }}
     name: 'Retry checkpoint: Build'
     runs-on: ubuntu-24.04
     steps:
@@ -80,7 +80,7 @@ jobs:
       tf_encryption: ${{ secrets.TF_ENCRYPTION }}
   test_retry:
     needs: test
-    if: ${{ always() && needs.test.result == 'failure' }}
+    if: ${{ needs.test.result == 'failure' }}
     name: 'Retry checkpoint: Test'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
       secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}
   build_retry:
     needs: build
-    if: ${{ always() && needs.build.result == 'failure' }}
+    if: ${{ needs.build.result == 'failure' }}
     name: 'Retry checkpoint: Build'
     runs-on: ubuntu-24.04
     steps:
@@ -61,7 +61,7 @@ jobs:
       tf_encryption: ${{ secrets.TF_ENCRYPTION }}
   test_retry:
     needs: test
-    if: ${{ always() && needs.test.result == 'failure' }}
+    if: ${{ needs.test.result == 'failure' }}
     name: 'Retry checkpoint: Test'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       version: ${{ needs.workflow_data.outputs.version }}
   publish_retry:
     needs: [ publish_oci_containers, publish_kmodbuild_container ]
-    if: ${{ always() && ( needs.publish_oci_containers.result == 'failure' || needs.publish_kmodbuild_container.result == 'failure' ) }}
+    if: ${{ needs.publish_oci_containers.result == 'failure' || needs.publish_kmodbuild_container.result == 'failure' }}
     name: 'Retry checkpoint: Publish to GitHub'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -120,7 +120,7 @@ jobs:
           cmd: glrd --type nightly --latest
   publish_retry:
     needs: [ upload_to_s3, upload_to_s3_cn, glrd ]
-    if: ${{ always() && ( needs.upload_to_s3.result == 'failure' || needs.glrd.result == 'failure' ) }}
+    if: ${{ needs.upload_to_s3.result == 'failure' || needs.glrd.result == 'failure' }}
     name: 'Retry checkpoint: Publish to S3'
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes some statements used in GitHub workflows:
- It removes `always()` from `manual_release.yml`, `nightly.yml`, `publish.yml`, and `publish_s3.yml` as based on [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always) it evaluates to true only for successful or canceled jobs.
- It removes `fail-on-cache-miss: true` from `build_kmodbuild_container.yml` as this prevents conditional execution afterwards