### PR TITLE
[test-ng] Migrate time config tests to new testing framework (fixed)

### DIFF
--- a/tests-ng/test_time_config.py
+++ b/tests-ng/test_time_config.py
@@ -121,7 +121,7 @@ def test_clocksource_amd64(systemd_detect_virt: Hypervisor, clocksource: str):
     match systemd_detect_virt:
         case Hypervisor.xen | Hypervisor.qemu:
             expected_clocksource = "tsc"
-        case Hypervisor.kvm | Hypervisor.amazon:
+        case Hypervisor.kvm | Hypervisor.amazon | Hypervisor.google:
             expected_clocksource = "kvm-clock"
         case _:
             assert False, f"unknown hypervisor {systemd_detect_virt}"
@@ -134,7 +134,7 @@ def test_clocksource_amd64(systemd_detect_virt: Hypervisor, clocksource: str):
 @pytest.mark.arch("amd64", "aarch64")
 def test_clocksource_arm64_aarch64(systemd_detect_virt: Hypervisor, clocksource: str):
     match systemd_detect_virt:
-        case Hypervisor.kvm | Hypervisor.qemu | Hypervisor.amazon:
+        case Hypervisor.kvm | Hypervisor.qemu | Hypervisor.amazon | Hypervisor.google:
             expected_clocksource = "arch_sys_counter"
         case _:
             assert False, f"unknown hypervisor {systemd_detect_virt}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate the test-time-config tests to the new testing framework. Fixed version of #3888 

**Which issue(s) this PR fixes**:
Fixes #3891 

**Definition of Done:**
- [x] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
