### PR TITLE
Fix renaming of cname to image_name

### DIFF
--- a/tests/platformSetup/platformSetup.py
+++ b/tests/platformSetup/platformSetup.py
@@ -139,7 +139,7 @@ class PytestConfig:
             yaml_data = {
                 "qemu": {
                     "platform": platform,
-                    "image": f"{image_path}/{cname}.raw" if image_path else None,
+                    "image": f"{image_path}/{image_name}.raw" if image_path else None,
                     "ip": "127.0.0.1",
                     "port": 2223,
                     "keep_running": True,


### PR DESCRIPTION


**What this PR does / why we need it**:

Fix renaming of cname to image_name
This broke in https://github.com/gardenlinux/gardenlinux/pull/2875
