### PR TITLE
bump python-gardenlinux-lib (s3 artifact manifest modifiers) - 2nd try

### DIFF
--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -78,7 +78,7 @@ jobs:
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/build_flavors_matrix.yml
+++ b/.github/workflows/build_flavors_matrix.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: true
       - id: matrix
         name: Generate flavors matrix
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: ${{ inputs.flags }}
           flavors_matrix: ${{ inputs.flavors_matrix }}

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -31,7 +31,7 @@ jobs:
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: --cname container-${{ matrix.arch }} cname
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
       - name: Set image reference for S3
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -82,12 +82,12 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME (amd64)
         id: cname_amd64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: --cname container-amd64 cname
       - name: Determine CNAME (ard64)
         id: cname_arm64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: --cname container-arm64 cname
       - name: Set CNAMEs
@@ -245,7 +245,7 @@ jobs:
           role-session-name: ${{ secrets.aws_session }}
           aws-region: ${{ secrets.aws_region }}
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.1
         with:
@@ -313,7 +313,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
       - name: Set flavor version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/test_flavor_chrooted.yml
+++ b/.github/workflows/test_flavor_chrooted.yml
@@ -35,7 +35,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -83,7 +83,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f4f5887ddf8b39b57a3b63341456bf78fa88a208 # pin@0.8.1
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@ab3ba864b1ab0ed6566c7cb1a49114210c895db1 # pin@0.8.1
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump python-gardenlinux-lib (s3 artifact manifest modifiers from https://github.com/gardenlinux/python-gardenlinux-lib/pull/135).

This is a follow up of https://github.com/gardenlinux/gardenlinux/pull/3166. Where the `0.8.1` tag missed the actual bump in the actions that are called from `gardenlinux`:
https://github.com/gardenlinux/python-gardenlinux-lib/commit/ab3ba864b1ab0ed6566c7cb1a49114210c895db1