### PR TITLE
fix: test-ng: test_nvme.py: use writable directory to not fail on trustedboot and USI flavors

### DIFF
--- a/tests-ng/test_nvme.py
+++ b/tests-ng/test_nvme.py
@@ -24,9 +24,9 @@ def test_kernel_module_availability(module_name, shell: ShellRunner):
 @pytest.mark.modify
 @pytest.mark.feature("nvme")
 def test_nvme_locally(nvme_device, shell: ShellRunner):
-    device, mount_point, size = nvme_device
-    mount_info_line = shell(f"df -m | grep {mount_point}", capture_output=True)
+    device, mount_dir, size = nvme_device
+    mount_info_line = shell(f"df -m | grep {mount_dir}", capture_output=True)
     mount_info = [x.strip() for x in mount_info_line.stdout.split(" ") if x]
     assert mount_info[0] == device
     assert mount_info[1] == size
-    assert Path("/mnt/nvme/bar").read_text().strip() == "foo", "NVME Test failed"
+    assert Path(f"{mount_dir}/bar").read_text().strip() == "foo", "NVME Test failed"


### PR DESCRIPTION
**What this PR does / why we need it**:

We noticed after merging https://github.com/gardenlinux/gardenlinux/pull/3481 and https://github.com/gardenlinux/gardenlinux/pull/3471 that NVME test-ng fail on trustedboot and USI flavors due to a not writable `/mnt/nvme` directory.

This PR changes the mount directory to be `/tmp/nvme` which is always writable.

**Which issue(s) this PR fixes**:
Fixes #3499