### PR TITLE
Add support to leave "bare flavors" empty while using GitHub workflow `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ on:
         description: 'Run bin/parse_flavors.py with these parameters for bare flavors'
         default: '--include-only "bare-*" --no-arch --json-by-arch --build --test'
         type: string
+      bare_flavors_matrix:
+        description: 'Already generated GitHub workflow bare flavors matrix'
+        type: string
       fail_fast:
         description: 'Cancel workflow run on first error'
         type: boolean
@@ -102,8 +105,10 @@ jobs:
     uses: ./.github/workflows/build_flavors_matrix.yml
     with:
       flags: ${{ inputs.bare_flavors_parse_params }}
+      flavors_matrix: ${{ inputs.bare_flavors_matrix }}
   bare_flavors:
     needs: [ bootstrap, bare_flavors_matrix, requirements ]
+    if: ${{ needs.bare_flavors_matrix.outputs.matrix != '{"include":[]}' }}
     name: Build bare flavors
     strategy:
       matrix: ${{ fromJson(needs.bare_flavors_matrix.outputs.matrix) }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Repositories like [gardenlinux-ccloud](https://github.com/gardenlinux/gardenlinux-ccloud) may not contain bare flavors in `flavors.yml`. This PR adds conditions to handle these cases.