### PR TITLE
Add workflow for CPE

### DIFF
--- a/.github/workflows/cpe.yml
+++ b/.github/workflows/cpe.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build local container 
-        run: docker pull ghcr.io/gardenlinux/cpe:latest
+        run: podman pull ghcr.io/gardenlinux/cpe:latest
 
       - name: Generate CPE 
-        run: docker run -i ghcr.io/gardenlinux/cpe:latest -p "${{ inputs.version }}" | tail -n1 > gardenlinux-cpe.json
+        run: podman run -i ghcr.io/gardenlinux/cpe:latest -p "${{ inputs.version }}" | tail -n1 > gardenlinux-cpe.json
 
       - name: Upload asset to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/cpe.yml
+++ b/.github/workflows/cpe.yml
@@ -1,0 +1,31 @@
+name: Generate and upload CPE to a release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        type: string
+        required: true
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build local container 
+        run: docker pull ghcr.io/gardenlinux/cpe:latest
+
+      - name: Generate CPE 
+        run: docker run -i ghcr.io/gardenlinux/cpe:latest -p "${{ inputs.version }}" | tail -n1 > gardenlinux-cpe.json
+
+      - name: Upload asset to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "${{ inputs.version }}"
+          files: gardenlinux-cpe.json 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
**What this PR does / why we need it**:

For some of our stakeholders, we need to provide a [CPE](https://nvd.nist.gov/products/cpe) within a release. This file needs to be encoded as a JSON file. In this PR, we add a workflow that allows us to 'predict' an entry CPE entry. This CPE file is incomplete but sufficient for our stakeholder. In a separate workflow, we will notify the NIST about a release; however, it takes several days or weeks until a proper CPE entry is updated by the NIST. With the prediction, we allow stakeholders to update their dataset and do not have to wait until the NIST has responded. 

The code responsible is placed in [here](https://github.com/gardenlinux/cpe/blob/main/predict-cpe.py). In this separate repository, which also builds the container.  

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/security/issues/147
