### PR TITLE
Disable DSA, since it shound't be longer used.

### DIFF
--- a/tests/platformSetup/chroot.py
+++ b/tests/platformSetup/chroot.py
@@ -203,8 +203,6 @@ class CHROOT:
         #  environment and still support amd64 and arm64 architectures)
         chroot_ssh_dir = rootfs + "/etc/ssh"
         cmd_ssh_keys = []
-        cmd_ssh_keys.append('ssh-keygen -q -N "" -t dsa -f {ssh_dir}/ssh_host_dsa_key'.format(
-          ssh_dir=chroot_ssh_dir))
         cmd_ssh_keys.append('ssh-keygen -q -N "" -t rsa -b 4096 -f {ssh_dir}/ssh_host_rsa_key'.format(
           ssh_dir=chroot_ssh_dir))
         cmd_ssh_keys.append('ssh-keygen -q -N "" -t ecdsa -f {ssh_dir}/ssh_host_ecdsa_key'.format(


### PR DESCRIPTION
During enablement of the [FIPS flavor](https://github.com/gardenlinux/gardenlinux/pull/3744), the old testing framework was running. The tests failed to boot up the chroot environment for a FIPS-enabled environment. The error is SUPER easy. We still generate a DSA key, which fails. I removed the necessary line. DSA shouldn't be used anyway since OpenSSH has removed it as well. It fails in FIPS, since FIPS disables the DSA function, which OpenSSH depends on to compute.
