### PR TITLE
Bump `python-gardenlinux-lib` to 1.0.0

### DIFF
--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -49,6 +49,8 @@ jobs:
           submodules: true
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set build reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
@@ -74,6 +76,8 @@ jobs:
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/build_flavors_matrix.yml
+++ b/.github/workflows/build_flavors_matrix.yml
@@ -32,6 +32,8 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - id: matrix
         name: Generate flavors matrix
         run: |

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -17,6 +17,7 @@ jobs:
         shell: bash
     env:
       CNAME: ""
+      VERSION: ""
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -36,10 +37,29 @@ jobs:
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname container-${{ matrix.arch }} cname)" | tee -a "$GITHUB_ENV"
+      - name: Set VERSION
+        run: |
+          version="$(bin/garden-version "${{ inputs.version }}")"
+
+          if [ "$version" == "today" ]; then
+            version="$(bin/garden-version now)"
+          fi
+
+          echo "VERSION=${version}" | tee -a "$GITHUB_ENV"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: gardenlinux/repo
+          path: repo
+          ref: ${{ env.VERSION }}
+          sparse-checkout: |
+            .container
+          sparse-checkout-cone-mode: false
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Load container build artifact (${{ matrix.arch }})
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
@@ -48,32 +68,22 @@ jobs:
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Build kernel module build dev container (${{ matrix.arch }})
         env:
-          GH_TOKEN: ${{ github.token }}
+          GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GL_CLI_REGISTRY_USERNAME: ${{ github.repository_owner }}
         run: |
           commit="$(./get_commit)"
           commit_short="${commit:0:8}"
-
-          version="$(bin/garden-version "${{ inputs.version }}")"
-
-          if [ "$version" == "today" ]; then
-            version="$(bin/garden-version now)"
-          fi
 
           mkdir ".build"
           tar -C ".build/" -xzf "$CNAME.tar.gz"
           rm "$CNAME.tar.gz"
 
-          base="ghcr.io/${{ github.repository }}:$version"
-          image="$(podman load -i .build/container-${{ matrix.arch }}-$(cat VERSION)-${commit_short}.oci | awk '{ print $NF }')"
-          podman tag "$image" "$base"
+          base="ghcr.io/${{ github.repository }}:${VERSION}"
+          image="$(gl-oci load-container --oci_archive ".build/container-${{ matrix.arch }}-$(cat VERSION)-${commit_short}.oci" --additional_tag "$base" | awk '{ print $NF }')"
+          snapshot="$(cat repo/.container)"
 
-          snapshot="$(gh api "/repos/gardenlinux/repo/contents/.container?ref=$version" | jq -r '.content' | base64 -d)"
-
-          podman login -u token -p "${GH_TOKEN}" ghcr.io
-          podman pull --arch ${{ matrix.arch }} "$snapshot"
-
-          podman build --arch ${{ matrix.arch }} --build-arg base="$base" --build-arg snapshot="$snapshot" -t ghcr.io/${{ github.repository }}/kmodbuild:${{ matrix.arch }}-${version} images/kmodbuild
-          podman save --format oci-archive ghcr.io/${{ github.repository }}/kmodbuild:${{ matrix.arch }}-${version} > kmodbuild_container_${{ matrix.arch }}.oci
+          gl-oci pull-container --container "$snapshot" --platform linux/${{ matrix.arch }}
+          gl-oci build-container --container "ghcr.io/${{ github.repository }}/kmodbuild" --tag "${{ matrix.arch }}-${VERSION}" --oci_archive "kmodbuild_container_${{ matrix.arch }}.oci" --platform linux/${{ matrix.arch }} --dir "images/kmodbuild" --build_arg base="$base" --build_arg snapshot="$snapshot"
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v7.0.0
         with:

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -43,6 +43,8 @@ jobs:
           submodules: true
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set image reference for S3
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -135,6 +135,8 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # pin@v4
         with:

--- a/.github/workflows/publish_kmodbuild_container.yml
+++ b/.github/workflows/publish_kmodbuild_container.yml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       packages: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+      - name: Install python-gardenlinux-lib
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@d64300c48bf9a0a262642b564c7aeea0b89be21f # pin@0.10.5
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           pattern: kmodbuild-container-*
@@ -34,18 +39,14 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
       - name: Publish kernel module build dev container
+        env:
+          GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GL_CLI_REGISTRY_USERNAME: ${{ github.repository_owner }}
         run: |
