### PR TITLE
feat: add option to run VM configure script via QEMU fw_cfg

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -16,6 +16,7 @@ main () {
     get_opts "$@"
     set_binaries
     qemu_opt_ignition
+    qemu_opt_fw_cfg
     qemu_opt_pxe
     qemu_opt_disk
     qemu_opt_uefi
@@ -115,6 +116,7 @@ set_defaults () {
     uefi=1
     uefi_code=
     uefi_vars=
+    fw_cfg_script=
     tpm=1
     vnc=
     keypress=1
@@ -157,6 +159,7 @@ source "${CURR_DIR}/.constants.sh" \
     --flags 'ignfile:' \
     --flags 'pidfile:' \
     --flags 'ueficode:,uefivars:' \
+    --flags 'fw-cfg-script:' \
     --flags 'destport:' \
     --usage '[ --daemonize ] [ --cpu:<#> ] [ --mem:<size> ] [ --pxe:<dir> ] [<image file>[,<size>]]*' \
     --sample '.build/rootfs.raw' \
@@ -198,6 +201,7 @@ while true; do
         --mac)          mac="$1";       shift ;;
         --ueficode)     uefi_code="$1"; shift ;;
         --uefivars)     uefi_vars="$1"; shift ;;
+        --fw-cfg-script) fw_cfg_script="$1"; shift ;;
         --bridge)       bridge="$1";    shift ;;
         --pxe )         pxe="$(realpath $1)";      shift ;;
         --ignfile )     ignfile="$(realpath $1)";  shift ;;
@@ -320,6 +324,14 @@ qemu_opt_ignition () {
 	    QEMU_OPTS+=( -fw_cfg name=opt/com.coreos/config,file=${ignfile} )
 	fi
     fi
+}
+
+qemu_opt_fw_cfg () {
+    [ -z "$fw_cfg_script" ] && return 0
+
+    QEMU_OPTS+=(
+        -fw_cfg name=opt/gardenlinux/config_script,file="$fw_cfg_script"
+    )
 }
 
 

--- a/features/_fwcfg/exec.config
+++ b/features/_fwcfg/exec.config
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+systemctl enable qemu-fw_cfg-script.service

--- a/features/_fwcfg/file.include/etc/systemd/system/qemu-fw_cfg-script.service
+++ b/features/_fwcfg/file.include/etc/systemd/system/qemu-fw_cfg-script.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Execute QEMU fw_cfg script
+ConditionPathExists=/sys/firmware/qemu_fw_cfg/by_name/opt/gardenlinux/config_script/raw
+After=default.target
+Requires=default.target
+
+[Service]
+Type=idle
+ExecStart=/usr/bin/run-qemu-fw_cfg-script
+
+[Install]
+WantedBy=default.target

--- a/features/_fwcfg/file.include/usr/bin/run-qemu-fw_cfg-script
+++ b/features/_fwcfg/file.include/usr/bin/run-qemu-fw_cfg-script
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -eufo pipefail
+
+fwcfg_path="/sys/firmware/qemu_fw_cfg/by_name/opt/gardenlinux/config_script/raw"
+tmp_script="/run/gardenlinux/qemu-fw_cfg-script"
+
+if ! grep -qi qemu /sys/class/dmi/id/sys_vendor; then
+	echo "Not running under QEMU, skipping." >&2
+	exit 0
+fi
+
+if [ ! -e "$fwcfg_path" ]; then
+	echo "No fw_cfg script provided, nothing to do." >&2
+	exit 0
+fi
+
+if [ "$(head -c 2 "$fwcfg_path" 2> /dev/null)" != "#!" ]; then
+	echo "fw_cfg script does not start with shebang (#!), refusing to execute" >&2
+	exit 1
+fi
+
+cleanup() {
+	rm -f "$tmp_script"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$tmp_script")"
+cp "$fwcfg_path" "$tmp_script"
+chmod +x "$tmp_script"
+
+exec "$tmp_script"

--- a/features/_fwcfg/info.yaml
+++ b/features/_fwcfg/info.yaml
@@ -1,0 +1,2 @@
+description: "enable support for QEMU fw_cfg based user config scripts"
+type: flag

--- a/features/cloud/info.yaml
+++ b/features/cloud/info.yaml
@@ -4,3 +4,4 @@ features:
   include:
     - server
     - _legacy
+    - _fwcfg

--- a/features/metal/info.yaml
+++ b/features/metal/info.yaml
@@ -4,3 +4,4 @@ features:
   include:
     - server
     - _legacy
+    - _fwcfg


### PR DESCRIPTION
**What this PR does / why we need it**:

This change will allow us to provide setup scripts (similar to the AWS user-data-script or equivalent on other cloud providers) while running in a VM under QEMU.

**Security considerations:**

While this at first glance appears to provide an easy attack surface / backdoor, we need to keep in mind that setting or spoofing such fw_cfg values would require an attacker to control the hypervisor and/or the firmware. Given an adversary with such capabilities it would also be possible for the attacker to directly modify system memory to modify / inject code into kernel space, so this fw_cfg based script execution does not provide such an attacker significant additional capabilites.