### PR TITLE
fix: test-ng: correctly detect errors in QEMU tests

### DIFF
--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -25,7 +25,7 @@ jobs:
       - name: install qemu
         run: |
           sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 qemu-system-arm swtpm socat
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 qemu-system-arm swtpm socat libxml2-utils
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0
         with:
           submodules: true

--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -66,6 +66,7 @@ Before running the test framework, make sure the following dependencies are inst
 - `make`
 - `curl`
 - `jq`
+- `libxml2-utils`
 - `unzip`
 - `qemu`
 - `qemu-utils`
@@ -74,14 +75,14 @@ Before running the test framework, make sure the following dependencies are inst
 
 ```
 apt-get update
-apt-get install podman make curl jq unzip qemu swtpm socat
+apt-get install podman make curl jq libxml2-utils unzip qemu swtpm socat
 
 ```
 
 #### Install on MacOS
 
 ```
-brew install coreutils bash gnu-sed gnu-getopt podman make curl jq unzip swtpm socat
+brew install coreutils bash gnu-sed gnu-getopt podman make curl jq libxml2 unzip swtpm socat
 ```
 
 ### Basic Usage

--- a/tests-ng/util/run_qemu.sh
+++ b/tests-ng/util/run_qemu.sh
@@ -396,5 +396,7 @@ else
 	cat "$tmpdir/serial.log"
 fi
 
-# TODO: find a better way to check if the tests failed
-! (tail -n1 "$tmpdir/serial.log" | grep failed >/dev/null)
+num_errors=$(xmllint --xpath 'string(/testsuites/testsuite/@errors)' "$tmpdir/junit.xml")
+if [ "${num_errors}" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

We noticed after merging https://github.com/gardenlinux/gardenlinux/pull/3481 that QEMU tests might fail but do not throw a correct error code.

This PR adds parsing the JUnit XML to get number of errors.

**Which issue(s) this PR fixes**:
Fixes #3499