### PR TITLE
output cmdline on _pxe feature build and use in tests

### DIFF
--- a/features/_pxe/file.include/etc/kernel/cmdline.d/80-pxe.cfg
+++ b/features/_pxe/file.include/etc/kernel/cmdline.d/80-pxe.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX ip=dhcp gl.live=1 gl.ovl=/:tmpfs"

--- a/features/_pxe/image.pxe.tar.gz
+++ b/features/_pxe/image.pxe.tar.gz
@@ -17,78 +17,18 @@ tar --extract --xattrs --xattrs-include '*' --directory "$chroot_dir" < "$input"
 cp "$chroot_dir/boot/"vmlinuz* vmlinuz
 cp "$chroot_dir/boot/"initrd* initrd
 
+read -r _ cmdline < "$chroot_dir/etc/kernel/cmdline"
+echo "$cmdline" > cmdline
+
 mksquashfs "$chroot_dir" root.squashfs -noappend -comp xz -mkfs-time "$BUILDER_TIMESTAMP" -all-time "$BUILDER_TIMESTAMP"
 
 sha256sum root.squashfs | head -c 64 > root.squashfs.sha256sum
 echo root.squashfs.sha256sum | cpio -H newc -o | xz --check=crc32 >> initrd
 
-echo "console=ttyS0 gl.live=1 gl.ovl=/:tmpfs" > cmdline
-
-touch tmp_initrd
-[[ ! -e "$chroot_dir/initrd" ]]
-touch "$chroot_dir/initrd"
-[[ ! -e "$chroot_dir/root.squashfs" ]]
-touch "$chroot_dir/root.squashfs"
-mount --bind root.squashfs "$chroot_dir/root.squashfs"
-
-[[ -d "$chroot_dir/proc" ]] && [[ -z "$(ls -A "$chroot_dir/proc")" ]]
-mount --rbind /proc "$chroot_dir/proc"
-
-kernel_file=$(find "$chroot_dir/boot/" -name 'vmlinuz-*')
-kernel_version="${kernel_file#*-}"
-
-unshare --user --map-root-user --mount -- bash -c 'mount -t tmpfs tmpfs '"$chroot_dir/var/tmp"' && mount -t tmpfs none /sys && mount --bind /usr/bin/false /usr/bin/systemd-detect-virt && "$@"' -- \
-chroot "$chroot_dir" env dracut \
-	--force \
-	--kver "$kernel_version" \
-	--modules "bash dash systemd systemd-initrd kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd fs-lib shutdown gardenlinux-live" \
-	--include "/root.squashfs" "root.squashfs" \
-	--reproducible \
-	--no-hostonly \
-	"/initrd"
-
-umount -l "$chroot_dir/proc"
-
-mv "$chroot_dir/initrd" tmp_initrd
-umount "$chroot_dir/root.squashfs"
-rm "$chroot_dir/root.squashfs"
-
-case "$BUILDER_ARCH" in
-	amd64)
-		uefi_arch=x64
-		;;
-	arm64)
-		uefi_arch=aa64
-		;;
-esac
-
-/lib/systemd/ukify build \
-	--stub "${chroot_dir}/usr/lib/systemd/boot/efi/linux$(tr '[:upper:]' '[:lower:]' <<< "$uefi_arch").efi.stub" \
-	--linux "vmlinuz" \
-	--initrd "tmp_initrd" \
-	--cmdline "cmdline" \
-	--output "unified_image"
-
-export PKCS11_MODULE_PATH="/usr/lib/$(uname -m)-linux-gnu/pkcs11/aws_kms_pkcs11.so"
-cert_base="/builder/cert/secureboot.db"
-
-if [ -f "$cert_base.key" ]; then
-	key_params=(--key "$cert_base.key")
-elif [ -f "$cert_base.arn" ]; then
-	key_params=(--engine pkcs11 --key "pkcs11:token=$(basename "$(cat "$cert_base.arn")" | cut -c -32)")
-else
-	echo "neither $cert_base.key nor $cert_base.arn exists, but at least one is required" >&2
-	exit 1
-fi
-
-# sign unified image
-datefudge -s "@$BUILDER_TIMESTAMP" sbsign --cert "$cert_base.crt" "${key_params[@]}" --output boot.efi unified_image
-
 umount "$chroot_dir"
 rmdir "$chroot_dir"
 
-mv tmp_initrd initrd.unified
-tar --create --mtime="@$BUILDER_TIMESTAMP" --sort name --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime vmlinuz initrd root.squashfs boot.efi initrd.unified | gzip > "$output"
+tar --create --mtime="@$BUILDER_TIMESTAMP" --sort name --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime vmlinuz initrd cmdline root.squashfs | gzip > "$output"
 
 popd > /dev/null
 rm -rf "$dir"

--- a/tests-ng/util/run_qemu.sh
+++ b/tests-ng/util/run_qemu.sh
@@ -135,7 +135,7 @@ if ((is_pxe_archive)); then
 	# 	required_files=("boot.efi")
 	# else
 	# Traditional case - require vmlinuz, initrd, root.squashfs
-	required_files=("vmlinuz" "initrd" "root.squashfs")
+	required_files=("vmlinuz" "initrd" "cmdline" "root.squashfs")
 	for file in "${required_files[@]}"; do
 		if [ ! -f "$pxe_extract_dir/$file" ]; then
 			echo "Error: Required PXE file '$file' not found in archive" >&2
@@ -283,7 +283,7 @@ if ((is_pxe_archive)); then
 		qemu_opts+=(
 			-kernel "$pxe_extract_dir/vmlinuz"
 			-initrd "$pxe_extract_dir/initrd"
-			-append "gl.ovl=/:tmpfs gl.url=http://10.0.2.2:8080/root.squashfs gl.live=1 ip=dhcp console=ttyS0 console=tty0 earlyprintk=ttyS0 consoleblank=0"
+			-append "$(cat "$pxe_extract_dir/cmdline") gl.url=http://10.0.2.2:8080/root.squashfs"
 		)
 	else
 		qemu_opts+=(
@@ -348,12 +348,12 @@ if ((is_pxe_archive)); then
 	# else
 	echo "✅ Using traditional vmlinuz/initrd boot via iPXE"
 	# Create iPXE script for traditional vmlinuz/initrd boot
-	cat >"$http_dir/boot.ipxe" <<'EOF'
+	cat >"$http_dir/boot.ipxe" <<EOF
 #!ipxe
 dhcp
 set base-url http://10.0.2.2:8080
-kernel ${base-url}/vmlinuz gl.ovl=/:tmpfs gl.url=${base-url}/root.squashfs gl.live=1 ip=dhcp console=ttyS0 console=tty0 earlyprintk=ttyS0 consoleblank=0
-initrd ${base-url}/initrd
+kernel \${base-url}/vmlinuz $(cat "$pxe_extract_dir/cmdline") gl.url=http://10.0.2.2:8080/root.squashfs
+initrd \${base-url}/initrd
 boot
 EOF
 	# fi


### PR DESCRIPTION
also drop support for clearly unused _pxe efi binaries (the cmdline arg was broken since some changes in ukify from quite a whiles back, so the fact that no one ever noticed validates the assumption that those binaries aren't used at all)