### PR TITLE
Add a security_mark for SRG-OS-000480-GPOS-00232

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -125,6 +125,7 @@ def test_that_nftables_firewall_service_is_running(systemd: Systemd):
         "nftables"
     ), "nftables should be active for firewall compliance"
 
+
 @pytest.mark.security_id(1127)
 @pytest.mark.root(reason="Required to query systemd units")
 @pytest.mark.booted(reason="firewall service check requires booted system")


### PR DESCRIPTION
**What this PR does / why we need it**:
Add security_id mark to 1127 for the SRG-OS-000480-GPOS-00232

**Which issue(s) this PR fixes**:
Fixes [260](https://github.com/gardenlinux/security/issues/260)