### PR TITLE
Fix: Remove content from `/etc/hostname` for container builds (#3867)

### DIFF
--- a/features/base/exec.post
+++ b/features/base/exec.post
@@ -30,3 +30,6 @@ rm "$rootfs/etc/.resolv.conf.systemd-resolved.bak"
 fi
 
 find "$rootfs/var/log/" "$rootfs/var/cache/" -type f -delete
+
+rm "$rootfs/etc/hostname"
+echo -n > "$rootfs/etc/hostname"

--- a/features/server/exec.post
+++ b/features/server/exec.post
@@ -4,8 +4,5 @@ set -eufo pipefail
 
 rootfs="$1"
 
-rm "$rootfs/etc/hostname"
-echo -n > "$rootfs/etc/hostname"
-
 rm "$rootfs/etc/resolv.conf"
 ln -s /run/systemd/resolve/resolv.conf "$rootfs/etc/resolv.conf"


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of 02a24ff

Includes bug fix for non-empty `/etc/hostname` files for future 1877 minor releases
