### PR TITLE
Tests: Migrate duplicate_uids to test-ng

### DIFF
--- a/tests-ng/plugins/utils.py
+++ b/tests-ng/plugins/utils.py
@@ -77,3 +77,18 @@ def parse_etc_file(
         entries.append(entry)
 
     return entries
+
+
+def check_for_duplicates(
+    entries: List[Dict[str, str | List[str]]], field: str
+) -> List[str]:
+    duplicates = list[str]()
+    visited_entries = list[str]()
+    for entry in entries:
+        item = entry[field]
+        if item in visited_entries:
+            duplicates.append(str(item))
+        else:
+            visited_entries.append(str(item))
+
+    return duplicates

--- a/tests-ng/test_duplicate_uids.py
+++ b/tests-ng/test_duplicate_uids.py
@@ -1,0 +1,25 @@
+from typing import Dict, List
+
+from plugins.password_shadow import passwd_entries
+from plugins.utils import check_for_duplicates
+
+
+def test_duplicate_uids(passwd_entries: List[Dict[str, str | List[str]]]):
+    """
+    Check if any duplicate userids are defined in /etc/passwd.
+    """
+    duplicates = check_for_duplicates(entries=passwd_entries, field="uid")
+    assert (
+        len(duplicates) == 0
+    ), f"uids {duplicates} are used multiple times in /etc/passwd"
+
+
+def test_duplicate_uids_detection(passwd_entries: List[Dict[str, str | List[str]]]):
+    """
+    Appending an existing entry to the list to check if the duplication check finds this.
+    """
+    passwd_entries.append(passwd_entries[0])
+
+    duplicates = check_for_duplicates(entries=passwd_entries, field="uid")
+    assert len(duplicates) == 1, f"duplicate uid is not found successfully"
+    assert duplicates[0] == passwd_entries[0]["uid"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrates https://github.com/gardenlinux/gardenlinux/blob/main/features/base/test/test_duplicate_uids.py to new test-ng.

**Which issue(s) this PR fixes**:
Fixes #3784

**Special notes for your reviewer**:
I've added a negative test.