### PR TITLE
fix: ignition-disable should just remove the ignition related options

### DIFF
--- a/features/kvm/file.include/etc/systemd/system/ignition-disable.service
+++ b/features/kvm/file.include/etc/systemd/system/ignition-disable.service
@@ -17,7 +17,7 @@ OnFailureJobMode=isolate
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env
-ExecStart=/bin/bash -c "rm -f /etc/kernel/cmdline.d/50-ignition.cfg && /usr/local/sbin/update-bootloaders"
+ExecStart=/bin/bash -c "set -e; source /etc/kernel/cmdline.d/50-ignition.cfg; for c in /efi/loader/entries/*.conf; do cp $c ${c}.old; sed \"s|$CMDLINE_LINUX||\" -i ${c}.old; mv ${c}.old $c; done; /usr/local/sbin/update-syslinux; rm -f /etc/kernel/cmdline.d/50-ignition.cfg"
 RemainAfterExit=yes
 
 [Install]

--- a/features/vmware/file.include/etc/systemd/system/ignition-disable.service
+++ b/features/vmware/file.include/etc/systemd/system/ignition-disable.service
@@ -17,7 +17,7 @@ OnFailureJobMode=isolate
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env
-ExecStart=/bin/bash -c "rm -f /etc/kernel/cmdline.d/50-ignition.cfg && /usr/local/sbin/update-bootloaders"
+ExecStart=/bin/bash -c "set -e; source /etc/kernel/cmdline.d/50-ignition.cfg; for c in /efi/loader/entries/*.conf; do cp $c ${c}.old; sed \"s|$CMDLINE_LINUX||\" -i ${c}.old; mv ${c}.old $c; done; /usr/local/sbin/update-syslinux; rm -f /etc/kernel/cmdline.d/50-ignition.cfg"
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
**What this PR does / why we need it**:
ignition-disable service should just remove the specific kernel cmdline parameters from the loader entries and syslinux.cfg
