### PR TITLE
Port SSH tests to new framework

### DIFF
--- a/tests-ng/plugins/sshd.py
+++ b/tests-ng/plugins/sshd.py
@@ -22,13 +22,7 @@ class Sshd:
                     else:
                         self._sshd_config[key] = {self._sshd_config[key], value}
                 else:
-                    # fixme: this is not ideal. what we want here is to have comma separated string values
-                    # as a set to make comparing them easier because the order of entries does not matter
-                    # the 3 is an arbitrary number to allow for real string values with commas
-                    if value.count(",") >= 3:
-                        self._sshd_config[key] = set(value.split(","))
-                    else:
-                        self._sshd_config[key] = value
+                    self._sshd_config[key] = value
             elif len(parts) == 1:
                 key = parts[0]
                 self._sshd_config[key] = None

--- a/tests-ng/plugins/sshd.py
+++ b/tests-ng/plugins/sshd.py
@@ -1,0 +1,9 @@
+import pytest
+from .shell import ShellRunner
+
+class Sshd:
+    def __init__(self, shell: ShellRunner):
+        self._shell = shell
+
+    def get_config():
+        

--- a/tests-ng/plugins/sshd.py
+++ b/tests-ng/plugins/sshd.py
@@ -42,17 +42,6 @@ class Sshd:
         self._sshd_config = config
         return config
 
-    def get_config_section(self, key: str) -> str:
+    def get_config_section(self, key: str) -> str|set:
         config = self.read_config()
-        return config.get(str.lower(key))
-
-    def get_normalized_sets(
-        self,
-        sshd_config_item: str,
-        actual_value: set,
-        expected_value: set,
-    ) -> tuple[set, set]:
-        assert isinstance(actual_value, set), f"{sshd_config_item} should be a set"
-        actual_set = {str(v).lower() for v in actual_value}
-        expected_set = {str(v).lower() for v in expected_value}
-        return actual_set, expected_set
+        return config.get(str.casefold(key))

--- a/tests-ng/plugins/sshd.py
+++ b/tests-ng/plugins/sshd.py
@@ -4,44 +4,39 @@ from .shell import ShellRunner
 
 class Sshd:
     def __init__(self, shell: ShellRunner):
