### PR TITLE
Define a created OpenTofu Azure NIC as a explicit dependency for the VM

### DIFF
--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -260,6 +260,9 @@ resource "azurerm_ssh_public_key" "ssh_public_key" {
 }
 
 resource "azurerm_linux_virtual_machine" "instance" {
+  # Ensure we mark NIC as dependency for VM
+  depends_on = [azurerm_network_interface.nic]
+
   name                  = local.instance_name
   location              = azurerm_resource_group.rg.location
   resource_group_name   = azurerm_resource_group.rg.name


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR defines `azurerm_network_interface.nic` to be a dependency for `azurerm_linux_virtual_machine.instance` in OpenTofu Azure platform tests. This results in a dependency graph where the attached VM of the NIC is deleted first and the NIC afterwards. This should resolve the error message `NicInUse [...] is used by existing resource`.

**Which issue(s) this PR fixes**:
Fixes #