### PR TITLE
tests-ng: Avoid unneeded write to stdout, avoid shell usage

### DIFF
--- a/tests-ng/handlers/configure_nvme.py
+++ b/tests-ng/handlers/configure_nvme.py
@@ -66,7 +66,7 @@ def nvme_device(shell: ShellRunner, dpkg: Dpkg, module: KernelModule):
     shell(f"mkfs.ext4 {local_device}")
     os.makedirs(mount_dir)
     shell(f"mount {local_device} {mount_dir}")
-    shell(f"echo 'foo' | tee {mount_dir}/bar")
+    Path(f"{mount_dir}/bar").write_text("foo\n")
 
     yield local_device, mount_dir, "488"
 


### PR DESCRIPTION
Minor refactoring:

"echo foo | tee" writes foo to stdout and the provided file, but we only need it inside that file. Also, we don't need to use shell for that as python is capable of writing files natively.

This is what this looked like before:
<img width="250" height="154" alt="Screenshot 2025-10-01 at 14 34 41" src="https://github.com/user-attachments/assets/aabb7a47-678c-42dc-848b-25855db7ee02" />

