### PR TITLE
Streamline GitHub workflow release target logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,9 @@ on:
         description: 'Garden Linux version'
         type: string
         default: today
-      signing_env:
+      target:
         type: string
-        default: ""
-      channel:
-        type: string
-        default: nightly
+        default: dev
       flavors_parse_params:
         description: 'Run bin/parse_flavors.py with these parameters'
         default: '--exclude "bare-*" --no-arch --json-by-arch --build --test'
@@ -56,8 +53,7 @@ jobs:
     uses: ./.github/workflows/build_requirements.yml
     with:
       version: ${{ inputs.version == '' && 'now' || inputs.version }}
-      use_kms: ${{ inputs.signing_env != '' }}
-      channel: ${{ inputs.channel }}
+      target: ${{ inputs.target }}
   bootstrap:
     needs: requirements
     name: Bootstrap build
@@ -90,8 +86,7 @@ jobs:
       flavor: ${{ matrix.flavor }}
       commit_id: ${{ needs.requirements.outputs.commit_id }}
       version: ${{ needs.requirements.outputs.version }}
-      signing_env: ${{ inputs.signing_env }}
-      channel: ${{ inputs.channel }}
+      signing_env: ${{ needs.requirements.outputs.signing_env }}
     uses: ./.github/workflows/build_flavor.yml
     secrets: inherit
   kmodbuild_container:
@@ -125,7 +120,11 @@ jobs:
     steps:
       - name: Store data in JSON file
         run: |
-          jq -r -n '{ "commit_id": "${{ needs.requirements.outputs.commit_id }}", "version": "${{ needs.requirements.outputs.version }}" }' '.' > flavor_version_data.json
+          jq -r -n '{
+            "commit_id": "${{ needs.requirements.outputs.commit_id }}",
+            "version": "${{ needs.requirements.outputs.version }}",
+            "target": "${{ needs.requirements.outputs.target }}"
+          }' '.' > flavor_version_data.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:
           name: flavor-version-data

--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -20,9 +20,6 @@ on:
       signing_env:
         type: string
         default: ''
-      channel:
-        type: string
-        required: true
     secrets:
       secureboot_db_kms_arn:
         required: false
@@ -43,7 +40,7 @@ jobs:
       id-token: write
     env:
       CNAME: ''
