### PR TITLE
Update SapMachine package to 25

### DIFF
--- a/features/sapmachine/exec.late
+++ b/features/sapmachine/exec.late
@@ -5,4 +5,4 @@ set -eufo pipefail
 gpg --dearmor -o /etc/apt/keyrings/sapmachine-apt-keyring.gpg < /builder/features/sapmachine/sapmachine.key
 echo "deb [signed-by=/etc/apt/keyrings/sapmachine-apt-keyring.gpg] https://dist.sapmachine.io/debian/$(dpkg --print-architecture)/ ./" | tee /etc/apt/sources.list.d/sapmachine.list
 apt-get update -y
-apt-get install -y sapmachine-21-jre-headless
+apt-get install -y sapmachine-25-jre-headless

--- a/tests-ng/test_sapmachine.py
+++ b/tests-ng/test_sapmachine.py
@@ -7,8 +7,8 @@ from plugins.shell import ShellRunner
 @pytest.mark.feature("sapmachine")
 def test_sapmachine_is_installed(dpkg: Dpkg):
     assert dpkg.package_is_installed(
-        "sapmachine-21-jre-headless"
-    ), "sapmachine-21-jre-headless package is not installed"
+        "sapmachine-25-jre-headless"
+    ), "sapmachine-25-jre-headless package is not installed"
 
 
 @pytest.mark.feature("sapmachine")


### PR DESCRIPTION
Provides the latest LTS version of the JRE to users of the `sapmachine` feature of Garden Linux.

Fixes #3483
