### PR TITLE
docs: add ADR - 26. Use Parser Plugins for Files and Command Output in Test Framework

### DIFF
--- a/docs/architecture/decisions/0026-test-ng-when-to-parsers.md
+++ b/docs/architecture/decisions/0026-test-ng-when-to-parsers.md
@@ -1,10 +1,10 @@
-# 25. Use Parser Plugins for Files and Command Output in Test Framework
+# 26. Use Parser Plugins for Files and Command Output in Test Framework
 
 **Date:** 2025-11-19
 
 ## Status
 
-Draft
+Accepted
 
 ## Context
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This ADR will document the decisions take on when to Use Parsing Abstractions for Files and Command Output in Test Framework.

Currently it includes 2 commits, a broader scoped one and a reworked version more focusing on the usage of parsing plugins.

**Which issue(s) this PR fixes**:
Fixes #3865
