### PR TITLE
Fix correct use of cache restore keys

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -298,9 +298,9 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
         with:
           path: manifests
-          key: oci-manifests-${{ matrix.flavor }}-${{ matrix.arch }}-${{ github.run_id }}
+          key: oci-manifests-${{ github.run_id }}-${{ matrix.flavor }}-${{ matrix.arch }}
           restore-keys: |
-            oci-manifests-${{ github.run_id }}
+            oci-manifests-${{ github.run_id }}-
       - uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
         with:
           path: oci_manifest_entry_${{ env.CNAME }}.json
@@ -326,6 +326,8 @@ jobs:
         with:
           path: manifests
           key: oci-manifests-${{ github.run_id }}
+          restore-keys: |
+            oci-manifests-${{ github.run_id }}-
           fail-on-cache-miss: true
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -189,7 +189,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - id: git_hash
         name: Get Git hash for "${{ needs.workflow_data.outputs.commit_id }}"
-        run: echo "hash=$(git log -1 --pretty=format:"%H" "${{ needs.workflow_data.outputs.commit_id }}")" | tee -a $GITHUB_OUTPUT
+        run: echo "hash=$(git log -1 --pretty=format:"%H" "${{ needs.workflow_data.outputs.commit_id }}" -- .)" | tee -a $GITHUB_OUTPUT
       - if: ${{ github.ref_name == 'main' }}
         name: Create GLRD nightly release
         uses: gardenlinux/glrd@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the cache keys for updateable caches to align with how `restore-keys` are implemented but unclear documented in GitHub workflow `publish_oci_containers.yml`.