### PR TITLE
docs: add Garden Linux Bare Container documentation

### DIFF
--- a/docs/01_developers/bare_container.md
+++ b/docs/01_developers/bare_container.md
@@ -34,7 +34,7 @@ Their development is streamlined by the [unbase_oci](https://github.com/gardenli
   - Contains the Python3 interpreter and necessary libraries.
   - Ideal for Python3-based applications.
   - Designed for improved security and efficiency.
-  - Note: The bare-Python3 container does not include pip or other Python3 package managers by default. You may need to install dependencies in a builder container and copy them into this bare container for runtime usage. This ensures Python3 scripts can run with required packages while keeping the container minimal.
+
 
 - **Container Link**: [bare-Python3](https://github.com/orgs/gardenlinux/packages/container/package/gardenlinux%2Fbare-Python3)
 - **Usage in Dockerfile**:


### PR DESCRIPTION
This PR introduces a new documentation file explaining the Garden Linux Bare Container images.
Highlights:
- Added an overview of all bare container variants:
|----bare-libc
|----bare-python3 (with example for installing runtime dependencies using requirements.txt)
|----bare-sapmachine
|----bare-nodejs
- Explained the role of the unbase_oci tool in creating minimal, distroless-like images.
- Provided links to container packages and their usage in Dockerfiles.
- Added guidance on extending the bare-python3 image with pip-installed dependencies.

This documentation aims to help developers understand the purpose, usage, and security benefits of the Garden Linux bare container images.
Fixes #3313