### PR TITLE
Feature/3165 dependabot for opentofu providers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,3 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "hashicorp/azurerm"
-
-  - package-ecosystem: "opentofu"
-    directory: "/tests/platformSetup/tofu/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "hashicorp/azurerm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "gardenlinux/garden-linux-maintainers"
-
+ 
   - package-ecosystem: "pip"
     directory: "/tests/util"
     schedule:
       interval: "weekly"
     versioning-strategy: "increase-if-necessary"
-    reviewers:
-      - "gardenlinux/garden-linux-maintainers"
+
+  - package-ecosystem: "opentofu"
+    directory: "/tests/util/tf/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "hashicorp/azurerm"
+
+  - package-ecosystem: "opentofu"
+    directory: "/tests/platformSetup/tofu/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "hashicorp/azurerm"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,12 @@
 
 # Gardener Responsibility for the Gardener Feature
 /features/gardener/* @gardenlinux/gardener-skipper-operating-system
+
+# terraform/opentofu configuration
+tests/platformSetup/tofu/*.tf @gardenlinux/maintainers
+tests-ng/util/tf/*.tf @gardenlinux/maintainers
+
+# python dependencies
+tests/Pipfile @gardenlinux/maintainers
+tests-ng/util/requirements.txt @gardenlinux/maintainers
+tests-ng/util/requirements-dev.txt @gardenlinux/maintainers

--- a/tests/util/install_tofu.sh
+++ b/tests/util/install_tofu.sh
@@ -104,11 +104,13 @@ install_tofu() {
         git clone --depth=1 https://github.com/tofuutils/tofuenv.git "$tofuenv_dir"
         echo 'trust-tofuenv: yes' >"$tofuenv_dir/use-gpgv"
     }
-    # go to tofu directory to automatically parse *.tf files
-    pushd "$tf_dir"
-    tofuenv install latest-allowed
-    tofuenv use latest-allowed
-    popd
+    # parse provider file and install fixed opentofu version
+    # tofuenv cannot handle fixed versions in providers.tf while 
+    # using tofuenv install latest-allowed
+    opentofu_ver=$(grep "required_version" "util/tf/providers.tf" | cut -d= -f2 | tr -d [=\"=] | tr -d [:space:])
+
+    tofuenv install $opentofu_ver
+    tofuenv use $opentofu_ver
 
     install_custom_azure_resource_manager
 }

--- a/tests/util/install_tofu.sh
+++ b/tests/util/install_tofu.sh
@@ -107,10 +107,10 @@ install_tofu() {
     # parse provider file and install fixed opentofu version
     # tofuenv cannot handle fixed versions in providers.tf while 
     # using tofuenv install latest-allowed
-    opentofu_ver=$(grep "required_version" "util/tf/providers.tf" | cut -d= -f2 | tr -d [=\"=] | tr -d [:space:])
+    opentofu_ver=$(grep "required_version" "util/tf/providers.tf" | cut -d= -f2 | tr -d "[=\"=]" | tr -d "[:space:]")
 
-    tofuenv install $opentofu_ver
-    tofuenv use $opentofu_ver
+    tofuenv install "$opentofu_ver"
+    tofuenv use "$opentofu_ver"
 
     install_custom_azure_resource_manager
 }

--- a/tests/util/tf/providers.tf
+++ b/tests/util/tf/providers.tf
@@ -1,21 +1,21 @@
 terraform {
-  required_version = "~> 1.10.0"
+  required_version = "1.10.6"
   required_providers {
     alicloud = {
       source  = "aliyun/alicloud"
-      version = "~> 1.253.0"
+      version = "1.253.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.2.0"
+      version = "6.2.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.35.0"
+      version = "4.35.0"
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.42.0"
+      version = "6.42.0"
     }
     openstack = {
       source = "terraform-provider-openstack/openstack"

--- a/tests/util/tf/variables.tf
+++ b/tests/util/tf/variables.tf
@@ -54,6 +54,7 @@ variable "cloud_provider" {
     condition     = contains(["aws", "gcp", "azure", "ali", "openstack"], var.cloud_provider)
     error_message = "Must be one of aws, gcp, azure, ali, or openstack."
   }
+  default     = "aws"
 }
 
 variable "provider_vars" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use dependabot to update opentofu providers. Second attempt. First attempt produced two issues in main workflows which were not reproducable in pull request branch.

This PR will cover #4030 and #4029.

**Which issue(s) this PR fixes**:
Fixes #3165 
