### PR TITLE
fix: test-ng: revert sysdiff to report to stderr

### DIFF
--- a/tests-ng/test_sysdiff.py
+++ b/tests-ng/test_sysdiff.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 from plugins.sysdiff import Sysdiff
@@ -50,7 +51,10 @@ def test_sysdiff_after_tests(sysdiff: Sysdiff):
             diff_output = sysdiff.diff_engine.generate_diff(
                 diff_result, before_snapshot, after_snapshot
             )
-            logger.info(f"System changes detected - detailed diff:\n{diff_output}")
+            print(
+                "System changes detected - detailed diff:\n" + diff_output,
+                file=sys.stderr,
+            )
             pytest.fail(
                 "System changes were detected during the test run. See stderr output for details."
             )


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/gardenlinux/gardenlinux/commit/9dffb3de51303b6898dd39ba4a2c269ff5ca181f initially introduced logging of sysdiff to stderr as pytest seems to swallow up long messages.
https://github.com/gardenlinux/gardenlinux/commit/5499d10da129810e2034fd73af66d48c9b287715#diff-55b854f8d7982f752d075217446036fa25a45c8d2da859b98c63486e26132ba5 seems to have broken the new behaviour again.

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/gardenlinux/actions/runs/19841459086/job/56851411985?pr=3986
