### PR TITLE
Bump kubernetes version to fix nightly issues

### DIFF
--- a/features/khost/exec.late
+++ b/features/khost/exec.late
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-K8S_VERSION=v1.30.7
+K8S_VERSION=v1.35.0
 K8S_VERSION_REPO="${K8S_VERSION%.*}"
 
 gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg < /builder/features/khost/release.key


### PR DESCRIPTION
Bump Kubernetes to 1.35.0

**What this PR does / why we need it**:
The old 1.30.7 version is not working any longer. As far as I understand it's because it's using gpg v3 signatures for packages which had an exception until 2026-02-01.

**Which issue(s) this PR fixes**:
Fixes #4226

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