-          for oci_archive in *.oci; do
-            podman load -i ${oci_archive}
-            rm ${oci_archive}
-          done
+          gl-oci load-containers-from-directory --dir "."
+          rm *.oci
 
-          podman login -u token -p ${{ github.token }} ghcr.io
-
-          podman push ghcr.io/${{ github.repository }}/kmodbuild:amd64-$VERSION
-          podman push ghcr.io/${{ github.repository }}/kmodbuild:arm64-$VERSION
-
-          podman manifest create ghcr.io/${{ github.repository }}/kmodbuild:$VERSION
-          podman manifest add ghcr.io/${{ github.repository }}/kmodbuild:$VERSION ghcr.io/${{ github.repository }}/kmodbuild:amd64-$VERSION
-          podman manifest add ghcr.io/${{ github.repository }}/kmodbuild:$VERSION ghcr.io/${{ github.repository }}/kmodbuild:arm64-$VERSION
-          podman manifest push ghcr.io/${{ github.repository }}/kmodbuild:$VERSION
+          gl-oci push-container --container "ghcr.io/${{ github.repository }}/kmodbuild" --tag "amd64-$VERSION"
+          gl-oci add-container-to-index --index "ghcr.io/${{ github.repository }}/kmodbuild" --index-tag "$VERSION" --container "ghcr.io/${{ github.repository }}/kmodbuild" --tag "amd64-$VERSION"
+          gl-oci push-container --container "ghcr.io/${{ github.repository }}/kmodbuild" --tag "arm64-$VERSION"
+          gl-oci add-container-to-index --index "ghcr.io/${{ github.repository }}/kmodbuild" --index-tag "$VERSION" --container "ghcr.io/${{ github.repository }}/kmodbuild" --tag "arm64-$VERSION"

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -78,9 +78,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      CNAME_AMD64: ""
-      CNAME_ARM64: ""
     permissions:
       packages: write
     strategy:
@@ -101,6 +98,10 @@ jobs:
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
+      - name: Install python-gardenlinux-lib
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
+        with:
+          version: 1.0.0-pre1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           name: build-${{ matrix.flavor }}-amd64
@@ -116,55 +117,53 @@ jobs:
           echo "CNAME_AMD64=$(gl-features-parse --cname ${{ matrix.flavor }} --arch amd64 --version ${{ inputs.version }} --commit ${{ inputs.commit_id }} cname)" | tee -a "$GITHUB_ENV"
           echo "CNAME_ARM64=$(gl-features-parse --cname ${{ matrix.flavor }} --arch arm64 --version ${{ inputs.version }} --commit ${{ inputs.commit_id }} cname)" | tee -a "$GITHUB_ENV"
       - name: Publish container images
+        env:
+          GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GL_CLI_REGISTRY_USERNAME: ${{ github.repository_owner }}
         run: |
-          if [ "${{ inputs.target }}" = "nightly" ]; then
-            is_nightly=true
+          CNAME_AMD64="$(gl-features-parse --cname container-amd64 cname)"
+          CNAME_ARM64="$(gl-features-parse --cname container-arm64 cname)"
+          CNAMES="${CNAME_AMD64} ${CNAME_ARM64}"
+
+          if [ "${{ inputs.original_workflow_name }}" = "nightly" ]; then
+            IS_NIGHTLY=true
           else
-            is_nightly=false
+            IS_NIGHTLY=false
           fi
 
-          version="$(cat VERSION)"
-
-          podman login -u token -p ${{ github.token }} ghcr.io
-          tar xzv < "${CNAME_AMD64}.tar.gz"
-          image="$(podman load < ${CNAME_AMD64}.oci | awk '{ print $NF }')"
-
-          # Tagging for amd64 nightly
-          if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:amd64-nightly
-            podman push ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:amd64-nightly
-          fi
-
-          # Tagging for amd64 with version
-          podman tag "$image" ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:amd64-${version}
-          podman push ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:amd64-${version}
-
-          tar xzv < "${CNAME_ARM64}.tar.gz"
-          image="$(podman load < ${CNAME_ARM64}.oci | awk '{ print $NF }')"
-
-          # Tagging for arm64 nightly
-          if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:arm64-nightly
-            podman push ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:arm64-nightly
-          fi
-
-          # Tagging for arm64 with version
-          podman tag "$image" ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:arm64-${version}
-          podman push ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:arm64-${version}
-
-          # Creating and pushing manifest for nightly
-          if [ $is_nightly = true ]; then
-            podman manifest create ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:nightly
-            podman manifest add ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:nightly ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:amd64-nightly
-            podman manifest add ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:nightly ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:arm64-nightly
-            podman manifest push ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:nightly
-          fi
+          VERSION=$(cat VERSION)
 
           # Creating and pushing manifest for version tag
