### PR TITLE
fix: add missing skip_tests variable to all cloud providers

### DIFF
--- a/tests-ng/util/tf/modules/ali/variables.tf
+++ b/tests-ng/util/tf/modules/ali/variables.tf
@@ -76,3 +76,9 @@ variable "provider_vars" {
     # feature_trustedboot = optional(bool, false)
   })
 }
+
+variable "skip_tests" {
+  description = "Skip deploying test disk and running tests"
+  type        = bool
+  default     = false
+}

--- a/tests-ng/util/tf/modules/aws/variables.tf
+++ b/tests-ng/util/tf/modules/aws/variables.tf
@@ -74,3 +74,9 @@ variable "provider_vars" {
     ssh_user = optional(string, "admin")
   })
 }
+
+variable "skip_tests" {
+  description = "Skip deploying test disk and running tests"
+  type        = bool
+  default     = false
+}

--- a/tests-ng/util/tf/modules/gcp/variables.tf
+++ b/tests-ng/util/tf/modules/gcp/variables.tf
@@ -78,3 +78,9 @@ variable "provider_vars" {
     # feature_trustedboot = optional(bool, false)
   })
 }
+
+variable "skip_tests" {
+  description = "Skip deploying test disk and running tests"
+  type        = bool
+  default     = false
+}

--- a/tests-ng/util/tf/modules/openstack/variables.tf
+++ b/tests-ng/util/tf/modules/openstack/variables.tf
@@ -72,3 +72,9 @@ variable "provider_vars" {
     # feature_trustedboot = optional(bool, false)
   })
 }
+
+variable "skip_tests" {
+  description = "Skip deploying test disk and running tests"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This was missed out in https://github.com/gardenlinux/gardenlinux/pull/4183.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4133
