### PR TITLE
Disable the apt workaround for FIPS

### DIFF
--- a/features/_fips/exec.config
+++ b/features/_fips/exec.config
@@ -32,11 +32,6 @@ sed -i \
     -e '73i \\n' \
     /etc/ssl/openssl.cnf
 
-# https://github.com/gardenlinux/gardenlinux/issues/3626
-# Disabled HTTPS for the apt mirror otherwise we can't keep using
-# apt.
-sed -i 's/https/http/' /etc/apt/sources.list.d/gardenlinux.sources
-
 # Enable FIPS KexAlgorithms and Ciphers for OpenSSH Server.
 echo "KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256" >> /etc/ssh/sshd_config
 echo "Ciphers aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr"  >> /etc/ssh/sshd_config


### PR DESCRIPTION
In this PR, we disable the workaround for `apt`. 

Since the code that broke during the usage of `apt` has been dealt with, we can use the mirror with HTTPS again. 

Fixes: #3878 
