### PR TITLE
Make containerd pull and rm quiet

### DIFF
--- a/tests-ng/plugins/containerd.py
+++ b/tests-ng/plugins/containerd.py
@@ -16,12 +16,12 @@ class CtrRunner:
 
     def pull_image(self, uri, capture_output=False, ignore_exit_code=False):
         validators.url(uri)
-        command = f"ctr image pull {uri}"
+        command = f"ctr --quiet image pull {uri}"
         return self.shell(command, capture_output=capture_output, ignore_exit_code=ignore_exit_code)
 
     def remove_image(self, uri, capture_output=False, ignore_exit_code=False):
         validators.url(uri)
-        command = f"ctr image rm {uri}"
+        command = f"ctr --quiet image rm {uri}"
         return self.shell(command, capture_output=capture_output, ignore_exit_code=ignore_exit_code)
 
     def run(self, uri, cmd, capture_output=False, ignore_exit_code=False):


### PR DESCRIPTION
Get rid of this noise in the test logs:
<img width="1296" height="902" alt="Screenshot 2025-09-11 at 11 11 38" src="https://github.com/user-attachments/assets/5fbf88fd-7b08-4241-91f1-ee01cea6d797" />

<img width="1247" height="839" alt="Screenshot 2025-09-11 at 11 11 12" src="https://github.com/user-attachments/assets/347fb3b8-ac8e-43f4-bd85-6ca697fe856f" />

Run is intentionally not run with the quiet flag as I suspect its output might be useful at times.