### PR TITLE
Fix permission to push image ghcr.io

### DIFF
--- a/.github/workflows/build_lima_yaml_container.yml
+++ b/.github/workflows/build_lima_yaml_container.yml
@@ -14,7 +14,6 @@ jobs:
       run:
         shell: bash
     permissions:
-      actions: write
       # Push container images
       packages: write
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Permission for github workflow to push image to ghcr.io
**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
