### PR TITLE
Fix "ambiguous argument" in GitHub workflow executed `git` for `publish_s3.yml`

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -189,7 +189,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - id: git_hash
         name: Get Git hash for "${{ needs.workflow_data.outputs.commit_id }}"
-        run: echo "hash=$(git log -1 --pretty=format:"%H" "${{ needs.workflow_data.outputs.commit_id }}")" | tee -a $GITHUB_OUTPUT
+        run: echo "hash=$(git log -1 --pretty=format:"%H" "${{ needs.workflow_data.outputs.commit_id }}" -- .)" | tee -a $GITHUB_OUTPUT
       - if: ${{ github.ref_name == 'main' }}
         name: Create GLRD nightly release
         uses: gardenlinux/glrd@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in GitHub workflow `publish_s3.yml`:
```
fatal: ambiguous argument '<short rev>': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
```

While not occured locally the Ubuntu variant seems to be more restrictive regarding command line parameters.