-      USE_KMS: ${{ inputs.signing_env != '' && 'true' || 'false' }}
+      USE_KMS: ${{ inputs.signing_env == '' && 'false' || 'true' }}
     environment: ${{ inputs.signing_env }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
@@ -59,23 +56,23 @@ jobs:
           path: .build
           key: base-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
-      - name: Load cert cache
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
+      - name: Load certs artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
-          path: cert/*.*
-          key: cert-${{ github.run_id }}
-          fail-on-cache-miss: true
-      - name: Write secureboot db arn for kms backed certificates
-        if: ${{ inputs.signing_env != '' }}
-        run: echo "${{ secrets.secureboot_db_kms_arn }}" > cert/gardenlinux-${{ inputs.channel }}-secureboot.db.arn
+          name: certs
+          path: cert/
       - name: Configure aws credentials for kms signing
-        if: ${{ inputs.signing_env != '' }}
+        id: aws_auth
+        if: ${{ env.USE_KMS == 'true' }}
         uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_kms_role }}
           role-session-name: ${{ secrets.aws_oidc_session }}
           aws-region: ${{ secrets.aws_region }}
           role-duration-seconds: 14400
+      - name: Write secureboot db arn for kms backed certificates
+        if: ${{ steps.aws_auth.conclusion == 'success' }}
+        run: echo "${{ secrets.secureboot_db_kms_arn }}" > cert/secureboot.db.arn
       - name: Update bootstrap stage build artifact timestamps
         run: |
           t="$(date '+%s')"

--- a/.github/workflows/build_requirements.yml
+++ b/.github/workflows/build_requirements.yml
@@ -11,10 +11,7 @@ on:
       use_glrd:
         type: boolean
         default: false
-      use_kms:
-        type: boolean
-        default: false
-      channel:
+      target:
         type: string
         required: true
     outputs:
@@ -22,9 +19,30 @@ on:
         value: ${{ jobs.calculate_version.outputs.commit_id }}
       version:
         value: ${{ jobs.calculate_version.outputs.version }}
-      use_kms:
-        value: ${{ inputs.use_kms }}
+      signing_env:
+        value: ${{ jobs.determine_environment.outputs.environment }}
+      target:
+        value: ${{ inputs.target }}
 jobs:
+  determine_environment:
+    name: Determine signing environment
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-24.04
+    outputs:
+      environment: ${{ steps.signing_environment.outputs.environment }}
+    steps:
+      - name: Set signing environment
+        id: signing_environment
+        run: |
+          if [[ "${{ inputs.target }}" == "release" ]]; then
+            echo "environment=oidc_aws_kms_release" | tee -a "$GITHUB_OUTPUT"
+          elif [[ "${{ inputs.target }}" == "nightly" ]]; then
+            echo "environment=oidc_aws_kms_nightly" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "environment=" | tee -a "$GITHUB_OUTPUT"
+          fi
   calculate_version:
     name: Build version
     defaults:
@@ -87,16 +105,17 @@ jobs:
       - name: Set VERSION=${{ needs.calculate_version.outputs.version }}
         run: echo "${{ needs.calculate_version.outputs.version }}" | tee VERSION
       - name: Build certificates
-        if: ${{ ! inputs.use_kms }}
+        if: ${{ inputs.target == 'dev' }}
         run: ./cert/build
       - name: Use kms backed certificates
-        if: ${{ inputs.use_kms }}
+        if: ${{ inputs.target != 'dev' }}
         run: |
-          touch cert/gardenlinux-${{ inputs.channel }}-secureboot.db.arn
+          touch cert/gardenlinux-${{ inputs.target }}-secureboot.db.arn
           for f in secureboot.{{pk,null.pk,kek,db}.{crt,der,auth},db.arn,aws-efivars} oci-sign.crt; do
-            ln -sr "cert/gardenlinux-${{ inputs.channel }}-$f" "cert/$f"
+            ln -sr "cert/gardenlinux-${{ inputs.target }}-$f" "cert/$f"
           done
-      - uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:
+          name: certs
           path: cert/*.*
-          key: cert-${{ github.run_id }}
+          if-no-files-found: error

--- a/.github/workflows/download_workflow_data.yml
+++ b/.github/workflows/download_workflow_data.yml
@@ -18,8 +18,8 @@ on:
         value: ${{ jobs.workflow_data.outputs.bare_flavors_matrix }}
       original_workflow_name:
         value: ${{ jobs.workflow_data.outputs.original_workflow_name }}
-      channel:
-        value: ${{ jobs.workflow_data.outputs.channel }}
+      target:
+        value: ${{ jobs.workflow_data.outputs.target }}
 jobs:
   workflow_data:
     name: Download workflow JSON data from trigger
@@ -30,7 +30,7 @@ jobs:
       flavors_matrix: ${{ steps.data.outputs.flavors_matrix }}
       bare_flavors_matrix: ${{ steps.data.outputs.bare_flavors_matrix }}
       original_workflow_name: ${{ steps.data.outputs.original_workflow_name }}
-      channel: ${{ steps.data.outputs.channel }}
+      target: ${{ steps.data.outputs.target }}
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
@@ -65,6 +65,6 @@ jobs:
             core.setOutput("flavors_matrix", workflowData.flavors_matrix);
             core.setOutput("bare_flavors_matrix", workflowData.bare_flavors_matrix);
             core.setOutput("original_workflow_name", workflowData.original_workflow_name);
-            core.setOutput("channel", workflowData.channel);
+            core.setOutput("target", flavorVersionData.target);
 
             return true;

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -7,6 +7,13 @@ on:
         description: 'Garden Linux version'
         type: string
         required: true
+      target:
+        description: 'Garden Linux release target'
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
       platform_test_tag:
         description: 'Tag to run platform-test containers. "latest" or GL version. Tag must be available in `ghcr.io/gardenlinux/gardenlinux/platform-test-*`'
         type: string
@@ -19,12 +26,6 @@ on:
         description: 'Run bin/parse_flavors.py with these parameters for bare flavors'
         default: '--include-only "bare-*" --no-arch --json-by-arch --build --test'
         type: string
-      channel:
-        required: true
-        type: choice
-        options:
-          - release
-          - nightly
 jobs:
   build:
     name: Build
@@ -33,8 +34,7 @@ jobs:
       id-token: write
     with:
       version: ${{ inputs.version }}
-      signing_env: ${{ inputs.channel == 'release' && 'oidc_aws_kms_release' || 'oidc_aws_kms_nightly' }}
-      channel: ${{ inputs.channel }}
+      target: ${{ inputs.target }}
       flavors_parse_params: ${{ inputs.flavors_parse_params }}
       platform_test_tag: ${{ inputs.platform_test_tag }}
       bare_flavors_parse_params: ${{ inputs.bare_flavors_parse_params }}
@@ -112,8 +112,7 @@ jobs:
             "flavors_matrix": $matrix,
             "bare_flavors_matrix": $bare_matrix,
             "version": "${{ needs.build.outputs.version }}",
-            "original_workflow_name": "${{ github.workflow }}",
-            "channel": "${{ inputs.channel }}"
+            "original_workflow_name": "${{ github.workflow }}"
           }' '.' > workflow_data.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:

--- a/.github/workflows/manual_tests.yml
+++ b/.github/workflows/manual_tests.yml
@@ -8,6 +8,14 @@ on:
         description: 'Garden Linux version'
         type: string
         default: now
+      target:
+        description: 'Garden Linux release target'
+        type: choice
+        default: dev
+        options:
+          - release
+          - nightly
+          - dev
       build:
         description: 'Build for version specified in version input parameter instead of downloading it from S3.'
         type: boolean
@@ -32,12 +40,6 @@ on:
         description: 'Execute platform tests'
         type: boolean
         default: true
-      channel:
-        required: true
-        type: choice
-        options:
-          - release
-          - nightly
 jobs:
   build:
     name: Build
@@ -83,7 +85,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       use_glrd: true
-      channel: ${{ inputs.channel }}
+      target: ${{ inputs.target }}
   download_store_flavor_version_data:
     name: Store flavor version data
     needs: download_build_requirements

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
     with:
       version: now
-      signing_env: oidc_aws_kms_nightly
+      target: nightly
       platform_test_tag: latest
       fail_fast: true
     secrets:
@@ -86,8 +86,7 @@ jobs:
             "flavors_matrix": $matrix,
             "bare_flavors_matrix": $bare_matrix,
             "version": "${{ needs.build.outputs.version }}",
-            "original_workflow_name": "${{ github.workflow }}",
-            "channel": "nightly"
+            "original_workflow_name": "${{ github.workflow }}"
           }' '.' > workflow_data.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,22 +16,6 @@ jobs:
     uses: ./.github/workflows/download_workflow_data.yml
     with:
       run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
-  determine_repository:
-    needs: workflow_data
-    runs-on: ubuntu-latest
-    outputs:
-      repository: ${{ steps.set_repository.outputs.repository }}
-    steps:
-      - id: set_repository
-        run: |
-          if [[ "${{ needs.workflow_data.outputs.channel }}" == "release" ]]; then
-            echo "repository=ghcr.io/gardenlinux/gardenlinux" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ needs.workflow_data.outputs.channel }}" == "nightly" ]]; then
-            echo "repository=ghcr.io/gardenlinux/nightly" >> "$GITHUB_OUTPUT"
-          else
-            echo "invalid channel ${{ needs.workflow_data.outputs.channel }}" >&2
-            exit 1
-          fi
   publish_oci_containers:
     needs: [ workflow_data, determine_repository ]
     name: Publish container base image
@@ -45,11 +29,10 @@ jobs:
       run_id: ${{ needs.workflow_data.outputs.run_id }}
       commit_id: ${{ needs.workflow_data.outputs.commit_id }}
       version: ${{ needs.workflow_data.outputs.version }}
+      target: ${{ needs.workflow_data.outputs.target }}
       flavors_matrix: ${{ needs.workflow_data.outputs.flavors_matrix }}
       bare_flavors_matrix: ${{ needs.workflow_data.outputs.bare_flavors_matrix }}
       original_workflow_name: ${{ needs.workflow_data.outputs.original_workflow_name }}
-      repository: ${{ needs.determine_repository.outputs.repository }}
-      signing_env: ${{ needs.workflow_data.outputs.channel == 'release' && 'oidc_aws_kms_release' || 'oidc_aws_kms_nightly' }}
     secrets:
       aws_region: ${{ secrets.AWS_REGION }}
       aws_role: ${{ secrets.KMS_SIGNING_IAM_ROLE }}

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -12,6 +12,9 @@ on:
       version:
         type: string
         required: true
+      target:
+        type: string
+        required: true
       flavors_matrix:
         type: string
         required: true
@@ -21,12 +24,6 @@ on:
       original_workflow_name:
         type: string
         default: ''
-      repository:
-        type: string
-        required: true
-      signing_env:
-        type: string
-        required: true
     secrets:
       aws_role:
         required: true
@@ -39,7 +36,24 @@ on:
 env:
   GLCLI_VERSION: 0.6.4
 jobs:
+  determine_repository:
+    name: Determine release repository to use for target ${{ inputs.target }}
+    runs-on: ubuntu-latest
+    outputs:
+      repository: ${{ steps.set_repository.outputs.repository }}
+    steps:
+      - id: set_repository
+        run: |
+          if [[ "${{ inputs.target }}" == "release" ]]; then
+            echo "repository=ghcr.io/gardenlinux/gardenlinux" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ inputs.target }}" == "nightly" ]]; then
+            echo "repository=ghcr.io/gardenlinux/nightly" >> "$GITHUB_OUTPUT"
+          else
+            echo "invalid release target ${{ inputs.target }}" >&2
+            exit 1
+          fi
   container:
+    needs: determine_repository
     name: Publish container base image
     runs-on: ubuntu-24.04
     defaults:
@@ -83,41 +97,42 @@ jobs:
 
           # Tagging for amd64 nightly
           if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ inputs.repository }}:amd64-nightly
-            podman push ${{ inputs.repository }}:amd64-nightly
+            podman tag "$image" ${{ needs.determine_repository.outputs.repository }}:amd64-nightly
+            podman push ${{ needs.determine_repository.outputs.repository }}:amd64-nightly
           fi
 
           # Tagging for amd64 with version
-          podman tag "$image" ${{ inputs.repository }}:amd64-${version}
-          podman push ${{ inputs.repository }}:amd64-${version}
+          podman tag "$image" ${{ needs.determine_repository.outputs.repository }}:amd64-${version}
+          podman push ${{ needs.determine_repository.outputs.repository }}:amd64-${version}
 
           tar xzv < "${CNAME_ARM64}.tar.gz"
           image="$(podman load < ${CNAME_ARM64}.oci | awk '{ print $NF }')"
 
           # Tagging for arm64 nightly
           if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ inputs.repository }}:arm64-nightly
-            podman push ${{ inputs.repository }}:arm64-nightly
+            podman tag "$image" ${{ needs.determine_repository.outputs.repository }}:arm64-nightly
+            podman push ${{ needs.determine_repository.outputs.repository }}:arm64-nightly
           fi
 
           # Tagging for arm64 with version
-          podman tag "$image" ${{ inputs.repository }}:arm64-${version}
-          podman push ${{ inputs.repository }}:arm64-${version}
+          podman tag "$image" ${{ needs.determine_repository.outputs.repository }}:arm64-${version}
+          podman push ${{ needs.determine_repository.outputs.repository }}:arm64-${version}
 
           # Creating and pushing manifest for nightly
           if [ $is_nightly = true ]; then
-            podman manifest create ${{ inputs.repository }}:nightly
-            podman manifest add ${{ inputs.repository }}:nightly ${{ inputs.repository }}:amd64-nightly
-            podman manifest add ${{ inputs.repository }}:nightly ${{ inputs.repository }}:arm64-nightly
-            podman manifest push ${{ inputs.repository }}:nightly
+            podman manifest create ${{ needs.determine_repository.outputs.repository }}:nightly
+            podman manifest add ${{ needs.determine_repository.outputs.repository }}:nightly ${{ needs.determine_repository.outputs.repository }}:amd64-nightly
+            podman manifest add ${{ needs.determine_repository.outputs.repository }}:nightly ${{ needs.determine_repository.outputs.repository }}:arm64-nightly
+            podman manifest push ${{ needs.determine_repository.outputs.repository }}:nightly
           fi
 
           # Creating and pushing manifest for version tag
-          podman manifest create ${{ inputs.repository }}:${version}
-          podman manifest add ${{ inputs.repository }}:${version} ${{ inputs.repository }}:amd64-${version}
-          podman manifest add ${{ inputs.repository }}:${version} ${{ inputs.repository }}:arm64-${version}
-          podman manifest push ${{ inputs.repository }}:${version}
+          podman manifest create ${{ needs.determine_repository.outputs.repository }}:${version}
+          podman manifest add ${{ needs.determine_repository.outputs.repository }}:${version} ${{ needs.determine_repository.outputs.repository }}:amd64-${version}
+          podman manifest add ${{ needs.determine_repository.outputs.repository }}:${version} ${{ needs.determine_repository.outputs.repository }}:arm64-${version}
+          podman manifest push ${{ needs.determine_repository.outputs.repository }}:${version}
   bare_flavors:
+    needs: determine_repository
     name: Publish bare flavors
     if: ${{ inputs.bare_flavors_matrix != '{"include":[]}' }}
     runs-on: ubuntu-24.04
@@ -150,42 +165,43 @@ jobs:
           image="$(podman load < ${{ matrix.config }}-amd64.oci | awk '{ print $NF }')"
 
           # Tagging and pushing amd64 with version
-          podman tag "$image" ${{ inputs.repository }}/bare-${{ matrix.config }}:amd64-$version
-          podman push ${{ inputs.repository }}/bare-${{ matrix.config }}:amd64-$version
+          podman tag "$image" ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:amd64-$version
+          podman push ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:amd64-$version
 
           # Tagging and pushing amd64 with nightly
           if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ inputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
-            podman push ${{ inputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
+            podman tag "$image" ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
+            podman push ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
           fi
 
           # Handling arm64 image
           image="$(podman load < ${{ matrix.config }}-arm64.oci | awk '{ print $NF }')"
 
           # Tagging and pushing arm64 with version
-          podman tag "$image" ${{ inputs.repository }}/bare-${{ matrix.config }}:arm64-$version
-          podman push ${{ inputs.repository }}/bare-${{ matrix.config }}:arm64-$version
+          podman tag "$image" ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:arm64-$version
+          podman push ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:arm64-$version
 
           # Tagging and pushing arm64 with nightly
           if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ inputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
-            podman push ${{ inputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
+            podman tag "$image" ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
+            podman push ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
           fi
 
           # Creating and pushing manifest for version tag
-          podman manifest create ${{ inputs.repository }}/bare-${{ matrix.config }}:$version
-          podman manifest add ${{ inputs.repository }}/bare-${{ matrix.config }}:$version ${{ inputs.repository }}/bare-${{ matrix.config }}:amd64-$version
-          podman manifest add ${{ inputs.repository }}/bare-${{ matrix.config }}:$version ${{ inputs.repository }}/bare-${{ matrix.config }}:arm64-$version
-          podman manifest push ${{ inputs.repository }}/bare-${{ matrix.config }}:$version
+          podman manifest create ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:$version
+          podman manifest add ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:$version ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:amd64-$version
+          podman manifest add ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:$version ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:arm64-$version
+          podman manifest push ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:$version
 
           # Creating and pushing manifest for nightly tag
           if [ $is_nightly = true ]; then
-            podman manifest create ${{ inputs.repository }}/bare-${{ matrix.config }}:nightly
-            podman manifest add ${{ inputs.repository }}/bare-${{ matrix.config }}:nightly ${{ inputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
-            podman manifest add ${{ inputs.repository }}/bare-${{ matrix.config }}:nightly ${{ inputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
-            podman manifest push ${{ inputs.repository }}/bare-${{ matrix.config }}:nightly
+            podman manifest create ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:nightly
+            podman manifest add ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:nightly ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
+            podman manifest add ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:nightly ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
+            podman manifest push ${{ needs.determine_repository.outputs.repository }}/bare-${{ matrix.config }}:nightly
           fi
   push_flavors:
+    needs: determine_repository
     name: Publish flavors
     runs-on: ubuntu-24.04
     defaults:
@@ -196,7 +212,7 @@ jobs:
     permissions:
       id-token: write
       packages: write
-    environment: ${{ inputs.signing_env }}
+    environment: ${{ inputs.target == 'release' && 'oidc_aws_kms_release' || 'oidc_aws_kms_nightly' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.flavors_matrix) }}
@@ -247,7 +263,7 @@ jobs:
           retry_count=0
           exit_code=0
           until [ $retry_count -ge $max_retries ]; do
-            if output=$(GLOCI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }} GLOCI_REGISTRY_USERNAME=${{ github.repository_owner }} python /opt/glcli/src/glcli.py push-manifest --dir "$CNAME" --container ${{ inputs.repository }} --arch ${{ matrix.arch }} --version ${{ inputs.version }} --cname "$CNAME" --cosign_file digest.txt --manifest_file "oci_manifest_entry_$CNAME.json" 2>&1); then
+            if output=$(GLOCI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }} GLOCI_REGISTRY_USERNAME=${{ github.repository_owner }} python /opt/glcli/src/glcli.py push-manifest --dir "$CNAME" --container ${{ needs.determine_repository.outputs.repository }} --arch ${{ matrix.arch }} --version ${{ inputs.version }} --cname "$CNAME" --cosign_file digest.txt --manifest_file "oci_manifest_entry_$CNAME.json" 2>&1); then
               cat digest.txt
               exit 0
             elif echo "$output" | grep -q "Bad Gateway"; then
@@ -267,10 +283,10 @@ jobs:
       - name: Sign the manifest
         run: |
           docker login ghcr.io -u token -p ${{ github.token }}
-          cosign sign -tlog-upload=false --key awskms://kms.${{ secrets.aws_region }}.amazonaws.com/${{ secrets.oci_kms_arn }} ${{ inputs.repository }}@$(cat digest.txt)
+          cosign sign -tlog-upload=false --key awskms://kms.${{ secrets.aws_region }}.amazonaws.com/${{ secrets.oci_kms_arn }} ${{ needs.determine_repository.outputs.repository }}@$(cat digest.txt)
       - name: Verify signature
         run: |
-          cosign verify --insecure-ignore-tlog=true --key awskms://kms.${{ secrets.aws_region}}.amazonaws.com/${{ secrets.oci_kms_arn }} ${{ inputs.repository }}@$(cat digest.txt)
+          cosign verify --insecure-ignore-tlog=true --key awskms://kms.${{ secrets.aws_region}}.amazonaws.com/${{ secrets.oci_kms_arn }} ${{ needs.determine_repository.outputs.repository }}@$(cat digest.txt)
       - uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
         with:
           path: oci_manifest_entry_${{ env.CNAME }}.json
@@ -315,7 +331,7 @@ jobs:
           mkdir -p "manifests"
           mv "oci_manifest_entry_$CNAME.json" "manifests/"
   update_manifest_index:
-    needs: aggregate_oci_manifests
+    needs: [ determine_repository, aggregate_oci_manifests ]
     name: Update OCI manifest index
     runs-on: ubuntu-24.04
     defaults:
@@ -346,4 +362,4 @@ jobs:
           pip install -r /opt/glcli/requirements.txt
       - name: Update index using glcli tool
         run: |
-          GLOCI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }} GLOCI_REGISTRY_USERNAME=${{ github.repository_owner }} python /opt/glcli/src/glcli.py update-index --container ${{ inputs.repository }} --version ${{ inputs.version }} --manifest_folder manifests
+          GLOCI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }} GLOCI_REGISTRY_USERNAME=${{ github.repository_owner }} python /opt/glcli/src/glcli.py update-index --container ${{ needs.determine_repository.outputs.repository }} --version ${{ inputs.version }} --manifest_folder manifests

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -7,7 +7,7 @@ on:
         type: number
         required: true
   workflow_run:
-    workflows: [ 'Build and publish a release', 'nightly' ]
+    workflows: [ 'Build and publish a release' ]
     types: [ 'completed' ]
 jobs:
   workflow_data:
@@ -18,14 +18,13 @@ jobs:
       run_id: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.id }}
   trustedboot_flavors_supported_matrix:
     needs: workflow_data
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
+    if: ${{ needs.workflow_data.outputs.target == 'release' }}
     name: Generate flavors matrix for trustedboot
     uses: ./.github/workflows/build_flavors_matrix.yml
     with:
       flags: '--include-only "*trustedboot*" --no-arch --json-by-arch'
   trustedboot_flavors_matrix:
     needs: [ trustedboot_flavors_supported_matrix, workflow_data ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
     name: Intersect matrix supporting trustedboot
     runs-on: 'ubuntu-24.04'
     defaults:
@@ -53,7 +52,6 @@ jobs:
             core.setOutput("flavors_matrix", matrix);
   non_trustedboot_flavors_matrix:
     needs: [ trustedboot_flavors_supported_matrix, workflow_data ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
     name: Exclude matrix of flavors supporting trustedboot
     runs-on: 'ubuntu-24.04'
     defaults:
@@ -81,7 +79,7 @@ jobs:
             core.setOutput("flavors_matrix", matrix);
   copy_artifacts:
     needs: [ non_trustedboot_flavors_matrix, workflow_data ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
+    if: ${{ needs.workflow_data.outputs.target == 'release' }}
     name: Copy without adding certs
     runs-on: ubuntu-24.04
     strategy:
@@ -101,7 +99,7 @@ jobs:
           path: '*.tar.gz'
   prepare_certs:
     needs: [ trustedboot_flavors_matrix, workflow_data ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
+    if: ${{ needs.workflow_data.outputs.target == 'release' }}
     name: Add certs
     runs-on: ubuntu-24.04
     defaults:
@@ -130,16 +128,17 @@ jobs:
           name: build-${{ matrix.flavor }}-${{ matrix.arch }}
           github-token: ${{ github.token }}
           run-id: ${{ needs.workflow_data.outputs.run_id }}
+      - name: Load certs artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
+        with:
+          name: certs
+          github-token: ${{ github.token }}
+          run-id: ${{ needs.workflow_data.outputs.run_id }}
+          path: ${{ env.CNAME }}/
       - name: Add certs to build artifacts
         run: |
-          mkdir "$CNAME/"
           tar -C "$CNAME/" -xzf "$CNAME.tar.gz"
           rm "$CNAME.tar.gz"
-
-          # USE_KMS in build_requirements.yml
-          for f in secureboot.{{pk,kek,db}.{crt,der,auth},aws-efivars} oci-sign.crt; do
-            cp "cert/gardenlinux-${{ needs.workflow_data.outputs.channel }}-$f" "$CNAME/$CNAME.$f"
-          done
 
           tar -cSzvf "$CNAME.tar.gz" -C $CNAME .
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
@@ -149,7 +148,6 @@ jobs:
           path: ${{ env.CNAME }}.tar.gz
   upload_to_s3:
     needs: [ copy_artifacts, prepare_certs, workflow_data ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
     name: Upload to S3
     permissions:
       id-token: write
@@ -166,7 +164,6 @@ jobs:
       aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
   upload_to_s3_cn:
     needs: [ copy_artifacts, prepare_certs, workflow_data ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
     name: Upload to S3 (China)
     permissions:
       id-token: write
@@ -183,7 +180,6 @@ jobs:
       aws_s3_bucket: ${{ secrets.AWS_CN_S3_BUCKET }}
   glrd:
     needs: [ workflow_data, upload_to_s3 ]
-    if: ${{ needs.workflow_data.outputs.channel == 'release' }}
     name: create GLRD release
     permissions:
       id-token: write

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -89,11 +89,11 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
           name: build-${{ inputs.flavor }}-${{ inputs.arch }}
-      - name: Load cert cache
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
+      - name: Load certs artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
-          path: cert/*.*
-          key: cert-${{ github.run_id }}
+          name: certs
+          path: cert/
       - name: Download platform-test OCI metadata (tofu)
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is intended to support intended changes of #3016 with a streamlined variant of GardenLinux release targets. It requires less input and reuses the given additional information internally to calculate settings required for build and release steps.