### PR TITLE
fix(pxe): use proper name for generated service

### DIFF
--- a/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
+++ b/features/_pxe/file.include/usr/lib/dracut/modules.d/98gardenlinux-live/squash-mount-generator.sh
@@ -7,7 +7,7 @@ set -e
 # should be gl.squashfs=url=http://...
 # or gl.squashfs=dev=/dev/vdx
 
-url=$(getarg gl.url=)
+url=$(getarg gl.url= || echo "")
 if [ -z "${url#gl.url=}" ] && [ ! -f /root.squashfs ]; then
 	exit 0
 fi
@@ -48,7 +48,7 @@ if [ -f /root.squashfs ]; then
 	ExecStart=/bin/bash -c "mv /root.squashfs /run/root.squashfs"
 	EOF
         mkdir -p "$GENERATOR_DIR"/basic.target.wants
-        ln -s ../symlink-squashfs.service "$GENERATOR_DIR"/basic.target.wants/symlink-squashfs.service
+        ln -s ../move-squashfs.service "$GENERATOR_DIR"/basic.target.wants/move-squashfs.service
 	exit 0
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When the root.squashfs is "baked in" into the initrd, the generator doesn't add the proper service to the basic target.
Also, when no gl.url kernel cmdline parameter is not specified _getarg_ will fail and the whole generator fails.