### PR TITLE
Skip containerd test until rate limit issue is resolved

### DIFF
--- a/tests-ng/test_containers.py
+++ b/tests-ng/test_containers.py
@@ -6,6 +6,7 @@ TEST_IMAGES = [
     "public.ecr.aws/docker/library/busybox:unstable-uclibc",  # AWS ECR, https://gallery.ecr.aws/docker/library/busybox
 ]
 
+@pytest.mark.skip(reason="Skip until https://github.com/gardenlinux/gardenlinux/issues/3567 is resolved to avoid false negative results")
 @pytest.mark.booted(reason="Container tests require systemd")
 @pytest.mark.root(reason="Needs to start containerd")
 @pytest.mark.feature("(gardener or chost or _debug) and not _pxe", reason="containerd is not installed, pxe has tmpfs for /")


### PR DESCRIPTION
Tracks https://github.com/gardenlinux/gardenlinux/issues/3567
