### PR TITLE
Tests: Implement 'no failed units' testcase

### DIFF
--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -8,6 +8,6 @@ Tests can be decorated with pytest markers to indicate certain limitations or pr
 
 `@pytest.mark.root(reason="Some reason, this is optional")`: This test is run as the root user, not as an unprivileged user. Use the optional `reason` argument to document why this is needed, in cases where this is not really obvious.
 
-`@pytest.mark.feature("a and not b")`: This test is only run if the boolean condition is true. Use this to limit feature-specific tests.
+`@pytest.mark.feature("a and not b", reason="Some reason, this is optional")`: This test is only run if the boolean condition is true. Use this to limit feature-specific tests. Use the optional `reason` argument to document why this is needed, in cases where this is not really obvious.
 
 `@pytest.mark.performance_metric`: This is a performance metric test that can be skipped when running under emulation.

--- a/tests-ng/plugins/features.py
+++ b/tests-ng/plugins/features.py
@@ -20,12 +20,18 @@ def check_feature_condition(condition: str):
 
 
 def pytest_configure(config: pytest.Config):
-    config.addinivalue_line("markers", "feature(condition): mark test to run only if feature set condition is met")
-
+    config.addinivalue_line(
+        "markers",
+        "feature(condition, reason=None): mark test to run only if feature set condition is met. Optionally provide a reason."
+    )
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
     for item in items:
         for mark in item.iter_markers(name="feature"):
             condition = mark.args[0]
+            reason = mark.kwargs.get("reason")
+            skip_msg = f"excluded by feature condition: {condition}"
+            if reason:
+                skip_msg += f" (reason: {reason})"
             if not check_feature_condition(condition):
-                item.add_marker(pytest.mark.skip(reason=f"excluded by feature condition: {condition}"))
+                item.add_marker(pytest.mark.skip(reason=skip_msg))

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -58,7 +58,7 @@ def test_startup_time(systemd: Systemd):
         f"(tolerated {tolerated_userspace}s)"
     )
 
-@pytest.mark.feature("not gcp and not metal and not openstack", reason='Does not work on gcp, metal and openstack features for various reasons, for example because it cannot communicate with external backends.')
+@pytest.mark.feature("not gcp and not metal and not openstack", reason='Not working on various features, for example because the vm cannot communicate with external backends.')
 @pytest.mark.root(reason="Needed for journalctl which is only needed when the test fails, but still very useful for understanding test failures")
 @pytest.mark.booted(reason="Systemctl needs a booted system")
 def test_no_failed_units(systemd: Systemd, shell: ShellRunner):

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -58,8 +58,8 @@ def test_startup_time(systemd: Systemd):
         f"(tolerated {tolerated_userspace}s)"
     )
 
-@pytest.mark.feature("not gcp and not metal and not openstack", reason='Not working on various features, for example because the vm cannot communicate with external backends.')
-@pytest.mark.root(reason="Needed for journalctl which is only needed when the test fails, but still very useful for understanding test failures")
+@pytest.mark.feature("not gcp and not metal and not openstack", reason='Not compatible, usually because of missing external backends')
+@pytest.mark.root(reason="Required for journalctl in case of errors")
 @pytest.mark.booted(reason="Systemctl needs a booted system")
 def test_no_failed_units(systemd: Systemd, shell: ShellRunner):
     units = systemd.list_units()

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -58,6 +58,7 @@ def test_startup_time(systemd: Systemd):
         f"(tolerated {tolerated_userspace}s)"
     )
 
+@pytest.mark.feature("not gcp and not metal and not openstack", reason='Does not work on gcp, metal and openstack features for various reasons, for example because it cannot communicate with external backends.')
 @pytest.mark.root(reason="Needed for journalctl which is only needed when the test fails, but still very useful for understanding test failures")
 @pytest.mark.booted(reason="Systemctl needs a booted system")
 def test_no_failed_units(systemd: Systemd, shell: ShellRunner):

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -57,3 +57,14 @@ def test_startup_time(systemd: Systemd):
         f"Userspace startup too slow: {userspace:.1f}s "
         f"(tolerated {tolerated_userspace}s)"
     )
+
+@pytest.mark.root(reason="Needed for journalctl which is only needed when the test fails, but still very useful for understanding test failures")
+@pytest.mark.booted(reason="Systemctl needs a booted system")
+def test_no_failed_units(systemd: Systemd, shell: ShellRunner):
+    units = systemd.list_units()
+    assert len(units) > 1, f"Failed to load systemd units: {units}"
+    failed_units = [u for u in units if u.load == 'loaded' and u.active != 'active']
+    for u in failed_units:
+        print(f'FAILED UNIT: {u}')
+        shell(f"journalctl --unit {u.unit}")
+    assert not failed_units, f"{len(failed_units)} systemd units failed to load"


### PR DESCRIPTION
Excludes the tests on features where the machine does not properly boot up in qemu for various reasons, such as backend systems that are required but not available 

This is okay because those features are not made for running in a plain qemu vm

Adds an optional 'reason' field to the 'features' fixture