### PR TITLE
Revert "Define a created OpenTofu Azure NIC as a explicit dependency for the VM"

### DIFF
--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -260,9 +260,6 @@ resource "azurerm_ssh_public_key" "ssh_public_key" {
 }
 
 resource "azurerm_linux_virtual_machine" "instance" {
-  # Ensure we mark NIC as dependency for VM
-  depends_on = [azurerm_network_interface.nic]
-
   name                  = local.instance_name
   location              = azurerm_resource_group.rg.location
   resource_group_name   = azurerm_resource_group.rg.name


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts PR with commit 60baf2303167a6018704d50aa46366e2268b2ee7. The `depends_on` definition has already been added and seems to be not correctly detecting dependencies.