### PR TITLE
update builder to latest version

### DIFF
--- a/build
+++ b/build
@@ -6,7 +6,7 @@ shopt -s nullglob
 exec 3>&1
 exec 1>&2
 
-container_image=ghcr.io/gardenlinux/builder:70b8f1f7cb627a67b1076eeec7e288110cce0fc8
+container_image=ghcr.io/gardenlinux/builder:33391d8821ac62794512753879942fc2155f1965
 container_engine=podman
 target_dir=.build
 
@@ -22,6 +22,7 @@ container_cmd=()
 
 use_kms=0
 resolve_cname=0
+apparmor_profile=
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -56,6 +57,10 @@ while [ $# -gt 0 ]; do
 			;;
 		--target)
 			target_dir="$2"
+			shift 2
+			;;
+		--apparmor-profile)
+			apparmor_profile="$2"
 			shift 2
 			;;
 		*)
@@ -101,6 +106,7 @@ make_opts=(
 	COMMIT="$commit"
 	TIMESTAMP="$timestamp"
 	DEFAULT_VERSION="$default_version"
+	LOG_WITH_TIMESTAMP="${LOG_WITH_TIMESTAMP:-true}"
 )
 
 if [ "$use_kms" = 1 ]; then
@@ -122,6 +128,45 @@ make_opts+=("TEMPFS_SIZE=$tempfs_size")
 
 if [ -d cert ]; then
 	container_mount_opts+=(-v "$PWD/cert:/builder/cert:ro")
+fi
+
+# Check if builder apparmor profile has to be created or selected
+if [ "$container_engine" = "docker" ] \
+	&& [ ! "$apparmor_profile" ] \
+	&& out=$(sysctl kernel.apparmor_restrict_unprivileged_userns 2> /dev/null) \
+	&& [[ $out = "kernel.apparmor_restrict_unprivileged_userns = 1" ]]; then
+	if [ ! -f /etc/apparmor.d/builder ]; then
+		echo "You are using Docker on a system restricting unprivileged user namespaces with apparmor, which prevents a successful build. For more information please refer to the #Usage section in the README."
+		read -r -p "Do you want to permanently create a new apparmor profile at /etc/apparmor.d/builder to solve the issue? [Y/n] " response
+		response=${response,,}
+		if [[ "$response" =~ ^(yes|y)$ ]]; then
+			if [ ! -f /etc/apparmor.d/builder ]; then
+				profile="abi <abi/4.0>, include <tunables/global> profile builder flags=(unconfined) {userns, }"
+				echo "$profile" | sudo tee /etc/apparmor.d/builder > /dev/null
+				sudo apparmor_parser -r -W /etc/apparmor.d/builder
+			fi
+			echo "Created profile builder at /etc/apparmor.d/builder"
+		else
+			echo Abort.
+			exit 1
+		fi
+	fi
+	apparmor_profile=builder
+fi
+
+# Apply apparmor profile if seleceted
+if [ "$apparmor_profile" ]; then
+	replaced=false
+	for i in "${!container_run_opts[@]}"; do
+			if [ "${container_run_opts[$i]}" = "apparmor=unconfined" ]; then
+					container_run_opts["$i"]="apparmor=$apparmor_profile"
+					replaced=true
+			fi
+	done
+
+	if ! $replaced; then
+			container_run_opts+=(--security-opt "apparmor=$apparmor_profile")
+	fi
 fi
 
 "$container_engine" run --rm "${container_run_opts[@]}" "${container_mount_opts[@]}" "$container_image" ${container_cmd[@]+"${container_cmd[@]}"} fake_xattr make --no-print-directory -C /builder "${make_opts[@]}" "$@" >&3


### PR DESCRIPTION
This builder update contains the following commits in the builder repo:

