### PR TITLE
docs: Add bare-container development and debugging guide

### DIFF
--- a/docs/01_developers/bare_container.md
+++ b/docs/01_developers/bare_container.md
@@ -98,7 +98,7 @@ chroot /mnt toybox sh
 
 ### Analyzing the Image Size
 
-Bare images may unexpectedly grow. To find the cause of the issue, we can install tools to them debian container and use the on the `/mnt` folder.
+Bare images may unexpectedly grow. To find the cause of the issue, we can install tools to the debian container and use them on the `/mnt` folder.
 For example, install dust:
 
 ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
- Debugging bare-containers is quite hard, as they don't have basic utilities like a shell installed
- This PR adds a guide in the bare image docs which shows a possible debugging strategy by mounting the bare image to a Debian image
- It recommends to use [toybox](https://landley.net/toybox) for installing a shell and other command line tools
- It also shows the installation and basic usage of `dust`

**Which issue(s) this PR fixes**:
Fixes #3795
