### PR TITLE
build: add e2fsprogs to the container installation in build_runtime.sh

### DIFF
--- a/tests-ng/util/build_runtime.sh
+++ b/tests-ng/util/build_runtime.sh
@@ -16,7 +16,7 @@ if [ "$0" != /init ]; then
 	cat > "$tmpdir/Containerfile" <<-'EOF'
 	FROM debian:stable
 	RUN apt-get update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl e2fsprogs
 	EOF
 
 	podman build -q --iidfile "$tmpdir/image_id" "$tmpdir" > /dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
