### PR TITLE
Allow "Frankenstein" during upload stages in GitHub workflows

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -238,6 +238,7 @@ jobs:
         shell: bash
     env:
       CNAME: ""
+      GL_ALLOW_FRANKENSTEIN: "1"
     permissions:
       id-token: write
       packages: write
@@ -311,6 +312,7 @@ jobs:
         shell: bash
     env:
       CNAME: ""
+      GL_ALLOW_FRANKENSTEIN: "1"
     permissions:
       id-token: write
       packages: write

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -35,6 +35,7 @@ jobs:
         shell: bash
     env:
       CNAME: ""
+      GL_ALLOW_FRANKENSTEIN: "1"
     permissions:
       id-token: write
     environment: oidc_aws_s3_upload


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR activates the "Frankenstein" setting while uploading in GitHub workflows until relevant features are splitted.