### PR TITLE
Fix: Update Python Runtime fails if PR exists and close superseeded PRs

### DIFF
--- a/.github/workflows/test_update_python_runtime.yml
+++ b/.github/workflows/test_update_python_runtime.yml
@@ -50,6 +50,12 @@ jobs:
             echo "release_date=$release_date" >> $GITHUB_OUTPUT
           fi
 
+      - name: Configure Git
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "Garden Linux Bot"
+          git config user.email gardenlinux[bot]@users.noreply.github.com
+
       - name: Create Branch and Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         env:
@@ -82,9 +88,6 @@ jobs:
             printf '%s\n' "${SUMMARY}"
           } > /tmp/commit_message.txt
 
-          git config user.name "Garden Linux Bot"
-          git config user.email gardenlinux[bot]@users.noreply.github.com
-
           git checkout -b ${BRANCH}
           git add tests-ng/util/python.env.sh
 
@@ -105,3 +108,28 @@ jobs:
             # is somewhat broken, see https://github.com/orgs/community/discussions/113519
             # error fetching organization teams: GraphQL: Resource not accessible by integration (organization.teams)
             # --reviewer "gardenlinux/maintainers" \
+
+      - name: Close Superseded Pull Requests
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="chore: update Tests-NG Python runtime version"
+
+          # Get PRs sorted by date (newest first)
+          prs=$(gh pr list --search "$TITLE" --json number,createdAt --jq 'sort_by(.createdAt) | reverse | .[].number')
+
+          pr_array=($prs)
+
+          if [ ${#pr_array[@]} -lt 2 ]; then
+            echo "Less than 2 PRs found, nothing to close."
+            exit 0
+          fi
+
+          latest=${pr_array[0]}
+          echo "Keeping latest PR: #$latest"
+
+          for pr in "${pr_array[@]:1}"; do
+            echo "Closing PR #$pr as superseded by #$latest"
+            gh pr close "$pr" --comment "Closing as superseded by #$latest"
+          done


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where Update Python Runtime fails if PR exists and adds the new feature of closing superseeded PRs.

**Which issue(s) this PR fixes**:
Fixes #4199 
