### PR TITLE
fix: dracut move of /initrd failed

### DIFF
--- a/features/_pxe/image.pxe.tar.gz
+++ b/features/_pxe/image.pxe.tar.gz
@@ -27,7 +27,6 @@ echo "console=ttyS0 gl.live=1 gl.ovl=/:tmpfs" > cmdline
 touch tmp_initrd
 [[ ! -e "$chroot_dir/initrd" ]]
 touch "$chroot_dir/initrd"
-mount --bind tmp_initrd "$chroot_dir/initrd"
 [[ ! -e "$chroot_dir/root.squashfs" ]]
 touch "$chroot_dir/root.squashfs"
 mount --bind root.squashfs "$chroot_dir/root.squashfs"
@@ -50,8 +49,7 @@ chroot "$chroot_dir" env dracut \
 
 umount -l "$chroot_dir/proc"
 
-umount "$chroot_dir/initrd"
-rm "$chroot_dir/initrd"
+mv "$chroot_dir/initrd" tmp_initrd
 umount "$chroot_dir/root.squashfs"
 rm "$chroot_dir/root.squashfs"
 

--- a/features/_usi/image.esp.tar
+++ b/features/_usi/image.esp.tar
@@ -50,7 +50,6 @@ done
 initrd="$(mktemp)"
 
 touch "$rootfs/initrd"
-mount --bind "$initrd" "$rootfs/initrd"
 
 kernel="$(find "$rootfs/boot/" -name 'vmlinuz-*' | sort -V | tail -n 1)"
 
@@ -70,7 +69,7 @@ umount -l "$rootfs/proc"
 umount -R "$rootfs/dev"
 umount "$rootfs/tmp"
 
-umount "$rootfs/initrd"
+mv "$rootfs/initrd" "$initrd"
 
 case "$BUILDER_ARCH" in
 	amd64)


### PR DESCRIPTION
**What this PR does / why we need it**:
```
[.build/kvm-gardener_prod_trustedboot-arm64-1962.0-adec8673.esp.tar 2025-08-14 07:03:13] dracut[I]: *** Creating initramfs image file '/initrd.tmp' done ***
[.build/kvm-gardener_prod_trustedboot-arm64-1962.0-adec8673.esp.tar 2025-08-14 07:03:13] dracut[I]: *** Moving image file '/initrd.tmp' to '/initrd' ***
[.build/kvm-gardener_prod_trustedboot-arm64-1962.0-adec8673.esp.tar 2025-08-14 07:03:13] mv: cannot move '/initrd.tmp' to '/initrd': Device or resource busy
[.build/kvm-gardener_prod_trustedboot-arm64-1962.0-adec8673.esp.tar 2025-08-14 07:03:13] rm: cannot remove '/initrd': Device or resource busy
[.build/kvm-gardener_prod_trustedboot-arm64-1962.0-adec8673.esp.tar 2025-08-14 07:03:13] dracut[F]: Move of /initrd failed
completed in 101 seconds

make: *** [Makefile:90: .build/kvm-gardener_prod_trustedboot-arm64-1962.0-adec8673.esp.tar] Error 1
make: *** [Makefile:89: kvm-gardener_prod_trustedboot-arm64-build] Error 2
```

Failing because of https://github.com/dracut-ng/dracut-ng/commit/39a765debe212407cce28e6d3a84a65e4efc1c6e so we shouldn't use bind mounts anymore for the temporary initrd.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3292
