### PR TITLE
 fix: test-ng: fix test_nvme.py teardown

### DIFF
--- a/tests-ng/handlers/configure_nvme.py
+++ b/tests-ng/handlers/configure_nvme.py
@@ -21,7 +21,7 @@ REQUIRED_NVME_MODULE = [
             ]
 #This fixture executes NVME configuration, yield to complete the test and then do bring back real system state after test
 @pytest.fixture
-def nvme_device(shell: ShellRunner, dpkg: Dpkg, module: KernelModule):
+def nvme_device(shell: ShellRunner, dpkg: Dpkg, kernel_module: KernelModule):
     mount_package_installed = False
     shell(f"truncate -s 512M {NVME_DEVICE}")
     if not dpkg.package_is_installed("mount"):
@@ -31,8 +31,8 @@ def nvme_device(shell: ShellRunner, dpkg: Dpkg, module: KernelModule):
 
     for entry in REQUIRED_NVME_MODULE:
         mod_name = entry["nvme_module"]
-        if not module.is_module_loaded(mod_name):
-            module.load_module(mod_name)
+        if not kernel_module.is_module_loaded(mod_name):
+            kernel_module.load_module(mod_name)
             entry["status"] = "Loaded"
     port = 1
     while os.path.exists(os.path.join("/sys/kernel/config/nvmet/ports", str(port))):
@@ -84,7 +84,7 @@ def nvme_device(shell: ShellRunner, dpkg: Dpkg, module: KernelModule):
     for entry in REQUIRED_NVME_MODULE:
         mod_name = entry["nvme_module"]
         if entry["status"] == "Loaded":
-            module.unload_module(mod_name)
+            kernel_module.unload_module(mod_name)
             entry["status"] = "None"
     if mount_package_installed == True:
         shell("DEBIAN_FRONTEND=noninteractive apt remove mount")

--- a/tests-ng/handlers/configure_nvme.py
+++ b/tests-ng/handlers/configure_nvme.py
@@ -58,23 +58,21 @@ def nvme_device(shell: ShellRunner, dpkg: Dpkg, kernel_module: KernelModule):
 
     os.symlink(f"/sys/kernel/config/nvmet/subsystems/{SUBSYSTEM_NAME}", f"/sys/kernel/config/nvmet/ports/{port}/subsystems/{SUBSYSTEM_NAME}")
 
-    shell("nvme connect -t tcp -n testnqn -a 127.0.0.1 -s 4420")
+    shell("nvme connect -t tcp -n testnqn -a 127.0.0.1 -s 4420", capture_output=True)
     output = shell("nvme list -o json", capture_output=True)
-    json_devices = json.loads(output.stdout)
+    json_devices = json.loads(output.stdout.strip())
     local_device = [device['DevicePath'] for device in json_devices['Devices'] if device["ModelNumber"] == "Linux"][0]
     mount_dir = "/tmp/nvme"
-    shell(f"mkfs.ext4 {local_device}")
+    shell(f"mkfs.ext4 -q {local_device}")
     os.makedirs(mount_dir)
     shell(f"mount {local_device} {mount_dir}")
-    shell(f"echo 'foo' | tee {mount_dir}/bar")
+    shell(f"echo 'foo' > {mount_dir}/bar")
 
     yield local_device, mount_dir, "488"
 
-    print("Teardown nvme device and clean up")
     shell(f"umount {mount_dir}", ignore_exit_code=True)
     os.rmdir(mount_dir)
-    shell(f"nvme disconnect -n {SUBSYSTEM_NAME}", ignore_exit_code=True)
-    os.remove(NVME_DEVICE)
+    shell(f"nvme disconnect -n {SUBSYSTEM_NAME}", capture_output=True, ignore_exit_code=True)
     Path(f"/sys/kernel/config/nvmet/subsystems/{SUBSYSTEM_NAME}/namespaces/{port}/enable").write_text("0")
     Path(f"/sys/kernel/config/nvmet/subsystems/{SUBSYSTEM_NAME}/attr_allow_any_host").write_text("0")
     os.rmdir(f"/sys/kernel/config/nvmet/subsystems/{SUBSYSTEM_NAME}/namespaces/{port}")

--- a/tests-ng/handlers/configure_nvme.py
+++ b/tests-ng/handlers/configure_nvme.py
@@ -14,10 +14,10 @@ PORT_NUMBER="4420"
 TRTYPE="tcp"
 ADRFAM="ipv4"
 
