### PR TITLE
glrd on gh release: fix check to find existing major version

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -192,7 +192,7 @@ jobs:
             minor=$(echo ${version} | cut -d'.' -f2)
             if [ ${type} = "patch" ]; then
               # check for stable version and create if missing
-              if ! glrd --no-header --type stable --version ${major}; then
+              if ! glrd --no-header --type stable --version ${major} | grep ${major}; then
                 glrd-manage --s3-update --create stable --version ${major}
               fi
               glrd-manage --s3-update --create patch --version ${version} --commit ${commit}


### PR DESCRIPTION
**What this PR does / why we need it**:

`glrd --no-header --type stable --version ${major}` currently returns `$?=0` even if not release is found. Adding a `grep` fixes this for now.

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/gardenlinux/actions/runs/15249634062/job/42883187795

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
