### PR TITLE
fix: test: pass GITHUB_* variables to podman for gh actions

### DIFF
--- a/tests/platformSetup/Makefile
+++ b/tests/platformSetup/Makefile
@@ -73,7 +73,7 @@ CRE_CMD_privileged = --privileged
 # privileged is required for virt-copy-in/guestfish
 CRE_CMD_kvm = $(CRE_CMD_BASE) $(CRE_CMD_privileged) $(KVM_DEVICE)
 CRE_CMD_kvm_image = $(GL_REGISTRY)/gardenlinux/platform-test-kvm:$(GL_VERSION)
-CRE_CMD_tofu = $(CRE_CMD_BASE) -e TF_* -v ~/.aliyun:/root/.aliyun -e ALIBABA_* -v ~/.aws:/root/.aws -e AWS_* -v ~/.azure:/root/.azure -e azure_* -e ARM_* -e ACTIONS_* -v ~/.config/gcloud:/root/.config/gcloud -e GOOGLE_* -e CLOUDSDK_* -e OS_* --rm -v ~/.ssh:/root/.ssh:ro $(GL_REGISTRY)/gardenlinux/platform-test-tofu:$(GL_VERSION)
+CRE_CMD_tofu = $(CRE_CMD_BASE) -e TF_* -v ~/.aliyun:/root/.aliyun -e ALIBABA_* -v ~/.aws:/root/.aws -e AWS_* -v ~/.azure:/root/.azure -e azure_* -e ARM_* -e ACTIONS_* -e GITHUB_* -v ~/.config/gcloud:/root/.config/gcloud -e GOOGLE_* -e CLOUDSDK_* -e OS_* --rm -v ~/.ssh:/root/.ssh:ro $(GL_REGISTRY)/gardenlinux/platform-test-tofu:$(GL_VERSION)
 MKDIRS = ~/.aliyun ~/.aws ~/.azure ~/.config/gcloud
 
 .PHONY: all

--- a/tests/platformSetup/platformSetup.py
+++ b/tests/platformSetup/platformSetup.py
@@ -304,7 +304,7 @@ class Tofu:
             if github_run_id and github_run_number:
                 workspace = f"test-{github_run_id}-{github_run_number}-{flavor}-{self.paths.seed}"
             else:
-                workspace = f"{flavor}-{self.paths.seed}"
+                workspace = f"test-{flavor}-{self.paths.seed}"
 
             logger.info(f"Workspace: {workspace}")
             workspace_cmd = ["tofu", "workspace", "select", workspace]


### PR DESCRIPTION
**What this PR does / why we need it**:

Pass `GITHUB_*` variables to podman for gh actions
Also always name workspace `test-*` like tests-ng does it.
This was missed in #3737.

**Which issue(s) this PR fixes**:
Fixes #3746
