### PR TITLE
Allow publishing lima images for released Garden Linux versions

### DIFF
--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 11 * * 2'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image version (default: today)'
+        required: false
+        default: 'today'
 
 jobs:
 
@@ -12,13 +17,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.version || 'main' }}
     - name: Build image with feature:lima for amd64
       run: |
         ./build kvm-lima-amd64
     - uses: actions/upload-artifact@v4
       with:
-        name: gardenlinux-lima-today-amd64
-        path: .build/lima-amd64-today*.qcow2
+        name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-amd64
+        path: .build/lima-amd64-${{ github.event.inputs.version || 'today' }}*.qcow2
         include-hidden-files: true
 
   build-arm:
@@ -26,13 +33,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.version || 'main' }}
     - name: Build image with feature:lima for arm64
       run: |
         ./build kvm-lima-arm64
     - uses: actions/upload-artifact@v4
       with:
-        name: gardenlinux-lima-today-arm64
-        path: .build/lima-arm64-today*.qcow2
+        name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-arm64
+        path: .build/lima-arm64-${{ github.event.inputs.version || 'today' }}*.qcow2
         include-hidden-files: true
 
   upload:
@@ -49,12 +58,12 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: gardenlinux-lima-today-amd64
+        name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-amd64
         path: images
 
     - uses: actions/download-artifact@v4
       with:
-        name: gardenlinux-lima-today-arm64
+        name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-arm64
         path: images
 
     - name: Calculate sha sums
@@ -72,22 +81,41 @@ jobs:
 
     - name: Create gardenlinux.yaml for limactl create config 
       run: |
