### PR TITLE
Test: Update structure of systemd-detect-virt plugin

### DIFF
--- a/tests-ng/plugins/systemd_detect_virt.py
+++ b/tests-ng/plugins/systemd_detect_virt.py
@@ -1,3 +1,33 @@
+"""
+Hypervisor detection for Gardenlinux cloud image tests.
+
+This module determines the effective virtualization environment an OS image
+is running in, in order to select or skip tests with environment-specific
+expectations.
+
+Detection is based on two independent signals:
+- The hypervisor the guest OS claims to be running on, as reported by
+  `systemd-detect-virt`.
+- Hardware metadata exposed via DMI/SMBIOS tables.
+
+`systemd-detect-virt` reports the innermost virtualization layer visible to
+the guest OS and may reflect cloud-specific branding embedded in the image.
+In some QEMU/KVM setups (i.e. with Hyper-V Enlightenments enabled), this can
+lead to false positives, as this option sets the specific CPUID flags
+`systemd-detect-virt` detects.
+
+To account for this, DMI indicators of generic virtualization are treated as
+authoritative. If a cloud hypervisor is claimed but not corroborated by DMI
+metadata, the environment is assumed to be a virtualized test setup rather
+than real cloud infrastructure.
+
+See:
+- systemd-detect-virt documentation:
+  https://www.freedesktop.org/software/systemd/man/systemd-detect-virt.html
+- qemu documentation
+  https://www.qemu.org/docs/master/system/i386/hyperv.html
+"""
+
 import subprocess
 from enum import Enum
 


### PR DESCRIPTION
**What this PR does / why we need it**:

While implementing #3428 an issue was raised about the clarity and complexity of the detection logic behind the `systemd_detect_virt` plugin and the approach of using two channels of information to determine the hypervisor. These concerns were put into #3843.
While trying to come up with a fix for these concerns, I came to the conclusion that *simplifying* the `systemd-detect-virt` module is not really possible as we need to distinguish between *what the image believes* it is, and *what it is truly running on* in order for us to reliably have vendor-specific cloud tests be filtered out.

So, instead, this PR splits the two detection mechanisms into two functions, separating the two concerns, and adding more documentation for better clarity about the approach.

**Which issue(s) this PR fixes**:
Fixes #3843 

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
