### PR TITLE
Disable the GnuTLS FIPS workaround

### DIFF
--- a/features/_fips/exec.config
+++ b/features/_fips/exec.config
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-
-# https://github.com/gardenlinux/gardenlinux/issues/3581
-# GnuTLS fails the selftest when set to FIPS mode.
-echo "export GNUTLS_SKIP_FIPS_INTEGRITY_CHECKS=1" >> /etc/profile
-
 # Setup the FIPS configration and link it into the /etc/ssl folder.
 # shellcheck disable=SC2046
 openssl fipsinstall -out /etc/ssl/fipsmodule.cnf -module /usr/lib/$(arch)-linux-gnu/ossl-modules/fips.so


### PR DESCRIPTION
In this PR, we will remove the FIPS workaround. Once https://github.com/gardenlinux/package-gnutls/pull/2 is merged, this PR can be merged as well. 


Fixes: [#3581](https://github.com/gardenlinux/gardenlinux/issues/3581)
Releates: #3436 