### PR TITLE
fix: platform-test: lifecycle rule for azure public IP to make sure

### DIFF
--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -202,6 +202,10 @@ resource "azurerm_public_ip" "pip" {
   # allocation_method   = "Dynamic"
   allocation_method = "Static"
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = local.labels
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a lifecycle rule for azure public IP to make sure destruction works.

**Which issue(s) this PR fixes**:
Fixes #3341
