### PR TITLE
fix: make image_variants optional in release page action

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -19,6 +19,8 @@ on:
         required: true
         type: string
         description: "Full commitish"
+      image_variants:
+        default: "_usi _tpm2_trustedboot"
 jobs:
   # Create new version in GLVD so it has the package list of the new release
   # This is needed for the automatic changelog generation
@@ -72,7 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          .github/workflows/release_note.py create --tag ${{ inputs.version }} --commit "$(echo "${{ inputs.commit }}")"
+          .github/workflows/release_note.py create --tag ${{ inputs.version }} --commit "$(echo "${{ inputs.commit }}")" --image-variants "${{ inputs.image_variants }}"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:
           name: release

--- a/.github/workflows/release_note.py
+++ b/.github/workflows/release_note.py
@@ -35,7 +35,7 @@ cloud_fullname_dict = {
 
 # https://github.com/gardenlinux/gardenlinux/issues/3044
 # Empty string is the 'legacy' variant with traditional root fs and still needed/supported
-image_variants = ['', '_usi', '_tpm2_trustedboot']
+image_variants = ['']
 
 def _ali_release_note(published_image_metadata):
     output = ""
@@ -412,6 +412,7 @@ def main():
     create_parser.add_argument('--tag', required=True)
     create_parser.add_argument('--commit', required=True)
     create_parser.add_argument('--dry-run', action='store_true', default=False)
+    create_parser.add_argument('--image-variants', default="_usi _tpm2_trustedboot")
 
     upload_parser = subparsers.add_parser('upload')
     upload_parser.add_argument('--release_id', required=True)
@@ -422,6 +423,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == 'create':
+        image_variants.extend(args.image_variants.split())
         body = create_github_release_notes(args.tag, args.commit, args.dry_run)
         if not args.dry_run:
             release_id = create_github_release(args.owner, args.repo, args.tag, args.commit, body)
@@ -451,4 +453,3 @@ if __name__ == "__main__":
 #     print(release_info)
 # except Exception as e:
 #     print(f"Error occurred: {e}")
-


### PR DESCRIPTION
should fix failing workflow run for rel-1592:
https://github.com/gardenlinux/gardenlinux/actions/runs/15341910973/job/43169784446

by allowing to run it with the new image_variants arg set to an empty string.