### PR TITLE
Limit containerd test to features that include it

### DIFF
--- a/tests-ng/test_containers.py
+++ b/tests-ng/test_containers.py
@@ -17,6 +17,7 @@ def container_image_setup(uri: str, ctr: CtrRunner):
 
 @pytest.mark.booted(reason="Container tests require systemd")
 @pytest.mark.root(reason="Needs to start containerd")
+@pytest.mark.feature("gardener or chost or _debug", reason="containerd is not installed")
 @pytest.mark.parametrize("uri", TEST_IMAGES)
 def test_basic_container_functionality(container_image_setup, uri: str, ctr: CtrRunner):
     out = ctr.run(uri, "uname", capture_output=True, ignore_exit_code=True)


### PR DESCRIPTION
Only runs the tests on images with appropriate features to avoid failed tests on images without containerd

Fixes https://github.com/gardenlinux/gardenlinux/issues/3433
