### PR TITLE
hack: add backwards compatibility for decoupled S3 upload logic

### DIFF
--- a/features/base/exec.config
+++ b/features/base/exec.config
@@ -13,6 +13,7 @@ HOME_URL="https://gardenlinux.io"
 SUPPORT_URL="https://github.com/gardenlinux/gardenlinux"
 BUG_REPORT_URL="https://github.com/gardenlinux/gardenlinux/issues"
 GARDENLINUX_CNAME=$BUILDER_CNAME
+GARDENLINUX_PLATFORM=${BUILDER_CNAME%%[-_]*}
 GARDENLINUX_FEATURES=$BUILDER_FEATURES
 GARDENLINUX_VERSION=$BUILDER_VERSION
 GARDENLINUX_COMMIT_ID=$(echo "$BUILDER_COMMIT" | head -c 8)


### PR DESCRIPTION
This restores compatibility with the following changes in the python lib: https://github.com/gardenlinux/python-gardenlinux-lib/commit/ce32bb0405fa89069798dbfaf421a098b9081730

This change deliberatly does NOT identify the actual set of platforms but pretends the first component in the cname is the one and only platform - even when multiple platforms are present. This was done in order to mirror the behaviour that the python lib exhibited with multiple platforms during the initial relaes of 1877 and is needed to not break the `openstackbaremetal` flavour which technically has both `openstackbaremetal` and `metal` platforms active, but should appear towards GLCI as only `openstackbaremetal`

**Which issue(s) this PR fixes**:
Fixes #3944
