### PR TITLE
Fix/ccloud build platform test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
         description: 'Tag to run platform-test containers. "latest" or GL version. Tag must be available in `ghcr.io/gardenlinux/gardenlinux/platform-test-*`'
         type: string
         default: latest
+      platform_test_build:
+        description: 'Run platform-test image build.'
+        type: boolean
+        default: true
       bare_flavors_parse_params:
         description: 'Run bin/parse_flavors.py with these parameters for bare flavors'
         default: '--include-only "bare-*" --no-arch --json-by-arch --build --test'
@@ -66,6 +70,7 @@ jobs:
       version: ${{ needs.requirements.outputs.version }}
       platforms: '["tofu"]'
       platform_test_tag: ${{ inputs.platform_test_tag }}
+      build: ${{ inputs.platform_test_build }}
   flavors_matrix:
     name: Generate flavors matrix to build
     uses: ./.github/workflows/build_flavors_matrix.yml

--- a/.github/workflows/build_platform_test_images.yml
+++ b/.github/workflows/build_platform_test_images.yml
@@ -96,7 +96,7 @@ jobs:
 
           echo "platforms_matrix=$MATRIX" | tee -a $GITHUB_OUTPUT
   build_base_images:
-    if: ${{ github.event_name == 'push' || inputs.build }}
+    if: ${{ inputs.build }}
     name: Build platform-test base image
     needs: generate_matrix
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -129,6 +129,7 @@ jobs:
           path: ${{ env.IMAGE_BASE }}-base-${{ matrix.arch }}.tar
           key: platform_test_base_${{ matrix.arch }}-${{ github.run_id }}
   build_images:
+    if: ${{ inputs.build }}
     name: Build platform-test image
     needs: [ generate_matrix, build_base_images ]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -183,7 +184,7 @@ jobs:
             platform-test.oci-version.txt
             platform-test.oci-tag.txt
   push_images:
-    if: ${{ github.event_name == 'push' && ( github.ref_name == 'main' || ( inputs.push == true && ( inputs.platform_test_tag != 'latest' || inputs.push_latest == true ) ) ) }}
+    if: ${{ inputs.build && github.event_name == 'push' && ( github.ref_name == 'main' || ( inputs.push == true && ( inputs.platform_test_tag != 'latest' || inputs.push_latest == true ) ) ) }}
     name: Push platform-test images
     needs: [ generate_matrix, build_images ]
     runs-on: ubuntu-24.04

--- a/.github/workflows/build_platform_test_images.yml
+++ b/.github/workflows/build_platform_test_images.yml
@@ -65,7 +65,7 @@ env:
   DEFAULT_PLATFORMS: '["kvm", "openstack", "tofu"]'
   GARDENLINUX_BUILD_CRE: podman
   IMAGE_BASE: platform-test
-  IMAGE_REGISTRY: ghcr.io/${{ github.repository }}
+  IMAGE_REGISTRY: ghcr.io/gardenlinux/gardenlinux
   PLATFORM_TEST_TAG: ${{ github.event_name == 'push' && 'nightly' || inputs.platform_test_tag }}
 jobs:
   generate_matrix:


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts the dynamic `IMAGE_REGISTRY` from #3151 (did not work out) and introduces another input to overwrite the building of platform-test images from `build.yml'. This new input is used in https://github.com/gardenlinux/gardenlinux-ccloud.