### PR TITLE
Include _usi and _tpm2_trustedboot variants in release page

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -91,7 +91,41 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
-        cname: [ kvm-gardener_prod, metal-gardener_prod, gcp-gardener_prod, gdch-gardener_prod, aws-gardener_prod, azure-gardener_prod, ali-gardener_prod, openstack-gardener_prod, openstackbaremetal-gardener_prod, vmware-gardener_prod, metal-gardener_prod_pxe ]
+        cname:
+          - kvm-gardener_prod
+          - metal-gardener_prod
+          - gcp-gardener_prod
+          - gdch-gardener_prod
+          - aws-gardener_prod
+          - azure-gardener_prod
+          - ali-gardener_prod
+          - openstack-gardener_prod
+          - openstackbaremetal-gardener_prod
+          - vmware-gardener_prod
+          - metal-gardener_prod_pxe
+          - kvm-gardener_prod_usi
+          - metal-gardener_prod_usi
+          - gcp-gardener_prod_usi
+          - gdch-gardener_prod_usi
+          - aws-gardener_prod_usi
+          - azure-gardener_prod_usi
+          - ali-gardener_prod_usi
+          - openstack-gardener_prod_usi
+          - openstackbaremetal-gardener_prod_usi
+          - vmware-gardener_prod_usi
+          - metal-gardener_prod_pxe_usi
+          - kvm-gardener_prod_tpm2_trustedboot
+          - metal-gardener_prod_tpm2_trustedboot
+          - gcp-gardener_prod_tpm2_trustedboot
+          - gdch-gardener_prod_tpm2_trustedboot
+          - aws-gardener_prod_tpm2_trustedboot
+          - azure-gardener_prod_tpm2_trustedboot
+          - ali-gardener_prod_tpm2_trustedboot
+          - openstack-gardener_prod_tpm2_trustedboot
+          - openstackbaremetal-gardener_prod_tpm2_trustedboot
+          - vmware-gardener_prod_tpm2_trustedboot
+          - metal-gardener_prod_pxe_tpm2_trustedboot
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -86,7 +86,7 @@ def generate_release_note_image_ids(manifests):
 
 def generate_release_note_image_id_single(manifest_path):
     """
-    Outputs a markdown formated string for github release notes,
+    Outputs a markdown formatted string for github release notes,
     containing the image-ids for the respective cloud regions
     """
     output = ""

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -33,6 +33,9 @@ cloud_fullname_dict = {
     'azure': 'Microsoft Azure'
 }
 
+# https://github.com/gardenlinux/gardenlinux/issues/3044
+# Empty string is the 'legacy' variant with traditional root fs and still needed/supported
+image_variants = ['', '_usi', '_tpm2_trustedboot']
 
 def _ali_release_note(published_image_metadata):
     output = ""
@@ -142,14 +145,15 @@ def download_all_singles(version, commitish):
     manifests = list()
     for a in arches:
         for p in cloud_fullname_dict:
-            fname = construct_full_image_name(p, "gardener_prod", a, version, commitish)
-            try:
-                manifests.append(download_meta_single_manifest(GARDENLINUX_GITHUB_RELEASE_BUCKET_NAME, "meta/singles", fname, "s3_downloads/"))
-            except Exception as e:
-                print(f"Failed to get manifest. Error: {e}")
-                print(f"\tfname: meta/singles/{fname}")
-                # Abort generation of Release Notes - Let the CI fail
-                sys.exit(1)
+            for v in image_variants:
+                fname = construct_full_image_name(p, f"gardener_prod{v}", a, version, commitish)
+                try:
+                    manifests.append(download_meta_single_manifest(GARDENLINUX_GITHUB_RELEASE_BUCKET_NAME, "meta/singles", fname, "s3_downloads/"))
+                except Exception as e:
+                    print(f"Failed to get manifest. Error: {e}")
+                    print(f"\tfname: meta/singles/{fname}")
+                    # Abort generation of Release Notes - Let the CI fail
+                    sys.exit(1)
 
     return manifests
 


### PR DESCRIPTION
For the new major release, we have those additional variants. The 'traditional' image variants still exist because the new variants have certain restrictions so they can't satisfy all use-cases.

Fixes #3044
