### PR TITLE
Fix: Upgrade `python-gardenlinux-lib` version to `0.10.7` to avoid problems with python `3.14`

### DIFF
--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -16,7 +16,7 @@ on:
         required: true
       signing_env:
         type: string
-        default: ''
+        default: ""
     secrets:
       secureboot_db_kms_arn:
         required: false
@@ -37,7 +37,7 @@ jobs:
       id-token: write
       actions: write
     env:
-      CNAME: ''
+      CNAME: ""
       USE_KMS: ${{ inputs.signing_env == '' && 'false' || 'true' }}
     environment: ${{ inputs.signing_env }}
     steps:
@@ -45,7 +45,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7
       - name: Set build reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
@@ -71,7 +71,7 @@ jobs:
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pint@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/build_flavors_matrix.yml
+++ b/.github/workflows/build_flavors_matrix.yml
@@ -2,19 +2,19 @@ on:
   workflow_call:
     inputs:
       flags:
-        description: 'Flags passed to bin/flavors_parse.py'
+        description: "Flags passed to bin/flavors_parse.py"
         type: string
         required: true
       flavors_matrix:
         type: string
     outputs:
       matrix:
-        description: 'Flavors matrix'
+        description: "Flavors matrix"
         value: ${{ jobs.generate_matrix.outputs.matrix }}
 jobs:
   generate_matrix:
     name: Build flavors matrix
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     defaults:
       run:
         shell: bash
@@ -26,7 +26,7 @@ jobs:
           submodules: true
       - id: matrix
         name: Generate flavors matrix
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@hotfix-disabled-python-cache-in-setup-action
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@0.10.7
         with:
           flags: ${{ inputs.flags }}
           flavors_matrix: ${{ inputs.flavors_matrix }}

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -13,10 +13,10 @@ jobs:
       run:
         shell: bash
     env:
-      CNAME: ''
+      CNAME: ""
     strategy:
       matrix:
-        arch: [ amd64, arm64 ]
+        arch: [amd64, arm64]
     permissions:
       actions: write
     steps:
@@ -33,7 +33,7 @@ jobs:
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname container-${{ matrix.arch }} cname
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}

--- a/.github/workflows/build_platform_test_images.yml
+++ b/.github/workflows/build_platform_test_images.yml
@@ -4,11 +4,11 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/build_platform_test_images.yml'
-      - 'tests/Pipfile*'
-      - 'tests/images/Makefile'
-      - 'tests/images/platform-test/**'
-      - 'tests/images/platform-test-base/**'
+      - ".github/workflows/build_platform_test_images.yml"
+      - "tests/Pipfile*"
+      - "tests/images/Makefile"
+      - "tests/images/platform-test/**"
+      - "tests/images/platform-test-base/**"
   # triggered by other workflows
   workflow_call:
     inputs:
@@ -37,26 +37,26 @@ on:
     inputs:
       version:
         type: string
-        default: 'nightly'
-        description: 'Version'
+        default: "nightly"
+        description: "Version"
       build:
         type: boolean
         default: false
-        description: 'Build images'
+        description: "Build images"
       push:
         type: boolean
         default: false
-        description: 'Push images'
+        description: "Push images"
       push_latest:
         type: boolean
         default: false
-        description: 'Push latest tag'
+        description: "Push latest tag"
       platforms:
         type: string
-        description: 'JSON array of platforms to build'
+        description: "JSON array of platforms to build"
       archs:
         type: string
-        description: 'JSON array of architectures to build'
+        description: "JSON array of architectures to build"
       platform_test_tag:
         description: "Tag to run platform-test containers. 'latest' or GL version. Tag must be available in ghcr.io/gardenlinux/gardenlinux/platform-test-*"
         type: string
@@ -72,7 +72,7 @@ env:
 jobs:
   generate_matrix:
     name: Build platforms matrix
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     defaults:
       run:
         shell: bash
@@ -118,7 +118,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - name: Set build reference
         run: |
           version="$(./bin/garden-version "$version")"
@@ -143,7 +143,7 @@ jobs:
   build_images:
     if: ${{ inputs.build }}
     name: Build platform-test image
-    needs: [ generate_matrix, build_base_images ]
+    needs: [generate_matrix, build_base_images]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     defaults:
       run:
@@ -205,7 +205,7 @@ jobs:
   push_images:
     if: ${{ inputs.build && ( (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name != 'push' && inputs.push == true) ) }}
     name: Push platform-test images
-    needs: [ generate_matrix, build_images ]
+    needs: [generate_matrix, build_images]
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -303,7 +303,7 @@ jobs:
           echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
   pull_images:
     name: Provide platform-test image
