### PR TITLE
Change GitHub workflow to cache only `secureboot*` files for further processing

### DIFF
--- a/.github/workflows/build_requirements.yml
+++ b/.github/workflows/build_requirements.yml
@@ -116,5 +116,5 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4.6.2
         with:
           name: certs
-          path: cert/*.*
+          path: cert/secureboot.*
           if-no-files-found: error


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes what the `certs` artifact contains to provide only the relevant set of `secureboot*` files.