### PR TITLE
Fix UEFI related keys for OpenTofu Azure

### DIFF
--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -162,12 +162,12 @@ resource "azurerm_shared_image_version" "shared_image_version" {
       ]
       additional_signatures {
         db {
-          key_type = "x509"
-          certificate_data = filebase64("cert/secureboot.db.der")
+          type = "x509"
+          certificate_base64 = filebase64("cert/secureboot.db.der")
         }
         kek {
-          key_type = "x509"
-          certificate_data = filebase64("cert/secureboot.kek.der")
+          type = "x509"
+          certificate_base64 = filebase64("cert/secureboot.kek.der")
         }
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes UEFI related keys for OpenTofu Azure v4.41.0 to reflect latest [proposed upstream changes](https://github.com/hashicorp/terraform-provider-azurerm/pull/28076).