### PR TITLE
fix: add missing chroot test-ng log upload

### DIFF
--- a/.github/workflows/test_flavor_chroot_ng.yml
+++ b/.github/workflows/test_flavor_chroot_ng.yml
@@ -58,6 +58,7 @@ jobs:
         if: always()
         run: |
           cp tests-ng/log/chroot.test-ng.log .build/${CNAME}.chroot.test-ng.log || true
+          cp tests-ng/log/chroot.test-ng.xml .build/${CNAME}.chroot.test-ng.xml || true
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         if: always()
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add missing chroot test-ng log upload. Currently this log is not part of the `test-ng-report` artifact and hence missing from the test reports.
