### PR TITLE
Backported !3209 to release 1877.10

### DIFF
--- a/features/gdch/file.include/etc/kernel/cmdline.d/00-cmdline.cfg
+++ b/features/gdch/file.include/etc/kernel/cmdline.d/00-cmdline.cfg
@@ -1,0 +1,2 @@
+CMDLINE_LINUX_DEFAULT=""
+CMDLINE_LINUX="console=ttyS0,38400n8d earlyprintk=ttyS0,38400n8d consoleblank=0"

--- a/features/gdch/file.include/etc/kernel/cmdline.d/10-console.cfg
+++ b/features/gdch/file.include/etc/kernel/cmdline.d/10-console.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX console=ttyS0"


### PR DESCRIPTION
Backport of https://github.com/gardenlinux/gardenlinux/pull/3209 to be included into 1877.10 release.

refs gardenlinux/gardenlinux#4190

On-behalf-of: SAP <b.ritter@sap.com>

