### PR TITLE
Fix "bad revision" in GitHub workflow executed `git` for `publish_s3.yml`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,8 +18,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: use VERSION file to support dev build on rel-branch
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+      - name: Use VERSION file to support dev build on rel-branch
         id: version
         run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
   build:

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -182,6 +182,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+        with:
+          fetch-depth: 0
       - uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
@@ -189,7 +191,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - id: git_hash
         name: Get Git hash for "${{ needs.workflow_data.outputs.commit_id }}"
-        run: echo "hash=$(git log -1 --pretty=format:"%H" "${{ needs.workflow_data.outputs.commit_id }}" -- .)" | tee -a $GITHUB_OUTPUT
+        run: echo "hash=$(git rev-list -1 "${{ needs.workflow_data.outputs.commit_id }}")" | tee -a $GITHUB_OUTPUT
       - if: ${{ github.ref_name == 'main' }}
         name: Create GLRD nightly release
         uses: gardenlinux/glrd@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in GitHub workflow `publish_s3.yml`:
```
fatal: bad revision '<short rev>'
```

Reason identified is that GitHub creates a shallow clone by default and truncates history therefore.
While not occurred locally the Ubuntu variant(?) seems to be more restrictive regarding command line parameters.