### PR TITLE
test: Allow expected users with home dir

### DIFF
--- a/tests-ng/test_users.py
+++ b/tests-ng/test_users.py
@@ -1,13 +1,14 @@
 import os
 import pwd
+from typing import Set
 import pytest
 import stat
 
-def test_service_accounts_have_nologin_shell(expected_users):
+def test_service_accounts_have_nologin_shell(expected_users: Set[str]):
     for entry in pwd.getpwall():
         if entry.pw_uid >= 1000:
             continue
-        if entry.pw_name in expected_users + ["root", "sync"]:
+        if entry.pw_name in expected_users + {"root", "sync"}:
             continue
         assert entry.pw_shell in [ "/usr/sbin/nologin", "/bin/false" ], f"User {entry.pw_name} has unexpected shell: {entry.pw_shell}"
 
@@ -17,7 +18,7 @@ def test_root_home_permissions():
     assert perm == 0o700, f"/root has incorrect permissions: {oct(perm)}"
 
 @pytest.mark.feature("not _dev")
-def test_no_extra_home_directories(expected_users):
+def test_no_extra_home_directories(expected_users: Set[str]):
     if os.path.islink("/home"):
         return
     entries = os.listdir("/home")

--- a/tests-ng/test_users.py
+++ b/tests-ng/test_users.py
@@ -8,7 +8,7 @@ def test_service_accounts_have_nologin_shell(expected_users: Set[str]):
     for entry in pwd.getpwall():
         if entry.pw_uid >= 1000:
             continue
-        if entry.pw_name in expected_users + {"root", "sync"}:
+        if entry.pw_name in expected_users | {"root", "sync"}:
             continue
         assert entry.pw_shell in [ "/usr/sbin/nologin", "/bin/false" ], f"User {entry.pw_name} has unexpected shell: {entry.pw_shell}"
 

--- a/tests-ng/test_users.py
+++ b/tests-ng/test_users.py
@@ -3,11 +3,11 @@ import pwd
 import pytest
 import stat
 
-def test_service_accounts_have_nologin_shell():
+def test_service_accounts_have_nologin_shell(expected_users):
     for entry in pwd.getpwall():
         if entry.pw_uid >= 1000:
             continue
-        if entry.pw_name in {"root", "sync"}:
+        if entry.pw_name in expected_users + ["root", "sync"]:
             continue
         assert entry.pw_shell in [ "/usr/sbin/nologin", "/bin/false" ], f"User {entry.pw_name} has unexpected shell: {entry.pw_shell}"
 


### PR DESCRIPTION
'expected users' are typically users created by configuration management, and they typically have a home dir which is expected and not a defect

Related to https://github.com/gardenlinux/gardenlinux/issues/3181