### PR TITLE
fix(Azure): add python3-passlib dependency

### DIFF
--- a/features/azure/pkg.include
+++ b/features/azure/pkg.include
@@ -1,4 +1,5 @@
 chrony
 cloud-init
 python3-cffi-backend
+python3-passlib
 azure-vm-utils


### PR DESCRIPTION
cloud-init requires passlib for Azure to support creating VMs with admin password.

See:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1093898
https://salsa.debian.org/cloud-team/debian-cloud-images/-/merge_requests/440/diffs

**Which issue(s) this PR fixes**:
Fixes #3144

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:

```bugfix dependency
Add python3-passlib dependency for Azure images.  Fixes cloud-init when using an admin password.
```
