### PR TITLE
fix: test-(ng-)report to only include JUnit XMLs - 2nd try

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: test-report
           path: |
-            test-artifacts/**/*.test.xml
+            test-artifacts/*.test.xml
           retention-days: 30
   test_ng_report:
     name: Generate Test-NG Report


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/gardenlinux/gardenlinux/pull/3644 had a wrong path in it. This hopefully fixes this finally.