-REQUIRED_NVME_MODULE = [
-            {"nvme_module": "nvme_tcp", "status": None},
-            {"nvme_module": "nvmet_tcp", "status": None},
-            {"nvme_module": "nvmet", "status": None},
+REQUIRED_NVME_MODULES = [
+            {"name": "nvmet", "status": None},
+            {"name": "nvmet_tcp", "status": None},
+            {"name": "nvme_tcp", "status": None},
             ]
 #This fixture executes NVME configuration, yield to complete the test and then do bring back real system state after test
 @pytest.fixture
@@ -27,12 +27,12 @@ def nvme_device(shell: ShellRunner, dpkg: Dpkg, kernel_module: KernelModule):
     if not dpkg.package_is_installed("mount"):
         mount_package_installed = True;
         shell("DEBIAN_FRONTEND=noninteractive apt-get install -y mount")
-    shell(f"losetup -fP {NVME_DEVICE}")
+    loop_device = shell(f"losetup -fP --show {NVME_DEVICE}", capture_output=True).stdout.strip()
 
-    for entry in REQUIRED_NVME_MODULE:
-        mod_name = entry["nvme_module"]
-        if not kernel_module.is_module_loaded(mod_name):
-            kernel_module.load_module(mod_name)
+    for entry in REQUIRED_NVME_MODULES:
+        name = entry["name"]
+        if not kernel_module.is_module_loaded(name):
+            kernel_module.load_module(name)
             entry["status"] = "Loaded"
     port = 1
     while os.path.exists(os.path.join("/sys/kernel/config/nvmet/ports", str(port))):
@@ -81,10 +81,13 @@ def nvme_device(shell: ShellRunner, dpkg: Dpkg, kernel_module: KernelModule):
     os.unlink(f"/sys/kernel/config/nvmet/ports/{port}/subsystems/{SUBSYSTEM_NAME}")
     os.rmdir(f"/sys/kernel/config/nvmet/subsystems/{SUBSYSTEM_NAME}")
     os.rmdir(f"/sys/kernel/config/nvmet/ports/{port}")
-    for entry in REQUIRED_NVME_MODULE:
-        mod_name = entry["nvme_module"]
+    os.remove(NVME_DEVICE)
+    shell(f"losetup -d {loop_device}")
+    # reorder the modules to unload in the reverse order of loading
+    for entry in REQUIRED_NVME_MODULES.reverse():
+        name = entry["name"]
         if entry["status"] == "Loaded":
-            kernel_module.unload_module(mod_name)
-            entry["status"] = "None"
+            kernel_module.unload_module(name)
+            entry["status"] = None
     if mount_package_installed == True:
         shell("DEBIAN_FRONTEND=noninteractive apt remove mount")

--- a/tests-ng/plugins/dpkg.py
+++ b/tests-ng/plugins/dpkg.py
@@ -26,6 +26,22 @@ class Dpkg:
         architectures.append(self.architecture())
         return architectures
 
+    def collect_packages(self) -> dict[str, str]:
+        """Collect all installed packages and their versions"""
+        result = self._shell(
+            "dpkg-query -W -f='${binary:Package}\t${Version}\n'",
+            capture_output=True,
+            ignore_exit_code=True
+        )
+
+        packages = {}
+        for line in result.stdout.strip().split('\n'):
+            if '\t' in line:
+                package, version = line.split('\t', 1)
+                packages[package] = version
+
+        return dict(sorted(packages.items()))
+
 @pytest.fixture
 def dpkg(shell: ShellRunner) -> Dpkg:
     return Dpkg(shell)

--- a/tests-ng/plugins/kernel_module.py
+++ b/tests-ng/plugins/kernel_module.py
@@ -9,13 +9,25 @@ class KernelModule:
     def is_module_loaded(self, module: str) -> bool:
         result = self._shell(f"lsmod | grep ^{module}", capture_output=True, ignore_exit_code=True)
         return result.returncode == 0
+
     def load_module(self, module: str) -> bool:
         result = self._shell(f"modprobe {module}", capture_output=True, ignore_exit_code=False)
         return result.returncode == 0
+
     def unload_module(self, module: str) -> bool:
         result = self._shell(f"rmmod {module}", capture_output=True, ignore_exit_code=True)
         return result.returncode == 0
 
+    def collect_loaded_modules(self) -> list[str]:
+        """Collect all currently loaded kernel modules"""
+        result = self._shell("lsmod", capture_output=True, ignore_exit_code=True)
+        modules = []
+        for line in result.stdout.strip().split('\n')[1:]:  # Skip header
+            if line.strip():
+                module_name = line.split()[0]
+                modules.append(module_name)
+        return sorted(modules)
+
 @pytest.fixture
-def module(shell: ShellRunner) -> KernelModule:
+def kernel_module(shell: ShellRunner) -> KernelModule:
         return KernelModule(shell)

--- a/tests-ng/plugins/sysctl.py
+++ b/tests-ng/plugins/sysctl.py
@@ -1,6 +1,5 @@
 import pytest
-
-from plugins.booted import is_system_booted
+from .shell import ShellRunner
 
 class SysctlWrapper:
     def __getitem__(self, key: str):
@@ -9,8 +8,99 @@ class SysctlWrapper:
             value = f.read().strip()
         return int(value) if value.isdigit() else value
 
+class Sysctl:
+    """Collects kernel parameters from /proc/sys/"""
+
+    # Parameters that change frequently and should be allow-listed
+    ALLOWLISTED_PARAMS = {
+        # File system dynamic parameters
+        'fs.dentry-state',
+        'fs.file-nr',
+        'fs.inode-nr',
+        'fs.inode-state',
+        'fs.quota.allocated_dquots',
+        'fs.quota.cache_hits',
+        'fs.quota.drops',
+        'fs.quota.free_dquots',
+        'fs.quota.lookups',
+        'fs.quota.reads',
+        'fs.quota.syncs',
+        'fs.quota.writes',
+
+        # Kernel dynamic parameters
+        'kernel.ns_last_pid',
+        'kernel.random.uuid',
+
+        # Network dynamic parameters
+        'net.netfilter.nf_conntrack_count',
+
+        # Memory dynamic parameters
+        'vm.nr_pdflush_threads',
+        'vm.stat.nr_dirty',
+        'vm.stat.nr_writeback',
+        'vm.stat.nr_unstable',
+        'vm.stat.nr_page_table_pages',
+        'vm.stat.nr_mapped',
+        'vm.stat.nr_slab',
+        'vm.stat.nr_pagecache',
+        'vm.stat.nr_reverse_maps',
+        'vm.stat.nr_dirty_background_threshold',
+        'vm.stat.nr_dirty_threshold',
+        'vm.stat.nr_dirty_background',
+        'vm.stat.nr_dirty',
+        'vm.stat.nr_writeback',
+        'vm.stat.nr_unstable',
+        'vm.stat.nr_page_table_pages',
+        'vm.stat.nr_mapped',
+        'vm.stat.nr_slab',
+        'vm.stat.nr_pagecache',
+        'vm.stat.nr_reverse_maps',
+    }
+
+    def __init__(self, shell: ShellRunner):
+        self.shell = shell
+
+    def is_sysctl_available(self) -> bool:
+        """Check if sysctl is available"""
+        try:
+            result = self.shell("command -v sysctl", capture_output=True, ignore_exit_code=True)
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def collect_sysctl_parameters(self) -> dict[str, str]:
+        """Collect all readable sysctl parameters, excluding allow-listed ones"""
+        if not self.is_sysctl_available():
+            return {}
+
+        sysctl_params = {}
+
+        try:
+            result = self.shell("sysctl -a 2>/dev/null", capture_output=True, ignore_exit_code=True)
+            if result.returncode == 0:
+                for line in result.stdout.strip().split('\n'):
+                    if '=' in line:
+                        key, value = line.split('=', 1)
+                        key = key.strip()
+                        value = value.strip()
+
+                        if key not in self.ALLOWLISTED_PARAMS:
+                            sysctl_params[key] = value
+        except Exception as e:
+            print(f"Warning: Failed to collect sysctl parameters: {e}")
+
+        return dict(sorted(sysctl_params.items()))
+
 @pytest.fixture
 def sysctl(request: pytest.FixtureRequest):
-    if not is_system_booted():
-        pytest.skip("sysctl only available when running on booted system")
+    try:
+        result = ShellRunner(None)("command -v sysctl", capture_output=True, ignore_exit_code=True)
+        if result.returncode != 0:
+            pytest.skip("sysctl command not available")
+    except Exception:
+        pytest.skip("sysctl command not available")
     return SysctlWrapper()
+
+@pytest.fixture
+def sysctl_collector(shell: ShellRunner) -> Sysctl:
+    return Sysctl(shell)

--- a/tests-ng/plugins/sysdiff.py
+++ b/tests-ng/plugins/sysdiff.py
@@ -1,0 +1,482 @@
+"""
+System state snapshot and diff functionality for tests-ng.
+
+Provides snapshot and comparison capabilities for:
+- packages (dpkg)
+- systemd units
+- files (sha256 checksums)
+- sysctl parameters
+- loaded kernel modules
+"""
+
+import difflib
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+from .shell import ShellRunner
+from .dpkg import Dpkg
+from .systemd import Systemd, SystemdUnit
+from .kernel_module import KernelModule
+from .sysctl import Sysctl
+
+
+DEFAULT_PATHS = [
+    "/etc", "/boot", "/usr/local/bin", "/usr/local/sbin",
+    "/usr/local/lib", "/opt", "/proc/mounts"
+]
+
+STATE_DIR = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "sysdiff"
+
+IGNORED_SYSTEMD_PATTERNS = []
+IGNORED_KERNEL_MODULES = []
+
+
+@dataclass
+class SnapshotMetadata:
+    """Metadata for a snapshot"""
+    created_at: str
+    paths: List[str]
+    ignore_file: bool
+
+
+@dataclass
+class Snapshot:
+    """Complete system snapshot"""
+    name: str
+    metadata: SnapshotMetadata
+    packages: Dict[str, str]  # package -> version
+    systemd_units: List[SystemdUnit]
+    files: Dict[str, str]  # path -> sha256
+    sysctl_params: Dict[str, str]  # parameter -> value
+    kernel_modules: List[str]  # loaded kernel modules
+
+
+@dataclass
+class DiffResult:
+    """Result of comparing two snapshots"""
+    package_changes: List[str]
+    systemd_changes: List[str]
+    file_changes: List[str]
+    sysctl_changes: List[str]
+    kernel_module_changes: List[str]
+    has_changes: bool
+
+
+class FileCollector:
+    """Collects file hashes and handles filtering"""
+
+    def __init__(self, shell: ShellRunner):
+        self.shell = shell
+
+    def normalize_paths(self, paths: List[str]) -> List[str]:
+        """Deduplicate and keep only existing directories/files"""
+        existing_paths = []
+        seen = set()
+
+        for path in paths:
+            if path and path not in seen:
+                try:
+                    result = self.shell(f'[ -e "{path}" ]', capture_output=True, ignore_exit_code=True)
+                    if result.returncode == 0:
+                        existing_paths.append(path)
+                        seen.add(path)
+                except Exception as e:
+                    print(f"Error normalizing paths: {e}")
+
+        return existing_paths
+
+    def load_ignore_patterns(self, ignore_file: Optional[Path]) -> List[str]:
+        """Load ignore patterns from file"""
+        if not ignore_file or not ignore_file.exists():
+            return []
+
+        patterns = []
+        try:
+            with open(ignore_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        patterns.append(line)
+        except Exception:
+            print(f"Error loading ignore patterns from {ignore_file}: {e}")
+
+        return patterns
+
+    def should_ignore_file(self, filepath: str, ignore_patterns: List[str]) -> bool:
+        """Check if file should be ignored based on patterns"""
+        for pattern in ignore_patterns:
+            try:
+                if re.search(pattern, filepath):
+                    return True
+            except re.error:
+                # If pattern is invalid regex, treat as literal string
+                if pattern in filepath:
+                    return True
+        return False
+
+    def collect_file_hashes(self, paths: List[str], ignore_patterns: List[str] = None) -> Dict[str, str]:
+        """Collect SHA256 hashes for files in given paths"""
+        if ignore_patterns is None:
+            ignore_patterns = []
+
+        file_hashes = {}
+
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+                for path in paths:
+                    f.write(f"{path}\n")
+                paths_file = f.name
+
+            try:
+                find_command = f"""
+                while IFS= read -r root; do
+                    [ -z "$root" ] && continue
+                    if [ -d "$root" ]; then
+                        find "$root" -xdev -type f -readable 2>/dev/null
+                    elif [ -f "$root" ]; then
+                        printf '%s\\n' "$root"
+                    fi
+                done < "{paths_file}"
+                """
+
+                result = self.shell(find_command, capture_output=True, ignore_exit_code=True)
+                files = [f.strip() for f in result.stdout.strip().split('\n') if f.strip()]
+
+                filtered_files = sorted([
+                    f for f in files
+                    if not self.should_ignore_file(f, ignore_patterns)
+                ])
+
+                for filepath in filtered_files:
+                    result = self.shell(f'sha256sum -- "{filepath}" 2>/dev/null', capture_output=True, ignore_exit_code=True)
+                    if result.stdout.strip():
+                        hash_part = result.stdout.strip().split()[0]
+                        file_hashes[filepath] = hash_part
+
+            finally:
+                os.unlink(paths_file)
+
+        except Exception as e:
+            print(f"Error collecting file hashes: {e}")
+
+        return file_hashes
+
+
+class SnapshotManager:
+    """Manages snapshot creation, storage, and retrieval"""
+
+    def __init__(self, state_dir: Path = None):
+        self.state_dir = state_dir or STATE_DIR
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def create_snapshot(self, name: str = None, paths: List[str] = None,
+                       ignore_file: Path = None) -> Snapshot:
+        """Create a new system snapshot"""
+        if paths is None:
+            paths = DEFAULT_PATHS
+
+        if name is None:
+            name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+        snapdir = self.state_dir / name
+        if snapdir.exists():
+            raise ValueError(f"Snapshot '{name}' already exists at {snapdir}")
+
+        snapdir.mkdir(parents=True)
+
+        shell = ShellRunner(None)
+        dpkg = Dpkg(shell)
+        systemd = Systemd(shell)
+        file_collector = FileCollector(shell)
+        sysctl_collector = Sysctl(shell)
+        kernel_module = KernelModule(shell)
+
+        packages = dpkg.collect_packages()
+        systemd_units = systemd.list_units()
+        sysctl_params = sysctl_collector.collect_sysctl_parameters()
+        kernel_modules = kernel_module.collect_loaded_modules()
+        ignore_patterns = file_collector.load_ignore_patterns(ignore_file)
+        normalized_paths = file_collector.normalize_paths(paths)
+        files = file_collector.collect_file_hashes(normalized_paths, ignore_patterns)
+
+        metadata = SnapshotMetadata(
+            created_at=datetime.now().isoformat(),
+            paths=normalized_paths,
+            ignore_file=bool(ignore_file and ignore_file.exists())
+        )
+
+        snapshot = Snapshot(name, metadata, packages, systemd_units, files, sysctl_params, kernel_modules)
+        self._save_snapshot(snapshot, snapdir)
+
+        return snapshot
+
+    def _save_snapshot(self, snapshot: Snapshot, snapdir: Path):
+        """Save snapshot to disk"""
+
+        with open(snapdir / "packages.txt", 'w') as f:
+            for package, version in snapshot.packages.items():
+                f.write(f"{package}\t{version}\n")
+
+        with open(snapdir / "systemd_units.txt", 'w') as f:
+            for unit in snapshot.systemd_units:
+                f.write(f"{unit.unit}\t{unit.load}\t{unit.active}\t{unit.sub}\n")
+
+        with open(snapdir / "files.txt", 'w') as f:
+            for path, hash_val in sorted(snapshot.files.items()):
+                f.write(f"{hash_val}  {path}\n")
+
+        with open(snapdir / "sysctl.txt", 'w') as f:
+            for param, value in snapshot.sysctl_params.items():
+                f.write(f"{param}={value}\n")
+
+        with open(snapdir / "kernel_modules.txt", 'w') as f:
+            for module in snapshot.kernel_modules:
+                f.write(f"{module}\n")
+
+        with open(snapdir / "meta", 'w') as f:
+            f.write(f"created_at={snapshot.metadata.created_at}\n")
+            f.write(f"paths={' '.join(snapshot.metadata.paths)}\n")
+            f.write(f"ignore_file={'present' if snapshot.metadata.ignore_file else ''}\n")
+
+    def load_snapshot(self, name: str) -> Snapshot:
+        """Load snapshot from disk"""
+        snapdir = self.state_dir / name
+        if not snapdir.exists():
+            raise ValueError(f"Snapshot '{name}' not found")
+
+        packages = {}
+        packages_file = snapdir / "packages.txt"
+        if packages_file.exists():
+            with open(packages_file, 'r') as f:
+                for line in f:
+                    if '\t' in line:
+                        package, version = line.strip().split('\t', 1)
+                        packages[package] = version
+
+        systemd_units = []
+        systemd_file = snapdir / "systemd_units.txt"
+        if systemd_file.exists():
+            with open(systemd_file, 'r') as f:
+                for line in f:
+                    parts = line.strip().split('\t')
+                    if len(parts) >= 4:
+                        systemd_units.append(SystemdUnit(
+                            unit=parts[0],
+                            load=parts[1],
+                            active=parts[2],
+                            sub=parts[3]
+                        ))
+
+        files = {}
+        files_file = snapdir / "files.txt"
+        if files_file.exists():
+            with open(files_file, 'r') as f:
+                for line in f:
+                    parts = line.strip().split('  ', 1)
+                    if len(parts) == 2:
+                        files[parts[1]] = parts[0]
+
+        sysctl_params = {}
+        sysctl_file = snapdir / "sysctl.txt"
+        if sysctl_file.exists():
+            with open(sysctl_file, 'r') as f:
+                for line in f:
+                    if '=' in line:
+                        param, value = line.strip().split('=', 1)
+                        sysctl_params[param] = value
+
+        kernel_modules = []
+        kernel_modules_file = snapdir / "kernel_modules.txt"
+        if kernel_modules_file.exists():
+            with open(kernel_modules_file, 'r') as f:
+                for line in f:
+                    module = line.strip()
+                    if module:
+                        kernel_modules.append(module)
+
+        metadata = SnapshotMetadata(
+            created_at="",
+            paths=[],
+            ignore_file=False,
+        )
+        meta_file = snapdir / "meta"
+        if meta_file.exists():
+            with open(meta_file, 'r') as f:
+                for line in f:
+                    if '=' in line:
+                        key, value = line.strip().split('=', 1)
+                        if key == "created_at":
+                            metadata.created_at = value
+                        elif key == "paths":
+                            metadata.paths = value.split() if value else []
+                        elif key == "ignore_file":
+                            metadata.ignore_file = value == "present"
+
+        return Snapshot(name, metadata, packages, systemd_units, files, sysctl_params, kernel_modules)
+
+    def list_snapshots(self) -> List[str]:
+        """List all available snapshots"""
+        if not self.state_dir.exists():
+            return []
+
+        snapshots = []
+        for item in self.state_dir.iterdir():
+            if item.is_dir():
+                snapshots.append(item.name)
+
+        return sorted(snapshots)
+
+
+class DiffEngine:
+    """Handles comparison between snapshots"""
+
+    def __init__(self):
+        self._compiled_patterns = [re.compile(pattern) for pattern in IGNORED_SYSTEMD_PATTERNS]
+        self._ignored_kernel_modules = set(IGNORED_KERNEL_MODULES)
+
+    def compare_snapshots(self, snapshot_a: Snapshot, snapshot_b: Snapshot) -> DiffResult:
+        """Compare two snapshots and return differences"""
+        changes = [
+            self._compare_packages(snapshot_a.packages, snapshot_b.packages),
+            self._compare_systemd_units(snapshot_a.systemd_units, snapshot_b.systemd_units),
+            self._compare_files(snapshot_a.files, snapshot_b.files),
+            self._compare_sysctl_params(snapshot_a.sysctl_params, snapshot_b.sysctl_params),
+            self._compare_kernel_modules(snapshot_a.kernel_modules, snapshot_b.kernel_modules),
+        ]
+
+        return DiffResult(*changes, has_changes=any(changes))
+
+    def _generate_diff(self, lines_a: List[str], lines_b: List[str],
+                              fromfile: str, tofile: str) -> List[str]:
+        """Generate diff for two line lists"""
+        return list(difflib.unified_diff(
+            lines_a, lines_b,
+            fromfile=fromfile,
+            tofile=tofile,
+            lineterm=""
+        ))
+
+    def _compare_packages(self, packages_a: Dict[str, str], packages_b: Dict[str, str]) -> List[str]:
+        """Compare package lists and return diff lines"""
+        lines_a = [f"{pkg}\t{ver}" for pkg, ver in packages_a.items()]
+        lines_b = [f"{pkg}\t{ver}" for pkg, ver in packages_b.items()]
+
+        return self._generate_diff(
+            lines_a, lines_b,
+            "packages@snapshot_a", "packages@snapshot_b"
+        )
+
+    def _compare_systemd_units(self, units_a: List[SystemdUnit], units_b: List[SystemdUnit]) -> List[str]:
+        """Compare systemd unit lists and return diff lines"""
+        def should_ignore_unit(unit: SystemdUnit) -> bool:
+            """Check if unit should be ignored based on filtering patterns"""
+            return any(pattern.search(unit.unit) for pattern in self._compiled_patterns)
+
+        def format_unit(unit: SystemdUnit) -> str:
+            """Format unit for comparison"""
+            return f"{unit.unit}\t{unit.load}\t{unit.active}\t{unit.sub}"
+
+        filtered_units_a = [format_unit(u) for u in units_a if not should_ignore_unit(u)]
+        filtered_units_b = [format_unit(u) for u in units_b if not should_ignore_unit(u)]
+
+        return self._generate_diff(
+            filtered_units_a, filtered_units_b,
+            "systemd_units@snapshot_a", "systemd_units@snapshot_b"
+        )
+
+    def _compare_files(self, files_a: Dict[str, str], files_b: Dict[str, str]) -> List[str]:
+        """Compare file lists and return diff lines"""
+        lines_a = [f"{hash_val}  {path}" for path, hash_val in sorted(files_a.items())]
+        lines_b = [f"{hash_val}  {path}" for path, hash_val in sorted(files_b.items())]
+
+        return self._generate_diff(
+            lines_a, lines_b,
+            "files@snapshot_a", "files@snapshot_b"
+        )
+
+    def _compare_sysctl_params(self, params_a: Dict[str, str], params_b: Dict[str, str]) -> List[str]:
+        """Compare sysctl parameter lists and return diff lines"""
+        lines_a = [f"{param}={value}" for param, value in params_a.items()]
+        lines_b = [f"{param}={value}" for param, value in params_b.items()]
+
+        return self._generate_diff(
+            lines_a, lines_b,
+            "sysctl@snapshot_a", "sysctl@snapshot_b"
+        )
+
+    def _compare_kernel_modules(self, modules_a: List[str], modules_b: List[str]) -> List[str]:
+        """Compare kernel module lists and return diff lines"""
+        filtered_modules_a = [m for m in modules_a if m not in self._ignored_kernel_modules]
+        filtered_modules_b = [m for m in modules_b if m not in self._ignored_kernel_modules]
+
+        lines_a = sorted(filtered_modules_a)
+        lines_b = sorted(filtered_modules_b)
+
+        return self._generate_diff(
+            lines_a, lines_b,
+            "kernel_modules@snapshot_a", "kernel_modules@snapshot_b"
+        )
+
+    def generate_diff(self, diff_result: DiffResult, snapshot_a_name: str, snapshot_b_name: str) -> str:
+        """Generate diff output compatible with shell script"""
+        change_types = [
+            ("Package changes", diff_result.package_changes),
+            ("Systemd unit state changes", diff_result.systemd_changes),
+            ("File content changes (sha256, path)", diff_result.file_changes),
+            ("Sysctl parameter changes", diff_result.sysctl_changes),
+            ("Kernel module changes", diff_result.kernel_module_changes),
+        ]
+
+        output = []
+        for change_type, changes in change_types:
+            if changes:
+                output.append(f"=== {change_type} ({snapshot_a_name} -> {snapshot_b_name}) ===")
+                output.extend(changes)
+                output.append("")
+
+        if diff_result.has_changes:
+            output.append("Tip: lines starting with '+' mean new/changed; '-' mean removed/previous state.")
+
+        return "\n".join(output)
+
+
+class Sysdiff:
+    """Main sysdiff class for tests-ng integration"""
+
+    def __init__(self, shell: ShellRunner):
+        self.shell = shell
+        self.manager = SnapshotManager()
+        self.diff_engine = DiffEngine()
+
+    def create_snapshot(self, name: str, paths: List[str] = None,
+                       ignore_file: Path = None) -> Snapshot:
+        """Create a snapshot using the shell context"""
+        return self.manager.create_snapshot(name, paths, ignore_file)
+
+    def compare_snapshots(self, name_a: str, name_b: str) -> DiffResult:
+        """Compare two snapshots"""
+        snapshot_a = self.manager.load_snapshot(name_a)
+        snapshot_b = self.manager.load_snapshot(name_b)
+        return self.diff_engine.compare_snapshots(snapshot_a, snapshot_b)
+
+    def cleanup_snapshots(self, names: List[str]):
+        """Cleanup snapshots"""
+        for name in names:
+            snapdir = self.manager.state_dir / name
+            if snapdir.exists():
+                import shutil
+                shutil.rmtree(snapdir)
+
+
+@pytest.fixture
+def sysdiff(shell: ShellRunner):
+    """Function-scoped sysdiff fixture for individual tests."""
+    return Sysdiff(shell)

--- a/tests-ng/plugins/systemd.py
+++ b/tests-ng/plugins/systemd.py
@@ -1,11 +1,13 @@
+import json
 import re
-import pytest
+import time
+from dataclasses import dataclass
 from typing import Tuple
+
+import pytest
+
 from .shell import ShellRunner
 from .modify import allow_system_modifications
-from dataclasses import dataclass
-import time
-import json
 
 @dataclass
 class SystemdUnit:
@@ -73,6 +75,11 @@ class Systemd:
         if not allow_system_modifications():
             pytest.skip("starting units is only supported when system state modifications are allowed")
         self._shell(f"{self._systemctl} start {unit_name}")
+
+    def stop_unit(self, unit_name: str):
+        if not allow_system_modifications():
+            pytest.skip("stopping units is only supported when system state modifications are allowed")
+        self._shell(f"{self._systemctl} stop {unit_name}")
 
     def list_units(self) -> list[SystemdUnit]:
         result = self._shell(f"{self._systemctl}", capture_output=True, ignore_exit_code=True)

--- a/tests-ng/test_sysdiff.py
+++ b/tests-ng/test_sysdiff.py
@@ -1,0 +1,46 @@
+import pytest
+from plugins.sysdiff import Sysdiff
+
+
+@pytest.mark.order("first")
+@pytest.mark.root(reason="Sysdiff needs to read all files.")
+def test_sysdiff_before_tests(sysdiff: Sysdiff):
+    """
+    Verifies no system changes were detected during the test run.
+    This test runs before all other tests and creates the before-tests snapshot.
+    """
+    name_a = "before-tests"
+    try:
+        snapshot = sysdiff.create_snapshot(name_a)
+        assert snapshot.name == name_a
+
+    except Exception as e:
+        pytest.fail(f"Error creating {name_a} snapshot: {e}")
+
+
+@pytest.mark.order("last")
+@pytest.mark.root(reason="Sysdiff needs to read all files.")
+def test_sysdiff_after_tests(sysdiff: Sysdiff):
+    """
+    Verifies no system changes were detected during the test run.
+    This test runs after all other tests, creates the after-tests snapshot and performs the sysdiff comparison.
+    """
+    name_a = "before-tests"
+    name_b = "after-tests"
+    try:
+        snapshot = sysdiff.create_snapshot(name_b)
+        assert snapshot.name == name_b
+
+        diff_result = sysdiff.compare_snapshots(name_a, name_b)
+
+        if diff_result.has_changes:
+            diff_output = sysdiff.diff_engine.generate_diff(diff_result, name_a, name_b)
+            pytest.fail(f"System changes were detected during the test run:\n{diff_output}")
+        else:
+            assert True
+
+    except Exception as e:
+        pytest.fail(f"Error during sysdiff comparison: {e}")
+
+    finally:
+        sysdiff.cleanup_snapshots([name_a, name_b])

--- a/tests-ng/util/requirements.txt
+++ b/tests-ng/util/requirements.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-order
 boolean.py
 validators==0.35.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a fix for the issues in the containerd tests found in https://github.com/gardenlinux/gardenlinux/pull/3506.

```
======================================================= FAILURES =======================================================
_______________________________________________ test_sysdiff_after_tests _______________________________________________
test_sysdiff.py:38: in test_sysdiff_after_tests
    pytest.fail(f"System changes were detected during the test run:\n{diff_output}")
E   Failed: System changes were detected during the test run:
E   === Systemd unit state changes (before-tests -> after-tests) ===
E   --- systemd_units@snapshot_a
E   +++ systemd_units@snapshot_b
E   @@ -11,6 +11,7 @@
E    sys-devices-platform-serial8250-serial8250:0-serial8250:0.2-tty-ttyS2.device	loaded	active	plugged
E    sys-devices-platform-serial8250-serial8250:0-serial8250:0.3-tty-ttyS3.device	loaded	active	plugged
E    sys-devices-pnp0-00:03-00:03:0-00:03:0.0-tty-ttyS0.device	loaded	active	plugged
E   +sys-devices-virtual-block-loop0.device	loaded	active	plugged
E    sys-module-configfs.device	loaded	active	plugged
E    sys-module-fuse.device	loaded	active	plugged
E    sys-subsystem-net-devices-enp0s3.device	loaded	active	plugged
E   @@ -19,6 +20,7 @@
E    dev-mqueue.mount	loaded	active	mounted
E    efi.mount	loaded	active	mounted
E    proc-sys-fs-binfmt_misc.mount	loaded	active	mounted
E    run-gardenlinux\x2dtests.mount	loaded	active	mounted
E    run-lock.mount	loaded	active	mounted
E    run-rpc_pipefs.mount	loaded	active	mounted
E   @@ -34,6 +36,7 @@
E    init.scope	loaded	active	running
E    apparmor.service	loaded	active	exited
E    auditd.service	loaded	active	running
E    dbus.service	loaded	active	running
E    dracut-shutdown.service	loaded	active	exited
E    getty@tty1.service	loaded	active	running
E   
E   === Kernel module changes (before-tests -> after-tests) ===
E   --- kernel_modules@snapshot_a
E   +++ kernel_modules@snapshot_b
E   @@ -33,6 +33,8 @@
E    nls_ascii
E    nls_cp437
E    nvme_fabrics
E   +nvmet
E    qemu_fw_cfg
E    quota_tree
E    quota_v2
E   
E   Tip: lines starting with '+' mean new/changed; '-' mean removed/previous state.

```

**Notes for reviewers**:

Needs https://github.com/gardenlinux/gardenlinux/pull/3506 to be merged first.