### PR TITLE
Synchronize flavors between nightly and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       commit_id: ${{ needs.requirements.outputs.commit_id }}
       version: ${{ needs.requirements.outputs.version }}
       # GitHub workflow workaround for bool
-      use_kms: ${{ needs.requirements.outputs.use_kms == true }}
+      use_kms: ${{ needs.requirements.outputs.use_kms == 'true' }}
     uses: ./.github/workflows/build_flavor.yml
     secrets: inherit
   kmodbuild_container:

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -13,7 +13,7 @@ on:
         default: latest
       flavors_parse_params:
         description: 'Run bin/flavors_parse.py with these parameters'
-        default: '--no-arch --json-by-arch --publish --test-platform'
+        default: '--exclude "bare-*" --no-arch --json-by-arch --build --test'
         type: string
       bare_flavors_parse_params:
         description: 'Run bin/parse_flavors.py with these parameters for bare flavors'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR synchronizes the flavors parse params used to create a release with the ones from `nightly`.