### PR TITLE
docs: Add ADR 30 about the scope of python-gardenlinux-lib

### DIFF
--- a/docs/architecture/decisions/0030-python-gardenlinux-lib.md
+++ b/docs/architecture/decisions/0030-python-gardenlinux-lib.md
@@ -26,7 +26,7 @@ To provide a basis for these discussions, this ADR defines the scope of the `pyt
 ## Consequences
 
 - The only intended group using `python-gardenlinux-lib` are Garden Linux developers
-- The `python-gardenlinux-lib` does not need to have an official release process or official support
+- The `python-gardenlinux-lib` is not required to have an official release schedule or official support
 - Scripts targeted to users may contain duplicated code and have to be tested separately 
 - Pipeline scripts are stored indirectly
     - Therefore, if no version was specified, it will always use the latest script version and not the script version of the potentially older branch


### PR DESCRIPTION
**What this PR does / why we need it**:
- Write down outcome of the last team meeting (20.01.)
- Define the scope of the `python-gardenlinux-lib`
- I've added some really strict rules to make decisions easer, please review them and comment if you agree with them
