### PR TITLE
fix: rename packages in `vhost` `pkg.include`

### DIFF
--- a/features/vhost/pkg.include
+++ b/features/vhost/pkg.include
@@ -6,8 +6,8 @@ qemu-utils
 qemu-block-extra
 libvirt-daemon-system
 libvirt-clients
-libgoogle-perftools4
-libtcmalloc-minimal4
+libgoogle-perftools4t64
+libtcmalloc-minimal4t64
 libvirt0
 #virtinst
 $(if [ $arch = amd64 ]; then echo ovmf; fi)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Rename `libgoogle-perftools4` and `libtcmalloc-minimal4` to `libgoogle-perftools4t64` and `libtcmalloc-minimal4t64`

**Which issue(s) this PR fixes**:
Fixes #3617
