### PR TITLE
fix: support arm64 machine hardware type for platform-test images

### DIFF
--- a/tests/images/Makefile
+++ b/tests/images/Makefile
@@ -15,6 +15,8 @@ endif
 ifeq ($(strip $(TARGETARCH)),)
 ifeq ($(shell uname -m), aarch64)	
 TARGETARCH := arm64
+else ifeq ($(shell uname -m), arm64)
+TARGETARCH := arm64
 else ifeq ($(shell uname -m), x86_64)
 TARGETARCH := amd64
 endif


### PR DESCRIPTION
**What this PR does / why we need it**:
`arm64` or `aarch64` should both resolve to `arm64` in this case. 

`uname -m` on osx returns `arm64`, which would result in an empty `TARGETARCH` variable during building , since no existing conditions are met. 


**Reproduce**:  
```
make --directory=tests/images build-platform-test
# Check logs for linux-image (see that apt can not install package, because we only have linux-image-${TARGETARCH}
# Check logs for TARGETARCH= 
```

