### PR TITLE
fix aws platform-tests

### DIFF
--- a/tests/platformSetup/tofu/modules/aws/main.tf
+++ b/tests/platformSetup/tofu/modules/aws/main.tf
@@ -225,6 +225,7 @@ resource "aws_s3_object" "image" {
 
   bucket = aws_s3_bucket.images.0.id
   key    = local.image_name
+  source = local.image
 
   tags = merge(
     local.labels,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix aws platform-tests.
Accidentally removed source of s3 object in #2875


**Which issue(s) this PR fixes**:
Fixes #3206
