### PR TITLE
fix(iscsi): generate initiator name on first bootup

### DIFF
--- a/features/iscsi/exec.config
+++ b/features/iscsi/exec.config
@@ -3,3 +3,6 @@
 sed -i 's/^\(node.session.scan\).*/\1 = manual/' /etc/iscsi/iscsid.conf
 sed -i 's/^\(node.session.auth.chap_algs\).*/\1 = MD5/' /etc/iscsi/iscsid.conf
 touch /var/lib/open-iscsi-configured0
+
+# Delete initiatorname.iscsi
+rm /etc/iscsi/initiatorname.iscsi

--- a/features/iscsi/file.include/etc/iscsi/initiatorname.iscsi.template
+++ b/features/iscsi/file.include/etc/iscsi/initiatorname.iscsi.template
@@ -1,0 +1,5 @@
+## DO NOT EDIT OR REMOVE THIS FILE!
+## If you remove this file, the iSCSI daemon will not start.
+## If you change the InitiatorName, existing access control lists
+## may reject this initiator.  The InitiatorName must be unique
+## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.

--- a/features/iscsi/file.include/etc/systemd/system/iscsi-initiatorname.service
+++ b/features/iscsi/file.include/etc/systemd/system/iscsi-initiatorname.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=iSCSI InitiatorName Generator
+ConditionPathExists=|!/etc/iscsi/initiatorname.iscsi
+After=multi-user.service
+Before=iscsid.service
+
+[Service]
+ExecStart=/bin/mv /etc/iscsi/initiatorname.iscsi.template /etc/iscsi/initiatorname.iscsi
+ExecStart=/bin/sh -c 'iscsi-iname -g >> /etc/iscsi/initiatorname.iscsi'
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**What this PR does / why we need it**:
On 1877 the initiator name was not cleared so it is the same on all images.

**Which issue(s) this PR fixes**:
Fixes #3665 


