### PR TITLE
fix test: disable test_clocksource on qemu without kvm support

### DIFF
--- a/features/base/test/test_time_config.py
+++ b/features/base/test/test_time_config.py
@@ -100,7 +100,7 @@ __EOF
     assert "FAIL" not in output
 
 
-def test_clocksource(client, aws):
+def test_clocksource(client, aws, non_qemu):
     """ Test for clocksource """
     # refer to https://aws.amazon.com/premiumsupport/knowledge-center/manage-ec2-linux-clock-source/
     # detect hypervisor type kvm or xen

--- a/tests/conftests/platforms.py
+++ b/tests/conftests/platforms.py
@@ -53,6 +53,11 @@ def kvm(platform):
         pytest.skip('test only supported on kvm platform')
 
 @pytest.fixture
+def qemu(platform):
+    if platform != 'qemu':
+        pytest.skip('test only supported on qemu platform')
+
+@pytest.fixture
 def metal(platform):
     if platform != 'metal':
         pytest.skip('test only supported on metal platform')
@@ -101,6 +106,11 @@ def non_gcp(platform):
 def non_kvm(platform):
     if platform == 'kvm':
         pytest.skip('test not supported on kvm')
+
+@pytest.fixture
+def non_qemu(platform):
+    if platform == 'qemu':
+        pytest.skip('test not supported on qemu')
 
 @pytest.fixture
 def non_metal(testconfig):


### PR DESCRIPTION
**What this PR does / why we need it**:

The test

	base/test/test_time_config.py::test_clocksource

will fail with

	AssertionError: unknown hypervisor qemu

This happens because systemd-detect-virt will output "qemu" in case we start tests via qemu target, e.g.:

	make --directory=tests aws-gardener_prod-amd64-qemu-test-platform

In order to exclude this test for this test target, we need to add new fixtures for "qemu" iaas. As defined in [tests/conftest.py::testconfig](https://github.com/gardenlinux/gardenlinux/blob/d659d9bc8a843ae1ba49bbff9fb2e14a826fd6b8/tests/conftest.py#L173), iaas can be set to qemu.

This commit adds:
- fixtures to exclude/include qemu iaas
- excludes test_time_config.py::test_clocksource for qemu platform


