### PR TITLE
fix: test-ng: use random seed for tf workspaces

### DIFF
--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -68,6 +68,7 @@ Before running the test framework, make sure the following dependencies are inst
 - `jq`
 - `libxml2-utils`
 - `unzip`
+- `uuid-runtime`
 - `qemu`
 - `qemu-utils`
 - `socat`
@@ -85,7 +86,7 @@ If you plan to provision cloud resources, the cloud provider specific CLIs might
 
 ```
 apt-get update
-apt-get install podman make curl jq libxml2-utils unzip qemu swtpm socat retry
+apt-get install podman make curl jq libxml2-utils unzip uuid-runtime qemu swtpm socat retry
 # install cloud provider CLIs
 apt-get install azure-cli awscli openstackclient # for GCP and ALI look at tip
 ```
@@ -101,7 +102,7 @@ apt-get install azure-cli awscli openstackclient # for GCP and ALI look at tip
 #### Install on MacOS
 
 ```
-brew install coreutils bash gnu-sed gnu-getopt podman make curl jq libxml2 unzip swtpm socat retry gnupg
+brew install coreutils bash gnu-sed gnu-getopt podman make curl jq libxml2 ossp-uuid unzip swtpm socat retry gnupg
 # install cloud provider CLIs
 brew install azure-cli awscli gcloud-cli aliyun-cli openstackclient
 ```

--- a/tests-ng/util/login_cloud.sh
+++ b/tests-ng/util/login_cloud.sh
@@ -14,13 +14,16 @@ image="$1"
 shift
 image_basename="$(basename -- "$image")"
 image_name=${image_basename/.*/}
-workspace="$image_name"
 
 util_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
 tf_dir="$util_dir/tf"
 tofuenv_dir="$tf_dir/.tofuenv"
 PATH="$tofuenv_dir/bin:$PATH"
 ssh_private_key="$util_dir/../.ssh/id_ed25519_gl"
+uuid_file="$util_dir/.uuid"
+uuid=$(<"$uuid_file")
+seed=${uuid%%-*}
+workspace="${image_name}-${seed}"
 
 vm_ip="$(cd "$tf_dir" && tofu workspace select "$workspace" >/dev/null && tofu output --raw vm_ip)"
 ssh_user="$(cd "$tf_dir" && tofu workspace select "$workspace" >/dev/null && tofu output --raw ssh_user)"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix test-ng to use random seed for tf workspaces.
This prevents reusing the same workspace across different CI runs.

It uses the same approach as the old test framework:
https://github.com/gardenlinux/gardenlinux/blob/cf6c4fdc55b73d27c3d3153b64c9f65fa6758561/tests/platformSetup/Makefile#L6-L14
https://github.com/gardenlinux/gardenlinux/blob/cf6c4fdc55b73d27c3d3153b64c9f65fa6758561/tests/platformSetup/Makefile#L112

**Which issue(s) this PR fixes**:
Fixes #3700 #3704
