### PR TITLE
Restore bits accidentally removed in #3692

### DIFF
--- a/.github/workflows/test_flavor_chroot.yml
+++ b/.github/workflows/test_flavor_chroot.yml
@@ -50,6 +50,11 @@ jobs:
           rm "$CNAME.tar.gz"
 
           make --directory=tests ${{ inputs.flavor }}-${{ inputs.arch }}-chroot-test
+      - name: Download test distribution artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # pin@v5.0.0
+        with:
+          name: test-distribution
+          path: tests-ng/.build
       # chroot.test.xml is written in the entrypoint tests/init
       - name: Rename test results
         if: always()

--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -71,6 +71,7 @@ Before running the test framework, make sure the following dependencies are inst
 - `uuid-runtime`
 - `qemu`
 - `qemu-utils`
+- `socat`
 
 If you plan to provision cloud resources, the cloud provider specific CLIs might be useful or even required:
 


### PR DESCRIPTION
Restore the following which was removed in #3692:

- Download test distribution artifact in chroot workflow
- socat in install instructions
