### PR TITLE
fix: Make 'no failed units' test more resilient by waiting for the system to be booted

### DIFF
--- a/tests-ng/plugins/systemd.py
+++ b/tests-ng/plugins/systemd.py
@@ -53,7 +53,6 @@ class Systemd:
             pytest.skip("starting units is only supported when system state modifications are allowed")
         self._shell(f"systemctl start {unit_name}")
 
-
     def list_units(self) -> list[SystemdUnit]:
         result = self._shell(f"{self._systemctl}", capture_output=True, ignore_exit_code=True)
         units = []
@@ -61,6 +60,19 @@ class Systemd:
             parts = line.split()
             units.append(SystemdUnit(parts[0], parts[1], parts[2], parts[3]))
         return units
+
+    def list_failed_units(self) -> list[SystemdUnit]:
+        result = self._shell(f"{self._systemctl} --failed", capture_output=True, ignore_exit_code=True)
+        units = []
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            units.append(SystemdUnit(parts[0], parts[1], parts[2], parts[3]))
+        return units
+
+    def wait_is_system_running(self) -> bool:
+        result = self._shell("{self._systemctl} is-system-running --wait", capture_output=True, ignore_exit_code=True)
+        return result.stdout.strip() == "running"
+
 
 @pytest.fixture
 def systemd(shell: ShellRunner):

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -68,10 +68,9 @@ def test_kernel_not_tainted():
 @pytest.mark.root(reason="Required for journalctl in case of errors")
 @pytest.mark.booted(reason="Systemctl needs a booted system")
 def test_no_failed_units(systemd: Systemd, shell: ShellRunner):
-    units = systemd.list_units()
-    assert len(units) > 1, f"Failed to load systemd units: {units}"
-    failed_units = [u for u in units if u.load == 'loaded' and u.active != 'active']
-    for u in failed_units:
+    assert systemd.wait_is_system_running(), "System failed to boot properly"
+    failed_systemd_units = systemd.list_failed_units()
+    for u in failed_systemd_units:
         print(f'FAILED UNIT: {u}')
         shell(f"journalctl --unit {u.unit}")
-    assert not failed_units, f"{len(failed_units)} systemd units failed to load"
+    assert not failed_systemd_units, f"{len(failed_systemd_units)} systemd units failed to load"


### PR DESCRIPTION
**What this PR does / why we need it**:

This should fix 'random' test failures by waiting for systemd to report the system is 'running', and by using systemd's check for failed units.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3414

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
