### PR TITLE
fix: do not trigger a initrd regen when using update-bootloaders

### DIFF
--- a/features/_legacy/file.include/usr/local/sbin/update-bootloaders
+++ b/features/_legacy/file.include/usr/local/sbin/update-bootloaders
@@ -4,6 +4,8 @@ set -e
 
 update-kernel-cmdline
 for kernel in /boot/vmlinuz-*; do
+   ln -sf "/boot/initrd.img-${kernel#*-}" /boot/initrd
    kernel-install add "${kernel#*-}" "${kernel}"
+   rm -f /boot/initrd
 done
 update-syslinux


### PR DESCRIPTION
**What this PR does / why we need it**:
Certain Gardener users use a DS (privileged) in order to change some kernel parameters and reboot the node.
In 1592 the update-boot loaders script worked as expected but in 1877 it is going to trigger a initrd regeneration and also the newly generated initrd will be placed under _/efi/Default/$(uname -r)/_ directory - this is not wanted as _/efi_ is usually extremely small.
This PR is going to make _update-bootloaders_ keep the old behavior and allow the Gardener users to keep using their custom DS in order to make changes to the boot loader configs.

**Which issue(s) this PR fixes**:
Fixes #3730 

