### PR TITLE
Use correct matrix source for GitHub workflow

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -26,7 +26,7 @@ jobs:
       CNAME: ''
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(inputs.flavors_matrix) }}
+      matrix: ${{ fromJson(needs.workflow_data.outputs.flavors_matrix) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the GitHub workflow `publish_s3.yml` to access the right source for the flavors matrix required.