### PR TITLE
do not log dmesg output and debug messages

### DIFF
--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -1,11 +1,8 @@
-import logging
 import os
 
 import pytest
 from plugins.shell import ShellRunner
 from plugins.systemd import Systemd
-
-logger = logging.getLogger(__name__)
 
 
 def test_gl_is_support_distro():
@@ -87,13 +84,13 @@ def test_kernel_not_tainted():
 @pytest.mark.booted(reason="Systemctl needs a booted system")
 def test_no_failed_units(systemd: Systemd, shell: ShellRunner):
     system_run_state = systemd.wait_is_system_running()
-    logger.debug(
+    print(
         f"Waiting for systemd to report the system is running took {system_run_state.elapsed_time:.2f} seconds, with state '{system_run_state.state}' and return code '{system_run_state.returncode}'."
     )
     failed_systemd_units = systemd.list_failed_units()
     for u in failed_systemd_units:
-        logger.debug(f"FAILED UNIT: {u}")
+        print(f"FAILED UNIT: {u}")
         shell(f"journalctl --unit {u.unit}")
     assert (
         not failed_systemd_units
-    ), f"{failed_systemd_units} systemd units failed to load"
+    ), f"{len(failed_systemd_units)} systemd units failed to load"


### PR DESCRIPTION
**What this PR does / why we need it**:

Test logs are not cluttered and important output if better visible.


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3874