-        self._shell = shell
-        result = shell("/usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True)
+        sshd_config_test_command = shell("/usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True)
         assert (
-            result.returncode == 0
-        ), f"Expected return code 0, got {result.returncode}"
-        self._sshd_config_text = result.stdout
-        self._sshd_config = None
-
-    def read_config(self) -> dict:
-        if self._sshd_config is not None:
-            return self._sshd_config
-        config = {}
-        for line in self._sshd_config_text.splitlines():
+            sshd_config_test_command.returncode == 0
+        ), f"Expected return code 0, got {sshd_config_test_command.returncode}"
+        self._sshd_config = {}
+        for line in sshd_config_test_command.stdout.splitlines():
             if not line.strip():
                 continue
             parts = line.split(maxsplit=1)
             if len(parts) == 2:
                 key, value = parts
                 # If key already exists, convert to set and append
-                if key in config:
-                    if isinstance(config[key], set):
-                        config[key].add(value)
+                if key in self._sshd_config:
+                    if isinstance(self._sshd_config[key], set):
+                        self._sshd_config[key].add(value)
                     else:
-                        config[key] = {config[key], value}
+                        self._sshd_config[key] = {self._sshd_config[key], value}
                 else:
                     # fixme: this is not ideal. what we want here is to have comma separated string values
                     # as a set to make comparing them easier because the order of entries does not matter
                     # the 3 is an arbitrary number to allow for real string values with commas
                     if value.count(",") >= 3:
-                        config[key] = set(value.split(","))
+                        self._sshd_config[key] = set(value.split(","))
                     else:
-                        config[key] = value
+                        self._sshd_config[key] = value
             elif len(parts) == 1:
                 key = parts[0]
-                config[key] = None
-        self._sshd_config = config
-        return config
+                self._sshd_config[key] = None
+
+
+    def get_config(self) -> dict:
+        return self._sshd_config
+
 
     def get_config_section(self, key: str) -> str|set:
-        config = self.read_config()
-        return config.get(str.casefold(key))
+        return self._sshd_config.get(str.casefold(key))

--- a/tests-ng/plugins/sshd.py
+++ b/tests-ng/plugins/sshd.py
@@ -1,9 +1,58 @@
 import pytest
 from .shell import ShellRunner
 
+
 class Sshd:
     def __init__(self, shell: ShellRunner):
         self._shell = shell
+        result = shell("/usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True)
+        assert (
+            result.returncode == 0
+        ), f"Expected return code 0, got {result.returncode}"
+        self._sshd_config_text = result.stdout
+        self._sshd_config = None
 
-    def get_config():
-        
+    def read_config(self) -> dict:
+        if self._sshd_config is not None:
+            return self._sshd_config
+        config = {}
+        for line in self._sshd_config_text.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split(maxsplit=1)
+            if len(parts) == 2:
+                key, value = parts
+                # If key already exists, convert to set and append
+                if key in config:
+                    if isinstance(config[key], set):
+                        config[key].add(value)
+                    else:
+                        config[key] = {config[key], value}
+                else:
+                    # fixme: this is not ideal. what we want here is to have comma separated string values
+                    # as a set to make comparing them easier because the order of entries does not matter
+                    # the 3 is an arbitrary number to allow for real string values with commas
+                    if value.count(",") >= 3:
+                        config[key] = set(value.split(","))
+                    else:
+                        config[key] = value
+            elif len(parts) == 1:
+                key = parts[0]
+                config[key] = None
+        self._sshd_config = config
+        return config
+
+    def get_config_section(self, key: str) -> str:
+        config = self.read_config()
+        return config.get(str.lower(key))
+
+    def get_normalized_sets(
+        self,
+        sshd_config_item: str,
+        actual_value: set,
+        expected_value: set,
+    ) -> tuple[set, set]:
+        assert isinstance(actual_value, set), f"{sshd_config_item} should be a set"
+        actual_set = {str(v).lower() for v in actual_value}
+        expected_set = {str(v).lower() for v in expected_value}
+        return actual_set, expected_set

--- a/tests-ng/plugins/systemd.py
+++ b/tests-ng/plugins/systemd.py
@@ -34,6 +34,11 @@ class Systemd:
 
         return tuple(_seconds(v) for v in m.groups())
 
+    def is_running(self, unit_name: str) -> bool:
+        result = self._shell(f"systemctl is-active {unit_name}", capture_output=True, ignore_exit_code=True)
+        return result.stdout.strip() == "active"
+
+
 @pytest.fixture
 def systemd(shell: ShellRunner):
     return Systemd(shell)

--- a/tests-ng/plugins/utils.py
+++ b/tests-ng/plugins/utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+# Various utility functions to make tests more readable
+# This should not contain test-assertions, but only abstract details that make tests harder to read
+
+def equals_ignore_case(a: str, b: str) -> str:
+    return a.casefold() == b.casefold()
+
+
+def get_normalized_sets(
+    actual_value: set,
+    expected_value: set,
+) -> tuple[set, set]:
+    actual_set = {str(v).casefold() for v in actual_value}
+    expected_set = {str(v).casefold() for v in expected_value}
+    return actual_set, expected_set
+
+
+def is_set(obj) -> bool:
+    return isinstance(obj, set)

--- a/tests-ng/plugins/utils.py
+++ b/tests-ng/plugins/utils.py
@@ -6,15 +6,9 @@ import pytest
 def equals_ignore_case(a: str, b: str) -> str:
     return a.casefold() == b.casefold()
 
-
-def get_normalized_sets(
-    actual_value: set,
-    expected_value: set,
-) -> tuple[set, set]:
-    actual_set = {str(v).casefold() for v in actual_value}
-    expected_set = {str(v).casefold() for v in expected_value}
-    return actual_set, expected_set
-
+def get_normalized_sets(*sets: set) -> tuple[set, ...]:
+    normalized_sets = tuple({str(v).casefold() for v in s} for s in sets)
+    return normalized_sets
 
 def is_set(obj) -> bool:
     return isinstance(obj, set)

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -1,15 +1,17 @@
 import os
 import pytest
+from plugins.shell import ShellRunner
+
 
 def test_gl_is_support_distro():
     with open("/etc/os-release", "r") as f:
         assert "ID=gardenlinux" in [ line.strip() for line in f], "/etc/os-release does not contain gardenlinux vendor field"
 
-def test_no_man(shell):
+def test_no_man(shell: ShellRunner):
     result = shell("man ls", capture_output=True, ignore_exit_code=True)
     assert result.returncode == 127 and "not found" in result.stderr, "man ls, did not fail with 'not found' as expected"
 
-def test_fhs(shell):
+def test_fhs(shell: ShellRunner):
     expected_dirs = {
         "bin",
         "boot",

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from plugins.shell import ShellRunner
+from plugins.systemd import Systemd
 
 
 def test_gl_is_support_distro():
@@ -41,7 +42,7 @@ def test_fhs(shell: ShellRunner):
 @pytest.mark.booted
 @pytest.mark.performance_metric
 @pytest.mark.feature("server and not azure") # server installs systemd and azure has notoriously bad startup times
-def test_startup_time(systemd):
+def test_startup_time(systemd: Systemd):
     tolerated_kernel = 60.0
     tolerated_userspace = 40.0
 

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -47,6 +47,15 @@ required_sshd_config = {
     "UsePAM": "yes",
 }
 
+
+@pytest.mark.booted
+@pytest.mark.feature("ssh")
+def test_sshd_is_running(shell: ShellRunner, systemd: Systemd):
+    print("xxx")
+    print(shell("systemctl status ssh"))
+    assert systemd.is_running("ssh")
+
+
 @pytest.mark.booted
 @pytest.mark.root
 @pytest.mark.feature("ssh")

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -1,81 +1,71 @@
 import pytest
 from plugins.shell import ShellRunner
 from plugins.systemd import Systemd
+from plugins.sshd import Sshd
 
-required_sshd_config = [
-    # Supported HostKey algorithms.
-    "HostKey /etc/ssh/ssh_host_ed25519_key",
-    "HostKey /etc/ssh/ssh_host_rsa_key",
-    # "HostKey /etc/ssh/ssh_host_ecdsa_key",
-    "KexAlgorithms sntrup761x25519-sha512,sntrup761x25519-sha512@openssh.com,mlkem768x25519-sha256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521",
-    "Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com",
-    "MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1",
-    # Password based logins are disabled - only public key based logins are allowed.
-    "AuthenticationMethods publickey",
-    # LogLevel VERBOSE logs user's key fingerprint on login. Needed to have a clear audit track of which key was using to log in.
-    "LogLevel VERBOSE",
-    # Log sftp level file access (read/write/etc.) that would not be easily logged otherwise - be aware that the path has to be adapted to the Distribution installed.
-    "Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
-    # Root login is not allowed for auditing reasons. This is because it's difficult to track which process belongs to which root user:
-    #
-    # On Linux, user sessions are tracking using a kernel-side session id, however, this session id is not recorded by OpenSSH.
-    # Additionally, only tools such as systemd and auditd record the process session id.
-    # On other OSes, the user session id is not necessarily recorded at all kernel-side.
-    # Using regular users in combination with /bin/su or /usr/bin/sudo ensure a clear audit track.
-    "PermitRootLogin No",
-    # Use kernel sandbox mechanisms where possible in unprivileged processes
-    # Systrace on OpenBSD, Seccomp on Linux, seatbelt on MacOSX/Darwin, rlimit elsewhere.
-    # "UsePrivilegeSeparation sandbox",
-    # Disable Tunneling and Forwarding
-    # AllowTcpForwarding no # required for Gardener
-    "X11Forwarding no",
-    # use PAM
-    "UsePAM yes",
-]
+required_sshd_config = {
+    "HostKey": {
+        "/etc/ssh/ssh_host_ed25519_key",
+        "/etc/ssh/ssh_host_rsa_key",
+    },
+    "KexAlgorithms": {
+        "sntrup761x25519-sha512",
+        "sntrup761x25519-sha512@openssh.com",
+        "mlkem768x25519-sha256",
+        "curve25519-sha256",
+        "curve25519-sha256@libssh.org",
+        "ecdh-sha2-nistp256",
+        "ecdh-sha2-nistp384",
+        "ecdh-sha2-nistp521",
+    },
+    "Ciphers": {
+        "chacha20-poly1305@openssh.com",
+        "aes128-ctr",
+        "aes192-ctr",
+        "aes256-ctr",
+        "aes128-gcm@openssh.com",
+        "aes256-gcm@openssh.com",
+    },
+    "MACs": {
+        "umac-64-etm@openssh.com",
+        "umac-128-etm@openssh.com",
+        "hmac-sha2-256-etm@openssh.com",
+        "hmac-sha2-512-etm@openssh.com",
+        "hmac-sha1-etm@openssh.com",
+        "umac-64@openssh.com",
+        "umac-128@openssh.com",
+        "hmac-sha2-256",
+        "hmac-sha2-512",
+        "hmac-sha1",
+    },
+    "AuthenticationMethods": "publickey",
+    "LogLevel": "VERBOSE",
+    "Subsystem": "sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
+    "PermitRootLogin": "No",
+    "X11Forwarding": "no",
+    "UsePAM": "yes",
+}
 
-
-def _create_list_of_tuples(input: str) -> list[tuple[str, set[str]]]:
-    """Takes a multiline string and returns a list containing every line
-    as a tuple. The 1st value of the tuple is the ssh option, the 2nd is
-    value"""
-    out = []
-    for line in input.lower().splitlines():
-        l = line.split(" ", 1)
-        option = l[0]
-        value = l[1]
-        normalized_value = _normalize_value(value)
-        out.append((option, normalized_value))
-    return out
-
-
-def _normalize_value(string: str) -> set[str]:
-    """Convert a given string.
-    The string will be returned as a set. If the element contains a comma
-    separated string, it will be split into a list first."""
-    normalized = string.split(" ")
-    if len(normalized) == 1 and "," in normalized[0]:
-        value_as_set = set(normalized[0].split(","))
-    else:
-        value_as_set = set(normalized)
-    return value_as_set
 
 @pytest.mark.booted
 @pytest.mark.feature("ssh")
 def test_sshd_is_running(systemd: Systemd):
     assert systemd.is_running("sshd")
 
+
 @pytest.mark.booted
 @pytest.mark.root
 @pytest.mark.feature("ssh")
 @pytest.mark.parametrize("sshd_config_item", required_sshd_config)
 def test_sshd_has_required_config(sshd_config_item: str, shell: ShellRunner):
-    result = shell("/usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True)
-    assert result.returncode == 0, f"Expected return code 0, got {result.returncode}"
-
-    sshd_config = _create_list_of_tuples(result.stdout)
-
-    expected = _create_list_of_tuples(sshd_config_item)
-
-    assert all(
-        option in sshd_config for option in expected
-    ), f"{expected} not found in sshd_config"
+    sshd = Sshd(shell)
+    actual_value = sshd.get_config_section(sshd_config_item)
+    expected_value = required_sshd_config[sshd_config_item]
+    if isinstance(expected_value, set):
+        actual_set, expected_set = sshd.get_normalized_sets(sshd_config_item, actual_value, expected_value)
+        missing_sshd_configuration = expected_set - actual_set
+        assert not missing_sshd_configuration, f"{sshd_config_item}: missing values {missing_sshd_configuration}"
+    else:
+        actual_str = str(actual_value).lower()
+        expected_str = str(expected_value).lower()
+        assert actual_str == expected_str, f"{sshd_config_item}: expected {expected_str}, got {actual_str}"

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -56,9 +56,9 @@ def test_sshd_has_required_config(sshd_config_item: str, shell: ShellRunner):
     actual_value = sshd.get_config_section(sshd_config_item)
     expected_value = required_sshd_config[sshd_config_item]
     if is_set(expected_value):
-        assert is_set(actual_value), f"{actual_value} should be a set"
+        if not is_set(actual_value):
+            actual_value = set(str(actual_value).split(','))
         actual_set, expected_set = get_normalized_sets(actual_value, expected_value)
-        missing_sshd_configuration = expected_set - actual_set
-        assert not missing_sshd_configuration, f"{sshd_config_item}: missing values {missing_sshd_configuration}"
+        assert expected_set.issubset(actual_value), f"{sshd_config_item}: missing values {expected_set - actual_set}"
     else:
         assert equals_ignore_case(actual_value, expected_value), f"{sshd_config_item}: expected {expected_value}, got {actual_value}"

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -47,14 +47,12 @@ required_sshd_config = {
     "UsePAM": "yes",
 }
 
-@pytest.fixture
 @pytest.mark.booted
 @pytest.mark.root
 @pytest.mark.feature("ssh")
 @pytest.mark.parametrize("sshd_config_item", required_sshd_config)
 def test_sshd_has_required_config(sshd_config_item: str, shell: ShellRunner):
     sshd = Sshd(shell)
-    yield sshd
     actual_value = sshd.get_config_section(sshd_config_item)
     expected_value = required_sshd_config[sshd_config_item]
     if is_set(expected_value):

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -59,12 +59,12 @@ def _normalize_value(string: str) -> set[str]:
         value_as_set = set(normalized)
     return value_as_set
 
-
+@pytest.mark.booted
 @pytest.mark.feature("ssh")
 def test_sshd_is_running(systemd: Systemd):
     assert systemd.is_running("sshd")
 
-
+@pytest.mark.booted
 @pytest.mark.root
 @pytest.mark.feature("ssh")
 @pytest.mark.parametrize("sshd_config_item", required_sshd_config)

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -6,9 +6,9 @@ required_sshd_config = [
     "HostKey /etc/ssh/ssh_host_ed25519_key",
     "HostKey /etc/ssh/ssh_host_rsa_key",
     # "HostKey /etc/ssh/ssh_host_ecdsa_key",
-    # "KexAlgorithms sntrup761x25519-sha512,sntrup761x25519-sha512@openssh.com,mlkem768x25519-sha256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521",
-    # "Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com",
-    # "MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1",
+    "KexAlgorithms sntrup761x25519-sha512,sntrup761x25519-sha512@openssh.com,mlkem768x25519-sha256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521",
+    "Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com",
+    "MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1",
     # Password based logins are disabled - only public key based logins are allowed.
     "AuthenticationMethods publickey",
     # LogLevel VERBOSE logs user's key fingerprint on login. Needed to have a clear audit track of which key was using to log in.
@@ -31,9 +31,6 @@ required_sshd_config = [
     # use PAM
     "UsePAM yes",
 ]
-
-def trim_and_lower(s):
-    return str.lower(str.lstrip(s))
 
 
 def _create_list_of_tuples(input):
@@ -61,13 +58,10 @@ def _normalize_value(string):
     return value_as_set
 
 
+@pytest.mark.root
 @pytest.mark.feature("ssh")
 @pytest.mark.parametrize("sshd_config_item", required_sshd_config)
 def test_sshd_has_required_config(sshd_config_item: str, shell: ShellRunner):
-
-    shell('ssh-keygen -A')
-    shell('systemctl daemon-reload')
-
     result = shell(
         "/usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True
     )
@@ -77,18 +71,5 @@ def test_sshd_has_required_config(sshd_config_item: str, shell: ShellRunner):
 
     expected = _create_list_of_tuples(sshd_config_item)
 
-
     assert all(option in sshd_config for option in expected), \
             f"{expected} not found in sshd_config"
-
-
-    # found = any(trim_and_lower(sshd_config_item) in trim_and_lower(line) for line in config_content)
-    # assert found, f"Expected {sshd_config_item} in sshd config, but did not find it"
-
-
-# @pytest.mark.feature("ssh")
-# def test_sshd_parse_config(shell: ShellRunner):
-#     result = shell(
-#         "sudo -u root /usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True
-#     )
-#     assert result.returncode == 0

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -1,6 +1,5 @@
 import pytest
 from plugins.shell import ShellRunner
-from plugins.systemd import Systemd
 from plugins.sshd import Sshd
 from plugins.utils import equals_ignore_case, get_normalized_sets, is_set
 
@@ -46,14 +45,6 @@ required_sshd_config = {
     "X11Forwarding": "no",
     "UsePAM": "yes",
 }
-
-
-@pytest.mark.booted
-@pytest.mark.feature("ssh")
-def test_sshd_is_running(shell: ShellRunner, systemd: Systemd):
-    print("xxx")
-    print(shell("systemctl status ssh"))
-    assert systemd.is_running("ssh")
 
 
 @pytest.mark.booted

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -1,0 +1,94 @@
+import pytest
+from plugins.shell import ShellRunner
+
+required_sshd_config = [
+    # Supported HostKey algorithms.
+    "HostKey /etc/ssh/ssh_host_ed25519_key",
+    "HostKey /etc/ssh/ssh_host_rsa_key",
+    # "HostKey /etc/ssh/ssh_host_ecdsa_key",
+    # "KexAlgorithms sntrup761x25519-sha512,sntrup761x25519-sha512@openssh.com,mlkem768x25519-sha256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521",
+    # "Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com",
+    # "MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1",
+    # Password based logins are disabled - only public key based logins are allowed.
+    "AuthenticationMethods publickey",
+    # LogLevel VERBOSE logs user's key fingerprint on login. Needed to have a clear audit track of which key was using to log in.
+    "LogLevel VERBOSE",
+    # Log sftp level file access (read/write/etc.) that would not be easily logged otherwise - be aware that the path has to be adapted to the Distribution installed.
+    "Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
+    # Root login is not allowed for auditing reasons. This is because it's difficult to track which process belongs to which root user:
+    #
+    # On Linux, user sessions are tracking using a kernel-side session id, however, this session id is not recorded by OpenSSH.
+    # Additionally, only tools such as systemd and auditd record the process session id.
+    # On other OSes, the user session id is not necessarily recorded at all kernel-side.
+    # Using regular users in combination with /bin/su or /usr/bin/sudo ensure a clear audit track.
+    "PermitRootLogin No",
+    # Use kernel sandbox mechanisms where possible in unprivileged processes
+    # Systrace on OpenBSD, Seccomp on Linux, seatbelt on MacOSX/Darwin, rlimit elsewhere.
+    # "UsePrivilegeSeparation sandbox",
+    # Disable Tunneling and Forwarding
+    # AllowTcpForwarding no # required for Gardener
+    "X11Forwarding no",
+    # use PAM
+    "UsePAM yes",
+]
+
+def trim_and_lower(s):
+    return str.lower(str.lstrip(s))
+
+
+def _create_list_of_tuples(input):
+    """Takes a multiline string and returns a list containing every line 
+    as a tuple. The 1st value of the tuple is the ssh option, the 2nd is
+    value"""
+    out = []
+    for line in input.lower().splitlines():
+        l = line.split(' ', 1)
+        option = l[0]
+        value = l[1]
+        normalized_value = _normalize_value(value)
+        out.append((option, normalized_value))
+    return out
+
+def _normalize_value(string):
+    """Convert a given string.
+    The string will be returned as a set. If the element contains a comma
+    separated string, it will be split into a list first."""
+    normalized = string.split(" ")
+    if len(normalized) == 1 and "," in normalized[0]:
+        value_as_set = set(normalized[0].split(','))
+    else:
+        value_as_set = set(normalized)
+    return value_as_set
+
+
+@pytest.mark.feature("ssh")
+@pytest.mark.parametrize("sshd_config_item", required_sshd_config)
+def test_sshd_has_required_config(sshd_config_item: str, shell: ShellRunner):
+
+    shell('ssh-keygen -A')
+    shell('systemctl daemon-reload')
+
+    result = shell(
+        "/usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True
+    )
+    assert result.returncode == 0, f"Expected return code 0, got {result.returncode}"
+
+    sshd_config = _create_list_of_tuples(result.stdout)
+
+    expected = _create_list_of_tuples(sshd_config_item)
+
+
+    assert all(option in sshd_config for option in expected), \
+            f"{expected} not found in sshd_config"
+
+
+    # found = any(trim_and_lower(sshd_config_item) in trim_and_lower(line) for line in config_content)
+    # assert found, f"Expected {sshd_config_item} in sshd config, but did not find it"
+
+
+# @pytest.mark.feature("ssh")
+# def test_sshd_parse_config(shell: ShellRunner):
+#     result = shell(
+#         "sudo -u root /usr/sbin/sshd -T", capture_output=True, ignore_exit_code=True
+#     )
+#     assert result.returncode == 0

--- a/tests-ng/util/run_cloud.sh
+++ b/tests-ng/util/run_cloud.sh
@@ -71,7 +71,7 @@ image_requirements = {
 cloud_provider = "$cloud"
 EOF
 
-echo "⚙️  seting up cloud resources via OpenTofu"
+echo "⚙️  setting up cloud resources via OpenTofu"
 (
 	cd "$tf_dir"
 	tofu apply --auto-approve


### PR DESCRIPTION
Convert test to assert desired properties are part of the sshd config.

Part of https://github.com/gardenlinux/gardenlinux/issues/3181