### PR TITLE
Fix/refactor find to work with Mac

### DIFF
--- a/tests-ng/README.md
+++ b/tests-ng/README.md
@@ -106,7 +106,7 @@ apt-get install azure-cli awscli openstackclient # for GCP and ALI look at tip
 #### Install on MacOS
 
 ```
-brew install bash coreutils curl findutils gnu-getopt gnu-sed gnupg jq libxml2 make ossp-uuid podman socat swtpm unzip
+brew install bash coreutils curl gnu-getopt gnu-sed gnupg jq libxml2 make ossp-uuid podman socat swtpm unzip
 # install cloud provider CLIs
 brew install azure-cli awscli gcloud-cli aliyun-cli openstackclient
 ```

--- a/tests-ng/util/install_tofu.sh
+++ b/tests-ng/util/install_tofu.sh
@@ -8,66 +8,49 @@ function die {
     exit 1
 }
 
-
-function test_for_supported_os(){
-	case "$(uname -s)" in
-        Darwin)
-            host_os=darwin
-            ;;
-        Linux)
-            host_os=linux
-            ;;
-        *)
-            die "Host operating system '$host_os' not supported"
-            ;;
-	esac
+function test_for_supported_os() {
+    case "$(uname -s)" in
+    Darwin)
+        host_os=darwin
+        ;;
+    Linux)
+        host_os=linux
+        ;;
+    *)
+        die "Host operating system '$host_os' not supported"
+        ;;
+    esac
 }
 
-function test_for_supported_cpu_architecture(){
-	case "$(uname -m)" in
-        x86_64)
-            host_arch=amd64
-            ;;
-        aarch64 | arm64)
-            host_arch=arm64
-            ;;
-        *)
-            die "Host architecture '$host_arch' not supported"
-            ;;
-	esac
+function test_for_supported_cpu_architecture() {
+    case "$(uname -m)" in
+    x86_64)
+        host_arch=amd64
+        ;;
+    aarch64 | arm64)
+        host_arch=arm64
+        ;;
+    *)
+        die "Host architecture '$host_arch' not supported"
+        ;;
+    esac
 }
 