- [33391d8](https://github.com/gardenlinux/builder/commit/33391d8821ac62794512753879942fc2155f1965) Merge pull request #121 from gardenlinux/feat/output_requirements
- [1e349a9](https://github.com/gardenlinux/builder/commit/1e349a933b1e93d2d720719e64c97d4a5d0f57b9) feat: output target requirements
- [fd7a1a9](https://github.com/gardenlinux/builder/commit/fd7a1a9a0b739ca82632694128508c751727f490) This commit supports `$LOG_WITH_TIMESTAMP` to generate shorter log output
- [6c9fd2a](https://github.com/gardenlinux/builder/commit/6c9fd2a2f7a4f500ba8b30246dd1896f7df15382) Merge pull request #118 from gardenlinux/feat/download-aws-library
- [9e4f860](https://github.com/gardenlinux/builder/commit/9e4f860878aa4c87a66663975aa38dd7724be753) build(deps): bump redhat-plumbers-in-action/differential-shellcheck (#119)
- [f8b2efc](https://github.com/gardenlinux/builder/commit/f8b2efc5225c1baaa1dd1f6c1d4aab202ff000f9) Merge pull request #116 from gardenlinux/feat/deprecate-native-bin
- [dab2796](https://github.com/gardenlinux/builder/commit/dab2796e60f551d44db7a9d81797b377ef24bfbe) feat: download release from gardenlinux/aws-kms-pkcs11 instead of building it
- [e4743a9](https://github.com/gardenlinux/builder/commit/e4743a93d06334366683f00309bef0da7212caf7) remove deprecated scripts
- [8a385a9](https://github.com/gardenlinux/builder/commit/8a385a931fa543c84ce9c3572239d1754508dada) Merge pull request #117 from gardenlinux/fix/apparmor-profile-reboot
- [1df3099](https://github.com/gardenlinux/builder/commit/1df3099616eb61a3806bfab2da071e08ced120b9) fix: move created builder profile directly in /etc/apparmor.d to stay enabled after reboot
- [2dac5f6](https://github.com/gardenlinux/builder/commit/2dac5f6f15b4238e468de9c898e92ce87e87c37f) Merge pull request #114 from gardenlinux/fix/container-engine-compability
- [bd55ff5](https://github.com/gardenlinux/builder/commit/bd55ff5866e02e50ac56745bb00cc121b4cffe28) feat: deprecate native bin
- [27ced01](https://github.com/gardenlinux/builder/commit/27ced010977f16a1ba0b8eb29e171319a419fef2) Fix ShellCheck
- [1d3ebae](https://github.com/gardenlinux/builder/commit/1d3ebae46357af419a0be7a059723939e652602c) changed permanent profile creation to opt-in
- [33a2d69](https://github.com/gardenlinux/builder/commit/33a2d6904ba2145af3a9295988b830a91888c9a9) added apparmor notice to readme
- [4204eee](https://github.com/gardenlinux/builder/commit/4204eee6c944009ece769690c848435b4ca0dd3a) added trap for the change permissions feature, replaced apparmor_restrict_unprivileged_userns setting change by custom apparmor profile for the container
- [c5d8c71](https://github.com/gardenlinux/builder/commit/c5d8c7128fd74f9185a96613b09f9428c626d90b) cleanup
- [284b254](https://github.com/gardenlinux/builder/commit/284b254e4a5e56d058e4623924944200847a3ab3) fix: set correct ownership of generated build files to make switching between docker and podman possible
- [9c4e4d2](https://github.com/gardenlinux/builder/commit/9c4e4d2a8afaeb6312089f19315a258b75407a5e) fix: enable unprivileged user namespaces for restricted systems (https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces)
- [c8d4430](https://github.com/gardenlinux/builder/commit/c8d44302592989e08e36c0662cacd2627e7f3138) Merge pull request #113 from gardenlinux/dependabot/github_actions/redhat-plumbers-in-action/differential-shellcheck-5.5.4
- [fc7b508](https://github.com/gardenlinux/builder/commit/fc7b508f247422390103160bc246e6674026b729) build(deps): bump redhat-plumbers-in-action/differential-shellcheck