### PR TITLE
Use long git hashes as commit ID input for GitHub workflows

### DIFF
--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -46,6 +46,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          commit="$(./get_commit)"
+          commit_short="${commit:0:8}"
+
           version="$(bin/garden-version "${{ inputs.version }}")"
 
           if [ "$version" == "today" ]; then
@@ -56,7 +59,7 @@ jobs:
           rm "$CNAME.tar.gz"
 
           base="ghcr.io/${{ github.repository }}:$version"
-          image="$(podman load -i .build/container-${{ matrix.arch }}-$(cat VERSION)-$(cat COMMIT).oci | awk '{ print $NF }')"
+          image="$(podman load -i .build/container-${{ matrix.arch }}-$(cat VERSION)-${commit_short}.oci | awk '{ print $NF }')"
           podman tag "$image" "$base"
 
           snapshot="$(gh api "/repos/gardenlinux/repo/contents/.container?ref=$version" | jq -r '.content' | base64 -d)"

--- a/.github/workflows/build_requirements.yml
+++ b/.github/workflows/build_requirements.yml
@@ -47,7 +47,7 @@ jobs:
             version="now"
           fi
 
-          echo "COMMIT_ID=$(git rev-parse HEAD | cut -c1-8)" | tee -a "$GITHUB_ENV"
+          echo "COMMIT_ID=$(git rev-parse HEAD)" | tee -a "$GITHUB_ENV"
           echo "VERSION=$(./bin/garden-version "$version")" | tee -a "$GITHUB_ENV"
       - name: Prepare build reference from GLRD
         if: ${{ steps.prepare_github_reference.conclusion == 'skipped' }}
@@ -60,7 +60,7 @@ jobs:
             glrd_data="$(./bin/glrd --type stable,patch,nightly,dev --output-format=json --version ${{ inputs.version }})"
           fi
 
-          commit_id=$(echo $glrd_data | jq -r '.releases[0].git.commit_short')
+          commit_id=$(echo $glrd_data | jq -r '.releases[0].git.commit')
           version=$(echo $glrd_data | jq -r '(.releases[0].version.major | tostring) + "." + (.releases[0].version.minor | tostring)')
 
           echo "COMMIT_ID=$commit_id" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR switches the value of commit ID to long `git` hashes (again). While most scripts in GardenLinux works for both hash variants and Git support both as committish some processes expect long hashes to be used. Additionally the commit ID got mixed up previously in GitHub workflow for [testing](https://github.com/gardenlinux/gardenlinux/blob/b5c0e06b6ad0de14be247d15129999e2c385ffd8/.github/workflows/tests.yml#L116). Restore previous behavior of always providing the long commit hash.