### PR TITLE
Add the what-is-python package to the python feature.

### DIFF
--- a/features/python/pkg.include
+++ b/features/python/pkg.include
@@ -1,1 +1,2 @@
 python3
+python-is-python3


### PR DESCRIPTION
In PR we add the package [what-is-python](https://tracker.debian.org/pkg/what-is-python) that contains a symlink from python to python3. By default, we will install the binary package `python-is-python3` to the Python feature. You can invoke the Python binary via `/usr/bin/python` or just invoking `python`. 

Related to: #3313 