### PR TITLE
fix: purge packages based on repo exlusion list

### DIFF
--- a/images/kmodbuild/Containerfile
+++ b/images/kmodbuild/Containerfile
@@ -20,11 +20,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --instal
 	python3-jinja2 \
 	sudo \
 	vim \
-	wget
-
-# Automatically purge all packages defined in package-exclude of gardenlinux/repo.
-RUN curl -s https://raw.githubusercontent.com/gardenlinux/repo/refs/heads/main/package-exclude | xargs -I {} bash -c 'apt-get purge -y {}'
-
+	wget && \
+	# Automatically purge all packages defined in package-exclude of gardenlinux/repo.
+	curl -s https://raw.githubusercontent.com/gardenlinux/repo/refs/heads/main/package-exclude | xargs -I {} bash -c 'apt-get purge -y {}'
 
 COPY list_headers /opt/
 RUN /opt/list_headers

--- a/images/kmodbuild/Containerfile
+++ b/images/kmodbuild/Containerfile
@@ -21,5 +21,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --instal
 	sudo \
 	vim \
 	wget
+
+# Automatically purge all packages defined in package-exclude of gardenlinux/repo.
+RUN curl -s https://raw.githubusercontent.com/gardenlinux/repo/refs/heads/main/package-exclude | xargs -I {} bash -c 'apt-get purge -y {}'
+
+
 COPY list_headers /opt/
 RUN /opt/list_headers


### PR DESCRIPTION
**What this PR does / why we need it**:
libdb in kmodbuild.

We download the package exclusion file from github.com/gardenlinux/repo main branch, and purge those packages that were installed.

We use main branch of gardenlinux/repo instead of dynamic inferred branch, since main branch will be most up-to-date and we can still build kmodbuild in feature branches.


**Which issue(s) this PR fixes**:
Fixes #2988 


**Notes for reviewer** 
How to build this PR and verify 

```
version="1592.9"
base="ghcr.io/gardenlinux/gardenlinux:$version
snapshot="$(gh api "/repos/gardenlinux/repo/contents/.container?ref=$version" | jq -r '.content' | base64 -d)"
arch=<your favorite arch (or the one you have)>
podman build --arch $arch --build-arg base="$base" --build-arg snapshot="$snapshot" -t ghcr.io/gardenlinux/gardenlinux/kmodbuild:${arch}-${version} images/kmodbuild

podman run --rm -it  ghcr.io/gardenlinux/gardenlinux/kmodbuild:$arch-$version
apt list --installed 2> /dev/null | grep libdb5
```


