### PR TITLE
fix: test-ng: remove explicit dependency on azurerm_network_interface and azurerm_shared_image_version

### DIFF
--- a/tests-ng/util/tf/modules/azure/vm.tf
+++ b/tests-ng/util/tf/modules/azure/vm.tf
@@ -45,12 +45,6 @@ resource "azurerm_linux_virtual_machine" "instance" {
 
   tags = local.labels
 
-  # wait until image version and nic are available
-  depends_on = [
-    azurerm_shared_image_version.shared_image_version.0,
-    azurerm_network_interface.nic
-  ]
-
   # replace if image source changes
   lifecycle {
     replace_triggered_by = [


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove explicit dependency on azurerm_network_interface and azurerm_shared_image_version and azurerm_shared_image_version.
These should be automatically resolved by OpenTofu. They might cause issues of e.g. NICs not being able to be deleted.

**Which issue(s) this PR fixes**:
Fixes #4133
