### PR TITLE
fix: make test_image_proc_is_empty run on booted only

### DIFF
--- a/tests-ng/test_proc.py
+++ b/tests-ng/test_proc.py
@@ -5,7 +5,7 @@ from plugins.booted import is_system_booted
 
 
 @pytest.mark.root
-@pytest.mark.feature("not container", reason="container not allowed to remount rootfs")
+@pytest.mark.booted
 def test_image_proc_is_empty(remounted_root):
     """
     Test for an empty /proc within the given rootfs tarball. Since /proc is mounted


### PR DESCRIPTION
Fixes #3669 