### PR TITLE
switch to free github-hosted runners for S3 upload

### DIFF
--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   upload_to_s3:
     name: upload to S3
-    runs-on: upload
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This PR adjust the behavior of the upload to S3 GitHub action to leverage GitHub hosted runners

**What this PR does / why we need it**:

Based on the discussion in #2961 using the (free) GitHub hosted directly should work for upload to S3 for both normal AWS and AWS China. If this change should not be compatible we can try again with a more suffisticated fallback solution as discussed in #2961. 

Switching to the free GitHub hosted runners reduces the amount of paid GitHub Action minutes by roughly 200k minutes / 10 days (https://github.com/gardenlinux/gardenlinux/actions/metrics/usage). 

**Which issue(s) this PR fixes**:
n/a

**Definition of Done:**
- [x] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Upload artifacts to S3 using free GitHub hosted runners
```
