### PR TITLE
Port 'security_id' mark to new test framework

### DIFF
--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -406,3 +406,5 @@ Tests can be decorated with pytest markers to indicate certain limitations or pr
 `@pytest.mark.feature("a and not b", reason="Some reason, this is optional")`: This test is only run if the boolean condition is true. Use this to limit feature-specific tests. Use the optional `reason` argument to document why this is needed, in cases where this is not really obvious.
 
 `@pytest.mark.performance_metric`: This is a performance metric test that can be skipped when running under emulation.
+
+`@pytest.mark.security_id(42)`: Map a test to a security id. Must be an positive integer value.

--- a/tests-ng/plugins/security_id.py
+++ b/tests-ng/plugins/security_id.py
@@ -1,0 +1,20 @@
+from typing import List
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config):
+    config.addinivalue_line(
+        "markers",
+        "security_id(id=None): Map a test to a security id.",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
+    for item in items:
+        for marker in item.iter_markers(name="security_id"):
+            # To map the required tests for our compliance, we define a custom marker.
+            # We add this marker to the user_properties field so it appears in any generated report.
+            # https://docs.pytest.org/en/4.6.x/reference.html#item
+            security_id = marker.args[0]
+            item.user_properties.append(("security_id", security_id))

--- a/tests-ng/test_password_hashes.py
+++ b/tests-ng/test_password_hashes.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-# @pytest.mark.security_id(325)
+@pytest.mark.security_id(325)
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
 )
@@ -20,7 +20,7 @@ def test_password_entry_present(pam_config):
     ), f"Expected exactly one password entry, found {len(candidates)}: {candidates}"
 
 
-# @pytest.mark.security_id(325)
+@pytest.mark.security_id(325)
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
 )

--- a/tests-ng/test_su.py
+++ b/tests-ng/test_su.py
@@ -2,7 +2,7 @@ import pytest
 from plugins.pam import PamConfig
 
 
-# @pytest.mark.security_id(166)
+@pytest.mark.security_id(166)
 @pytest.mark.root
 @pytest.mark.feature("not container")
 @pytest.mark.parametrize("pam_config", ["/etc/pam.d/su"], indirect=["pam_config"])


### PR DESCRIPTION
We had used `security_id` in tests without having the mark implemented in the new test framework. This PR ports the old implementation of the mark into the new framework, in the form of a plugin. This allows us to remove the warnings without commenting out the marks, and should be the way forward.

Port of #2477
Related to #3691
Fixes #3707
