### PR TITLE
Enhance test markers to include optional 'reasons' argument

### DIFF
--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -1,14 +1,12 @@
-## Markers
+### Markers
 
 Tests can be decorated with pytest markers to indicate certain limitations or properties of the test:
 
-`@pytest.mark.booted`: This test can only be run in a booted system, not in a chroot test.
+`@pytest.mark.booted(reason="Some reason, this is optional")`: This test can only be run in a booted system, not in a chroot test. Use the optional `reason` argument to document why this is needed, in cases where this is not really obvious.
 
+`@pytest.mark.modify(reason="Some reason, this is optional")`: This test modifies the underlying system, like starting services, installing software or creating files. Use the optional `reason` argument to document why this is needed, in cases where this is not really obvious.
 
-`@pytest.mark.modify`: This test modifies the underlying system, like starting services, installing software or creating files.
-
-`@pytest.mark.root`: This test is run as the root user, not as an unprivileged user.
-
+`@pytest.mark.root(reason="Some reason, this is optional")`: This test is run as the root user, not as an unprivileged user. Use the optional `reason` argument to document why this is needed, in cases where this is not really obvious.
 
 `@pytest.mark.feature("a and not b")`: This test is only run if the boolean condition is true. Use this to limit feature-specific tests.
 

--- a/tests-ng/plugins/booted.py
+++ b/tests-ng/plugins/booted.py
@@ -20,10 +20,16 @@ def pytest_configure(config: pytest.Config):
     global system_booted
     system_booted = config.getoption("--system-booted")
 
-    config.addinivalue_line("markers", "booted: mark test to run only on a booted target, i.e. not in a container or chroot")
+    config.addinivalue_line("markers", "booted(reason=None): mark test to run only on a booted target, i.e. not in a container or chroot. Optionally provide a reason why mutation is required.")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
     for item in items:
-        if item.get_closest_marker("booted") and not system_booted:
-            item.add_marker(pytest.mark.skip(reason="not running on a booted system"))
+        booted_marker = item.get_closest_marker("booted")
+        if booted_marker and not system_booted:
+
+            reason = booted_marker.kwargs.get("reason")
+            skip_msg = "not running on a booted system"
+            if reason:
+                skip_msg += f" (reason: {reason})"
+            item.add_marker(pytest.mark.skip(skip_msg))

--- a/tests-ng/plugins/booted.py
+++ b/tests-ng/plugins/booted.py
@@ -20,7 +20,7 @@ def pytest_configure(config: pytest.Config):
     global system_booted
     system_booted = config.getoption("--system-booted")
 
-    config.addinivalue_line("markers", "booted(reason=None): mark test to run only on a booted target, i.e. not in a container or chroot. Optionally provide a reason why mutation is required.")
+    config.addinivalue_line("markers", "booted(reason=None): mark test to run only on a booted target, i.e. not in a container or chroot. Optionally provide a reason why system must be booted.")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):

--- a/tests-ng/plugins/modify.py
+++ b/tests-ng/plugins/modify.py
@@ -6,7 +6,6 @@ run_mutating_tests = False
 def allow_system_modifications() -> bool:
     return run_mutating_tests
 
-
 def pytest_addoption(parser: pytest.Parser):
     parser.addoption(
         "--allow-system-modifications",
@@ -14,15 +13,21 @@ def pytest_addoption(parser: pytest.Parser):
         help="Run tests that mutate system state. Disabling this is useful if running tests on a long-running system."
     )
 
-
 def pytest_configure(config: pytest.Config):
     global run_mutating_tests
     run_mutating_tests = config.getoption("--allow-system-modifications")
 
-    config.addinivalue_line("markers", "modify: this test mutates system state")
-
+    config.addinivalue_line(
+        "markers",
+        "modify(reason=None): this test mutates system state. Optionally provide a reason why mutation is required."
+    )
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
     for item in items:
-        if item.get_closest_marker("modify") and not run_mutating_tests:
-            item.add_marker(pytest.mark.skip(reason="skipping tests that mutate system state"))
+        modify_marker = item.get_closest_marker("modify")
+        if modify_marker and not run_mutating_tests:
+            reason = modify_marker.kwargs.get("reason")
+            skip_msg = "skipping tests that mutate system state"
+            if reason:
+                skip_msg += f" (reason: {reason})"
+            pytest.skip(skip_msg)

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -39,7 +39,7 @@ def test_fhs(shell: ShellRunner):
     for dir in sorted(expected_dirs):
         assert os.path.isdir(f"/{dir}"), f"expected FHS directory /{dir} does not exist"
 
-@pytest.mark.booted(reason="Only useful in a booted system because chroot does not 'boot'")
+@pytest.mark.booted(reason="We can only measure startup time if we actually boot the system")
 @pytest.mark.performance_metric
 @pytest.mark.feature("server and not azure") # server installs systemd and azure has notoriously bad startup times
 def test_startup_time(systemd: Systemd):

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -39,7 +39,7 @@ def test_fhs(shell: ShellRunner):
     for dir in sorted(expected_dirs):
         assert os.path.isdir(f"/{dir}"), f"expected FHS directory /{dir} does not exist"
 
-@pytest.mark.booted
+@pytest.mark.booted(reason="Only useful in a booted system because chroot does not 'boot'")
 @pytest.mark.performance_metric
 @pytest.mark.feature("server and not azure") # server installs systemd and azure has notoriously bad startup times
 def test_startup_time(systemd: Systemd):

--- a/tests-ng/test_ssh.py
+++ b/tests-ng/test_ssh.py
@@ -49,8 +49,8 @@ required_sshd_config = {
 }
 
 
-@pytest.mark.booted
-@pytest.mark.root
+@pytest.mark.booted(reason="Calling sshd -T requires a booted system")
+@pytest.mark.root(reason="Calling sshd -T requires root")
 @pytest.mark.feature("ssh")
 @pytest.mark.parametrize("sshd_config_item", required_sshd_config)
 def test_sshd_has_required_config(sshd_config_item: str, sshd: Sshd):
@@ -82,9 +82,9 @@ def test_users_have_no_authorized_keys():
             )
 
 
-@pytest.mark.booted
-@pytest.mark.modify
-@pytest.mark.root
+@pytest.mark.booted(reason="Starting the unit requires a booted system")
+@pytest.mark.modify(reason="Starting the unit modifies the system state")
+@pytest.mark.root(reason="Starting the unit requires root")
 @pytest.mark.feature("ssh")
 def test_ssh_unit_running(systemd: Systemd):
     systemd.start_unit('ssh')


### PR DESCRIPTION
This PR allows us to better keep track of the reason for certain markers. This field is optional, so for obvious cases it can be left empty, but I think in most cases it is actually useful to document the reasoning for setting a certain marker.

Fixes https://github.com/gardenlinux/gardenlinux/issues/3319
