### PR TITLE
fix: Cloud Test Cleanup workflow needs dummy files

### DIFF
--- a/.github/workflows/cloud_test_cleanup.yml
+++ b/.github/workflows/cloud_test_cleanup.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y retry
       - name: "Authenticate to Google Cloud"
-        if: ${{ startsWith(matrix.workspace, 'test-ng-gcp-') }}
+        if: ${{ contains(matrix.workspace, '-gcp-') }}
         uses: google-github-actions/auth@140bb5113ffb6b65a7e9b937a81fa96cf5064462 # pin@v1
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -214,7 +214,7 @@ jobs:
           cleanup_credentials: true
           export_environment_variables: true
       - name: Set GCP environment
-        if: ${{ startsWith(matrix.workspace, 'test-ng-gcp-') }}
+        if: ${{ contains(matrix.workspace, '-gcp-') }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -223,7 +223,7 @@ jobs:
             core.exportVariable("GOOGLE_REGION", "${{ secrets.GCP_REGION }}");
             core.exportVariable("GOOGLE_ZONE", "${{ secrets.GCP_ZONE }}");
       - id: "auth_aws"
-        name: "Authenticate to AWS"
+        name: "Authenticate to AWS (S3 backend)"
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_TESTS_IAM_ROLE }}
@@ -231,7 +231,6 @@ jobs:
           aws-region: ${{ secrets.aws_region }}
           output-credentials: true
       - name: Set AWS environment
-        if: ${{ startsWith(matrix.workspace, 'test-ng-aws-') }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -245,7 +244,7 @@ jobs:
             // tf provider vars
             core.exportVariable("AWS_REGION", "${{ secrets.aws_region }}");
       - id: "auth_azure"
-        if: ${{ startsWith(matrix.workspace, 'test-ng-azure-') }}
+        if: ${{ contains(matrix.workspace, '-azure-') }}
         name: "Authenticate to Azure"
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # pin@v1
         with:
@@ -253,7 +252,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Set Azure environment
-        if: ${{ startsWith(matrix.workspace, 'test-ng-azure-') }}
+        if: ${{ contains(matrix.workspace, '-azure-') }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -267,7 +266,7 @@ jobs:
             core.setSecret("${{ secrets.AZURE_TENANT_ID }}");
             core.exportVariable("ARM_TENANT_ID", "${{ secrets.AZURE_TENANT_ID }}");
       - name: "Create ali cloud credential file"
-        if: ${{ startsWith(matrix.workspace, 'test-ng-ali-') }}
+        if: ${{ contains(matrix.workspace, '-ali-') }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -310,6 +309,12 @@ jobs:
           source ../install_tofu.sh
           install_tofu "$PWD"
 
+          # ssh key generation (if missing)
+          test -f ~/.ssh/id_ed25519 || ssh-keygen -t ed25519 -P "" -f ~/.ssh/id_ed25519
+          # secureboot certificate files
+          mkdir -p cert
+          touch cert/secureboot.db.crt cert/secureboot.pk.der cert/secureboot.db.der cert/secureboot.kek.der cert/secureboot.aws-efivars
+
           # Create minimal tfvars
           cat > empty.tfvars <<EOF
             root_disk_path        = "empty.raw"
@@ -324,6 +329,10 @@ jobs:
               tpm2 = false
             }
           EOF
+
+          # Create non-empty placeholder artifacts required by tofu destroy
+          cp empty.tfvars empty.raw
+          cp empty.tfvars empty.sh
 
           # Enable remote state S3 backend and init
           if [ ! -f backend.tf ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the Cloud Test Cleanup is silently failing in some cases.
This fixes the workflow by adding dummy files and fixing authentication by workspace name.

https://github.com/gardenlinux/gardenlinux/actions/runs/20020933096/job/57407815278 is a successful test run.
