### PR TITLE
feat: test-ng: support multiarch builds for tofu provider azurerm

### DIFF
--- a/tests-ng/util/run_cloud.sh
+++ b/tests-ng/util/run_cloud.sh
@@ -125,6 +125,32 @@ get_logs() {
 
 trap cleanup EXIT
 
+case "$(uname -s)" in
+Linux)
+	os=linux
+	;;
+Darwin)
+	os=darwin
+	;;
+*)
+	echo "Operating System not supported"
+	exit 1
+	;;
+esac
+
+case "$(uname -m)" in
+x86_64)
+	arch=amd64
+	;;
+aarch64 | arm64)
+	arch=arm64
+	;;
+*)
+	echo "Arch not supported"
+	exit 1
+	;;
+esac
+
 tofuenv_dir="$tf_dir/.tofuenv"
 PATH="$tofuenv_dir/bin:$PATH"
 # in case we pass a GITHUB_TOKEN, we can work around rate limiting
@@ -143,8 +169,14 @@ tofuenv use "$tofu_version"
 TF_CLI_CONFIG_FILE="$tf_dir/.terraformrc"
 export TF_CLI_CONFIG_FILE
 TOFU_PROVIDERS_CUSTOM="$tf_dir/.terraform/providers/custom"
-TOFU_PROVIDER_AZURERM_URL="https://github.com/gardenlinux/terraform-provider-azurerm/releases/download/v4.41.0-post1-secureboot1/terraform-provider-azurerm"
-TOFU_PROVIDER_AZURERM_CHECKSUM="d0724b2b33270dbb0e7946a4c125e78b5dd0f34697b74a08c04a1c455764262e"
+TOFU_PROVIDER_AZURERM_VERSION="v4.41.0"
+TOFU_PROVIDER_AZURERM_VERSION_LONG="${TOFU_PROVIDER_AZURERM_VERSION}-post1-secureboot2"
+TOFU_PROVIDER_AZURERM_BIN="terraform-provider-azurerm_${TOFU_PROVIDER_AZURERM_VERSION}_${os}_${arch}"
+TOFU_PROVIDER_AZURERM_URL="https://github.com/gardenlinux/terraform-provider-azurerm/releases/download/$TOFU_PROVIDER_AZURERM_VERSION_LONG/$TOFU_PROVIDER_AZURERM_BIN"
+TOFU_PROVIDER_AZURERM_CHECKSUM_linux_amd64="d0724b2b33270dbb0e7946a4c125e78b5dd0f34697b74a08c04a1c455764262e"
+TOFU_PROVIDER_AZURERM_CHECKSUM_linux_arm64="b5a5610bef03fcfd6b02b4da804a69cbca64e2c138c1fe943a09a1ff7b123ff7"
+TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_amd64="0f4676ad2f0d16ec3e24f6ced1414b1f638c20da0a0b2c2b19e5bd279f0f1d32"
+TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_arm64="bdda99a9139363676b1edf2f0371a285e1e1d9e9b9524de4f30b7c2b08224a86"
 
 cat >"$TF_CLI_CONFIG_FILE" <<EOF
 provider_installation {
@@ -158,7 +190,18 @@ if [ ! -f "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" ] || ! sha256sum
 	echo "Downloading terraform-provider-azurerm"
 	mkdir -p "${TOFU_PROVIDERS_CUSTOM}"
 	retry -d "1,2,5,10,30" curl -LO --create-dirs --output-dir "${TOFU_PROVIDERS_CUSTOM}" "${TOFU_PROVIDER_AZURERM_URL}"
-	echo "$TOFU_PROVIDER_AZURERM_CHECKSUM ${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" >"${TOFU_PROVIDERS_CUSTOM}/checksum.txt"
+	mv "${TOFU_PROVIDERS_CUSTOM}/${TOFU_PROVIDER_AZURERM_BIN}" "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
+	case "${os}_${arch}" in
+	linux_amd64) checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_linux_amd64" ;;
+	linux_arm64) checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_linux_arm64" ;;
+	darwin_amd64) checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_amd64" ;;
+	darwin_arm64) checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_arm64" ;;
+	*)
+		echo "Unsupported OS/arch combination: ${os}_${arch}" >&2
+		exit 1
+		;;
+	esac
+	echo "$checksum ${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" >"${TOFU_PROVIDERS_CUSTOM}/checksum.txt"
 	sha256sum -c "${TOFU_PROVIDERS_CUSTOM}/checksum.txt"
 	chmod +x "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Support multiarch builds for tofu provider azurerm in test-ng.