-          podman manifest create ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:${version}
-          podman manifest add ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:${version} ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:amd64-${version}
-          podman manifest add ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:${version} ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:arm64-${version}
-          podman manifest push ${{ needs.determine_environment.outputs.repository }}${{ matrix.subpath }}:${version}
+          gl-oci new-index --index "${{ needs.determine_environment.outputs.repository }}" --index-tag "${VERSION}"
+
+          # Creating and pushing manifest for nightly
+          if [ $IS_NIGHTLY = true ]; then
+            gl-oci new-index --index "${{ needs.determine_environment.outputs.repository }}" --index-tag nightly
+          fi
+
+          for cname in $CNAMES; do
+            tar xzv < "${cname}.tar.gz"
+
+            ARCH="$(gl-features-parse --cname "${cname}" arch)"
+            IMAGE_ID="$(gl-oci load-container --oci_archive "${cname}.oci" | awk '{ print $NF }')"
+
+            # Tagging with version
+            gl-oci tag-container --container "${IMAGE_ID}" --additional_tag "${{ needs.determine_environment.outputs.repository }}:${ARCH}-${VERSION}"
+            gl-oci push-container --container "${{ needs.determine_environment.outputs.repository }}" --tag "${ARCH}-${VERSION}"
+
+            # Tagging for nightly
+            if [ $IS_NIGHTLY = true ]; then
+              gl-oci tag-container --container "${IMAGE_ID}" --additional_tag "${{ needs.determine_environment.outputs.repository }}:${ARCH}-nightly"
+              gl-oci push-container --container "${{ needs.determine_environment.outputs.repository }}" --tag "${ARCH}-nightly"
+            fi
+
+            # Image index handling
+            gl-oci add-container-to-index --index "${{ needs.determine_environment.outputs.repository }}" --index-tag "${VERSION}" --container "${{ needs.determine_environment.outputs.repository }}" --tag "${ARCH}-${VERSION}"
+
+            if [ $IS_NIGHTLY = true ]; then
+              gl-oci add-container-to-index --index "${{ needs.determine_environment.outputs.repository }}" --index-tag nightly --container "${{ needs.determine_environment.outputs.repository }}" --tag "${ARCH}-nightly"
+            fi
+          done
   bare_flavors:
     needs: determine_environment
     name: Publish bare flavors
