### PR TITLE
Warn more explicitly about memory consumption of build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The build system utilises the [gardenlinux/builder](https://github.com/gardenlin
 > [!TIP]
 > For further information about the build process, and how to set it up on your machine, refer to [the _Build Image_ documentation page](docs/01_developers/build_image.md).
 
+> [!WARNING]
+> Be sure to provide enough memory (at least 8GiB) to your container runtime or the VM that hosts your container runtime (in Podman or Docker Desktop).
+> Otherwise your build may fail silently.
+
 To initiate a build, use the command:
 ```bash
 ./build ${platform}-${feature1}-${feature2}-${feature3}-${arch}

--- a/docs/01_developers/build_image.md
+++ b/docs/01_developers/build_image.md
@@ -3,7 +3,11 @@ The build system utilizes the [gardenlinux/builder](https://github.com/gardenlin
 
 ## Build Requirements
 
-- **Memory:** The build process may require up to 8GiB of memory, depending on the selected targets. If your system has insufficient RAM, configure swap space accordingly.
+
+> [!WARNING]
+> Be sure to provide enough **memory** (at least 8GiB) to your container runtime or the VM that hosts your container runtime (in Podman or Docker Desktop).
+> Otherwise your build may fail silently.
+
 - **Container Engine:** The Builder has minimal dependencies and only requires a working container engine. You have two options:
   - **Rootless Podman:** It's recommended to use rootless Podman. Please refer to the [Podman rootless setup guide](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md) for instructions on setting it up.
   - **Sudo Podman:** Alternatively, you can use Podman with sudo for elevated privileges.


### PR DESCRIPTION
Feedback from new contributors shows that this part was too easy to miss, so making it a bit more explicit may help to avoid frustration.
