### PR TITLE
Refactor containerd test to make it easier to read

### DIFF
--- a/tests-ng/plugins/containerd.py
+++ b/tests-ng/plugins/containerd.py
@@ -35,3 +35,11 @@ class CtrRunner:
 @pytest.fixture
 def ctr(shell: ShellRunner, systemd: Systemd):
     return CtrRunner(shell, systemd)
+
+@pytest.fixture
+def container_image_setup(uri: str, ctr: CtrRunner):
+    # capture output to avoid it cluttering the test logs
+    # ctr is very verbose when pulling an image
+    ctr.pull_image(uri, capture_output=True)
+    yield
+    ctr.remove_image(uri, capture_output=True)

--- a/tests-ng/test_containers.py
+++ b/tests-ng/test_containers.py
@@ -7,14 +7,6 @@ TEST_IMAGES = [
     "public.ecr.aws/debian/debian:latest",    # AWS ECR, https://gallery.ecr.aws/debian/debian
 ]
 
-
-@pytest.fixture
-def container_image_setup(uri: str, ctr: CtrRunner):
-    ctr.pull_image(uri)
-    yield
-    ctr.remove_image(uri)
-
-
 @pytest.mark.booted(reason="Container tests require systemd")
 @pytest.mark.root(reason="Needs to start containerd")
 @pytest.mark.feature("gardener or chost or _debug", reason="containerd is not installed")


### PR DESCRIPTION
move container_image_setup fixture to plugins and capture output to unclutter the logs

here is what we have in the logs before this pr:

<img width="1296" height="902" alt="Screenshot 2025-09-11 at 11 11 38" src="https://github.com/user-attachments/assets/123c69f3-1ef3-41b9-a0ba-8979fba0a9d0" />

<img width="1247" height="839" alt="Screenshot 2025-09-11 at 11 11 12" src="https://github.com/user-attachments/assets/9289ca48-39ff-4fbd-bfc8-024138887d70" />
