### PR TITLE
Tests: Migrate nft-config to test-ng

### DIFF
--- a/tests-ng/plugins/nft.py
+++ b/tests-ng/plugins/nft.py
@@ -1,0 +1,46 @@
+import json
+from dataclasses import dataclass
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@dataclass
+class Chain:
+    family: str
+    table: str
+    name: str
+    handle: int
+    type: str
+    hook: str
+    prio: int
+    policy: str
+
+
+@dataclass
+class TableInterFilter:
+    chains: list[Chain]
+
+
+class Nft:
+    def __init__(self, shell: ShellRunner):
+        self._shell = shell
+
+    def list_table_inet_filter(self) -> list[Chain]:
+        result = self._shell(
+            cmd="nft -j list table inet filter",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        if result.returncode != 0:
+            raise ValueError(f"nft list table inet filter failed: {result.stderr}")
+
+        output_json = json.loads(result.stdout)
+        return [
+            Chain(**obj["chain"]) for obj in output_json["nftables"] if obj.get("chain")
+        ]
+
+
+@pytest.fixture
+def nft(shell: ShellRunner):
+    return Nft(shell)

--- a/tests-ng/test_firewall.py
+++ b/tests-ng/test_firewall.py
@@ -1,0 +1,17 @@
+import pytest
+from plugins.nft import Nft
+
+
+@pytest.mark.root(reason="nft is only accessible by root")
+@pytest.mark.booted(reason="Firewall needs booted system")
+@pytest.mark.feature("firewall")
+def test_nft_config(nft: Nft):
+    matching_policies = [
+        chain
+        for chain in nft.list_table_inet_filter()
+        if chain.type == "filter"
+        and chain.hook == "input"
+        and chain.prio == 0
+        and chain.policy == "drop"
+    ]
+    assert len(matching_policies) == 1, f"input has policy drop not as default"


### PR DESCRIPTION
**What this PR does / why we need it**:
Migration of https://github.com/gardenlinux/gardenlinux/blob/main/features/firewall/test/test_nft_config.py to the new testing framework.

**Which issue(s) this PR fixes**:
fxies #3603