### PR TITLE
add timeout while deleting NIC in azure tests-ng

### DIFF
--- a/tests-ng/util/tf/modules/azure/net.tf
+++ b/tests-ng/util/tf/modules/azure/net.tf
@@ -64,6 +64,10 @@ resource "azurerm_network_interface" "nic" {
     create_before_destroy = true
   }
 
+  timeouts {
+    delete = "10m"
+  }
+
   tags = local.labels
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a NIC delete timeout of 10mins to override Azure wait time of 3mins while Destroying resources

**Which issue(s) this PR fixes**:
Fixes #4133 