### PR TITLE
test: migrate test_orphan to new testing framework.

### DIFF
--- a/tests-ng/plugins/apt.py
+++ b/tests-ng/plugins/apt.py
@@ -19,6 +19,26 @@ class Apt:
                     repos.add(line.split()[1])
         return list(repos)
 
+    def update(self) -> bool:
+        """
+        Updates the repository cache
+        """
+        result = self._shell(f"apt-get update", capture_output=True, ignore_exit_code=True)
+        if result.returncode != 0:
+            print(result.stderr)
+
+        return result.returncode == 0
+
+    def install(self, package_name: str) -> bool:
+        """
+        Installs the designated package package_name
+        """
+        result = self._shell(f"DEBIAN_FRONTEND=noninteractive apt-get install -y {package_name}", capture_output=True, ignore_exit_code=True)
+        if result.returncode != 0:
+            print(result.stderr)
+
+        return result.returncode == 0
+
 @pytest.fixture
 def apt(shell: ShellRunner) -> Apt:
     return Apt(shell)

--- a/tests-ng/plugins/deborphan.py
+++ b/tests-ng/plugins/deborphan.py
@@ -1,0 +1,32 @@
+import pytest
+from .shell import ShellRunner
+
+class DebOrphan:
+    """
+    Defines a wrapper around the deborphan command.
+    """
+    def __init__(self, shell: ShellRunner):
+        self._shell = shell
+
+    def save_manually_installed_packages(self, savefile: str = "/var/lib/deborphan/keep") -> bool:
+        result = self._shell(f"DEBIAN_FRONTEND=noninteractive apt-mark showmanual > {savefile}", ignore_exit_code=True)
+        if result.returncode != 0:
+            print(result.stderr)
+
+        return result.returncode == 0
+    
+    def find_orphans(self) -> list[str]:
+        """
+        Find orphaned packages
+        """
+        result = self._shell("deborphan -an --no-show-section", capture_output=True, ignore_exit_code=True)
+
+        if result.returncode != 0:
+            raise ValueError(f"deborphan failed: {result.stderr}")
+
+        # Get orphaned packages
+        return list(filter(None, result.stdout.split('\n')))
+
+@pytest.fixture
+def deborphan(shell: ShellRunner) -> DebOrphan:
+    return DebOrphan(shell)

--- a/tests-ng/test_orphaned.py
+++ b/tests-ng/test_orphaned.py
@@ -1,0 +1,18 @@
+import pytest
+
+from plugins.apt import Apt
+from plugins.deborphan import DebOrphan
+
+@pytest.mark.root
+@pytest.mark.feature("not booted")
+def test_for_no_orphaned_files(apt: Apt, deborphan: DebOrphan):
+    """
+    Check for orphaned files from package installations.
+    """
+    assert apt.update() == True, f"updating package cache failed"
+    assert apt.install("deborphan") == True, f"installing deborphan failed"
+    assert deborphan.save_manually_installed_packages() == True, f"saving manually installed files failed"
+
+    pkgs = deborphan.find_orphans()
+
+    assert len(pkgs) == 0, f"Found {len(pkgs)} orphaned packages"

--- a/tests-ng/util/run_chroot.sh
+++ b/tests-ng/util/run_chroot.sh
@@ -52,6 +52,7 @@ tar --extract --xattrs --xattrs-include 'security.*' --directory "$tmpdir/chroot
 mount --rbind --make-rprivate /proc "$tmpdir/chroot/proc"
 mount --rbind --make-rprivate /sys "$tmpdir/chroot/sys"
 mount --rbind --make-rprivate /dev "$tmpdir/chroot/dev"
+mount --rbind --make-rprivate /etc/resolv.conf "$tmpdir/chroot/etc/resolv.conf"
 
 echo "⚙️  setting up test framework"
 

--- a/tests/helper/tests/orphaned.py
+++ b/tests/helper/tests/orphaned.py
@@ -2,7 +2,6 @@ from helper.utils import AptUpdate
 from helper.utils import execute_remote_command
 from helper.utils import install_package_deb
 
-
 def orphaned(client):
     """ Test for orphaned files """
     # Update repo info and install package(s)


### PR DESCRIPTION
Migrate [test_orphaned.py](https://github.com/gardenlinux/gardenlinux/blob/main/features/base/test/test_orphaned.py) to new testing framework.

**Which issue(s) this PR fixes**:
Refs #3181 

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested

**Special notes for your reviewer**:
The chroot environment had not yet a proper `resolv.conf`, which made the apt-update fail. This PR adds to `run_chroot.sh` a mount that binds the `/etc/resolv.conf` from the container to the chroot environment.

A negative test could not be added yet, as from [Debian's list of orphaned packages](https://www.debian.org/devel/wnpp/orphaned_byage) I could not pick a package find a package. Maybe we need to provide a package as offline file?

**Release note**:
NONE
