### PR TITLE
do not prevent deletion of azure resource groups if it still contains resources

### DIFF
--- a/tests/platformSetup/tofu/main.tf
+++ b/tests/platformSetup/tofu/main.tf
@@ -141,7 +141,11 @@ provider "aws" {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 provider "google" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not prevent deletion of azure resource groups if it still contains resources
This is fine in our platform-tests as these are not production resources.

**Which issue(s) this PR fixes**:
Fixes #3193