+        VERSION="${{ github.event.inputs.version || 'today' }}"
         SHA_AMD=$(cat images/*amd*.sha512|cut -d' ' -f1)
         SHA_ARM=$(cat images/*arm*.sha512|cut -d' ' -f1)
         echo "Reading SHA_AMD" $SHA_AMD
         echo "Reading SHA_ARM" $SHA_ARM
-        cat <<EOF > gardenlinux.yaml
+
+        if [ "$VERSION" = "today" ]; then
+          cat <<EOF > gardenlinux.yaml
         vmType: qemu
         os: Linux
         images:
-        - location: "https://images.gardenlinux.io/gardenlinux-amd64-today.qcow2"
+        - location: "https://images.gardenlinux.io/gardenlinux-amd64-${VERSION}.qcow2"
           arch: "x86_64"
-        - location: "https://images.gardenlinux.io/gardenlinux-arm64-today.qcow2"
+        - location: "https://images.gardenlinux.io/gardenlinux-arm64-${VERSION}.qcow2"
           arch: "aarch64"
         containerd:
           system: false
           user: false
         EOF
+        else
+          cat <<EOF > gardenlinux-${VERSION}.yaml
+        vmType: qemu
+        os: Linux
+        images:
+        - location: "https://images.gardenlinux.io/gardenlinux-amd64-${VERSION}.qcow2"
+          arch: "x86_64"
+          digest: "sha512:$SHA_AMD"
+        - location: "https://images.gardenlinux.io/gardenlinux-arm64-${VERSION}.qcow2"
+          arch: "aarch64"
+          digest: "sha512:$SHA_ARM"
+        containerd:
+          system: false
+          user: false
+        EOF
+        fi
 
     - name: Authenticate to GCloud via OIDC
       uses: google-github-actions/auth@v2
@@ -105,13 +133,14 @@ jobs:
           
     - name: Upload image and checksum to GCS
       run: |
+        VERSION="${{ github.event.inputs.version || 'today' }}"
         IMAGE_AMD=$(ls images/*amd*.qcow2)
         IMAGE_ARM=$(ls images/*arm*.qcow2)
         SHA_AMD=$(ls images/*amd*.sha512)
         SHA_ARM=$(ls images/*arm*.sha512)
         echo $IMAGE_AMD $IMAGE_ARM $SHA_AMD $SHA_ARM
         gsutil cp "gardenlinux.yaml" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux.yaml
-        gsutil cp "$IMAGE_AMD" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-amd64-today.qcow2
-        gsutil cp "$SHA_AMD" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-amd64-today.qcow2.sha512
-        gsutil cp "$IMAGE_ARM" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-arm64-today.qcow2
-        gsutil cp "$SHA_ARM" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-arm64-today.qcow2.sha512
+        gsutil cp "$IMAGE_AMD" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-amd64-${VERSION}.qcow2
+        gsutil cp "$SHA_AMD" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-amd64-${VERSION}.qcow2.sha512
+        gsutil cp "$IMAGE_ARM" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-arm64-${VERSION}.qcow2
+        gsutil cp "$SHA_ARM" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-arm64-${VERSION}.qcow2.sha512

--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -139,7 +139,11 @@ jobs:
         SHA_AMD=$(ls images/*amd*.sha512)
         SHA_ARM=$(ls images/*arm*.sha512)
         echo $IMAGE_AMD $IMAGE_ARM $SHA_AMD $SHA_ARM
-        gsutil cp "gardenlinux.yaml" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux.yaml
+        if [ "$VERSION" = "today" ]; then
+          gsutil cp "gardenlinux.yaml" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux.yaml
+        else
+          gsutil cp "gardenlinux-${VERSION}.yaml" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-${VERSION}.yaml
+        fi
         gsutil cp "$IMAGE_AMD" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-amd64-${VERSION}.qcow2
         gsutil cp "$SHA_AMD" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-amd64-${VERSION}.qcow2.sha512
         gsutil cp "$IMAGE_ARM" gs://${{ secrets.GCP_LIMA_BUCKET }}/gardenlinux-arm64-${VERSION}.qcow2

--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-amd64
-        path: .build/kvm-lima-amd64-${{ github.event.inputs.version || 'today' }}*.qcow2
+        path: .build/*lima-amd64-${{ github.event.inputs.version || 'today' }}*.qcow2
         include-hidden-files: true
 
   build-arm:
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-arm64
-        path: .build/kvm-lima-arm64-${{ github.event.inputs.version || 'today' }}*.qcow2
+        path: .build/*lima-arm64-${{ github.event.inputs.version || 'today' }}*.qcow2
         include-hidden-files: true
 
   upload:

--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -21,7 +21,7 @@ jobs:
         ref: ${{ github.event.inputs.version || 'main' }}
     - name: Build image with feature:lima for amd64
       run: |
-        ./build kvm-lima-amd64
+        ./build lima-amd64
     - uses: actions/upload-artifact@v4
       with:
         name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-amd64
@@ -37,7 +37,7 @@ jobs:
         ref: ${{ github.event.inputs.version || 'main' }}
     - name: Build image with feature:lima for arm64
       run: |
-        ./build kvm-lima-arm64
+        ./build lima-arm64
     - uses: actions/upload-artifact@v4
       with:
         name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-arm64

--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -21,11 +21,11 @@ jobs:
         ref: ${{ github.event.inputs.version || 'main' }}
     - name: Build image with feature:lima for amd64
       run: |
-        ./build lima-amd64
+        ./build kvm-lima-amd64
     - uses: actions/upload-artifact@v4
       with:
         name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-amd64
-        path: .build/lima-amd64-${{ github.event.inputs.version || 'today' }}*.qcow2
+        path: .build/kvm-lima-amd64-${{ github.event.inputs.version || 'today' }}*.qcow2
         include-hidden-files: true
 
   build-arm:
@@ -37,11 +37,11 @@ jobs:
         ref: ${{ github.event.inputs.version || 'main' }}
     - name: Build image with feature:lima for arm64
       run: |
-        ./build lima-arm64
+        ./build kvm-lima-arm64
     - uses: actions/upload-artifact@v4
       with:
         name: gardenlinux-lima-${{ github.event.inputs.version || 'today' }}-arm64
-        path: .build/lima-arm64-${{ github.event.inputs.version || 'today' }}*.qcow2
+        path: .build/kvm-lima-arm64-${{ github.event.inputs.version || 'today' }}*.qcow2
         include-hidden-files: true
 
   upload:

--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.version || 'main' }}
+        ref: ${{ github.event.inputs.version == 'today' && 'main' || github.event.inputs.version }}
     - name: Build image with feature:lima for amd64
       run: |
         ./build kvm-lima-amd64
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.version || 'main' }}
+        ref: ${{ github.event.inputs.version == 'today' && 'main' || github.event.inputs.version }}
     - name: Build image with feature:lima for arm64
       run: |
         ./build kvm-lima-arm64

--- a/features/lima/README.md
+++ b/features/lima/README.md
@@ -14,7 +14,10 @@ How to use the pre-built image:
 1. Create and start the VM
 
 ```
+# for the latest nightly build, use:
 limactl start --name gardenlinux https://images.gardenlinux.io/gardenlinux.yaml
+# for a released version, use this (see released versions at https://github.com/gardenlinux/gardenlinux/releases):
+limactl start --name gardenlinux https://images.gardenlinux.io/gardenlinux-$VERSION.yaml
 ```
 
 2. Open a shell inside the VM: `limactl shell gardenlinux`


### PR DESCRIPTION
Add a 'version' parameter to the workflow for publishing lima images, which allows us to publish images for stable versions.

This is not yet part of the proper release workflow.

Part of https://github.com/gardenlinux/gardenlinux/issues/2963