### PR TITLE
firewall service compliance SRG-OS-000480-GPOS-00232

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -127,7 +127,7 @@ def test_that_nftables_firewall_service_is_running(systemd: Systemd):
 
 @pytest.mark.root(reason="Required to query systemd units")
 @pytest.mark.booted(reason="firewall service check requires booted system")
-@pytest.mark.feature("lima and gardener and server and ssh and fedramp ")
+@pytest.mark.feature("lima and gardener and server and ssh")
 def test_that_iptables_firewall_service_is_running(systemd: Systemd):
     """
     As per DISA STIG requirement, either iptables or nftables firewall service should be active


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a test_network to check for firewall service presence and active, for STIG compliance 

**Which issue(s) this PR fixes**:
Fixes [160](https://github.com/gardenlinux/security/issues/160)

**Observations:**
pytest.mark.security_id(SRG-OS-000480-GPOS-00232) / pytest.mark.security_id(00232)
fails below:

