### PR TITLE
platform-test images: optionally authenticate to github because of rate limiting

### DIFF
--- a/.github/workflows/build_platform_test_images.yml
+++ b/.github/workflows/build_platform_test_images.yml
@@ -67,6 +67,7 @@ env:
   IMAGE_BASE: platform-test
   IMAGE_REGISTRY: ghcr.io/gardenlinux/gardenlinux
   PLATFORM_TEST_TAG: ${{ github.event_name == 'push' && 'nightly' || inputs.platform_test_tag }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   generate_matrix:
     name: Build platforms matrix

--- a/tests/images/Makefile
+++ b/tests/images/Makefile
@@ -93,7 +93,7 @@ pull-platform-test: pull-platform-test-base $(addprefix pull-platform-test-,$(PL
 # build-platform-test-base		Build the platform test base image
 build-platform-test-base:
 	$(call copy_files, platform-test-base)
-	$(call build_image, $(GL_REGISTRY), gardenlinux/platform-test-base, latest, platform-test-base, --build-arg GL_VERSION=nightly --pull=missing )
+	$(call build_image, $(GL_REGISTRY), gardenlinux/platform-test-base, latest, platform-test-base, --build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) --build-arg GL_VERSION=nightly --pull=missing )
 	$(call clean_files, platform-test-base)
 
 # build-platform-test			Build all platform test images
@@ -109,7 +109,7 @@ $(foreach platform,$(PLATFORMS),\
     build-platform-test-$(platform): ; \
 		$(call copy_files, platform-test/$(platform)) ; \
 		$(call pull_image, nightly, nightly) ; \
-		$(call build_image, $(GL_REGISTRY), gardenlinux/platform-test-$(platform), latest, platform-test/$(platform), --build-arg GL_VERSION=latest --pull=never ) ; \
+		$(call build_image, $(GL_REGISTRY), gardenlinux/platform-test-$(platform), latest, platform-test/$(platform), --build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) --build-arg GL_VERSION=latest --pull=never ) ; \
 		$(call clean_files, platform-test/$(platform)) \
   ) \
 )

--- a/tests/images/platform-test-base/Containerfile
+++ b/tests/images/platform-test-base/Containerfile
@@ -6,6 +6,8 @@ FROM ${GL_REGISTRY}/${GL_IMAGE}:${GL_VERSION}
 
 ENV PYTHON=python3.13
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features

--- a/tests/images/platform-test/ali/Containerfile
+++ b/tests/images/platform-test/ali/Containerfile
@@ -3,6 +3,8 @@ ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/aws/Containerfile
+++ b/tests/images/platform-test/aws/Containerfile
@@ -3,6 +3,8 @@ ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/azure/Containerfile
+++ b/tests/images/platform-test/azure/Containerfile
@@ -3,6 +3,8 @@ ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/firecracker/Containerfile
+++ b/tests/images/platform-test/firecracker/Containerfile
@@ -3,6 +3,8 @@ ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/gcp/Containerfile
+++ b/tests/images/platform-test/gcp/Containerfile
@@ -3,6 +3,8 @@ ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/kvm/Containerfile
+++ b/tests/images/platform-test/kvm/Containerfile
@@ -5,6 +5,8 @@ FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
 ARG TARGETARCH=amd64
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/openstack/Containerfile
+++ b/tests/images/platform-test/openstack/Containerfile
@@ -3,6 +3,8 @@ ARG GL_VERSION=nightly
 # use platform-test-base image
 FROM ghcr.io/gardenlinux/gardenlinux/platform-test-base:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 

--- a/tests/images/platform-test/tofu/Containerfile
+++ b/tests/images/platform-test/tofu/Containerfile
@@ -4,6 +4,8 @@ ARG GL_IMAGE=gardenlinux/platform-test-base
 ARG GL_VERSION=latest
 FROM ${GL_REGISTRY}/${GL_IMAGE}:${GL_VERSION}
 
+# optionally authenticate to github because of rate limiting
+ARG GITHUB_TOKEN
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
 
@@ -24,7 +26,7 @@ RUN git clone --depth=1 https://github.com/tofuutils/tofuenv.git ${TOFUENV_INSTA
 # providers.tf contains OpenTofu version
 COPY providers.tf ${TOFU_HOME}/providers.tf
 # install pinned OpenTofu version
-RUN cd ${TOFU_HOME} && tofuenv install latest-allowed && tofuenv list | head -1 | xargs tofuenv use
+RUN export TOFUENV_GITHUB_TOKEN="$GITHUB_TOKEN" && cd ${TOFU_HOME} && tofuenv install latest-allowed && tofuenv list | head -1 | xargs tofuenv use
 
 # install pinned providers (pinned in providers.tf and .terraform.lock.hcl)
 COPY .terraform.lock.hcl ${TOFU_HOME}/.terraform.lock.hcl


### PR DESCRIPTION
**What this PR does / why we need it**:

platform-test images: optionally authenticate to github because of rate limiting
Enable this for the tofu image build to fix #3277.

https://github.com/gardenlinux/gardenlinux/actions/runs/16966934803/job/48093420389 is a successful test build.

**Which issue(s) this PR fixes**:
Fixes #3277
