### PR TITLE
fix: test-ng: correctly detect errors and failures in QEMU tests

### DIFF
--- a/tests-ng/util/run_qemu.sh
+++ b/tests-ng/util/run_qemu.sh
@@ -397,6 +397,7 @@ else
 fi
 
 num_errors=$(xmllint --xpath 'string(/testsuites/testsuite/@errors)' "$tmpdir/junit.xml")
-if [ "${num_errors}" -gt 0 ]; then
-    exit 1
+num_failures=$(xmllint --xpath 'string(/testsuites/testsuite/@failures)' "$tmpdir/junit.xml")
+if [ "${num_errors}" -gt 0 ] || [ "${num_failures}" -gt 0 ]; then
+	exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

We noticed after merging https://github.com/gardenlinux/gardenlinux/pull/3481 that QEMU tests might fail but do not throw a correct error code.

This PR adds parsing the JUnit XML to get number of errors and failures.

Follow up of https://github.com/gardenlinux/gardenlinux/pull/3500 that also catches "failures".
