### PR TITLE
fix: Remove old Test Cleanup

### DIFF
--- a/.github/workflows/cloud_test_cleanup.yml
+++ b/.github/workflows/cloud_test_cleanup.yml
@@ -40,152 +40,10 @@ jobs:
           echo "matrix_test=${TEST_WORKSPACES}" >> $GITHUB_OUTPUT
           echo "matrix_test_ng=${TEST_NG_WORKSPACES}" >> $GITHUB_OUTPUT
 
-  cleanup_test:
-    needs: collect_workspaces
-    if: ${{ needs.collect_workspaces.outputs.matrix_test != '[]' && needs.collect_workspaces.outputs.matrix_test != '' }}
-    name: Cleanup Test Workspaces
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-    environment: oidc_platform_tests
-    env:
-      IMAGE: ghcr.io/gardenlinux/gardenlinux/platform-test-tofu:latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        workspace: ${{ fromJson(needs.collect_workspaces.outputs.matrix_test) }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          submodules: true
-      - name: "Authenticate to Google Cloud"
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          create_credentials_file: true
-          cleanup_credentials: true
-          export_environment_variables: true
-      - name: Set GCP environment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const path = await import("path");
-
-            const basePath = "/gardenlinux/";
-            const credentialsFileName = path.basename(process.env.GOOGLE_APPLICATION_CREDENTIALS);
-
-            core.exportVariable("GOOGLE_APPLICATION_CREDENTIALS", basePath + credentialsFileName);
-            core.exportVariable("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", basePath + credentialsFileName);
-            core.exportVariable("GOOGLE_GHA_CREDS_PATH", basePath + credentialsFileName);
-      - id: "auth_aws"
-        name: "Authenticate to AWS"
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_TESTS_IAM_ROLE }}
-          role-session-name: ${{ secrets.AWS_TESTS_OIDC_SESSION }}
-          aws-region: ${{ secrets.AWS_TESTS_REGION }}
-          output-credentials: true
-      - name: Set AWS environment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            core.setSecret("${{ steps.auth_aws.outputs.aws-access-key-id }}");
-            core.exportVariable("AWS_ACCESS_KEY_ID", "${{ steps.auth_aws.outputs.aws-access-key-id }}");
-            core.setSecret("${{ steps.auth_aws.outputs.aws-secret-access-key }}");
-            core.exportVariable("AWS_SECRET_ACCESS_KEY", "${{ steps.auth_aws.outputs.aws-secret-access-key }}");
-            core.setSecret("${{ steps.auth_aws.outputs.aws-session-token }}");
-            core.exportVariable("AWS_SESSION_TOKEN", "${{ steps.auth_aws.outputs.aws-session-token }}");
-      - name: "Authenticate to Azure"
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # pin@v1
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Set Azure environment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            core.exportVariable("ARM_USE_OIDC", "true");
-
-            core.setSecret("${{ secrets.AZURE_CLIENT_ID }}");
-            core.exportVariable("ARM_CLIENT_ID", "${{ secrets.AZURE_CLIENT_ID }}");
-            core.setSecret("${{ secrets.AZURE_SUBSCRIPTION_ID }}");
-            core.exportVariable("ARM_SUBSCRIPTION_ID", "${{ secrets.AZURE_SUBSCRIPTION_ID }}");
-            core.setSecret("${{ secrets.AZURE_TENANT_ID }}");
-            core.exportVariable("ARM_TENANT_ID", "${{ secrets.AZURE_TENANT_ID }}");
-      - name: "Create ali cloud credential file"
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const credentials = JSON.parse(atob("${{ secrets.CCC_CREDENTIALS }}"));
-            const aliCredentials = credentials.alicloud["gardenlinux-platform-test"];
-
-            core.exportVariable("ALIBABA_CLOUD_REGION", aliCredentials.region);
-
-            core.setSecret(aliCredentials.access_key_id);
-            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_ID", aliCredentials.access_key_id);
-            core.setSecret(aliCredentials.access_key_secret);
-            core.exportVariable("ALIBABA_CLOUD_ACCESS_KEY_SECRET", aliCredentials.access_key_secret);
-      - name: Set additional OpenTofu variables
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const tfEncryption = Buffer.from("${{ secrets.TF_ENCRYPTION }}", 'base64').toString('utf-8');
-            core.setSecret(tfEncryption);
-            core.exportVariable("TF_ENCRYPTION", tfEncryption);
-
-            core.setSecret("${{ secrets.GCP_PROJECT }}");
-            core.exportVariable("TF_VAR_gcp_project_id", "${{ secrets.GCP_PROJECT }}");
-
-            core.exportVariable("OS_AUTH_URL", "http://localhost:3000");
-
-            core.exportVariable("WORKSPACE", "${{ matrix.workspace }}");
-            // Extract flavor by removing test- and suffix seed (last 8 chars after last hyphen)
-            const workspace = "${{ matrix.workspace }}";
-            let flavor = workspace.replace(/^test-\d+-\d+-/, "").replace(/-........$/, "");
-            core.exportVariable("FLAVOR", flavor);
-      - name: Setup Environment
-        run: |
-          # ssh key generation (if missing)
-          test -f ~/.ssh/id_ed25519 || ssh-keygen -t ed25519 -P "" -f ~/.ssh/id_ed25519
-          # secureboot certificate files
-          mkdir -p cert
-          touch cert/secureboot.db.crt cert/secureboot.pk.der cert/secureboot.db.der cert/secureboot.kek.der cert/secureboot.aws-efivars
-          # create directories for credentials
-          mkdir -p ~/.aws ~/.azure ~/.aliyun ~/.config/gcloud
-      - name: Destroy OpenTofu Resources and delete workspaces
-        run: |
-          echo "Processing workspace: ${WORKSPACE}"
-          echo "Processing flavor: ${FLAVOR}"
-
-          podman run --rm \
-            -v ${PWD}:/gardenlinux \
-            -v ~/.ssh:/root/.ssh:ro \
-            -e "TF_*" \
-            -v ~/.aliyun:/root/.aliyun -e "ALIBABA_*" \
-            -v ~/.aws:/root/.aws -e "AWS_*" \
-            -v ~/.azure:/root/.azure -e "azure_*" -e "ARM_*" -e "ACTIONS_*" \
-            -v ~/.config/gcloud:/root/.config/gcloud -e "GOOGLE_*" -e "CLOUDSDK_*" \
-            -e "OS_*" \
-            ${IMAGE} \
-            bash -c "
-              cd /gardenlinux/tests/platformSetup/tofu && \
-              if [ ! -f backend.tf ]; then cp backend.tf.github backend.tf; tofu init; fi && \
-              ../platformSetup.py --provisioner tofu --test-prefix gh-actions --flavor ${FLAVOR} --create-tfvars && \
-              tofu workspace select ${WORKSPACE} && \
-              tofu destroy -var-file variables.${FLAVOR}.tfvars -auto-approve && \
-              tofu workspace select default && \
-              tofu workspace delete ${WORKSPACE}
-            "
-
-  cleanup_test_ng:
+  cleanup:
     needs: collect_workspaces
     if: ${{ needs.collect_workspaces.outputs.matrix_test_ng != '[]' && needs.collect_workspaces.outputs.matrix_test_ng != '' }}
-    name: Cleanup Test-ng Workspaces
+    name: Cleanup Test Workspaces
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -348,3 +206,20 @@ jobs:
           tofu destroy -var-file empty.tfvars -auto-approve || true
           tofu workspace select default
           tofu workspace delete "${WORKSPACE}" || true
+  cleanup_retry:
+    needs: cleanup
+    if: ${{ failure() && needs.cleanup.result == 'failure' }}
+    name: "Retry checkpoint: Cleanup"
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Retry failed cleanup
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const gitHubLib = await import("${{ github.workspace }}/.github/workflows/github.mjs");
+
+            const gitHubRef = "${{ github.head_ref == '' && github.ref_name || github.head_ref }}";
+            return await gitHubLib.dispatchRetryWorkflow(core, github.rest.actions, context, gitHubRef, 5);


### PR DESCRIPTION
**What this PR does / why we need it**:

"Cloud Test Cleanup" job fail in github actions because it is also still triggered for the old test framework.
This was missed in https://github.com/gardenlinux/gardenlinux/pull/4129

**Which issue(s) this PR fixes**:
Fixes #4170
