### PR TITLE
Add a Wants= dependency for the check-tpm service for the tpm device

### DIFF
--- a/features/_tpm2/initrd.include/etc/systemd/system/check-tpm.service
+++ b/features/_tpm2/initrd.include/etc/systemd/system/check-tpm.service
@@ -1,6 +1,7 @@
 [Unit]
 DefaultDependencies=no
 After=tpm2.target
+Wants=tpm2.target
 Before=systemd-repart.service
 
 [Service]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the boot sequence in cases where the TPM device is too slow to show up and the check-tpm service terminates the boot too soon.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Add a Wants= dependency for the check-tpm service for the tpm device
```
