### PR TITLE
Move `secureboot` files to be prefixed with "cname" before upload S3

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -137,6 +137,10 @@ jobs:
           tar -C "$CNAME/" -xzf "$CNAME.tar.gz"
           rm "$CNAME.tar.gz"
 
+          for file in "$CNAME/secureboot."*; do
+            echo mv "$CNAME/$file" "$CNAME/$CNAME.$file"
+          done
+
           tar -cSzvf "$CNAME.tar.gz" -C $CNAME .
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames (moves) `secureboot` certificate files to be prefixed with the "cname". This restores the file names used before #2842.