### PR TITLE
feat: _usi: append EROFS directly to initrd

### DIFF
--- a/features/_usi/image.esp.tar
+++ b/features/_usi/image.esp.tar
@@ -11,14 +11,11 @@ rootfs="$(mktemp -d)"
 mount -t tmpfs -o size="$TEMPFS_SIZE" tmpfs "$rootfs"
 tar --extract --xattrs --xattrs-include '*' --directory "$rootfs" < "$input"
 
-# # shellcheck disable=SC2115
-# rm -rf "$rootfs/var"
-# mkdir "$rootfs/var"
-
 echo "creating root EROFS disk"
 
-erofs="$(mktemp -u)"
-mkfs.erofs --quiet -z lz4 -E force-inode-compact -T "$BUILDER_TIMESTAMP" -U "$(echo "gardenlinux:$BUILDER_VERSION:erofs:root" | uuid_hash)" "$erofs" "$rootfs"
+erofs_cpio_dir="$(mktemp -d)"
+erofs="$erofs_cpio_dir/root.img"
+mkfs.erofs --quiet -z zstd,12 -E force-inode-compact -T "$BUILDER_TIMESTAMP" -U "$(echo "gardenlinux:$BUILDER_VERSION:erofs:root" | uuid_hash)" "$erofs" "$rootfs"
 
 size_chroot="$(du -s "$rootfs" | cut -f 1)"
 size_erofs="$(du "$erofs" | cut -f 1)"
@@ -26,6 +23,10 @@ echo "root disk compressed by $(( ( ( size_chroot - size_erofs ) * 100 ) / size_
 
 echo
 echo "building initrd with embedded root disk"
+
+erofs_cpio="$(mktemp)"
+(cd "$erofs_cpio_dir" && echo root.img | cpio -o -H newc) > "$erofs_cpio"
+rm -rf "$erofs_cpio_dir"
 
 mount --rbind /proc "$rootfs/proc"
 
@@ -46,9 +47,6 @@ for feature in "${features[@]}"; do
 	fi
 done
 
-touch "$rootfs/tmp/initrd.include/root.img"
-mount --bind "$erofs" "$rootfs/tmp/initrd.include/root.img"
-
 initrd="$(mktemp)"
 
 touch "$rootfs/initrd"
@@ -68,9 +66,6 @@ chroot "$rootfs" dracut \
 	--add-drivers erofs \
 	/initrd
 
-umount "$rootfs/tmp/initrd.include/root.img"
-rm "$erofs"
-
 umount -l "$rootfs/proc"
 umount -R "$rootfs/dev"
 umount "$rootfs/tmp"
@@ -89,6 +84,12 @@ esac
 uki="$(mktemp)"
 
 read -r _ cmdline < "$rootfs/etc/kernel/cmdline"
+
+size_initrd="$(du -h "$initrd" | cut -f 1)"
+size_erofs_cpio="$(du -h "$erofs_cpio" | cut -f 1)"
+cat "$erofs_cpio" >> "$initrd"
+size_initrd_total="$(du -h "$initrd" | cut -f 1)"
+echo "initrd size: $size_initrd (dracut) + $size_erofs_cpio (EROFS) = $size_initrd_total"
 
 /usr/lib/systemd/ukify build \
 	--stub "$rootfs/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \


### PR DESCRIPTION
For UKI based images use zstd compression inside the EROFS rather than wrapping the EROFS inside dracuts xz compression. The EROFS is then appended as a secondary uncompressed CPIO archive after dracuts.

This results in faster pre-init kernel boot time by reducing up-front decompression overhead and decompressing more on-the-fly.

In tests this improved the total boot time by a factor of 31% from 25.5 sec to 17.5 sec.

```
before: 
5.171s (firmware) + 364ms (loader) + 10.513s (kernel) + 6.020s (initrd) + 3.442s (userspace) = 25.511s

after:
5.140s (firmware) + 445ms (loader) + 2.421s (kernel) + 6.220s (initrd) + 3.301s (userspace) = 17.529s
```

Switching the EROFS compression to zstd also has a positive effect on the amount of `Shmem` used during idle, since the EROFS image is always resident in memory (backed by tmpfs). Cutting it by 33% from 285828 kB down to 191884 kB.

---

> [!IMPORTANT]
> This requires kernel support for zstd compressed EROFS via the `CONFIG_EROFS_FS_ZIP_ZSTD` so https://github.com/gardenlinux/package-linux/pull/144 must be merged first.