### PR TITLE
Fix docs for how to call python3 in bare container

### DIFF
--- a/docs/01_developers/bare_container.md
+++ b/docs/01_developers/bare_container.md
@@ -39,7 +39,7 @@ Their development is streamlined by the [unbase_oci](https://github.com/gardenli
   ```Dockerfile
   FROM ghcr.io/gardenlinux/gardenlinux/bare-python:nightly
   COPY hello.py /
-  CMD ["python", "/hello.py"]
+  CMD ["python3", "/hello.py"]
   ```
 
 ### bare-sapmachine


### PR DESCRIPTION
Fixes https://github.com/gardenlinux/gardenlinux/issues/3313

The existing docs create confusion, see the linked issue