### PR TITLE
tofu: remove provider overwrite for GCP

### DIFF
--- a/tests/images/platform-test/tofu/.terraformrc
+++ b/tests/images/platform-test/tofu/.terraformrc
@@ -2,7 +2,6 @@ provider_installation {
 
   dev_overrides {
     "hashicorp/azurerm" = "/root/.terraform/providers/custom"
-    "hashicorp/google"  = "/root/.terraform/providers/custom"
   }
 
   direct {}


### PR DESCRIPTION
**What this PR does / why we need it**:

In OpenTofu remove provider overwrite for GCP since https://github.com/gardenlinux/gardenlinux/pull/3164 the upstream provider ist used.

**Which issue(s) this PR fixes**:
Currently nightly.