### PR TITLE
Allow `publish_s3.yml` to complete successfully if `$CNAME` directory exists

### DIFF
--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -94,7 +94,7 @@ jobs:
             core.setOutput("flavors_matrix", matrix);
   upload_trustedboot_flavors_to_s3:
     needs: [ trustedboot_flavors_matrix, workflow_data ]
-    name: Upload to S3
+    name: Upload flavors supporting trustedboot to S3
     permissions:
       id-token: write
     uses: ./.github/workflows/upload_to_s3.yml
@@ -111,7 +111,7 @@ jobs:
       aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
   upload_trustedboot_flavors_to_s3_china:
     needs: [ trustedboot_flavors_matrix, workflow_data ]
-    name: Upload to S3 (China)
+    name: Upload flavors supporting trustedboot to S3 (China)
     permissions:
       id-token: write
     uses: ./.github/workflows/upload_to_s3.yml
@@ -128,7 +128,7 @@ jobs:
       aws_s3_bucket: ${{ secrets.AWS_CN_S3_BUCKET }}
   upload_non_trustedboot_flavors_to_s3:
     needs: [ non_trustedboot_flavors_matrix, workflow_data ]
-    name: Upload to S3
+    name: Upload flavors not supporting trustedboot to S3
     permissions:
       id-token: write
     uses: ./.github/workflows/upload_to_s3.yml
@@ -144,7 +144,7 @@ jobs:
       aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
   upload_non_trustedboot_flavors_to_s3_china:
     needs: [ non_trustedboot_flavors_matrix, workflow_data ]
-    name: Upload to S3 (China)
+    name: Upload flavors not supporting trustedboot to S3 (China)
     permissions:
       id-token: write
     uses: ./.github/workflows/upload_to_s3.yml

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -82,8 +82,8 @@ jobs:
           path: ${{ env.CNAME }}/
       - name: Prepare S3 upload artifacts
         run: |
-          mkdir "$CNAME"
-          tar -cSzvf "$CNAME.tar.gz" -C $CNAME .
+          mkdir -p "$CNAME"
+          tar -C $CNAME -xzvf "$CNAME.tar.gz"
           rm "$CNAME.tar.gz"
 
           if [ -f "$CNAME.chroot.test.log" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows `publish_s3.yml` to complete successfully if `$CNAME` directory exists or has been already created in a previous step.