### PR TITLE
fix: in manual_gh_release_page.yml put flavors_matrix into own step - fetch full history to find commit in release_note.py

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0
         with:
           submodules: true
+          fetch-depth: 0
       - name: install dependencies for generate_release_note.py script
         run: sudo apt-get update && sudo apt-get install -qy --no-install-recommends python3-boto3
       - name: Install python-gardenlinux-lib


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up of https://github.com/gardenlinux/gardenlinux/pull/3407 that fixes manual_gh_release_page.yml:
  - fetch full history to find commit in release_note.py


**Which issue(s) this PR fixes**:
This fixes #3406 and it's wrong checkout of files.
