### PR TITLE
tiger test adr

### DIFF
--- a/docs/architecture/decisions/0021-use-of-tiger-tool-in-tests-ng.md
+++ b/docs/architecture/decisions/0021-use-of-tiger-tool-in-tests-ng.md
@@ -9,8 +9,8 @@ Proposed
 ## Context
 
 While migrating server feature tests to the new framework, we need to take another look on certain decisions that were
-made in the past. One such decision was the development of a test case based on the results of running of the tiger
-security scanner. It's usefulness in the new test framework, however, is questionable.
+made in the past. One such decision was the development of a test case based on the results of running of the [tiger
+security scanner](https://www.nongnu.org/tiger/). It's usefulness in the new test framework, however, is questionable.
 
 The reasons are:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Chances are, we don't need to migrate tiger (https://www.nongnu.org/tiger/) test to the new test framework. This ADR proposes that.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3828
