### PR TITLE
feat: add ID_LIKE=debian in /etc/os-release

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 rm /etc/os-release
 cat > /etc/os-release << EOF
 ID=gardenlinux
+ID_LIKE=debian
 NAME="Garden Linux"
 PRETTY_NAME="Garden Linux $BUILDER_VERSION"
 IMAGE_VERSION=${BUILDER_VERSION}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #3745

**Definition of Done:**
- [ ] ~The code is sufficiently documented~ N/A
- [ ] ~Shared the changes with the Team so everyone is aware~ N/A
- [ ] ~The code is appropriately tested~ N/A
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
  - backported to rel-1877: https://github.com/gardenlinux/gardenlinux/commit/b984df285e3a61a42d51957ce60b1bec5f2c7bc6

