### PR TITLE
Fix regular expression to not only change a commented out line

### DIFF
--- a/features/iscsi/exec.config
+++ b/features/iscsi/exec.config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # config change requested by gardener
 sed -i 's/^\(node.session.scan\).*/\1 = manual/' /etc/iscsi/iscsid.conf
-sed -i 's/^.\(node.session.auth.chap_algs\).*/\1 = MD5/' /etc/iscsi/iscsid.conf
+sed -i 's/^#\(node.session.auth.chap_algs\).*/\1 = SHA3-256,SHA256,SHA1,MD5/' /etc/iscsi/iscsid.conf
 touch /var/lib/open-iscsi-configured0
 
 # Delete initiatorname.iscsi


### PR DESCRIPTION
but actually remove the '#' at the beginning of the line to comment the line in

**What this PR does / why we need it**:
To make the algorithm default choice explicit and to allow any changes to the algorithm to be respected in the config

**Which issue(s) this PR fixes**:
Fixes #4305 

**Definition of Done:**
- [x ] The code is sufficiently documented
- [x ] Shared the changes with the Team so everyone is aware
- [x ] The code is appropriately tested
- [x ] Checked if the code needs to be backported to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:e

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugifx developer

make default algorithm choice explicit and also, should one change the line to get the desired results and not be surprised by the config line still being commented out

```
