### PR TITLE
Bump `python-gardenlinux-lib` to 0.7.2

### DIFF
--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -78,7 +78,7 @@ jobs:
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/build_flavors_matrix.yml
+++ b/.github/workflows/build_flavors_matrix.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: true
       - id: matrix
         name: Generate flavors matrix
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: ${{ inputs.flags }}
           flavors_matrix: ${{ inputs.flavors_matrix }}

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -31,7 +31,7 @@ jobs:
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname container-${{ matrix.arch }} cname
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -46,7 +46,7 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -82,12 +82,12 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME (amd64)
         id: cname_amd64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname container-amd64 cname
       - name: Determine CNAME (ard64)
         id: cname_arm64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname container-arm64 cname
       - name: Set CNAMEs
@@ -317,7 +317,7 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME
@@ -359,7 +359,7 @@ jobs:
             oci-manifests-${{ github.run_id }}-
           fail-on-cache-miss: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
       - name: Update index using glcli tool
         run: |
           export GL_CLI_REGISTRY_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -117,7 +117,7 @@ jobs:
           echo "${{ needs.workflow_data.outputs.version }}" | tee VERSION
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_flavor_chrooted.yml
+++ b/.github/workflows/test_flavor_chrooted.yml
@@ -35,7 +35,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -83,7 +83,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@095332c92d0d3ed83be59db6f1d3e44f63fbc46d # pin@0.7.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -54,7 +54,7 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@269fcc4e7c7cd2e1995b02c1646673d030e496e6 # pin@0.7.0
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@73355804cd1b4774914681699135a6051633f94f # pin@0.7.2
         with:
           flags: --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname
       - name: Set CNAME


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the `python-gardenlinux-lib` based GitHub actions to 0.7.2. The new version is less restrictive in checking existing OCI image indices.

**Which issue(s) this PR fixes**:
Fixes #3097