-function find_local_version_of_tofuenv_and_return_version_string(){
-    # This find will detect the folder from the local tofuenv with it's installation and 
-    # extract the version field out. The result will be sorted. The highest version should 
-    # be s on top. Then we cut to a single parameter, otherwise the tofuenv use will fail.
-    # shellcheck disable=SC2046
-    basename $(\
-        find "$tf_dir/.tofuenv/versions"\
-            -mindepth 1 \
-            -maxdepth 1 \
-            -type d \
-            -print \
-            | sort -r \
-            | head -1
-        )
-}
-
-function install_custom_azure_resource_manager(){
+function install_custom_azure_resource_manager() {
     # We have to install the custom Resource Manager to use Secure Boot.
-	TF_CLI_CONFIG_FILE="$tf_dir/.terraformrc"
-	export TF_CLI_CONFIG_FILE
-	TOFU_PROVIDERS_CUSTOM="$tf_dir/.terraform/providers/custom"
-	TOFU_PROVIDER_AZURERM_VERSION="v4.41.0"
-	TOFU_PROVIDER_AZURERM_VERSION_LONG="${TOFU_PROVIDER_AZURERM_VERSION}-post1-secureboot2"
-	TOFU_PROVIDER_AZURERM_BIN="terraform-provider-azurerm_${TOFU_PROVIDER_AZURERM_VERSION}_${host_os}_${host_arch}"
-	TOFU_PROVIDER_AZURERM_URL="https://github.com/gardenlinux/terraform-provider-azurerm/releases/download/$TOFU_PROVIDER_AZURERM_VERSION_LONG/$TOFU_PROVIDER_AZURERM_BIN"
-	TOFU_PROVIDER_AZURERM_CHECKSUM_linux_amd64="d0724b2b33270dbb0e7946a4c125e78b5dd0f34697b74a08c04a1c455764262e"
-	TOFU_PROVIDER_AZURERM_CHECKSUM_linux_arm64="b5a5610bef03fcfd6b02b4da804a69cbca64e2c138c1fe943a09a1ff7b123ff7"
-	TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_amd64="0f4676ad2f0d16ec3e24f6ced1414b1f638c20da0a0b2c2b19e5bd279f0f1d32"
-	TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_arm64="bdda99a9139363676b1edf2f0371a285e1e1d9e9b9524de4f30b7c2b08224a86"
+    TF_CLI_CONFIG_FILE="$tf_dir/.terraformrc"
+    export TF_CLI_CONFIG_FILE
+    TOFU_PROVIDERS_CUSTOM="$tf_dir/.terraform/providers/custom"
+    TOFU_PROVIDER_AZURERM_VERSION="v4.41.0"
+    TOFU_PROVIDER_AZURERM_VERSION_LONG="${TOFU_PROVIDER_AZURERM_VERSION}-post1-secureboot2"
+    TOFU_PROVIDER_AZURERM_BIN="terraform-provider-azurerm_${TOFU_PROVIDER_AZURERM_VERSION}_${host_os}_${host_arch}"
+    TOFU_PROVIDER_AZURERM_URL="https://github.com/gardenlinux/terraform-provider-azurerm/releases/download/$TOFU_PROVIDER_AZURERM_VERSION_LONG/$TOFU_PROVIDER_AZURERM_BIN"
+    TOFU_PROVIDER_AZURERM_CHECKSUM_linux_amd64="d0724b2b33270dbb0e7946a4c125e78b5dd0f34697b74a08c04a1c455764262e"
+    TOFU_PROVIDER_AZURERM_CHECKSUM_linux_arm64="b5a5610bef03fcfd6b02b4da804a69cbca64e2c138c1fe943a09a1ff7b123ff7"
+    TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_amd64="0f4676ad2f0d16ec3e24f6ced1414b1f638c20da0a0b2c2b19e5bd279f0f1d32"
+    TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_arm64="bdda99a9139363676b1edf2f0371a285e1e1d9e9b9524de4f30b7c2b08224a86"
 
-	cat >"$TF_CLI_CONFIG_FILE" <<EOF
+    cat >"$TF_CLI_CONFIG_FILE" <<EOF
 provider_installation {
   dev_overrides {
     "hashicorp/azurerm" = "$TOFU_PROVIDERS_CUSTOM"
@@ -75,67 +58,64 @@ provider_installation {
   direct {}
 }
 EOF
-	if [ ! -f "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" ] || ! sha256sum -c "${TOFU_PROVIDERS_CUSTOM}/checksum.txt" >/dev/null 2>&1; then
-		echo "Downloading terraform-provider-azurerm"
-		mkdir -p "${TOFU_PROVIDERS_CUSTOM}"
-		curl -LO --create-dirs --output-dir "${TOFU_PROVIDERS_CUSTOM}" "${TOFU_PROVIDER_AZURERM_URL}"
-		mv "${TOFU_PROVIDERS_CUSTOM}/${TOFU_PROVIDER_AZURERM_BIN}" "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
+    if [ ! -f "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm" ] || ! sha256sum -c "${TOFU_PROVIDERS_CUSTOM}/checksum.txt" >/dev/null 2>&1; then
+        echo "Downloading terraform-provider-azurerm"
+        mkdir -p "${TOFU_PROVIDERS_CUSTOM}"
+        curl -LO --create-dirs --output-dir "${TOFU_PROVIDERS_CUSTOM}" "${TOFU_PROVIDER_AZURERM_URL}"
+        mv "${TOFU_PROVIDERS_CUSTOM}/${TOFU_PROVIDER_AZURERM_BIN}" "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
 
-		case "${host_os}_${host_arch}" in
-            linux_amd64) 
-                checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_linux_amd64" 
-                ;;
-            linux_arm64) 
-                checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_linux_arm64" 
-                ;;
-            darwin_amd64) 
-                checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_amd64" 
-                ;;
-            darwin_arm64) 
-                checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_arm64" 
-                ;;
-            *)
-                die "Unsupported OS/arch combination: ${host_os}_${host_arch}" >&2
-			;;
-		esac
+        case "${host_os}_${host_arch}" in
+        linux_amd64)
+            checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_linux_amd64"
+            ;;
+        linux_arm64)
+            checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_linux_arm64"
+            ;;
+        darwin_amd64)
+            checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_amd64"
+            ;;
+        darwin_arm64)
+            checksum="$TOFU_PROVIDER_AZURERM_CHECKSUM_darwin_arm64"
+            ;;
+        *)
+            die "Unsupported OS/arch combination: ${host_os}_${host_arch}" >&2
+            ;;
+        esac
 
