### PR TITLE
fix: configure 9p as mountTypesUnsupported for lima image

### DIFF
--- a/.github/workflows/lima_upload_oidc.yml
+++ b/.github/workflows/lima_upload_oidc.yml
@@ -99,6 +99,7 @@ jobs:
         containerd:
           system: false
           user: false
+        mountTypesUnsupported: [9p]
         EOF
         else
           cat <<EOF > gardenlinux-${VERSION}.yaml
@@ -114,6 +115,7 @@ jobs:
         containerd:
           system: false
           user: false
+        mountTypesUnsupported: [9p]
         EOF
         fi
 

--- a/features/lima/exec.config
+++ b/features/lima/exec.config
@@ -9,4 +9,6 @@ images:
 containerd:
   system: false
   user: false
+
+mountTypesUnsupported: [9p]
 EOF

--- a/features/lima/samples/gardenlinux-containerd.yaml
+++ b/features/lima/samples/gardenlinux-containerd.yaml
@@ -8,6 +8,7 @@ images:
 containerd:
   system: false
   user: false
+mountTypesUnsupported: [9p]
 
 provision:
 - mode: system

--- a/features/lima/samples/gardenlinux-rootless-podman.yaml
+++ b/features/lima/samples/gardenlinux-rootless-podman.yaml
@@ -8,6 +8,7 @@ images:
 containerd:
   system: false
   user: false
+mountTypesUnsupported: [9p]
 
 provision:
 - mode: system


### PR DESCRIPTION
This addresses an issue with failed systemd units in a Garden Linux lima guest.

This configuration is also done for Debian guests, so it should be fine for us to do the same.

See https://github.com/gardenlinux/gardenlinux/issues/3302 for more info.