@@ -187,62 +186,57 @@ jobs:
           sparse-checkout: |
             bin/**
           sparse-checkout-cone-mode: false
+      - name: Install python-gardenlinux-lib
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@d64300c48bf9a0a262642b564c7aeea0b89be21f # pin@0.10.5
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           pattern: build-bare-${{ matrix.config }}-*
           merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
-      - name: Publish bare flavor image ${{ matrix.config }}
+      - name: Publish bare flavor image ${{ matrix.config }} (${{ matrix.arch }})
+        env:
+          GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GL_CLI_REGISTRY_USERNAME: ${{ github.repository_owner }}
         run: |
-          if [ "${{ inputs.target }}" = "nightly" ]; then
-            is_nightly=true
+          ARCHS="amd64 arm64"
+
+          if [ "${{ inputs.original_workflow_name }}" = "nightly" ]; then
+            IS_NIGHTLY=true
           else
-            is_nightly=false
-          fi
-          version=$(bin/garden-version "${{ inputs.version }}")
-
-          podman login -u token -p ${{ github.token }} ghcr.io
-
-          # Handling amd64 image
-          image="$(podman load < ${{ matrix.config }}-amd64.oci | awk '{ print $NF }')"
-
-          # Tagging and pushing amd64 with version
-          podman tag "$image" ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:amd64-$version
-          podman push ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:amd64-$version
-
-          # Tagging and pushing amd64 with nightly
-          if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
-            podman push ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
+            IS_NIGHTLY=false
           fi
 
-          # Handling arm64 image
-          image="$(podman load < ${{ matrix.config }}-arm64.oci | awk '{ print $NF }')"
-
-          # Tagging and pushing arm64 with version
-          podman tag "$image" ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:arm64-$version
-          podman push ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:arm64-$version
-
-          # Tagging and pushing arm64 with nightly
-          if [ $is_nightly = true ]; then
-            podman tag "$image" ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
-            podman push ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
-          fi
+          VERSION=$(bin/garden-version "${{ inputs.version }}")
 
           # Creating and pushing manifest for version tag
-          podman manifest create ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:$version
-          podman manifest add ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:$version ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:amd64-$version
-          podman manifest add ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:$version ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:arm64-$version
-          podman manifest push ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:$version
+          gl-oci new-index --index "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --index-tag "${VERSION}"
 
-          # Creating and pushing manifest for nightly tag
-          if [ $is_nightly = true ]; then
-            podman manifest create ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:nightly
-            podman manifest add ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:nightly ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:amd64-nightly
-            podman manifest add ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:nightly ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:arm64-nightly
-            podman manifest push ${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:nightly
+          # Creating and pushing manifest for nightly
+          if [ $IS_NIGHTLY = true ]; then
+            gl-oci new-index --index "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --index-tag nightly
           fi
+
+          for ARCH in $ARCHS; do
+            IMAGE_ID="$(gl-oci load-container --oci_archive "${{ matrix.config }}-${ARCH}.oci" | awk '{ print $NF }')"
+
+            # Tagging with version
+            gl-oci tag-container --container "${IMAGE_ID}" --additional_tag "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:${ARCH}-${VERSION}"
+            gl-oci push-container --container "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --tag "${ARCH}-${VERSION}"
+
+            # Tagging for nightly
+            if [ $IS_NIGHTLY = true ]; then
+              gl-oci tag-container --container "${IMAGE_ID}" --additional_tag "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}:${ARCH}-nightly"
+              gl-oci push-container --container "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --tag "${ARCH}-nightly"
+            fi
+
+            # Image index handling
+            gl-oci add-container-to-index --index "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --index-tag "${VERSION}" --container "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --tag "${ARCH}-${VERSION}"
+
+            if [ $IS_NIGHTLY = true ]; then
+              gl-oci add-container-to-index --index "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --index-tag nightly --container "${{ needs.determine_environment.outputs.repository }}/bare-${{ matrix.config }}" --tag "${ARCH}-nightly"
+            fi
+          done
   push_flavors:
     needs: determine_environment
     name: Publish flavors
@@ -273,6 +267,8 @@ jobs:
           aws-region: ${{ secrets.aws_region }}
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
@@ -339,6 +335,8 @@ jobs:
           submodules: true
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }} --arch ${{ matrix.arch }} --version ${{ inputs.version }} --commit ${{ inputs.commit_id }} cname)" | tee -a "$GITHUB_ENV"
@@ -346,7 +344,7 @@ jobs:
         with:
           path: oci_manifest_entry_${{ env.CNAME }}.json
           key: oci-manifest-${{ matrix.flavor }}-${{ matrix.arch }}-${{ github.run_id }}
-      - name: Update index using glcli tool
+      - name: Update index using gl-oci tool
         env:
           GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GL_CLI_REGISTRY_USERNAME: ${{ github.repository_owner }}
@@ -367,10 +365,6 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Set container version reference
-        run: |
-          echo "${{ inputs.commit_id }}" | tee COMMIT
-          echo "${{ inputs.version }}" | tee VERSION
       - id: tests_containers
         name: Download built tests archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
@@ -379,46 +373,56 @@ jobs:
           merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
-      - name: Load OCI archives
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+      - name: Install python-gardenlinux-lib
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
+        with:
+          version: 1.0.0-pre1
+      - name: Set container version reference
         run: |
-          for oci in *.oci; do
-            podman load -i "${oci}"
-            rm -f "${oci}"
-          done
+          echo "${{ inputs.commit_id }}" | tee COMMIT
+          echo "${{ inputs.version }}" | tee VERSION
       - name: Publish tests images and manifest
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ inputs.target }}" = "nightly" ]; then
-            is_nightly=true
+          ARCHS="amd64 arm64"
+
+          if [ "${{ inputs.original_workflow_name }}" = "nightly" ]; then
+            IS_NIGHTLY=true
           else
-            is_nightly=false
+            IS_NIGHTLY=false
           fi
 
-          version="$(cat VERSION)"
+          VERSION=$(bin/garden-version "${{ inputs.version }}")
 
-          podman login -u token -p ${GITHUB_TOKEN} ghcr.io
+          # Creating and pushing manifest for version tag
+          gl-oci new-index --index "ghcr.io/${{ github.repository_owner }}/test" --index-tag "${VERSION}"
 
-          # Push amd64 and arm64 images
-          podman push ghcr.io/${{ github.repository_owner }}/test:amd64-${version}
-          podman push ghcr.io/${{ github.repository_owner }}/test:arm64-${version}
-
-          if [ "$is_nightly" = true ]; then
-            podman tag ghcr.io/${{ github.repository_owner }}/test:amd64-${version} ghcr.io/${{ github.repository_owner }}/test:amd64-nightly
-            podman tag ghcr.io/${{ github.repository_owner }}/test:arm64-${version} ghcr.io/${{ github.repository_owner }}/test:arm64-nightly
-            podman push ghcr.io/${{ github.repository_owner }}/test:amd64-nightly
-            podman push ghcr.io/${{ github.repository_owner }}/test:arm64-nightly
+          # Creating and pushing manifest for nightly
+          if [ $IS_NIGHTLY = true ]; then
+            gl-oci new-index --index "ghcr.io/${{ github.repository_owner }}/test" --index-tag nightly
           fi
 
-          # Create and push manifests
-          if [ "$is_nightly" = true ]; then
-            podman manifest create ghcr.io/${{ github.repository_owner }}/test:nightly
-            podman manifest add ghcr.io/${{ github.repository_owner }}/test:nightly ghcr.io/${{ github.repository_owner }}/test:amd64-nightly
-            podman manifest add ghcr.io/${{ github.repository_owner }}/test:nightly ghcr.io/${{ github.repository_owner }}/test:arm64-nightly
-            podman manifest push ghcr.io/${{ github.repository_owner }}/test:nightly
-          fi
+          for ARCH in $ARCHS; do
+            IMAGE_ID="$(gl-oci load-container --oci_archive "tests_container_${ARCH}.oci" | awk '{ print $NF }')"
 
-          podman manifest create ghcr.io/${{ github.repository_owner }}/test:${version}
-          podman manifest add ghcr.io/${{ github.repository_owner }}/test:${version} ghcr.io/${{ github.repository_owner }}/test:amd64-${version}
-          podman manifest add ghcr.io/${{ github.repository_owner }}/test:${version} ghcr.io/${{ github.repository_owner }}/test:arm64-${version}
-          podman manifest push ghcr.io/${{ github.repository_owner }}/test:${version}
+            # Tagging with version
+            gl-oci tag-container --container "${IMAGE_ID}" --additional_tag "ghcr.io/${{ github.repository_owner }}/test:${ARCH}-${VERSION}"
+            gl-oci push-container --container "ghcr.io/${{ github.repository_owner }}/test" --tag "${ARCH}-${VERSION}"
+
+            # Tagging for nightly
+            if [ $IS_NIGHTLY = true ]; then
+              gl-oci tag-container --container "${IMAGE_ID}" --additional_tag "ghcr.io/${{ github.repository_owner }}/test:${ARCH}-nightly"
+              gl-oci push-container --container "ghcr.io/${{ github.repository_owner }}/test" --tag "${ARCH}-nightly"
+            fi
+
+            # Image index handling
+            gl-oci add-container-to-index --index "ghcr.io/${{ github.repository_owner }}/test" --index-tag "${VERSION}" --container "ghcr.io/${{ github.repository_owner }}/test" --tag "${ARCH}-${VERSION}"
+
+            if [ $IS_NIGHTLY = true ]; then
+              gl-oci add-container-to-index --index "ghcr.io/${{ github.repository_owner }}/test" --index-tag nightly --container "ghcr.io/${{ github.repository_owner }}/test" --tag "${ARCH}-nightly"
+            fi
+          done

--- a/.github/workflows/tag_latest_container.yml
+++ b/.github/workflows/tag_latest_container.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Tag manifest
         env:
           GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_flavor_chroot.yml
+++ b/.github/workflows/test_flavor_chroot.yml
@@ -39,6 +39,8 @@ jobs:
           key: test-distribution-${{ github.run_id }}
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test_flavor_cloud.yml
+++ b/.github/workflows/test_flavor_cloud.yml
@@ -84,6 +84,8 @@ jobs:
           path: cert/
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test_flavor_oci.yml
+++ b/.github/workflows/test_flavor_oci.yml
@@ -43,6 +43,8 @@ jobs:
           key: test-distribution-${{ github.run_id }}
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -49,6 +49,8 @@ jobs:
           path: cert/
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -56,6 +56,8 @@ jobs:
           submodules: true
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
+        with:
+          version: 1.0.0-pre1
       - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps `python-gardenlinux-lib` to 0.11.0. This version adds new support in `gl-oci` to handle containers and OCI archives.