### PR TITLE
ADR: Garden Linux canonical name structure

### DIFF
--- a/docs/architecture/decisions/0032-garden-linux-canonical-name.md
+++ b/docs/architecture/decisions/0032-garden-linux-canonical-name.md
@@ -1,0 +1,30 @@
+# 32. Garden Linux canonical name structure
+
+Date: 2026-02-26
+
+## Status
+
+Draft
+
+## Context
+
+While Garden Linux canonical names (short `cname`) as a representation of flavors for specific architectures, versions and commits are commonly referred to an ADR is missing defining the parts of it. Historically the `cname` contains the platform, zero or more features, the architecture and version information. The platform and features part is referred to as "flavor".
+
+## Decision
+
+- `cname` contains exactly one platform as of [ADR 0020](0020-enforce-single-platform-by-default-in-builder.md) as long as it is not superseded.
+- The platform should but do not have to be at the first position of the flavor string.
+- Features are divided with `-`. `_` is used alternately as stated below.
+- Feature flags are prefixed with `_`. The `-` is omitted in this case.
+- Features are typically sorted by alphabet or a dependency and feature type based algorithm.
+- All features combined form a "flavor".
+- Appended to a "flavor" are in exact the following order, divided by a `-`:
+  - Architecture
+  - Semantic version string or `today` for local builds
+  - Commit ID (currently configured as first eight characters of an Git commit hash) or `local` for local build
+- Version information can be read from `COMMIT` and `VERSION` files of the `gardenlinux` Git repository to form the `cname` as described above.
+
+## Consequences
+
+- To ensure compatibility between tooling the `python-gardenlinux-lib` based tools should be used if applicable. The `python-gardenlinux-lib` contains unit-tests to ensure and conform to this ADR.
+- Additional generators and parsers must ensure the structure and all parts mentioned in this ADR are provided in the correct order.

--- a/docs/architecture/decisions/0032-garden-linux-canonical-name.md
+++ b/docs/architecture/decisions/0032-garden-linux-canonical-name.md
@@ -8,7 +8,7 @@ Draft
 
 ## Context
 
-While Garden Linux canonical names (short `cname`) as a representation of flavors for specific architectures, versions and commits are commonly referred to an ADR is missing defining the parts of it. Historically the `cname` contains the platform, zero or more features, the architecture and version information. The platform and features part is referred to as "flavor".
+While Garden Linux canonical names (short `cname`) as a representation of flavors for specific architectures, versions and commits are commonly referred to an ADR is missing defining the parts of it. Historically the `cname` contains the platform, zero or more features, the architecture and version information. The platform and features part is referred to as "flavor". It forms the shortest possible representation of selected features of a `cname`.
 
 ## Decision
 
@@ -16,13 +16,13 @@ While Garden Linux canonical names (short `cname`) as a representation of flavor
 - The platform should but do not have to be at the first position of the flavor string.
 - Features are divided with `-`. `_` is used alternately as stated below.
 - Feature flags are prefixed with `_`. The `-` is omitted in this case.
-- Features are typically sorted by alphabet or a dependency and feature type based algorithm.
+- Features are typically sorted by alphabet or a feature type based algorithm.
 - All features combined form a "flavor".
 - Appended to a "flavor" are in exact the following order, divided by a `-`:
-  - Architecture
-  - Semantic version string or `today` for local builds
-  - Commit ID (currently configured as first eight characters of an Git commit hash) or `local` for local build
-- Version information can be read from `COMMIT` and `VERSION` files of the `gardenlinux` Git repository to form the `cname` as described above.
+  - Architecture, allowed characters are `a-z` and `0-9`
+  - Semantic version string or `today` for local builds, allowed characters are `a-z`, `0-9` and `.`
+  - Commit ID (currently configured as first eight characters of an Git commit hash) or `local` for local build, allowed characters are `a-z` and `0-9`
+- Version information can be received from `./get_commit` and `./get_version` scripts of a `gardenlinux` derived Git repository to form the `cname` as described above.
 
 ## Consequences
 


### PR DESCRIPTION
**What this PR does / why we need it**:
An ADR is required to align existing and new code to interpret correctly all possible variants of Garden Linux canonical names. This PR adds the ADR as 0032 as 0031 is in `Draft` state in PR #4238.

**Which issue(s) this PR fixes**:
Closes: #4263

**Definition of Done:**
- [x] Write ADR documenting the expected Garden Linux canonical name structure
- [x] Document consequences
- [ ] Review ADR with the team
- [ ] Address any feedback or concerns
- [ ] Update ADR status from "Draft" to "Accepted"