-		echo "$checksum  terraform-provider-azurerm" >"${TOFU_PROVIDERS_CUSTOM}/checksum.txt"
-		(cd "${TOFU_PROVIDERS_CUSTOM}" && sha256sum -c checksum.txt)
-		chmod +x "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
-	fi
+        echo "$checksum  terraform-provider-azurerm" >"${TOFU_PROVIDERS_CUSTOM}/checksum.txt"
+        (cd "${TOFU_PROVIDERS_CUSTOM}" && sha256sum -c checksum.txt)
+        chmod +x "${TOFU_PROVIDERS_CUSTOM}/terraform-provider-azurerm"
+    fi
 }
 
-
 install_tofu() {
-	set -eufo pipefail
+    set -eufo pipefail
 
     test_for_supported_os
     test_for_supported_cpu_architecture
 
-	local tf_dir="${1}"
-	tofuenv_dir="$tf_dir/.tofuenv"
-	PATH="$tofuenv_dir/bin:$PATH"
-	export PATH
-	# in case we pass a GITHUB_TOKEN, we can work around rate limiting
-	export TOFUENV_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
-	command -v tofuenv >/dev/null || {
-		git clone --depth=1 https://github.com/tofuutils/tofuenv.git "$tofuenv_dir"
-		echo 'trust-tofuenv: yes' >"$tofuenv_dir/use-gpgv"
-	}
-	# go to tofu directory to automatically parse *.tf files
-	pushd "$tf_dir"
-	tofuenv install latest-allowed
-
-	popd
-    tofu_version=$(find_local_version_of_tofuenv_and_return_version_string)
-	tofuenv use "$tofu_version"
+    local tf_dir="${1}"
+    tofuenv_dir="$tf_dir/.tofuenv"
+    PATH="$tofuenv_dir/bin:$PATH"
+    export PATH
+    # in case we pass a GITHUB_TOKEN, we can work around rate limiting
+    export TOFUENV_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+    command -v tofuenv >/dev/null || {
+        git clone --depth=1 https://github.com/tofuutils/tofuenv.git "$tofuenv_dir"
+        echo 'trust-tofuenv: yes' >"$tofuenv_dir/use-gpgv"
+    }
+    # go to tofu directory to automatically parse *.tf files
+    pushd "$tf_dir"
+    tofuenv install latest-allowed
+    tofuenv use latest-allowed
+    popd
 
     install_custom_azure_resource_manager
 }
 
 # If script is sourced, don't run main function automatically
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
-	return 0
+    return 0
 fi
 
 install_tofu "${1}"


### PR DESCRIPTION
In this PR, we add a bit of logic to detect `find` independent of the underlying operating system. 

When running the test-ng with the `--cloud` parameter, on a Mac this fails:


```
/src/gardenlinux/gardenlinux4/tests-ng/util/tf ~/src/gardenlinux/gardenlinux4/tests-ng
######################################################################## 100.0%
gpgv: Signature made Thu Nov  6 14:23:13 2025 CET
gpgv:                using RSA key E3E6E43D84CB852EADB0051D0C0AF313E5FD9F80
gpgv: Good signature from "OpenTofu (This key is used to sign opentofu providers) <core@opentofu.org>"
Installing OpenTofu v1.10.7
Downloading release tarball from https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_darwin_arm64.zip
Downloading SHA hash file from https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_SHA256SUMS
Downloading SHA hash signature file from https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_SHA256SUMS.gpgsig
Archive:  /var/folders/yx/h2rdqf_d54d_hs2v_8cm_lnw0000gn/T/tofuenv_download.XXXXXX.nVFTzxLx6p/tofu_1.10.7_darwin_arm64.zip
  inflating: ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/versions/1.10.7/CHANGELOG.md
  inflating: ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/versions/1.10.7/LICENSE
  inflating: ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/versions/1.10.7/README.md
  inflating: ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/versions/1.10.7/tofu
Installation of tofu v1.10.7 successful. To make this your default version, run 'tofuenv use 1.10.7'
~/src/gardenlinux/gardenlinux4/tests-ng
find: -printf: unknown primary or operator
cat: ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/version: No such file or directory
Version could not be resolved (set by ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/version or tofuenv use <version>)
⚙️   cleaning up cloud resources
cat: ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/version: No such file or directory
Version could not be resolved (set by ~/src/gardenlinux/gardenlinux4/tests-ng/util/tf/.tofuenv/version or tofuenv use <version>)
```


The main problem is here:

```
find: -printf: unknown primary or operator
```

Since by default Mac has a different version of the `find` command that does not support the `-printf` parameter. This code refactors to allow the use of the `find` command with parameters that are supported on GNU `find` and Mac `find`.

Additionally, we clean up the code to make it more readable, with some more notes on it.  