### PR TITLE
Bump python-gardenlinux-lib to 0.8.8

### DIFF
--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -78,7 +78,7 @@ jobs:
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/build_flavors_matrix.yml
+++ b/.github/workflows/build_flavors_matrix.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: true
       - id: matrix
         name: Generate flavors matrix
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: ${{ inputs.flags }}
           flavors_matrix: ${{ inputs.flavors_matrix }}

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -31,7 +31,7 @@ jobs:
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: --cname container-${{ matrix.arch }} cname
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
       - name: Set image reference for S3
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -82,12 +82,12 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME (amd64)
         id: cname_amd64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: --cname container-amd64 cname
       - name: Determine CNAME (ard64)
         id: cname_arm64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: --cname container-arm64 cname
       - name: Set CNAMEs
@@ -253,7 +253,7 @@ jobs:
           role-session-name: ${{ secrets.aws_session }}
           aws-region: ${{ secrets.aws_region }}
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.9.2
         with:
@@ -321,7 +321,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
       - name: Set flavor version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/test_flavor_chrooted.yml
+++ b/.github/workflows/test_flavor_chrooted.yml
@@ -35,7 +35,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_platform_flavor.yml
+++ b/.github/workflows/test_platform_flavor.yml
@@ -83,7 +83,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@97e65f61273bd5d84cc2316ce78d15af880c0022 # pin@0.8.8
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@bf448cc2172a8248030a73f96304810543e6c1ed # pin@0.8.8
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ networkx = "*"
 pyyaml = "*"
 requests = "*"
 jsonschema = "*"
-gardenlinux = {ref = "0.8.7", git = "https://github.com/gardenlinux/python-gardenlinux-lib.git"}
+gardenlinux = {ref = "0.8.8", git = "https://github.com/gardenlinux/python-gardenlinux-lib.git"}
 
 [dev-packages]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ networkx
 PyYAML
 requests
 jsonschema
-gardenlinux @ git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.8.7
+gardenlinux @ git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.8.8


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump python-gardenlinux-lib to 0.8.8

Not sure if this is related to https://github.com/gardenlinux/gardenlinux/actions/runs/16668198895/job/47179414305
