### PR TITLE
Revert UEFI keys for OpenTofu Azure related changes

### DIFF
--- a/tests/images/platform-test/tofu/Containerfile
+++ b/tests/images/platform-test/tofu/Containerfile
@@ -32,10 +32,10 @@ RUN export TOFUENV_GITHUB_TOKEN="$GITHUB_TOKEN" && cd ${TOFU_HOME} && tofuenv in
 COPY .terraform.lock.hcl ${TOFU_HOME}/.terraform.lock.hcl
 RUN cd ${TOFU_HOME} && tofu init -upgrade && tofu providers mirror ${TOFU_HOME}/.terraform
 
-# install provider from development fork
+# install providers from development forks
 COPY .terraformrc ${TOFU_HOME}/.terraformrc
-RUN curl -LO --create-dirs --output-dir ${TOFU_PROVIDERS_CUSTOM} https://github.com/gardenlinux/terraform-provider-azurerm/releases/download/v4.41.0-post1-secureboot1/terraform-provider-azurerm \
-    && echo "d0724b2b33270dbb0e7946a4c125e78b5dd0f34697b74a08c04a1c455764262e ${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" >${TOFU_PROVIDERS_CUSTOM}/checksum.txt \
+RUN curl -LO --create-dirs --output-dir ${TOFU_PROVIDERS_CUSTOM} https://github.com/gardenlinux/terraform-provider-azurerm/releases/download/v4.20.1-alpha1-secureboot1/terraform-provider-azurerm \
+    && echo "526ae7f43ead2895b037f460f4d0e1f3b66d77f4ff436b3a5a68fad2e5cb3b30 ${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" >${TOFU_PROVIDERS_CUSTOM}/checksum.txt \
     && sha256sum -c ${TOFU_PROVIDERS_CUSTOM}/checksum.txt \
     && chmod +x ${TOFU_PROVIDERS_CUSTOM}/terraform-provider-*
 

--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -162,12 +162,12 @@ resource "azurerm_shared_image_version" "shared_image_version" {
       ]
       additional_signatures {
         db {
-          type = "x509"
-          certificate_base64 = filebase64("cert/secureboot.db.der")
+          key_type = "x509"
+          certificate_data = filebase64("cert/secureboot.db.der")
         }
         kek {
-          type = "x509"
-          certificate_base64 = filebase64("cert/secureboot.kek.der")
+          key_type = "x509"
+          certificate_data = filebase64("cert/secureboot.kek.der")
         }
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts commit 1b2cc5c4422fe966b0e3fcf5e1d3eb26e2c2b455 and 6bcdf6ef9d5f6fc9f6676331e8384f819173972d. As the underlying bumped OpenTofu provider for Azure currently causes issues for `nighlty` builds. This is an alternative PR for #3332.