### PR TITLE
Fix dependencies on `python-gardenlinux-lib` in `Pipefile`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ networkx = "*"
 pyyaml = "*"
 requests = "*"
 jsonschema = "*"
-python-gardenlinux-lib = {ref = "0.7.0", git = "https://github.com/gardenlinux/python-gardenlinux-lib.git"}
+gardenlinux = {ref = "0.8.3", git = "https://github.com/gardenlinux/python-gardenlinux-lib.git"}
 
 [dev-packages]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ networkx
 PyYAML
 requests
 jsonschema
-python-gardenlinux-lib @ git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.8.3
+gardenlinux @ git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.8.3


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix dependencies on `python-gardenlinux-lib` in `Pipefile` as it was renamed to `gardenlinux`.
`Pipfile` is not currently used anywhere and is just an alternative to `requirements.txt`.

`tests/Pipfile` cannot be bumped until https://github.com/gardenlinux/python-gardenlinux-lib/pull/132 is merged.
