### PR TITLE
Fix `secureboot` file moves to not include directory names in `for` loop

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -137,9 +137,11 @@ jobs:
           tar -C "$CNAME/" -xzf "$CNAME.tar.gz"
           rm "$CNAME.tar.gz"
 
-          for file in "$CNAME/secureboot."*; do
-            mv "$CNAME/$file" "$CNAME/$CNAME.$file"
+          pushd $CNAME
+          for file in "secureboot."*; do
+            mv "$file" "$CNAME.$file"
           done
+          popd
 
           tar -cSzvf "$CNAME.tar.gz" -C $CNAME .
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR takes `$CNAME` out of the `for` loop for moving `secureboot` certificate files. This ensures the file name is used correctly in the loop instead.