### PR TITLE
Add tests for gnutls to check if it's in FIPS-mode.

### DIFF
--- a/tests-ng/test_fips.py
+++ b/tests-ng/test_fips.py
@@ -49,8 +49,7 @@ def test_gnutls_is_in_fips_mode():
     """
     shared_lib_name = find_library("gnutls")
     gnutls = CDLL(shared_lib_name)
-    rc = gnutls.gnutls_fips140_mode_enabled()
-    assert bool(rc), "Error GnuTLS can't be started in FIPS mode."
+    assert gnutls.gnutls_fips140_mode_enabled(), "Error GnuTLS can't be started in FIPS mode."
 
 
 @pytest.mark.feature("_fips")


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, we add a Python test to invoke the C function [`gnutls_fips140_mode_enabled`](https://manpages.debian.org/testing/gnutls-doc/gnutls_fips140_mode_enabled.3.en.html) to ensure that 

While there are some Python implementations that allow the usage of GnuTLS, all implementations are not working or too old to be used in our testing frame. With this approach, we are using ctypes to invoke the function directly.  

Relates: [#3898](https://github.com/gardenlinux/gardenlinux/issues/3898)