### PR TITLE
fix: use new major and minor naming scheme in GLRD throughout workflows

### DIFF
--- a/.github/workflows/build_platform_test_images.yml
+++ b/.github/workflows/build_platform_test_images.yml
@@ -291,9 +291,9 @@ jobs:
         id: version_reference
         run: |
           if [[ "${{ env.PLATFORM_TEST_TAG }}" == "latest" ]]; then
-            glrd_data="$(./bin/glrd --type stable,patch,nightly,dev --output-format=json --latest)"
+            glrd_data="$(./bin/glrd --type major,minor,nightly,dev --output-format=json --latest)"
           else
-            glrd_data="$(./bin/glrd --type stable,patch,nightly,dev --output-format=json --version ${{ inputs.platform_test_tag }})"
+            glrd_data="$(./bin/glrd --type major,minor,nightly,dev --output-format=json --version ${{ inputs.platform_test_tag }})"
           fi
 
           COMMIT_ID="$(echo $glrd_data | jq -r '.releases[0].git.commit_short')"

--- a/.github/workflows/build_requirements.yml
+++ b/.github/workflows/build_requirements.yml
@@ -73,9 +73,9 @@ jobs:
           version=$(./bin/garden-version "${{ inputs.version }}")
 
           if [[ "${{ inputs.version }}" == "today" ]]; then
-            glrd_data="$(./bin/glrd --type stable,patch,nightly,dev --output-format=json --latest)"
+            glrd_data="$(./bin/glrd --type major,minor,nightly,dev --output-format=json --latest)"
           else
-            glrd_data="$(./bin/glrd --type stable,patch,nightly,dev --output-format=json --version ${{ inputs.version }})"
+            glrd_data="$(./bin/glrd --type major,minor,nightly,dev --output-format=json --version ${{ inputs.version }})"
           fi
 
           commit_id=$(echo $glrd_data | jq -r '.releases[0].git.commit')

--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -4,10 +4,10 @@ on:
     inputs:
       type:
         type: choice
-        default: patch
+        default: minor
         description: 'Patch'
         options:
-        - patch
+        - minor
         - dev
       version:
         required: true
@@ -25,7 +25,7 @@ jobs:
   # Create new version in GLVD so it has the package list of the new release
   # This is needed for the automatic changelog generation
   glvd:
-    if: ${{ inputs.type }} == 'patch'
+    if: ${{ inputs.type }} == 'minor'
     name: Update GLVD distro list
     runs-on: ubuntu-latest
     permissions:
@@ -173,7 +173,7 @@ jobs:
           done
 
   tag_container_as_latest:
-    if: ${{ inputs.type }} == 'patch'
+    if: ${{ inputs.type }} == 'minor'
     uses: ./.github/workflows/tag_latest_container.yml
     with:
       version: ${{ inputs.version }}
@@ -203,12 +203,12 @@ jobs:
             version=${{ inputs.version }}
             major=$(echo ${version} | cut -d'.' -f1)
             minor=$(echo ${version} | cut -d'.' -f2)
-            if [ ${type} = "patch" ]; then
-              # check for stable version and create if missing
-              if ! glrd --no-header --type stable --version ${major} | grep ${major}; then
-                glrd-manage --s3-update --create stable --version ${major}
+            if [ ${type} = "minor" ]; then
+              # check for major version and create if missing
+              if ! glrd --no-header --type major --version ${major} | grep ${major}; then
+                glrd-manage --s3-update --create major --version ${major}
               fi
-              glrd-manage --s3-update --create patch --version ${version} --commit ${commit}
+              glrd-manage --s3-update --create minor --version ${version} --commit ${commit}
             elif [ ${type} = "dev" ]; then
               glrd-manage --s3-update --create dev --version ${version} --commit ${commit}
             fi
@@ -219,4 +219,4 @@ jobs:
             version=${{ inputs.version }}
             major=$(echo ${version} | cut -d'.' -f1)
             minor=$(echo ${version} | cut -d'.' -f2)
-            glrd --type stable,patch,dev --version ${major}
+            glrd --type major,minor,dev --version ${major}

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -184,10 +184,10 @@ jobs:
         with:
           cmd: glrd-manage --s3-update --create nightly --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
       - if: ${{ github.ref_name != 'main' }}
-        name: Create GLRD patch release
+        name: Create GLRD minor release
         uses: gardenlinux/glrd@v4
         with:
-          cmd: glrd-manage --s3-update --create patch --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
+          cmd: glrd-manage --s3-update --create minor --version "${{ needs.workflow_data.outputs.version }}" --commit "${{ needs.workflow_data.outputs.commit_id }}"
       - name: Get latest GL nightly
         id: gl_version_nightly
         uses: gardenlinux/glrd@v4


### PR DESCRIPTION
**What this PR does / why we need it**:

Use new major and minor naming scheme in GLRD throughout workflows.
Follow up of https://github.com/gardenlinux/gardenlinux/pull/3631
