### PR TITLE
feat: measure constant string into PCR7 before switch-root

### DIFF
--- a/features/_tpm2/initrd.include/etc/systemd/system/initrd-switch-root.target.requires/tpm2-measure.service
+++ b/features/_tpm2/initrd.include/etc/systemd/system/initrd-switch-root.target.requires/tpm2-measure.service
@@ -1,0 +1,1 @@
+../tpm2-measure.service

--- a/features/_tpm2/initrd.include/etc/systemd/system/tpm2-measure.service
+++ b/features/_tpm2/initrd.include/etc/systemd/system/tpm2-measure.service
@@ -1,0 +1,11 @@
+[Unit]
+DefaultDependencies=no
+After=tpm2.target
+Wants=tpm2.target
+Before=initrd-switch-root.target
+OnFailure=emergency.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/measure-pcr7
+RemainAfterExit=yes

--- a/features/_tpm2/initrd.include/usr/bin/measure-pcr7
+++ b/features/_tpm2/initrd.include/usr/bin/measure-pcr7
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+/usr/lib/systemd/systemd-pcrextend --pcr 7 "switch-root" || halt -f

--- a/features/_usi/image.esp.tar
+++ b/features/_usi/image.esp.tar
@@ -70,7 +70,7 @@ chroot "$rootfs" dracut \
 	--kver "${kernel#*-}" \
 	--modules "bash dash systemd systemd-initrd systemd-repart systemd-cryptsetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt" \
 	--reproducible \
-	--install 'find findmnt grep lsblk tail head realpath basename sfdisk mkfs.ext4 resizefat32 dd cryptsetup' \
+	--install 'find findmnt grep lsblk tail head realpath basename sfdisk mkfs.ext4 resizefat32 dd cryptsetup /usr/lib/systemd/systemd-pcrextend' \
 	--include '/tmp/initrd.include' / \
 	--add-drivers erofs \
 	/initrd


### PR DESCRIPTION
This makes the PCR7 unusable for cryptsetup on the /var partition after switch-root, while still allowing the PCR7 to be used for other runtime user-space operations. Essentially this splits the PCR7 values into two distinct domains: inside the intird and in the main rootfs
