### PR TITLE
Add labels to container images

### DIFF
--- a/features/container/image.oci
+++ b/features/container/image.oci
@@ -29,8 +29,8 @@ cat > config << EOF
       "org.opencontainers.image.architecture": "$BUILDER_ARCH",
       "org.opencontainers.image.source": "https://github.com/gardenlinux/gardenlinux",
       "org.opencontainers.image.revision": "$BUILDER_COMMIT",
-      "org.opencontainers.image.description": "$BUILDER_FEATURES"
-    }
+      "org.opencontainers.image.description": "Garden Linux $BUILDER_VERSION $BUILDER_ARCH $BUILDER_FEATURES"
+}
   },
   "rootfs": {
     "type": "layers",


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds labels to container images, which allows to identify an image even if it has no tag.

**Which issue(s) this PR fixes**:
Fixes #4057 