### PR TITLE
Propose ADR to remove debsums test

### DIFF
--- a/docs/architecture/decisions/0025-disable-debsums-tests.md
+++ b/docs/architecture/decisions/0025-disable-debsums-tests.md
@@ -1,4 +1,4 @@
-# 22. Disable Debsums Tests entirely
+# 25. Disable Debsums Tests entirely
 
 Date: 2025-11-24
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Find a decision to remove the debsums test by not porting it to test-ng.

**Which issue(s) this PR fixes**:
Fixes #3785 

**notes**
The sequential number of this ADR is not fixed and depends on already existing and prior merged ADRs.