-    needs: [ generate_matrix, pull_images_version ]
+    needs: [generate_matrix, pull_images_version]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     defaults:
       run:

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -34,7 +34,7 @@ jobs:
     # @TODO: We could use a better name for the required environment
     environment: oidc_platform_tests
     env:
-      CNAME: ''
+      CNAME: ""
     strategy:
       matrix: ${{ fromJSON(inputs.flavors_matrix) }}
     steps:
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - name: Set image reference for S3
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
@@ -50,7 +50,7 @@ jobs:
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname)" | tee -a "$GITHUB_ENV"
-      - name: 'Authenticate to AWS'
+      - name: "Authenticate to AWS"
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}

--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -5,14 +5,14 @@ on:
       type:
         type: choice
         default: minor
-        description: 'Patch'
+        description: "Patch"
         options:
-        - minor
-        - dev
+          - minor
+          - dev
       version:
         required: true
         type: string
-        description: 'Version'
+        description: "Version"
       is_latest:
         default: false
         type: boolean
@@ -77,10 +77,10 @@ jobs:
             flavors.yaml
           sparse-checkout-cone-mode: false
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - id: matrix
         name: Generate flavors matrix
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@8e147dfa4af22349cea3b9bc867d3572ee0859ae # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/flavors_parse@d1506f825861ee1b87b13b93498b0047a84e92a2 # pin@0.10.7
         with:
           flags: "--no-arch --json-by-arch --publish"
   github_release:
@@ -103,7 +103,7 @@ jobs:
       - name: install dependencies for generate_release_note.py script
         run: sudo apt-get update && sudo apt-get install -qy --no-install-recommends python3-boto3
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
@@ -141,7 +141,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
@@ -185,7 +185,7 @@ jobs:
     uses: ./.github/workflows/tag_latest_container.yml
     with:
       version: ${{ inputs.version }}
-      is_latest:  ${{ inputs.is_latest }}
+      is_latest: ${{ inputs.is_latest }}
     permissions:
       packages: write
   glrd:

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -84,12 +84,12 @@ jobs:
           echo "${{ inputs.version }}" | tee VERSION
       - name: Determine CNAME (amd64)
         id: cname_amd64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname container-amd64 cname
       - name: Determine CNAME (ard64)
         id: cname_arm64
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname container-arm64 cname
       - name: Set CNAMEs
@@ -257,7 +257,7 @@ jobs:
           role-session-name: ${{ secrets.aws_session }}
           aws-region: ${{ secrets.aws_region }}
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
         with:
@@ -325,7 +325,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - name: Set flavor version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
@@ -358,7 +358,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        arch: [ amd64, arm64 ]
+        arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:

--- a/.github/workflows/tag_latest_container.yml
+++ b/.github/workflows/tag_latest_container.yml
@@ -1,4 +1,4 @@
-name: 'Tag latest and release container'
+name: "Tag latest and release container"
 on:
   workflow_call:
     inputs:
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - name: Tag manifest
         env:
           GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_flavor_bare.yml
+++ b/.github/workflows/test_flavor_bare.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4.3.0
         with:
           path: |

--- a/.github/workflows/test_flavor_chroot.yml
+++ b/.github/workflows/test_flavor_chroot.yml
@@ -34,7 +34,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_flavor_chroot_ng.yml
+++ b/.github/workflows/test_flavor_chroot_ng.yml
@@ -39,7 +39,7 @@ jobs:
           path: tests-ng/.build
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_flavor_cloud.yml
+++ b/.github/workflows/test_flavor_cloud.yml
@@ -76,7 +76,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_flavor_cloud_ng.yml
+++ b/.github/workflows/test_flavor_cloud_ng.yml
@@ -80,7 +80,7 @@ jobs:
           path: cert/
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_flavor_oci.yml
+++ b/.github/workflows/test_flavor_oci.yml
@@ -43,7 +43,7 @@ jobs:
           path: tests-ng/.build
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -49,7 +49,7 @@ jobs:
           path: cert/
       - name: Determine CNAME
         id: cname
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/features_parse@0.10.7 # pin@0.10.7
         with:
           flags: --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname
       - name: Set CNAME

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         shell: bash
     env:
-      CNAME: ''
+      CNAME: ""
     permissions:
       id-token: write
     environment: oidc_aws_s3_upload
@@ -46,7 +46,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.6 # pin@0.10.6
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7 # pin@0.10.7
       - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates all workflows to use the newest versions of `python-gardenlinux-lib`, `0.10.7` which pins the python version to `3.13` in order to circumvent a bug in python `3.14` which breaks all `dataclasses`.

**Which issue(s) this PR fixes**:
Fixes n/A

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
