### PR TITLE
Revert "Disable GitHub workflow execution for changes in `.github`"

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,7 +11,6 @@ on:
       - "**/README.md"
   pull_request:
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - '**/README.md'
 jobs:


### PR DESCRIPTION
This reverts commit ca0acad3e87eb445b726ea35550ad8919ddf4f80.

**What this PR does / why we need it**:

Not running GitHub actions on changes to GitHub actions does not sound good. This for example results in the changes of #3819 not running any tests despite it making sense to this this before merging.