### PR TITLE
Configure AWS S3 multipart upload

### DIFF
--- a/.github/workflows/upload_to_s3.sh
+++ b/.github/workflows/upload_to_s3.sh
@@ -68,6 +68,10 @@ cat << EOF >> "$meta_yml"
 EOF
 object_key="objects/$file"
 
+aws configure set default.s3.multipart_threshold 100MB
+aws configure set default.s3.multipart_chunksize 100MB
+aws configure set default.s3.max_concurrent_requests 16
+
 aws s3api put-object --body "$file" --bucket "$bucket" --key "$object_key" \
   --content-md5 "$md5bin" --checksum-algorithm sha256 --checksum-sha256 "$sha256bin" \
   --tagging "md5sum=$md5sum&sha256sum=$sha256sum&platform=$platform&architecture=$arch&version=$GARDENLINUX_VERSION&committish=$GARDENLINUX_COMMIT_ID_LONG"

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -47,7 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.aws_role }}
           role-session-name: ${{ secrets.aws_session }}
           aws-region: ${{ secrets.aws_region }}
-          role-duration-seconds: 14400
+          role-duration-seconds: 14400 # 4 hours
       - name: Set flavor version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT


### PR DESCRIPTION
**What this PR does / why we need it**:

Our S3 uploads to China are currently taking ~12 hours.

Let's [Configure AWS S3 multipart upload](https://github.com/gardenlinux/gardenlinux/commit/8495196ad10b3f0d7fc19f006e92e334c8e0ef44) and see if this improves things.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3087

**Special notes for reviewer**:

I confirmed in https://github.com/gardenlinux/gardenlinux/actions/runs/15467586915 to not break the non China S3 upload.