### PR TITLE
Add Lima image in flavors.yaml to build with nightly and release (#3818)

### DIFF
--- a/features/base/test/test_sgid_suid_files.py
+++ b/features/base/test/test_sgid_suid_files.py
@@ -28,7 +28,8 @@ import pytest
                  "/usr/bin/passwd,root,root",
                  "/usr/lib/polkit-1/polkit-agent-helper-1,root,root",
                  "/usr/bin/pkexec,root,root",
-                 "/usr/sbin/mount.nfs,root,root"
+                 "/usr/sbin/mount.nfs,root,root",
+                 "/usr/bin/fusermount3,root,root"
                  ]
         )
     ]

--- a/features/lima/info.yaml
+++ b/features/lima/info.yaml
@@ -6,5 +6,4 @@ features:
   exclude:
     - sap
     - firewall
-    - log
     - _selinux

--- a/features/lima/pkg.include
+++ b/features/lima/pkg.include
@@ -6,3 +6,4 @@ efitools
 openssh-server
 qemu-guest-agent
 sshfs
+python3-cffi-backend

--- a/flavors.yaml
+++ b/flavors.yaml
@@ -658,3 +658,18 @@ targets:
         test: true
         test-platform: false
         publish: true
+  - name: lima
+    category: hypervisor
+    flavors:
+      - features: []
+        arch: amd64
+        build: true
+        test: true
+        test-platform: false
+        publish: true
+      - features: []
+        arch: arm64
+        build: true
+        test: true
+        test-platform: false
+        publish: true


### PR DESCRIPTION
Add lima flavor to flavors.yaml

Backport of https://github.com/gardenlinux/gardenlinux/commit/d1e159b24f7e3b7abd304600ee69f2f6c3ff39ea

This should add the lima images to new minor releases of 1877

**Special notes for your reviewer**:

I am not sure if we need to do more for this