### PR TITLE
fix: test-ng: containerd needs root to start

### DIFF
--- a/tests-ng/test_containers.py
+++ b/tests-ng/test_containers.py
@@ -16,6 +16,7 @@ def container_image_setup(uri: str, ctr: CtrRunner):
 
 
 @pytest.mark.booted(reason="Container tests require systemd")
+@pytest.mark.root(reason="Needs to start containerd")
 @pytest.mark.parametrize("uri", TEST_IMAGES)
 def test_basic_container_functionality(container_image_setup, uri: str, ctr: CtrRunner):
     out = ctr.run(uri, "uname", capture_output=True, ignore_exit_code=True)


### PR DESCRIPTION
**What this PR does / why we need it**:

Without `@pytest.mark.root` I get the following errors:

```
❯ ./test-ng .build/aws-gardener_prod-amd64-today-local.raw

_____________ ERROR at setup of test_basic_container_functionality[ghcr.io/gardenlinux/gardenlinux:latest] _____________
plugins/containerd.py:37: in ctr
    return CtrRunner(shell, systemd)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
plugins/containerd.py:15: in __init__
    systemd.start_unit("containerd")
plugins/systemd.py:54: in start_unit
    self._shell(f"systemctl start {unit_name}")
plugins/shell.py:27: in __call__
    raise RuntimeError(f"command {cmd} failed with exit code {result.returncode}")
E   RuntimeError: command systemctl start containerd failed with exit code 1
------------------------------------------------ Captured stderr setup -------------------------------------------------
Failed to start containerd.service: Interactive authentication required.
See system logs and 'systemctl status containerd.service' for details.
________________ ERROR at setup of test_basic_container_functionality[docker.io/library/debian:latest] _________________
plugins/containerd.py:37: in ctr
    return CtrRunner(shell, systemd)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
plugins/containerd.py:15: in __init__
    systemd.start_unit("containerd")
plugins/systemd.py:54: in start_unit
    self._shell(f"systemctl start {unit_name}")
plugins/shell.py:27: in __call__
    raise RuntimeError(f"command {cmd} failed with exit code {result.returncode}")
E   RuntimeError: command systemctl start containerd failed with exit code 1
------------------------------------------------ Captured stderr setup -------------------------------------------------
Failed to start containerd.service: Interactive authentication required.
See system logs and 'systemctl status containerd.service' for details.
______________ ERROR at setup of test_basic_container_functionality[public.ecr.aws/debian/debian:latest] _______________
plugins/containerd.py:37: in ctr
    return CtrRunner(shell, systemd)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
plugins/containerd.py:15: in __init__
    systemd.start_unit("containerd")
plugins/systemd.py:54: in start_unit
    self._shell(f"systemctl start {unit_name}")
plugins/shell.py:27: in __call__
    raise RuntimeError(f"command {cmd} failed with exit code {result.returncode}")
E   RuntimeError: command systemctl start containerd failed with exit code 1
```
