### PR TITLE
Disable 'fail fast' in dev workflow matrix

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.set_version.outputs.version }}
-      fail_fast: true
+      fail_fast: false
     permissions:
       id-token: write # TODO: 3215 elevated permissions for included workflow
       actions: write  # TODO: 3215 elevated permissions for included workflow


### PR DESCRIPTION
'Fail fast' is not a good idea in cases where one failed build does not mean other builds will fail with the same issue. In test-ng, results may vary much between different feature sets, and in those cases fail fast obfuscates patterns of test failures, i.e. 'this always fails if the capi feature is included'.

For this reason I think it does more harm than good and should be disabled.
