### PR TITLE
Reduce number of features included in 'lima' image

### DIFF
--- a/features/lima/info.yaml
+++ b/features/lima/info.yaml
@@ -1,2 +1,12 @@
 description: "image suitable for using with [lima](https://lima-vm.io)"
 type: flag
+features:
+  include:
+    - kvm
+  exclude:
+    - sap
+    - firewall
+    - log
+    - ssh
+    - _ignite
+    - _selinux

--- a/features/lima/pkg.include
+++ b/features/lima/pkg.include
@@ -1,2 +1,3 @@
 cloud-init
 sshfs
+openssh-server


### PR DESCRIPTION
The lima-vm image included a bunch of features that are probably not useful or needed in the lima use-case. This PR excludes some features to build smaller and more focussed images for the lima use-case.

Related to https://github.com/gardenlinux/gardenlinux/issues/2965