### PR TITLE
add gnupg as a prerequisite in macos for test-ng

### DIFF
--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -101,7 +101,7 @@ apt-get install azure-cli awscli openstackclient # for GCP and ALI look at tip
 #### Install on MacOS
 
 ```
-brew install coreutils bash gnu-sed gnu-getopt podman make curl jq libxml2 unzip swtpm socat retry
+brew install coreutils bash gnu-sed gnu-getopt podman make curl jq libxml2 unzip swtpm socat retry gnupg
 # install cloud provider CLIs
 brew install azure-cli awscli gcloud-cli aliyun-cli openstackclient
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Add package "gnupg" as a prerequisite for MacOS, as the tests cannot be initiated without them `gpgv`

**Which issue(s) this PR fixes**:
Fixes issue for tests not starting in macos

<img width="1123" height="238" alt="image" src="https://github.com/user-attachments/assets/c16c1fb4-19d9-4aab-9330-2d25ae24e303" />