### PR TITLE
fix: test: test-ng: fix azure NIC deletion

### DIFF
--- a/tests-ng/util/tf/modules/azure/net.tf
+++ b/tests-ng/util/tf/modules/azure/net.tf
@@ -60,6 +60,10 @@ resource "azurerm_network_interface" "nic" {
     public_ip_address_id          = azurerm_public_ip.pip.id
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = local.labels
 }
 

--- a/tests/platformSetup/tofu/modules/azure/main.tf
+++ b/tests/platformSetup/tofu/modules/azure/main.tf
@@ -241,6 +241,10 @@ resource "azurerm_network_interface" "nic" {
     public_ip_address_id          = azurerm_public_ip.pip.id
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = local.labels
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This tries to fix the azure NIC deletion issues in the old and new test framework.
According to these issues, adding "create_before_destroy = true" should solve the ongoing issues:
  - https://github.com/hashicorp/terraform-provider-azurerm/issues/18915
  - https://github.com/hashicorp/terraform/issues/25993
  - https://github.com/Azure/terraform-azurerm-compute/issues/107

**Which issue(s) this PR fixes**:
Fixes #3928


**Notes for reviewers**:

This is a successful test run of the changed tofu code:
https://github.com/gardenlinux/gardenlinux/actions/runs/19823074210