### PR TITLE
Fix alicloud resource Provisioning fails randomly

### DIFF
--- a/tests/platformSetup/tofu/modules/ali/main.tf
+++ b/tests/platformSetup/tofu/modules/ali/main.tf
@@ -141,7 +141,7 @@ resource "alicloud_vswitch" "subnet" {
 }
 
 resource "alicloud_security_group" "sg" {
-  name   = local.fw_name
+  security_group_name = local.fw_name
   vpc_id = alicloud_vpc.net.id
 
   tags = merge(


### PR DESCRIPTION
**What this PR does / why we need it**:

- use `bucket` instead of `id` as referenced in the documents https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/oss_bucket
- fix deprecation warning

**Which issue(s) this PR fixes**:
Fixes #3477
