### PR TITLE
remove pkexec for CIS compliance from features/server

### DIFF
--- a/features/server/pkg.include
+++ b/features/server/pkg.include
@@ -14,7 +14,6 @@ lsb-release
 net-tools
 netbase
 nvme-cli
-pkexec
 polkitd
 procps
 quota


### PR DESCRIPTION
**What this PR does / why we need it**:
CIS hardening check warned us of SUID daemons presence, one of them is `pkexec` from `features/server`. As discussed for CIS readiness, it was decided to remove `pkexec` as its no more needed

**Which issue(s) this PR fixes**:
Fixes #3598 