### PR TITLE
Replace deprecated openjdk image with sapmachine image

### DIFF
--- a/bare_flavors/sapmachine/test/Containerfile
+++ b/bare_flavors/sapmachine/test/Containerfile
@@ -1,6 +1,6 @@
 ARG image
 
-FROM openjdk AS compile
+FROM docker.io/library/sapmachine:latest AS compile
 COPY Test.java /
 RUN javac Test.java && jar -c -f test.jar -e Test Test.class
 


### PR DESCRIPTION
The deprecated image failed our tests in CI:

```
[1/2] STEP 1/3: FROM openjdk AS compile
Resolving "openjdk" using unqualified-search registries (/etc/containers/registries.conf)
Trying to pull docker.io/library/openjdk:latest...
Trying to pull quay.io/openjdk:latest...
Error: creating build container: 2 errors occurred while pulling:
 * initializing source docker://openjdk:latest: reading manifest latest in docker.io/library/openjdk: manifest unknown
 * initializing source docker://quay.io/openjdk:latest: reading manifest latest in quay.io/openjdk: StatusCode: 404, "<!doctype html>\n<html lang=en>\n<title>404 Not Foun..."
make: *** [Makefile:129: bare-sapmachine-amd64-container-test] Error 125
make: Leaving directory '/home/runner/work/gardenlinux/gardenlinux/tests'
```

There is a deprecation notice on the docker hub page: https://hub.docker.com/_/openjdk#deprecation-notice

Fixes https://github.com/gardenlinux/gardenlinux/issues/3794
