### PR TITLE
tests-ng: rework runtime build

### DIFF
--- a/tests-ng/.gitignore
+++ b/tests-ng/.gitignore
@@ -1,1 +1,2 @@
 .build
+.cache

--- a/tests-ng/Makefile
+++ b/tests-ng/Makefile
@@ -1,20 +1,38 @@
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := all
+
 MAKEFLAGS += --no-builtin-rules
 
 .SILENT:
 .DELETE_ON_ERROR:
 
-.PHONY: dist clean
+.PHONY: all dist clean help
+
+# Calculate checksum of all files under git control (tracked + untracked, excluding gitignored)
+.build/checksum: | .build
+	( git ls-files && git ls-files --others --exclude-standard ) \
+		| sort -u \
+		| xargs sha256sum \
+		| sha256sum \
+		| cut -d' ' -f1 > $@
+
+all: .build/dist.tar.gz
 
 dist: .build/dist.tar.gz
 
-clean:
-	rm -f dist.tar.gz runtime-*.tar.gz
-
 .build:
-	mkdir .build
+	mkdir -p .build
 
-.build/dist.tar.gz: util/build_dist.sh .build/runtime-x86_64.tar.gz .build/runtime-aarch64.tar.gz conftest.py $(wildcard plugins/*.py) $(wildcard test_*.py) | .build
-	./$< $@ x86_64:$(word 2,$^) aarch64:$(word 3,$^)
+.build/dist.tar.gz: .build/checksum util/build_dist.sh .build/runtime-x86_64.tar.gz .build/runtime-aarch64.tar.gz conftest.py $(wildcard plugins/*.py) $(wildcard test_*.py) | .build
+	@checksum=$$(cat .build/checksum); \
+	checksummed_file=".build/tests-ng-dist-$$checksum.tar.gz"; \
+	util/build_dist.sh "$$checksummed_file" x86_64:.build/runtime-x86_64.tar.gz aarch64:.build/runtime-aarch64.tar.gz; \
+	ln -sf "tests-ng-dist-$$checksum.tar.gz" .build/tests-ng-dist.tar.gz
 
 .build/runtime-%.tar.gz: util/build_runtime.sh util/requirements.txt | .build
 	./$< $* $(word 2,$^) $@
+
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf .build
+

--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -1,0 +1,59 @@
+# Garden Linux Tests-NG
+
+This directory contains the next-generation testing framework for Garden Linux. It provides a modern, streamlined approach to testing Garden Linux images across different platforms and architectures.
+
+## What is Tests-NG?
+
+Tests-NG is a lightweight, portable testing framework that:
+
+- **Bundles Python runtime and dependencies** into self-contained archives
+- **Provides cross-architecture support** (x86_64 and aarch64)
+- **Offers platform-agnostic testing** that works on chroot, containers, QEMU, cloud platforms, and bare metal
+- **Uses pytest** as the underlying test framework for familiar syntax and powerful features
+
+## Directory Structure
+
+```
+tests-ng/
+├── README.md             # This file
+├── Makefile              # Build system
+├── conftest.py           # Pytest configuration
+├── test_*.py             # Individual test files
+├── plugins/              # Pytest plugins
+├── util/                 # Build utilities
+│   ├── build_runtime.sh  # Runtime builder with caching
+│   ├── build_dist.sh     # Distribution packager
+│   └── requirements.txt  # Python dependencies
+├── .build                # Built runtimes and distributables (gitignored)
+│   ├── tests-ng-dist.tar.gz        # Symlink to checksummed distribution
+│   ├── tests-ng-dist-{hash}.tar.gz # Checksummed distribution file
+│   ├── checksum          # Content checksum of source files
+│   └── runtime-*.tar.gz  # Runtime archive by arch
+└── .cache/               # Cached runtime files (gitignored)
+    └── runtime/
+        └── runtime-*.tar.gz
+```
+
+## Usage
+
+### Building the Distribution
+
+```bash
+# Build the tests-ng distribution
+make --directory=tests-ng
+```
+
+This creates `.build/tests-ng-dist.tar.gz` containing:
+
+- Python runtimes for supported architectures
+- All test files and plugins
+- Self-contained `run_tests` script
+
+### Container Platform Tests
+
+Simply invoke this `podman` command:
+
+```bash
+podman run --rm -v "$PWD/.build/tests-ng-dist.tar.gz:/mnt/tests-ng-dist.tar.gz:ro" --read-only --tmpfs /opt/tests -w /opt/tests ghcr.io/gardenlinux/gardenlinux /bin/bash -c 'gzip -d < /mnt/tests-ng-dist.tar.gz | tar -x && ./run_tests'
+```
+

--- a/tests-ng/util/build_runtime.sh
+++ b/tests-ng/util/build_runtime.sh
@@ -48,7 +48,10 @@ export PYTHONPATH="$tmpdir/runtime/lib/python3.14/site-packages"
 # Create site-packages directory in target runtime
 mkdir -p "$tmpdir/runtime/lib/python3.14/site-packages"
 
-pip install --target "$tmpdir/runtime/lib/python3.14/site-packages" -r "$requirements"
+pip install \
+    --only-binary=:all: \
+    --target "$tmpdir/runtime/lib/python3.14/site-packages" \
+    -r "$requirements"
 
 # Create the final runtime archive
 tar -c -C "$tmpdir/runtime" . | gzip >"$output"

--- a/tests-ng/util/build_runtime.sh
+++ b/tests-ng/util/build_runtime.sh
@@ -33,13 +33,17 @@ arch_target="$1"
 requirements="$2"
 output="$3"
 
-# Download host architecture Python runtime for package installation
-mkdir "$tmpdir/host_runtime"
-curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250626/cpython-3.14.0b3%2B20250626-$arch_host-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/host_runtime" --strip-components 1
-
 # Download target architecture Python runtime
 mkdir "$tmpdir/runtime"
 curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250712/cpython-3.13.5%2B20250712-$arch_target-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/runtime" --strip-components 1
+
+# Download host architecture Python runtime for package installation
+mkdir "$tmpdir/host_runtime"
+if [ "$arch_host" != "$arch_target" ]; then
+    curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250712/cpython-3.13.5%2B20250712-$arch_host-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/host_runtime" --strip-components 1
+else
+    (cd "$tmpdir/runtime" && cp -r . "$tmpdir/host_runtime/")
+fi
 
 # Use host Python to install packages into target runtime
 export PATH="$tmpdir/host_runtime/bin:$PATH"

--- a/tests-ng/util/build_runtime.sh
+++ b/tests-ng/util/build_runtime.sh
@@ -39,18 +39,18 @@ curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/downlo
 
 # Download target architecture Python runtime
 mkdir "$tmpdir/runtime"
-curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250626/cpython-3.14.0b3%2B20250626-$arch_target-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/runtime" --strip-components 1
+curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250712/cpython-3.13.5%2B20250712-$arch_target-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/runtime" --strip-components 1
 
 # Use host Python to install packages into target runtime
 export PATH="$tmpdir/host_runtime/bin:$PATH"
-export PYTHONPATH="$tmpdir/runtime/lib/python3.14/site-packages"
+export PYTHONPATH="$tmpdir/runtime/lib/python3.13/site-packages"
 
 # Create site-packages directory in target runtime
-mkdir -p "$tmpdir/runtime/lib/python3.14/site-packages"
+mkdir -p "$tmpdir/runtime/lib/python3.13/site-packages"
 
 pip install \
     --only-binary=:all: \
-    --target "$tmpdir/runtime/lib/python3.14/site-packages" \
+    --target "$tmpdir/runtime/lib/python3.13/site-packages" \
     -r "$requirements"
 
 # Create the final runtime archive

--- a/tests-ng/util/build_runtime.sh
+++ b/tests-ng/util/build_runtime.sh
@@ -2,11 +2,64 @@
 
 set -eufo pipefail
 
+set -x
+
+PYTHON_SOURCE="https://github.com/astral-sh/python-build-standalone/releases/download"
+PYTHON_VERSION="3.13.5"
+RELEASE_DATE="20250712"
+PYTHON_ARCHIVE_CHECKSUM_AMD64="9af1a2a3a3c06ee7fd264e677a551c399fa534f92ecdafbbb3e8b4af34adcb84"
+PYTHON_ARCHIVE_CHECKSUM_ARM64="d3b6805d8a12610d45917aa5cac69f53f8dd1ee3faef86fc8d2d1488825edd9a"
+CACHE_DIR=".cache"
+
 tmpdir=
 
 cleanup () {
 	[ -n "$tmpdir" ] || rm -rf "$tmpdir"
 	tmpdir=
+}
+
+validate_checksum() {
+	local arch_pkg="$1"
+	local file_path="$2"
+	local checksum_var="PYTHON_ARCHIVE_CHECKSUM_$(echo ${arch_pkg} | tr '[:lower:]' '[:upper:]')"
+	local expected_checksum=${!checksum_var}
+	local actual_checksum=$(sha256sum "$file_path" | cut -d' ' -f1)
+
+	if [ "$actual_checksum" != "$expected_checksum" ]; then
+		echo "Checksum mismatch for $arch_pkg"
+		echo "Expected: $expected_checksum"
+		echo "Actual: $actual_checksum"
+		exit 1
+	fi
+}
+
+get_arch_pkg() {
+	local arch="$1"
+	case "$arch" in
+	aarch64) echo "arm64" ;;
+	x86_64) echo "amd64" ;;
+	*)
+		echo "Unsupported architecture: $arch" >&2
+		exit 1
+		;;
+	esac
+}
+
+get_python_archive_name() {
+	local arch="$1"
+	echo "cpython-${PYTHON_VERSION}%2B${RELEASE_DATE}-${arch}-unknown-linux-gnu-install_only.tar.gz"
+}
+
+download_and_extract_python() {
+	local arch="$1"
+	local target_dir="$2"
+	local arch_pkg=$(get_arch_pkg "$arch")
+	local python_tgz=$(get_python_archive_name "$arch")
+
+	mkdir -p "$target_dir"
+	test -f "$CACHE_DIR/${python_tgz}" || curl -sSLf "${PYTHON_SOURCE}/${RELEASE_DATE}/${python_tgz}" -o "$CACHE_DIR/${python_tgz}"
+	validate_checksum "$arch_pkg" "$CACHE_DIR/${python_tgz}"
+	gzip -dc "$CACHE_DIR/${python_tgz}" | tar -x -C "$target_dir" --strip-components 1
 }
 
 trap cleanup EXIT
@@ -30,32 +83,37 @@ fi
 
 arch_host="$(uname -m)"
 arch_target="$1"
+arch_target_pkg=$(get_arch_pkg "$arch_target")
+arch_host_pkg=$(get_arch_pkg "$arch_host")
+
 requirements="$2"
 output="$3"
 
-# Download target architecture Python runtime
-mkdir "$tmpdir/runtime"
-curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250712/cpython-3.13.5%2B20250712-$arch_target-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/runtime" --strip-components 1
+requirements_hash=$(sha256sum "$requirements" | cut -d' ' -f1 | cut -c1-8)
+cache_filename="runtime-${arch_target}-${PYTHON_VERSION}-${RELEASE_DATE}-${requirements_hash}.tar.gz"
+cache_path="${CACHE_DIR}/${cache_filename}"
 
-# Download host architecture Python runtime for package installation
-mkdir "$tmpdir/host_runtime"
+if [ -f "$cache_path" ]; then
+	echo "Using cached runtime: $cache_filename"
+	cp "$cache_path" "$output"
+	exit 0
+fi
+mkdir -p "$CACHE_DIR"
+
+download_and_extract_python "$arch_target" "$tmpdir/runtime"
+
 if [ "$arch_host" != "$arch_target" ]; then
-    curl -sSLf "https://github.com/astral-sh/python-build-standalone/releases/download/20250712/cpython-3.13.5%2B20250712-$arch_host-unknown-linux-gnu-install_only.tar.gz" | gzip -d | tar -x -C "$tmpdir/host_runtime" --strip-components 1
+	download_and_extract_python "$arch_host" "$tmpdir/host_runtime"
 else
-    (cd "$tmpdir/runtime" && cp -r . "$tmpdir/host_runtime/")
+	mkdir "$tmpdir/host_runtime"
+	(cd "$tmpdir/runtime" && cp -r . "$tmpdir/host_runtime/")
 fi
 
-# Use host Python to install packages into target runtime
-export PATH="$tmpdir/host_runtime/bin:$PATH"
-export PYTHONPATH="$tmpdir/runtime/lib/python3.13/site-packages"
-
-# Create site-packages directory in target runtime
+PATH="$tmpdir/host_runtime/bin:$PATH"
+PYTHONPATH="$tmpdir/runtime/lib/python3.13/site-packages"
 mkdir -p "$tmpdir/runtime/lib/python3.13/site-packages"
+pip install --only-binary=:all: --target "$tmpdir/runtime/lib/python3.13/site-packages" -r "$requirements"
 
-pip install \
-    --only-binary=:all: \
-    --target "$tmpdir/runtime/lib/python3.13/site-packages" \
-    -r "$requirements"
-
-# Create the final runtime archive
 tar -c -C "$tmpdir/runtime" . | gzip >"$output"
+cp "$output" "$cache_path"
+find "$CACHE_DIR" -name "runtime-${arch_target}-*" ! -name "$cache_filename" -delete 2>/dev/null || true


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up to #3183 (merge first).
It enables for test-ng:
  - README (including explanation of new distribution build features)
  - runtime build
    - Checksums for downloaded archives
    - Content-Based Checksums for build artifacts
    - Caching of python tgz dependencies
    - Caching of build artifacts