### PR TITLE
Use "python-gardenlinux-lib" based CNAME parser for GitHub workflows

### DIFF
--- a/.github/workflows/build_bare_flavor.yml
+++ b/.github/workflows/build_bare_flavor.yml
@@ -26,8 +26,6 @@ jobs:
         shell: bash
     permissions:
       id-token: write
-    env:
-      CNAME: ''
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
         with:

--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -79,10 +79,14 @@ jobs:
           find .build -exec touch -d "@$t" {} +
       - name: Build
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ inputs.flavor }}-${{ inputs.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - name: Pack build artifacts for upload
         run: tar -cSzvf "$CNAME.tar.gz" -C .build -T ".build/$CNAME.artifacts"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -32,10 +32,15 @@ jobs:
             VERSION
           key: build-container-${{ matrix.arch }}-${{ github.run_id }}
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname container-${{ matrix.arch }} cname
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname container-${{ matrix.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Load container build artifact (${{ matrix.arch }})
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -44,10 +44,14 @@ jobs:
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ matrix.flavor }}-${{ matrix.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - name: 'Authenticate to AWS'
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # pin@v4
         with:

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -70,12 +70,20 @@ jobs:
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
-      - name: Set CNAME
+      - name: Determine CNAME (amd64)
+        id: cname_amd64
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname container-amd64 cname
+      - name: Determine CNAME (ard64)
+        id: cname_arm64
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname container-arm64 cname
+      - name: Set CNAMEs
         run: |
-          cname_amd64="$(./build --resolve-cname container-amd64)"
-          cname_arm64="$(./build --resolve-cname container-arm64)"
-          echo "CNAME_AMD64=$cname_amd64" | tee -a "$GITHUB_ENV"
-          echo "CNAME_ARM64=$cname_arm64" | tee -a "$GITHUB_ENV"
+          echo "CNAME_AMD64=${{ steps.cname_amd64.outputs.result }}" | tee -a "$GITHUB_ENV"
+          echo "CNAME_ARM64=${{ steps.cname_arm64.outputs.result }}" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
           name: build-container-amd64
@@ -230,10 +238,14 @@ jobs:
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ matrix.flavor }}-${{ matrix.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
           name: build-${{ matrix.flavor }}-${{ matrix.arch }}
@@ -311,10 +323,14 @@ jobs:
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ matrix.flavor }}-${{ matrix.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - name: Cache OCI manifests
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
         with:

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -115,10 +115,14 @@ jobs:
         run: |
           echo "${{ needs.workflow_data.outputs.commit_id }}" | tee COMMIT
           echo "${{ needs.workflow_data.outputs.version }}" | tee VERSION
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ matrix.flavor }}-${{ matrix.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - name: Load flavor build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:

--- a/.github/workflows/test_bare_flavor.yml
+++ b/.github/workflows/test_bare_flavor.yml
@@ -18,8 +18,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      CNAME: ''
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test_flavor_chrooted.yml
+++ b/.github/workflows/test_flavor_chrooted.yml
@@ -33,10 +33,14 @@ jobs:
             VERSION
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ inputs.flavor }}-${{ inputs.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - name: Load flavor build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -81,10 +81,14 @@ jobs:
             VERSION
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ inputs.flavor }}-${{ inputs.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - name: Load flavor build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -52,10 +52,14 @@ jobs:
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
+      - name: Determine CNAME
+        id: cname
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@main
+        with:
+          flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME
         run: |
-          cname="$(./build --resolve-cname ${{ matrix.flavor }}-${{ matrix.arch }})"
-          echo "CNAME=$cname" | tee -a "$GITHUB_ENV"
+          echo "CNAME=${{ steps.cname.outputs.result }}" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4.3.0
         with:
           name: build-${{ matrix.flavor }}-${{ matrix.arch }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes occurences of parsing the canonical name in GitHub workflows to always use the "python-gardenlinux-lib" based one.