### PR TITLE
Test that kernel is not tainted

### DIFF
--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -57,3 +57,9 @@ def test_startup_time(systemd: Systemd):
         f"Userspace startup too slow: {userspace:.1f}s "
         f"(tolerated {tolerated_userspace}s)"
     )
+
+@pytest.mark.booted(reason="Kernel test makes sense only on booted system")
+def test_kernel_not_tainted():
+    with open("/proc/sys/kernel/tainted", "r") as f:
+        tainted = f.read().strip()
+    assert tainted == "0", f"Kernel is tainted (value: {tainted})"


### PR DESCRIPTION
This would have helped us identify the issue fixed here https://github.com/gardenlinux/package-linux/commit/b52e5a9688c80c016ac13cb04702bf4f8103c9d4

This test case is new, suggested by @5kt based on issues with booting the kernel in secure boot mode