### PR TITLE
feat: test-ng: migrate selinux tests

### DIFF
--- a/tests-ng/plugins/kernel_cmdline.py
+++ b/tests-ng/plugins/kernel_cmdline.py
@@ -1,0 +1,13 @@
+from typing import List
+
+import pytest
+
+from .booted import is_system_booted
+
+
+@pytest.fixture
+def kernel_cmdline() -> List[str]:
+    if not is_system_booted():
+        pytest.skip("can't get kernel cmdline when not running on a booted system")
+    with open("/proc/cmdline", "r") as f:
+        return f.read().strip().split()

--- a/tests-ng/test_selinux.py
+++ b/tests-ng/test_selinux.py
@@ -1,0 +1,16 @@
+import os
+from typing import List
+
+import pytest
+
+
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires a running kernel to read /proc/cmdline")
+def test_selinux_cmdline(kernel_cmdline: List[str]):
+    assert "security=selinux" in kernel_cmdline
+
+
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires a running kernel to access sysfs")
+def test_selinux_enabled():
+    assert os.path.exists("/sys/fs/selinux/enforce"), "SELinux not enabled"


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate the selinux tests to the new test framework. Instead of plainly migrating the old test that just did:

```python
@pytest.mark.parametrize(
    "file,args",
    [
        ("/etc/kernel/cmdline", "security=selinux"),
    ]
)


def test_kernel_cmdline(client, file, args):
    file_content(client, file, args, only_line_match=True)
```

So was looking at the contents of `/etc/kernel/cmdline` this migrated version instead actually reads `/proc/cmdline` from within the running system and additionally also checks for the presence of `/sys/fs/selinux/enforce` to double validate that selinux is actually on and not e.g. overwritten by some other `lsm=` cmdline arg.

> [!NOTE]
> It is purposefully only checking for existence of `/sys/fs/selinux/enforce`, **not** reading it, since (at least for now) we only care about selinux being on, we don't care if we are running in enforcing or permissive mode.

**Which issue(s) this PR fixes**:
Resolves #3590