### PR TITLE
Add missing `needs` to job `prepare_certs` in GitHub workflow `publish_s3.yml`

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
   prepare_certs:
+    needs: workflow_data
     name: Add certs to S3 artifacts
     runs-on: ubuntu-24.04
     defaults:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the missing `needs` declaration for job `prepare_certs` of the GitHub workflow `publish_s3.yml` to correctly access the output of it.