### PR TITLE
Properly disable TLS config via libvirtd-tls.socket without touching libvirtd.conf

### DIFF
--- a/features/vhost/exec.config
+++ b/features/vhost/exec.config
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -Eeuo pipefail
-
-sed -i '/#listen_tls = 0/a listen_tls = 0' /etc/libvirt/libvirtd.conf
-sed -i '/#ca_file = "\/etc\/pki\/CA\/cacert.pem"/a ca_file = ""' /etc/libvirt/libvirtd.conf
-sed -i '/#key_file = "\/etc\/pki\/libvirt\/private\/serverkey.pem"/a key_file = ""' /etc/libvirt/libvirtd.conf
-sed -i '/#cert_file = "\/etc\/pki\/libvirt\/servercert.pem"/a cert_file = ""' /etc/libvirt/libvirtd.conf

--- a/features/vhost/file.include/etc/systemd/system-preset/00-disable-libvirtd-tls-socket.preset
+++ b/features/vhost/file.include/etc/systemd/system-preset/00-disable-libvirtd-tls-socket.preset
@@ -1,0 +1,1 @@
+disable libvirtd-tls.socket


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/gardenlinux/gardenlinux/issues/1225 initially disabled the TLS config and set empty certificate paths. This way not work anymore in the recent libvirt version `11.10.0-2gl0`.
This PR properly disables TLS by disabling `libvirtd-tls.socket` without touching `libvirtd.conf`.

**Which issue(s) this PR fixes**:
Fixes #4172
