### PR TITLE
Move secureboot files to be prefixed with "cname" before upload S3 (v2)

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -138,7 +138,7 @@ jobs:
           rm "$CNAME.tar.gz"
 
           for file in "$CNAME/secureboot."*; do
-            echo mv "$CNAME/$file" "$CNAME/$CNAME.$file"
+            mv "$CNAME/$file" "$CNAME/$CNAME.$file"
           done
 
           tar -cSzvf "$CNAME.tar.gz" -C $CNAME .


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames (moves) secureboot certificate files to be prefixed with the "cname". This restores the file names used before #2842. This PR (v2) fixes a typical Friday issue with committing an `echo mv` statement instead of the actual `mv`. ;)