### PR TITLE
Fix GLRD creating wrong nightly releases under certain circumstances

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -188,17 +188,17 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - if: ${{ github.ref_name == 'main' }}
         name: Create GLRD nightly release
-        uses: gardenlinux/glrd@v2
+        uses: gardenlinux/glrd@v3
         with:
           cmd: glrd-manage --s3-update --create nightly --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
       - if: ${{ github.ref_name != 'main' }}
         name: Create GLRD patch release
-        uses: gardenlinux/glrd@v2
+        uses: gardenlinux/glrd@v3
         with:
           cmd: glrd-manage --s3-update --create patch --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
       - name: Get latest GL nightly
         id: gl_version_nightly
-        uses: gardenlinux/glrd@v2
+        uses: gardenlinux/glrd@v3
         with:
           cmd: glrd --type nightly --latest
   publish_retry:

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
   trustedboot_flavors_supported_matrix:
+    needs: workflow_data
     name: Generate flavors matrix for trustedboot
     uses: ./.github/workflows/build_flavors_matrix.yml
     with:
@@ -189,7 +190,12 @@ jobs:
         name: Create GLRD nightly release
         uses: gardenlinux/glrd@v2
         with:
-          cmd: glrd-manage --s3-update --create nightly
+          cmd: glrd-manage --s3-update --create nightly --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
+      - if: ${{ github.ref_name != 'main' }}
+        name: Create GLRD patch release
+        uses: gardenlinux/glrd@v2
+        with:
+          cmd: glrd-manage --s3-update --create patch --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
       - name: Get latest GL nightly
         id: gl_version_nightly
         uses: gardenlinux/glrd@v2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates GLRD action to v3 and uses the provided `--version` and `--commit` parameters to create releases based on the given information.

**Which issue(s) this PR fixes**:
Fixes #2923