### PR TITLE
fix: tests-ng: move sysdiff output to stderr

### DIFF
--- a/tests-ng/test_sysdiff.py
+++ b/tests-ng/test_sysdiff.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from plugins.sysdiff import Sysdiff
 
@@ -46,8 +48,12 @@ def test_sysdiff_after_tests(sysdiff: Sysdiff):
             diff_output = sysdiff.diff_engine.generate_diff(
                 diff_result, before_snapshot, after_snapshot
             )
+            print(
+                "System changes detected - detailed diff:\n" + diff_output,
+                file=sys.stderr,
+            )
             pytest.fail(
-                f"System changes were detected during the test run:\n{diff_output}"
+                "System changes were detected during the test run. See stderr output for details."
             )
 
     except Exception as e:


### PR DESCRIPTION
**What this PR does / why we need it**:

Move detailed sysdiff output to stderr. This makes it easier to understand where to find the actual diff.

Old:

```
test_sysdiff.py F                                                                                                [100%]

======================================================= FAILURES =======================================================
_______________________________________________ test_sysdiff_after_tests _______________________________________________
test_sysdiff.py:49: in test_sysdiff_after_tests
    pytest.fail(
E   Failed: System changes were detected during the test run:
E   === Kernel module changes (2025-11-17T20:27:22.513396-root-before-tests -> 2025-11-17T20:28:46.944018-root-after-tests) ===
E   --- kernel_modules@snapshot_a
E   +++ kernel_modules@snapshot_b
E   @@ -50,6 +50,7 @@
E    scsi_mod
E    scsi_transport_iscsi
E    serio_raw
E   +sg
E    sunrpc
E    vfat
E    virtio_blk
E   
E   Tip: lines starting with '+' mean new/changed; '-' mean removed/previous state.
...
 FAILED test_sysdiff.py::test_sysdiff_after_tests - Failed: System changes were detected during the test run:
================================= 1 failed, 77 passed, 49 skipped in 95.83s (0:01:35) ==================================
```

New:
```
test_sysdiff.py F                                                                                                [100%]

======================================================= FAILURES =======================================================
_______________________________________________ test_sysdiff_after_tests _______________________________________________
test_sysdiff.py:55: in test_sysdiff_after_tests
    pytest.fail(
E   Failed: System changes were detected during the test run. See stderr output above for details.
------------------------------------------------- Captured stderr call -------------------------------------------------
System changes detected - detailed diff:
=== Kernel module changes (2025-11-20T08:14:54.407081-root-before-tests -> 2025-11-20T08:15:06.294724-root-after-tests) ===
--- kernel_modules@snapshot_a
+++ kernel_modules@snapshot_b
E   @@ -50,6 +50,7 @@
E    scsi_mod
E    scsi_transport_iscsi
E    serio_raw
E   +sg
E    sunrpc
E    vfat
E    virtio_blk

Tip: lines starting with '+' mean new/changed; '-' mean removed/previous state.
...
FAILED test_sysdiff.py::test_sysdiff_after_tests - Failed: System changes were detected during the test run. See stderr output for details.
====================================== 1 failed, 84 passed, 56 skipped in 12.25s =======================================
```


**Which issue(s) this PR fixes**:
Fixes #3906
