### PR TITLE
update python-gardenlinux-cli to 0.6.4

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -31,7 +31,7 @@ on:
       oci_kms_arn:
         required: true
 env:
-  GLCLI_VERSION: 0.6.3
+  GLCLI_VERSION: 0.6.4
 jobs:
   container:
     name: Publish container base image


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for more file types. 

https://github.com/gardenlinux/python-gardenlinux-cli/releases/tag/0.6.4 required by @5kt  for CC. 