### PR TITLE
feat: provide empty folder for nvidia driver installation

### DIFF
--- a/features/gardener/info.yaml
+++ b/features/gardener/info.yaml
@@ -6,6 +6,7 @@ features:
     - sap
     - iscsi
     - nvme
+    - nvidia
   exclude:
     - _selinux
     - firewall

--- a/features/nvidia/README.md
+++ b/features/nvidia/README.md
@@ -1,0 +1,5 @@
+## Feature: nvidia
+
+Prepare Garden Linux image for https://github.com/gardenlinux/gardenlinux-nvidia-installer 
+
+

--- a/features/nvidia/exec.config
+++ b/features/nvidia/exec.config
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Empty folder required for nvidia driver installation
+# Installer will bind mount this folder to a writable folder
+mkdir /usr/local/nvidia
+

--- a/features/nvidia/info.yaml
+++ b/features/nvidia/info.yaml
@@ -1,0 +1,2 @@
+description: 'nvidia installer preparations'
+type: element


### PR DESCRIPTION

**What this PR does / why we need it**:
Folder will be mount --bind to a writable folder by nvidia-driver-installer.

**Which issue(s) this PR fixes**:
Fixes #3137 

**Special notes for your reviewer**:
https://github.com/gardenlinux/gardenlinux-nvidia-installer still works as of now, but this PR is required for next https://github.com/gardenlinux/gardenlinux-nvidia-installer version 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
