### PR TITLE
Read the Git hash for short commit ID in GitHub workflow `publish_s3.yml`

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -181,21 +181,25 @@ jobs:
       id-token: write
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: ${{ secrets.AWS_OIDC_SESSION }}
           aws-region: ${{ secrets.AWS_REGION }}
+      - id: git_hash
+        name: Get Git hash for "${{ needs.workflow_data.outputs.commit_id }}"
+        run: echo "hash=$(git log -1 --pretty=format:"%H" "${{ needs.workflow_data.outputs.commit_id }}")" | tee -a $GITHUB_OUTPUT
       - if: ${{ github.ref_name == 'main' }}
         name: Create GLRD nightly release
         uses: gardenlinux/glrd@v3
         with:
-          cmd: glrd-manage --s3-update --create nightly --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
+          cmd: glrd-manage --s3-update --create nightly --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ steps.git_hash.outputs.hash }}"
       - if: ${{ github.ref_name != 'main' }}
         name: Create GLRD patch release
         uses: gardenlinux/glrd@v3
         with:
-          cmd: glrd-manage --s3-update --create patch --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
+          cmd: glrd-manage --s3-update --create patch --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ steps.git_hash.outputs.hash }}"
       - name: Get latest GL nightly
         id: gl_version_nightly
         uses: gardenlinux/glrd@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reads the Git hash for the (known) short commit ID for calling `glrd`.