### PR TITLE
fix: test-ng: exclude kubelet and google-guest-agent from sysdiff

### DIFF
--- a/tests-ng/plugins/sysdiff.py
+++ b/tests-ng/plugins/sysdiff.py
@@ -49,6 +49,9 @@ IGNORED_SYSTEMD_PATTERNS = [
     "sysstat-collect.timer",
     "sysstat-rotate.timer",
     "sysstat-summary.timer",
+    # https://github.com/gardenlinux/gardenlinux/issues/3769
+    "kubelet.service",
+    "google-guest-agent.service",
 ]
 IGNORED_KERNEL_MODULES = []
 IGNORED_SYSCTL_PARAMS = {


### PR DESCRIPTION
**What this PR does / why we need it**:

Exclude kubelet and google-guest-agent from sysdiff.
This is temporarily until https://github.com/gardenlinux/gardenlinux/issues/3769 is fixed.

**Which issue(s) this PR fixes**:
Adresses #3769
