### PR TITLE
fix: specify full path for mkfs.ext2 command in build_ext2.sh

### DIFF
--- a/tests-ng/util/build_ext2.sh
+++ b/tests-ng/util/build_ext2.sh
@@ -23,4 +23,4 @@ mkdir "$tmpdir/dist"
 gzip -d < "$input" | tar -x -C "$tmpdir/dist"
 
 truncate -s 1G "$output"
-mkfs.ext2 -q -d "$tmpdir/dist" -L GL_TESTS "$output"
+/usr/sbin/mkfs.ext2 -q -d "$tmpdir/dist" -L GL_TESTS "$output"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
