### PR TITLE
fix: change default version to 'latest' in generate-lima-yaml.py

### DIFF
--- a/bin/generate-lima-yaml.py
+++ b/bin/generate-lima-yaml.py
@@ -96,12 +96,9 @@ def main():
         description="Generate lima-vm manifests for use with Garden Linux guests"
     )
 
-    # FIXME: Change the default value to 'latest' prior to our next major release
-    # Using nightly as the default value temporarily for easier usage because no released version is built with the lima feature.
-    # 'latest' should be the default value starting with the next major version.
     parser.add_argument(
         "--version",
-        default='nightly',
+        default='latest',
         help="Provide a specific Garden Linux version, or use 'latest' or 'nightly'."
     )
 


### PR DESCRIPTION
This is a follow up for https://github.com/gardenlinux/gardenlinux/pull/3945

Garden Linux 1877.9 was released with the lima image, so it is not required to have nightly as the default option anymore.

Resolves https://github.com/gardenlinux/gardenlinux/issues/3937
