### PR TITLE
fix: test-(ng-)report to only include JUnit XMLs

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -74,7 +74,8 @@ jobs:
         if: always()
         with:
           name: test-report
-          path: test-artifacts
+          path: |
+            test-artifacts/**/*.test.xml
           retention-days: 30
   test_ng_report:
     name: Generate Test-NG Report
@@ -138,5 +139,6 @@ jobs:
         if: always()
         with:
           name: test-ng-report
-          path: test-artifacts
+          path: |
+            test-artifacts/*.test-ng.xml
           retention-days: 30


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix test-(ng-)report to only include JUnit XMLs.

**Which issue(s) this PR fixes**:
Currently the `test-report` artifact includes `platform-test-tofu-*.tar` which is unwanted and quite large.
