### PR TITLE
Feature/3165 dependabot for opentofu providers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# terraform/opentofu configuration
-tests/platformSetup/tofu/*.tf @gardenlinux/maintainers
-tests-ng/util/tf/*.tf @gardenlinux/maintainers
-
-# python dependencies
-tests/Pipfile @gardenlinux/maintainers
-tests-ng/util/requirements.txt @gardenlinux/maintainers
-tests-ng/util/requirements-dev.txt @gardenlinux/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
     directory: "/tests-ng/util/tf/"
     schedule:
       interval: "weekly"
-    versioning-strategy: "increase-if-necessary"
     ignore:
       - dependency-name: "hashicorp/azurerm"
 
@@ -31,6 +30,5 @@ updates:
     directory: "/tests/platformSetup/tofu/"
     schedule:
       interval: "weekly"
-    versioning-strategy: "increase-if-necessary"
     ignore:
       - dependency-name: "hashicorp/azurerm"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,12 @@
 
 # Gardener Responsibility for the Gardener Feature
 /features/gardener/* @gardenlinux/gardener-skipper-operating-system
+
+# terraform/opentofu configuration
+tests/platformSetup/tofu/*.tf @gardenlinux/maintainers
+tests-ng/util/tf/*.tf @gardenlinux/maintainers
+
+# python dependencies
+tests/Pipfile @gardenlinux/maintainers
+tests-ng/util/requirements.txt @gardenlinux/maintainers
+tests-ng/util/requirements-dev.txt @gardenlinux/maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables opentofu support für dependabot.

**Which issue(s) this PR fixes**:
Fixes #3165