### PR TITLE
update python-gardenlinux-cli to 0.6.5

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -34,7 +34,7 @@ on:
       oci_kms_arn:
         required: true
 env:
-  GLCLI_VERSION: 0.6.4
+  GLCLI_VERSION: 0.6.5
 jobs:
   determine_repository:
     name: Determine release repository to use for target ${{ inputs.target }}


### PR DESCRIPTION

**What this PR does / why we need it**:
Bumps python-gardenlinux-cli for oci upload.

New features:
* Add initrd.unified - initrd containing the rootfs

