### PR TITLE
Fix UEFI certificate data for OpenTofu Azure

### DIFF
--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -163,11 +163,11 @@ resource "azurerm_shared_image_version" "shared_image_version" {
       additional_signatures {
         db {
           type = "x509"
-          certificate_base64 = filebase64("cert/secureboot.db.der")
+          certificate_base64 = [ filebase64("cert/secureboot.db.der") ]
         }
         kek {
           type = "x509"
-          certificate_base64 = filebase64("cert/secureboot.kek.der")
+          certificate_base64 = [ filebase64("cert/secureboot.kek.der") ]
         }
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the base64-encoded UEFI certificate data for OpenTofu Azure.