### PR TITLE
Disable `tests-ng` test for tainted kernels for `_trustedboot`

### DIFF
--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -69,6 +69,10 @@ def test_startup_time(systemd: Systemd):
     )
 
 
+@pytest.mark.feature(
+    "not _trustedboot",
+    reason="Test fails for unknown reason. See #3927",
+)
 @pytest.mark.booted(reason="Kernel test makes sense only on booted system")
 def test_kernel_not_tainted():
     with open("/proc/sys/kernel/tainted", "r") as f:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `nightly` fails because kernels are marked as tainted without a known reason if `_trustedboot` is enabled.

**Which issue(s) this PR fixes**:
Related #3927

**Special notes for your reviewer**:
 See #3927 for details. This change is temporarily to enable nightly builds again and will be reverted.