### PR TITLE
fix: test-ng: Tests should never modify the users home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ __pycache__
 !tests/config/*.yaml.example
 tests/config
 tests-ng/log
+tests-ng/.ssh
 make_targets.cache
 /bin/*.vars
 /bin/*.ipxe

--- a/tests-ng/util/login_cloud.sh
+++ b/tests-ng/util/login_cloud.sh
@@ -16,12 +16,14 @@ image_basename="$(basename -- "$image")"
 image_name=${image_basename/.*/}
 workspace="$image_name"
 
-tf_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")/tf")"
+util_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
+tf_dir="$util_dir/tf"
 tofuenv_dir="$tf_dir/.tofuenv"
 PATH="$tofuenv_dir/bin:$PATH"
+ssh_private_key="$util_dir/../.ssh/id_ed25519_gl"
 
 vm_ip="$(cd "$tf_dir" && tofu workspace select "$workspace" >/dev/null && tofu output --raw vm_ip)"
 ssh_user="$(cd "$tf_dir" && tofu workspace select "$workspace" >/dev/null && tofu output --raw ssh_user)"
-ssh_opts=(-o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519_gl)
+ssh_opts=(-o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$ssh_private_key")
 
 exec ssh "${ssh_opts[@]}" "$ssh_user@$vm_ip" "$@"

--- a/tests-ng/util/login_qemu.sh
+++ b/tests-ng/util/login_qemu.sh
@@ -3,6 +3,8 @@
 set -eufo pipefail
 
 ssh_user=gardenlinux
+util_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
+ssh_private_key="$util_dir/../.ssh/id_ed25519_gl"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -17,6 +19,6 @@ while [ $# -gt 0 ]; do
 done
 
 vm_ip="127.0.0.1"
-ssh_opts=(-p 2222 -o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519_gl)
+ssh_opts=(-p 2222 -o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$ssh_private_key")
 
 exec ssh "${ssh_opts[@]}" "$ssh_user@$vm_ip" "$@"

--- a/tests-ng/util/run_cloud.sh
+++ b/tests-ng/util/run_cloud.sh
@@ -58,10 +58,11 @@ image="$2"
 image_basename="$(basename -- "$image")"
 image_name=${image_basename/.*/}
 user_data_script=
-tf_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")/tf")"
-login_cloud_sh="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")/login_cloud.sh")"
+util_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
+tf_dir="$util_dir/tf"
+login_cloud_sh="$util_dir/login_cloud.sh"
 
-log_dir="$test_dist_dir/../log"
+log_dir="$util_dir/../log"
 log_file_log="cloud.test-ng.log"
 log_file_junit="cloud.test-ng.xml"
 
@@ -162,10 +163,10 @@ if [ ! -f "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" ] || ! sha256sum
 	chmod +x "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
 fi
 
-ssh_private_key_path="$HOME/.ssh/id_ed25519_gl"
-if [ ! -f "$ssh_private_key_path" ]; then
-	mkdir -p "$(dirname "$ssh_private_key_path")"
-	ssh-keygen -t ed25519 -f "$ssh_private_key_path" -N "" >/dev/null
+ssh_private_key="$util_dir/../.ssh/id_ed25519_gl"
+if [ ! -f "$ssh_private_key" ]; then
+	mkdir -p "$(dirname "$ssh_private_key")"
+	ssh-keygen -t ed25519 -f "$ssh_private_key" -N "" >/dev/null
 fi
 
 user_data_script="$(mktemp)"
@@ -198,6 +199,7 @@ fi
 cat >"${tf_dir}/$image_name.tfvars" <<EOF
 root_disk_path        = "$root_disk_path_var"
 test_disk_path        = "$(realpath -- "$test_dist_dir/dist.ext2.raw")"
+ssh_public_key_path   = "$ssh_private_key.pub"
 user_data_script_path = "$user_data_script"
 existing_root_disk    = "$existing_root_disk_var"
 

--- a/tests-ng/util/run_qemu.sh
+++ b/tests-ng/util/run_qemu.sh
@@ -50,7 +50,8 @@ done
 
 test_dist_dir="$1"
 image="$2"
-log_dir="$test_dist_dir/../log"
+util_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
+log_dir="$util_dir/../log"
 log_file_log="qemu.test-ng.log"
 log_file_junit="qemu.test-ng.xml"
 
@@ -173,13 +174,13 @@ exec 2>&1
 EOF
 
 if ((ssh)); then
-	ssh_private_key_path="$HOME/.ssh/id_ed25519_gl"
-	ssh_public_key_path="${ssh_private_key_path}.pub"
-	if [ ! -f "$ssh_private_key_path" ]; then
-		mkdir -p "$(dirname "$ssh_private_key_path")"
-		ssh-keygen -t ed25519 -f "$ssh_private_key_path" -N "" >/dev/null
+	ssh_private_key="$util_dir/../.ssh/id_ed25519_gl"
+	ssh_public_key="$ssh_private_key.pub"
+	if [ ! -f "$ssh_private_key" ]; then
+		mkdir -p "$(dirname "$ssh_private_key")"
+		ssh-keygen -t ed25519 -f "$ssh_private_key" -N "" >/dev/null
 	fi
-	ssh_public_key=$(cat "$ssh_public_key_path")
+	ssh_public_key=$(cat "$ssh_public_key")
 	ssh_user="gardenlinux"
 	cat >>"$tmpdir/fw_cfg-script.sh" <<EOF
 systemctl enable --now ssh

--- a/tests-ng/util/tf/modules/ali/variables.tf
+++ b/tests-ng/util/tf/modules/ali/variables.tf
@@ -23,7 +23,6 @@ variable "existing_root_disk" {
 variable "ssh_public_key_path" {
   description = "Path to your ssh public key"
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
 }
 
 variable "user_data_script_path" {

--- a/tests-ng/util/tf/modules/aws/variables.tf
+++ b/tests-ng/util/tf/modules/aws/variables.tf
@@ -23,7 +23,6 @@ variable "existing_root_disk" {
 variable "ssh_public_key_path" {
   description = "Path to your ssh public key"
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
 }
 
 variable "user_data_script_path" {

--- a/tests-ng/util/tf/modules/azure/variables.tf
+++ b/tests-ng/util/tf/modules/azure/variables.tf
@@ -23,7 +23,6 @@ variable "existing_root_disk" {
 variable "ssh_public_key_path" {
   description = "Path to your ssh public key"
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
 }
 
 variable "user_data_script_path" {

--- a/tests-ng/util/tf/modules/gcp/variables.tf
+++ b/tests-ng/util/tf/modules/gcp/variables.tf
@@ -23,7 +23,6 @@ variable "existing_root_disk" {
 variable "ssh_public_key_path" {
   description = "Path to your ssh public key"
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
 }
 
 variable "user_data_script_path" {

--- a/tests-ng/util/tf/modules/openstack/variables.tf
+++ b/tests-ng/util/tf/modules/openstack/variables.tf
@@ -23,7 +23,6 @@ variable "existing_root_disk" {
 variable "ssh_public_key_path" {
   description = "Path to your ssh public key"
   type        = string
-  default     = "~/.ssh/id_ed25519.pub"
 }
 
 variable "user_data_script_path" {

--- a/tests-ng/util/tf/variables.tf
+++ b/tests-ng/util/tf/variables.tf
@@ -23,7 +23,8 @@ variable "existing_root_disk" {
 variable "ssh_public_key_path" {
   description = "Path to your ssh public key"
   type        = string
-  default     = "~/.ssh/id_ed25519_gl.pub"
+  # Only supply a default value. Variables is overwritten by run_cloud.sh.
+  default     = "~/.ssh/id_ed25519.pub"
 }
 
 variable "user_data_script_path" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Tests should never modify the users home directory.
A ssh key is created inside the `tests-ng/.ssh` folder and reused if it already exist. References to "~/.ssh/id_ed25519.pub only exist to have a default value.

**Which issue(s) this PR fixes**:
Fixes #3579
