### PR TITLE
fix: test: test-ng: disable bucket versioning and add exception tag

### DIFF
--- a/tests-ng/util/tf/modules/aws/disks.tf
+++ b/tests-ng/util/tf/modules/aws/disks.tf
@@ -16,8 +16,16 @@ resource "aws_s3_bucket" "upload" {
 
   tags = merge(
     local.labels,
-    { Name = local.bucket_name }
+    { Name = local.bucket_name },
+    { sec-by-def-objectversioning-exception = "enabled" }
   )
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.upload.id
+  versioning_configuration {
+    status = "Disabled"
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "owner" {

--- a/tests/platformSetup/tofu/modules/aws/main.tf
+++ b/tests/platformSetup/tofu/modules/aws/main.tf
@@ -50,8 +50,18 @@ resource "aws_s3_bucket" "images" {
 
   tags = merge(
     local.labels,
-    { Name = local.bucket_name }
+    { Name = local.bucket_name },
+    { sec-by-def-objectversioning-exception = "enabled" }
   )
+}
+
+resource "aws_s3_bucket_versioning" "images_versioning" {
+  count = local.image_source_type == "file" ? 1 : 0
+
+  bucket = aws_s3_bucket.images.0.id
+  versioning_configuration {
+    status = "Disabled"
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "images_owner" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable AWS S3 bucket versioning and add exception tag for old an new test framework.

**Which issue(s) this PR fixes**:
Fixes #3862

**Notes for reviewer**:

@saubhikdattagithub Maybe you can double check if this run still threw any alerts.

Tested in this workflow run:

```
gh workflow run .github/workflows/manual_tests.yml \
  --ref fix/orca_s3_objectversioning \
  -f version=2052.0 -f target=nightly -f ignore_workflow_concurrency=true \
  -f test_types=cloud -f \
  build=true \
  -f flavors_parse_params_test='--exclude "bare-*" --no-arch --json-by-arch --test --include-only "aws-*" --exclude "*_usi*" --exclude "*trustedboot*"'
```
- https://github.com/gardenlinux/gardenlinux/actions/runs/19325639047