### PR TITLE
Fix access to alicloud access credentials in GitHub workflows

### DIFF
--- a/.github/workflows/platform_test_cleanup.yml
+++ b/.github/workflows/platform_test_cleanup.yml
@@ -121,14 +121,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const aliCredentials = JSON.parse(atob("${{ secrets.CCC_CREDENTIALS }}"));
+            const credentials = JSON.parse(atob("${{ secrets.CCC_CREDENTIALS }}"));
+            const aliCredentials = credentials.alicloud["gardenlinux-platform-test"];
 
-            core.exportVariable("ALIBABA_CLOUD_REGION", aliCredentials["gardenlinux-platform-test"].region);
+            core.exportVariable("ALIBABA_CLOUD_REGION", aliCredentials.region);
 
             core.setSecret("ALIBABA_CLOUD_ACCESS_KEY_ID");
-            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_ID", aliCredentials["gardenlinux-platform-test"].access_key_id);
+            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_ID", aliCredentials.access_key_id);
             core.setSecret("ALIBABA_CLOUD_ACCESS_KEY_SECRET");
-            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_SECRET", aliCredentials["gardenlinux-platform-test"].access_key_secret);
+            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_SECRET", aliCredentials.access_key_secret);
       - name: Setup Environment
         run: |
           # ssh key generation (if missing)

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -179,14 +179,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const aliCredentials = JSON.parse(atob("${{ secrets.ccc_credentials }}"));
+            const credentials = JSON.parse(atob("${{ secrets.ccc_credentials }}"));
+            const aliCredentials = credentials.alicloud["gardenlinux-platform-test"];
 
-            core.exportVariable("ALIBABA_CLOUD_REGION", aliCredentials["gardenlinux-platform-test"].region);
+            core.exportVariable("ALIBABA_CLOUD_REGION", aliCredentials.region);
 
             core.setSecret("ALIBABA_CLOUD_ACCESS_KEY_ID");
-            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_ID", aliCredentials["gardenlinux-platform-test"].access_key_id);
+            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_ID", aliCredentials.access_key_id);
             core.setSecret("ALIBABA_CLOUD_ACCESS_KEY_SECRET");
-            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_SECRET", aliCredentials["gardenlinux-platform-test"].access_key_secret);
+            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_SECRET", aliCredentials.access_key_secret);
       - name: Deploy platform-test resources for ${{ inputs.flavor }} (${{ inputs.arch }})
         run: |
           export TF_ENCRYPTION="$(base64 -d <<< ${{ secrets.tf_encryption }})"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the access to the structure where alicloud credentials are stored in the secret for GitHub workflows.