### PR TITLE
fix: test-ng: correctly parse all possible fields in systemd-analyze

### DIFF
--- a/tests-ng/plugins/systemd.py
+++ b/tests-ng/plugins/systemd.py
@@ -109,7 +109,12 @@ class Systemd:
         summary = output.splitlines()[0]
 
         m = re.search(
-            r"^Startup finished in (.*) \(kernel\) \+ (.*) \(initrd\) \+ (.*) \(userspace\)",
+            r"^Startup finished in "
+            r"(?:([0-9a-z. ]+) \(firmware\) \+ )?"
+            r"(?:([0-9a-z. ]+) \(loader\) \+ )?"
+            r"(?:([0-9a-z. ]+) \(kernel\) \+ )?"
+            r"(?:([0-9a-z. ]+) \(initrd\) \+ )?"
+            r"(?:([0-9a-z. ]+) \(userspace\) )?",
             summary,
         )
         if not m:

--- a/tests-ng/test_basics.py
+++ b/tests-ng/test_basics.py
@@ -56,7 +56,7 @@ def test_startup_time(systemd: Systemd):
     tolerated_kernel = 60.0
     tolerated_userspace = 60.0
 
-    kernel, initrd, userspace = systemd.analyze()
+    firmware, loader, kernel, initrd, userspace = systemd.analyze()
     kernel_total = kernel + initrd
 
     assert kernel_total < tolerated_kernel, (


### PR DESCRIPTION
Fixes #4020