### PR TITLE
fix: remove hardcoded iscsi initiator name from image

### DIFF
--- a/features/iscsi/exec.config
+++ b/features/iscsi/exec.config
@@ -3,3 +3,6 @@
 sed -i 's/^\(node.session.scan\).*/\1 = manual/' /etc/iscsi/iscsid.conf
 sed -i 's/^\(node.session.auth.chap_algs\).*/\1 = MD5/' /etc/iscsi/iscsid.conf
 touch /var/lib/open-iscsi-configured0
+
+# Delete unique InitiatorName from image
+rm /etc/iscsi/initiatorname.iscsi 

--- a/features/iscsi/file.include/etc/systemd/system/iscsi-initiatorname.service
+++ b/features/iscsi/file.include/etc/systemd/system/iscsi-initiatorname.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=iSCSI InitiatorName Generator
+ConditionPathExists=|!/etc/iscsi/initiatorname.iscsi
+After=multi-user.service
+
+[Service]
+ExecStart=/bin/sh -c 'echo "## DO NOT EDIT OR REMOVE THIS FILE!\n## If you remove this file, the iSCSI daemon will not start.\n## If you change the InitiatorName, existing access control lists\n## may reject this initiator.  The InitiatorName must be unique\n## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames." > /etc/iscsi/initiatorname.iscsi; \
+                      iscsi-iname -g >> /etc/iscsi/initiatorname.iscsi'
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**What this PR does / why we need it**:
- Installing `open-iscsi` automatically generated a unique InitiatorName in the `/etc/iscsi/initiatorname.iscsi` file
- This name was released with the image, which could cause problems when running it in the same network on several machines



**Definition of Done:**
- [ ] The code is appropriately tested

**Special notes for your reviewer**:

I was not able to test iscsi locally as `test_iscsi.py` is skipped
