### PR TITLE
fix(start-vm): specifically use machine type q35

### DIFF
--- a/bin/start-vm
+++ b/bin/start-vm
@@ -597,6 +597,7 @@ qemu_opt_cpu () {
                 if [ -w "/dev/kvm" ]; then
                     QEMU_OPTS+=("-enable-kvm" "-cpu host" "-machine q35,smm=on")
                 else
+                    QEMU_OPTS+=("-machine q35,smm=on")
                     echo -e "WARNING: Can not use KVM acceleration. Please see:\n https://github.com/gardenlinux/gardenlinux/tree/main/bin#start-vm \n\n"
                 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the _start-vm_ script in order to test things locally on a amd64 machine with no KVM acceleration the machine type should be explicitly set to q35 as the default, i440fx, can't do secure boot, for example.

**Which issue(s) this PR fixes**:
Fixes #