### PR TITLE
try first to upload artifacts via GitHub hosted runners, if that fails fallback to custom upload runner

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -147,11 +147,15 @@ jobs:
     name: Upload to S3
     permissions:
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.workflow_data.outputs.flavors_matrix) }}
     uses: ./.github/workflows/upload_to_s3.yml
     with:
       commit_id: ${{ needs.workflow_data.outputs.commit_id }}
       version: ${{ needs.workflow_data.outputs.version }}
-      flavors_matrix: ${{ needs.workflow_data.outputs.flavors_matrix }}
+      flavor: ${{ matrix.flavor }}
+      arch: ${{ matrix.arch }}
       run_id: ${{ github.run_id }}
     secrets:
       aws_region: ${{ secrets.AWS_REGION }}
@@ -163,11 +167,15 @@ jobs:
     name: Upload to S3 (China)
     permissions:
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.workflow_data.outputs.flavors_matrix) }}
     uses: ./.github/workflows/upload_to_s3.yml
     with:
       commit_id: ${{ needs.workflow_data.outputs.commit_id }}
       version: ${{ needs.workflow_data.outputs.version }}
-      flavors_matrix: ${{ needs.workflow_data.outputs.flavors_matrix }}
+      flavor: ${{ matrix.flavor }}
+      arch: ${{ matrix.arch }}
       run_id: ${{ github.run_id }}
     secrets:
       aws_region: ${{ secrets.AWS_CN_REGION }}

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -8,7 +8,10 @@ on:
       version:
         type: string
         required: true
-      flavors_matrix:
+      flavor:
+        type: string
+        required: true
+      arch:
         type: string
         required: true
       run_id:
@@ -26,18 +29,15 @@ on:
 jobs:
   upload_to_s3:
     name: upload to S3
-    runs-on: upload
+    runs-on: "ubuntu-24.04"
     defaults:
       run:
         shell: bash
     env:
-      CNAME: ''
+      CNAME: ""
     permissions:
       id-token: write
     environment: oidc_aws_s3_upload
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(inputs.flavors_matrix) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
         with:
@@ -54,11 +54,50 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ matrix.flavor }}-${{ matrix.arch }})"
+          cname="$(./build --resolve-cname ${{ inputs.flavor }}-${{ inputs.arch }})"
           echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
         with:
-          name: build-${{ matrix.flavor }}-${{ matrix.arch }}
+          name: build-${{ inputs.flavor }}-${{ inputs.arch }}
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.run_id }}
+      - name: Upload to S3 bucket ${{ secrets.aws_s3_bucket }}
+        run: ${{ github.workspace }}/.github/workflows/upload_to_s3.sh ${{ secrets.aws_s3_bucket }} $CNAME.tar.gz
+
+  # Fallback job to upload to S3 using a custom runner if the main upload job fails
+  upload_to_s3_fallback_runner:
+    needs: [ upload_to_s3 ]
+    if: failure() && needs.upload_to_s3.result == 'failure'
+    runs-on: upload
+    defaults:
+      run:
+        shell: bash
+    env:
+      CNAME: ""
+    permissions:
+      id-token: write
+    environment: oidc_aws_s3_upload
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+        with:
+          submodules: true
+      - uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # pin@v4
+        with:
+          role-to-assume: ${{ secrets.aws_role }}
+          role-session-name: ${{ secrets.aws_session }}
+          aws-region: ${{ secrets.aws_region }}
+          role-duration-seconds: 14400
+      - name: Set flavor version reference
+        run: |
+          echo "${{ inputs.commit_id }}" | tee COMMIT
+          echo "${{ inputs.version }}" | tee VERSION
+      - name: Set CNAME
+        run: |
+          cname="$(./build --resolve-cname ${{ inputs.flavor }}-${{ inputs.arch }})"
+          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # pin@v4.2.1
+        with:
+          name: build-${{ inputs.flavor }}-${{ inputs.arch }}
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
       - name: Upload to S3 bucket ${{ secrets.aws_s3_bucket }}


### PR DESCRIPTION
This PR adjust the behavior of the upload to S3 GitHub action to leverage GitHub hosted runners

**What this PR does / why we need it**:
Currently all upload jobs are using custom paid GitHub-hosted runners. Trying to upload first with the free GitHub-hosted runners avoids paying for these. The fallback to the custom `upload` runners ensures that in case the GitHub-hosted runners get blocked (especially for china uploads) the custom runners are used. 
The hope is that this will not happen to often and thus cuts the cost of the runners a lot. 

Currently `publish_s3.yml` already consumed 200k paid minutes in the first 10 days of April: https://github.com/gardenlinux/gardenlinux/actions/metrics/usage


**Which issue(s) this PR fixes**:
n/a

**Definition of Done:**
- [x] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:
To allow for better retry behavior for individual uploads the matrix is now generated in the main `publish_s3.yml` and `upload_to_s3` is only called with one specific `flavor` & `arch` to upload that single thing.
If that upload fails using the GitHub hosted runner (`ubuntu-24.04`)  it is retried within `upload_to_s3` via the `upload` custom runner.

Rather than the ugly code duplication for both upload attempts the same could be archived using an external action, but as the duplicated code is rather small and anyway was mentioned that this should be removed in the future I think this is okay for now.

//cc @nkraetzschmar 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Upload artifacts to S3 using GitHub hosted runners; fallback to custom runners on failure
```
