### PR TITLE
Allow building images suitable for use with lima-vm

### DIFF
--- a/features/lima/README.md
+++ b/features/lima/README.md
@@ -1,0 +1,8 @@
+## Feature: lima
+### Description
+<website-feature>
+This feature flag produces an image suitable for using with [lima](https://lima-vm.io)
+</website-feature>
+
+For the time being, this only supports `qemu` virtual machines.
+Using `vz` is not supported.

--- a/features/lima/README.md
+++ b/features/lima/README.md
@@ -6,3 +6,26 @@ This feature flag produces an image suitable for using with [lima](https://lima-
 
 For the time being, this only supports `qemu` virtual machines.
 Using `vz` is not supported.
+
+How to use:
+
+1. Build an image: `./build kvm-lima`
+
+2. Create the manifest.yaml file
+
+```yaml
+vmType: qemu
+os: Linux
+images:
+  - location: /path/to/your/gardenlinux/.build/kvm-lima-[ARCH]-[VERSION]-[COMMIT_SHA].qcow2
+
+containerd:
+  system: false
+  user: false
+```
+
+3. Create the VM: `cat manifest.yaml | limactl create --name=gardenlinux -`
+
+4. Start the VM: `limactl start gardenlinux`
+
+5. Open a shell inside the VM: `limactl shell gardenlinux`

--- a/features/lima/convert.qcow2
+++ b/features/lima/convert.qcow2
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+set -o nounset
+
+RAW_DISK_IMAGE=$1
+COMPRESSED_DISK_IMAGE=$2
+
+qemu-img convert -f raw -O qcow2 "$RAW_DISK_IMAGE" "$COMPRESSED_DISK_IMAGE"

--- a/features/lima/info.yaml
+++ b/features/lima/info.yaml
@@ -1,0 +1,2 @@
+description: "image suitable for using with [lima](https://lima-vm.io)"
+type: flag

--- a/features/lima/pkg.include
+++ b/features/lima/pkg.include
@@ -1,0 +1,2 @@
+cloud-init
+sshfs


### PR DESCRIPTION
This PR adds a `lima` feature that enables the resulting image to be usable with https://lima-vm.io

This is useful for a few reasons:
- lima takes care of creating a user, generating an ssh key and some other aspects that Garden Linux does not have its own tooling for
- This allows developers and interested externals to create Garden Linux virtual machines for testing, evaluation and similar purposes

Part of https://github.com/gardenlinux/gardenlinux/issues/2964
