### PR TITLE
properly output platform and platform variants in os-release

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+if grep , <<< "$BUILDER_FEATURES_PLATFORMS" >/dev/null; then
+  GARDENLINUX_PLATFORM=frankenstein
+else
+  GARDENLINUX_PLATFORM=$BUILDER_FEATURES_PLATFORMS
+fi
+
 rm /etc/os-release
 cat > /etc/os-release << EOF
 ID=gardenlinux
@@ -13,6 +19,7 @@ HOME_URL="https://gardenlinux.io"
 SUPPORT_URL="https://github.com/gardenlinux/gardenlinux"
 BUG_REPORT_URL="https://github.com/gardenlinux/gardenlinux/issues"
 GARDENLINUX_CNAME=$BUILDER_CNAME
+GARDENLINUX_PLATFORM=$GARDENLINUX_PLATFORM
 GARDENLINUX_FEATURES=$BUILDER_FEATURES
 GARDENLINUX_FEATURES_PLATFORMS=$BUILDER_FEATURES_PLATFORMS
 GARDENLINUX_FEATURES_ELEMENTS=$BUILDER_FEATURES_ELEMENTS

--- a/features/openstack/exec.config
+++ b/features/openstack/exec.config
@@ -11,3 +11,9 @@ rm /etc/cloud/cloud.cfg.bak
 # => libmspack0t64 wrongly detected as orphan during tests
 
 apt-mark manual libmspack0t64
+
+# TODO: once migrating from openstackbaremetal to a combined openstack with openstack-metal option
+# this must be made dynamic by checking whether the metal feature is enabled
+cat >> /etc/os-release << EOF
+GARDENLINUX_PLATFORM_VARIANT=vmware
+EOF

--- a/features/openstackbaremetal/exec.config
+++ b/features/openstackbaremetal/exec.config
@@ -5,3 +5,7 @@ set -Eeuo pipefail
 mv /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak
 grep -v "^ - growpart$" /etc/cloud/cloud.cfg.bak | grep -v "^ - resizefs$" | grep -v "^ - ntp$" > /etc/cloud/cloud.cfg
 rm /etc/cloud/cloud.cfg.bak
+
+cat >> /etc/os-release << EOF
+GARDENLINUX_PLATFORM_VARIANT=baremetal
+EOF


### PR DESCRIPTION
set `GARDENLINUX_PLATFORM` to the one and only one platform in /etc/os-release

This value is going to be consumed by the changed upload logic of https://github.com/gardenlinux/python-gardenlinux-lib/pull/249 In cases where there are unexpectedly more or less then 1 platform active this value will be replaced with "frankenstein" to indicate something went wrong

Additionally add the optional `GARDENLINUX_PLATFORM_VARIANT` key for openstack images