### PR TITLE
Run github artifact upload on ubuntu-latest-64core

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -86,7 +86,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-64core
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
this should hopefully allow the artifact upload and download run when generating a new release page

Fixes #3056
