### PR TITLE
fix: follow up on test_clocksource on aws image test on qemu

### DIFF
--- a/features/base/test/test_time_config.py
+++ b/features/base/test/test_time_config.py
@@ -100,7 +100,7 @@ __EOF
     assert "FAIL" not in output
 
 
-def test_clocksource(client, aws, non_qemu):
+def test_clocksource(client, aws):
     """ Test for clocksource """
     # refer to https://aws.amazon.com/premiumsupport/knowledge-center/manage-ec2-linux-clock-source/
     # detect hypervisor type kvm or xen


### PR DESCRIPTION
Commit b26c78fb9884fba07c44bc507d69b67854755361 introduced non_qemu fixture and added it to test_clocksource.

However, this does not work as intended since we would have contradicting fixutes. Therefore, this commit follows up and cleans this up.

This means, we should test AWS on AWS platform. For local testing during development, we just accept the failing tests.
