### PR TITLE
Add support to provide compatibility flags to GitHub publishing workflows

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -79,13 +79,6 @@ jobs:
       actions: write
     environment: oidc_aws_s3_upload
     steps:
-      - name: Checkout full repository (current branch)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-          fetch-depth: 0
-      - name: install dependencies for generate_release_note.py script
-        run: sudo apt-get update && sudo apt-get install -qy --no-install-recommends python3-boto3
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Configure AWS credentials
@@ -123,8 +116,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: '${{ inputs.commit }}'
-          submodules: true
+          sparse-checkout: |
+            .github/**
+          sparse-checkout-cone-mode: false
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
@@ -137,14 +131,11 @@ jobs:
           key: release-${{ github.run_id }}
           path: .github_release_id
           fail-on-cache-miss: true
+      - name: Set CNAME
+        run: |
+          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }} --arch ${{ matrix.arch }} --version "${{ inputs.version }}" --commit "${{ inputs.commit }}" cname)" | tee -a "$GITHUB_ENV"
       - name: Download from S3 bucket ${{ secrets.aws_s3_bucket }} for ${{ matrix.flavor }} (${{ matrix.arch }})
         run: |
-          commit="$(echo "${{ inputs.commit }}" | cut -c -8)"
-          resolved_cname="$(./build --resolve-cname '${{ matrix.flavor }}-${{ matrix.arch }}-${{ inputs.version }}')"
-          CNAME="${resolved_cname%-*}-$commit"
-
-          echo "CNAME=$CNAME" | tee -a "$GITHUB_ENV"
-
           mkdir "$CNAME"
           gl-s3 --bucket ${{ secrets.aws_s3_bucket }} --path "$CNAME" download-artifacts-from-bucket --cname "$CNAME"
           tar -cJf "$CNAME.tar.xz" -C "$CNAME" .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,13 +6,15 @@ on:
         description: Workflow run ID
         type: number
         required: true
-      checkout_commit:
+      compatibility_flags:
+        description: "Flags to activate compatibility modes"
         type: string
-        required: false
         default: ""
   workflow_run:
     workflows: [ 'Build and publish a release', 'nightly' ]
     types: [ 'completed' ]
+env:
+  GL_COMPATIBILITY_FLAGS: ${{ inputs.compatibility_flags }}
 jobs:
   workflow_data:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.conclusion == 'success' }}
@@ -50,12 +52,12 @@ jobs:
     with:
       run_id: ${{ needs.workflow_data.outputs.run_id }}
       commit_id: ${{ needs.workflow_data.outputs.commit_id }}
-      checkout_commit: ${{ github.event_name == 'workflow_dispatch' && inputs.checkout_commit || '' }}
       version: ${{ needs.workflow_data.outputs.version }}
       target: ${{ needs.workflow_data.outputs.target }}
       flavors_matrix: ${{ needs.workflow_data.outputs.flavors_matrix }}
       bare_flavors_matrix: ${{ needs.workflow_data.outputs.bare_flavors_matrix }}
       original_workflow_name: ${{ needs.workflow_data.outputs.original_workflow_name }}
+      compatibility_flags: ${{ inputs.compatibility_flags }}
     secrets:
       aws_region: ${{ secrets.AWS_REGION }}
       aws_role: ${{ secrets.KMS_SIGNING_IAM_ROLE }}
@@ -72,6 +74,7 @@ jobs:
     with:
       run_id: ${{ needs.workflow_data.outputs.run_id }}
       version: ${{ needs.workflow_data.outputs.version }}
+      compatibility_flags: ${{ inputs.compatibility_flags }}
     permissions:
       packages: write
   publish_retry:

--- a/.github/workflows/publish_kmodbuild_container.yml
+++ b/.github/workflows/publish_kmodbuild_container.yml
@@ -9,6 +9,12 @@ on:
       version:
         type: string
         required: true
+      compatibility_flags:
+        description: "Flags to activate compatibility modes"
+        type: string
+        default: ""
+env:
+  GL_COMPATIBILITY_FLAGS: ${{ inputs.compatibility_flags }}
 jobs:
   kmodbuild_container:
     name: Publish kernel module build dev container
@@ -21,9 +27,6 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
         with:
           pattern: kmodbuild-container-*

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -9,10 +9,6 @@ on:
       commit_id:
         type: string
         required: true
-      checkout_commit:
-        type: string
-        required: false
-        default: ""
       version:
         type: string
         required: true
@@ -28,6 +24,10 @@ on:
       original_workflow_name:
         type: string
         default: ""
+      compatibility_flags:
+        description: "Flags to activate compatibility modes"
+        type: string
+        default: ""
     secrets:
       aws_role:
         required: true
@@ -37,6 +37,8 @@ on:
         required: true
       oci_kms_arn:
         required: true
+env:
+  GL_COMPATIBILITY_FLAGS: ${{ inputs.compatibility_flags }}
 jobs:
   determine_environment:
     name: Determine release environment and repository for ${{ inputs.target }}
@@ -47,7 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
+          sparse-checkout: |
+            .github/**
+          sparse-checkout-cone-mode: false
       - name: Set environment and repository
         id: set_values
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -86,19 +90,17 @@ jobs:
           - flavor: "container-pythonDev"
             subpath: "/container-python-dev"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: ${{ contains(inputs.compatibility_flags, "full_checkout") }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.commit_id }}
           submodules: true
+      - name: Install python-gardenlinux-lib
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@e68236134acc7416606052599f4cfab7b9ea3b7c # pin@0.10.14
       - name: Set container version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
-      - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
-      - name: Set CNAMEs
-        run: |
-          echo "CNAME_AMD64=$(gl-features-parse --cname ${{ matrix.flavor }}-amd64 cname)" | tee -a "$GITHUB_ENV"
-          echo "CNAME_ARM64=$(gl-features-parse --cname ${{ matrix.flavor }}-arm64 cname)" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
         with:
           name: build-${{ matrix.flavor }}-amd64
@@ -109,6 +111,10 @@ jobs:
           name: build-${{ matrix.flavor }}-arm64
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
+      - name: Set CNAMEs
+        run: |
+          echo "CNAME_AMD64=$(gl-features-parse --cname ${{ matrix.flavor }}-amd64 --release-file "${{ matrix.flavor }}-amd64-*.release" cname)" | tee -a "$GITHUB_ENV"
+          echo "CNAME_ARM64=$(gl-features-parse --cname ${{ matrix.flavor }}-arm64 --release-file "${{ matrix.flavor }}-arm64-*.release" cname)" | tee -a "$GITHUB_ENV"
       - name: Publish container images
         run: |
           if [ "${{ inputs.original_workflow_name }}" = "nightly" ]; then
@@ -116,7 +122,8 @@ jobs:
           else
             is_nightly=false
           fi
-          version=$(cat VERSION)
+
+          version="$(cat VERSION)"
 
           podman login -u token -p ${{ github.token }} ghcr.io
           tar xzv < "${CNAME_AMD64}.tar.gz"
@@ -176,7 +183,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
+          ref: ${{ inputs.commit_id }}
+          sparse-checkout: |
+            bin/**
+          sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
         with:
           pattern: build-bare-${{ matrix.config }}-*
@@ -252,10 +262,11 @@ jobs:
       matrix: ${{ fromJson(inputs.flavors_matrix) }}
       max-parallel: 8
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: ${{ contains(inputs.compatibility_flags, "full_checkout") }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.commit_id }}
           submodules: true
-          ref: ${{ inputs.checkout_commit != '' && inputs.checkout_commit || github.sha }}
       - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}
@@ -267,18 +278,14 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: "v2.4.1"
-      - name: Set flavor version reference
-        run: |
-          echo "${{ inputs.commit_id }}" | tee COMMIT
-          echo "${{ inputs.version }}" | tee VERSION
-      - name: Set CNAME
-        run: |
-          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname)" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
         with:
           name: build-${{ matrix.flavor }}-${{ matrix.arch }}
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
+      - name: Set CNAME
+        run: |
+          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} --release-file "${{ matrix.flavor }}-${{ matrix.arch }}-*.release" cname)" | tee -a "$GITHUB_ENV"
       - name: Push using the glcli util
         env:
           GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -327,22 +334,20 @@ jobs:
       matrix: ${{ fromJson(inputs.flavors_matrix) }}
       max-parallel: 1
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: ${{ contains(inputs.compatibility_flags, "full_checkout") }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.commit_id }}
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
-      - name: Set flavor version reference
-        run: |
-          echo "${{ inputs.commit_id }}" | tee COMMIT
-          echo "${{ inputs.version }}" | tee VERSION
-      - name: Set CNAME
-        run: |
-          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname)" | tee -a "$GITHUB_ENV"
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@e68236134acc7416606052599f4cfab7b9ea3b7c # pin@0.10.14
       - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # pin@v5.0.3
         with:
           path: oci_manifest_entry_${{ env.CNAME }}.json
           key: oci-manifest-${{ matrix.flavor }}-${{ matrix.arch }}-${{ github.run_id }}
+      - name: Set CNAME
+        run: |
+          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} --release-file "${{ matrix.flavor }}-${{ matrix.arch }}-*.release" cname)" | tee -a "$GITHUB_ENV"
       - name: Update index using glcli tool
         env:
           GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -355,7 +360,6 @@ jobs:
             --index ${{ needs.determine_environment.outputs.repository }} \
             --index-tag ${{ inputs.version }} \
             --manifest_folder manifests
-
   publish_tests:
     name: Publish tests container
     runs-on: ubuntu-24.04
@@ -365,9 +369,10 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
+      - name: Set container version reference
+        run: |
+          echo "${{ inputs.commit_id }}" | tee COMMIT
+          echo "${{ inputs.version }}" | tee VERSION
       - id: tests_containers
         name: Download built tests archives
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
@@ -394,7 +399,7 @@ jobs:
             is_nightly=false
           fi
 
-          version=$(bin/garden-version "${{ inputs.version }}")
+          version="$(cat VERSION)"
 
           podman login -u token -p ${GITHUB_TOKEN} ghcr.io
 

--- a/.github/workflows/publish_s3.yml
+++ b/.github/workflows/publish_s3.yml
@@ -6,9 +6,15 @@ on:
         description: Workflow run ID
         type: number
         required: true
+      compatibility_flags:
+        description: "Flags to activate compatibility modes"
+        type: string
+        default: ""
   workflow_run:
     workflows: ["Build and publish a release", "nightly"]
     types: ["completed"]
+env:
+  GL_COMPATIBILITY_FLAGS: ${{ inputs.compatibility_flags }}
 jobs:
   workflow_data:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || github.event.workflow_run.conclusion == 'success' }}
@@ -52,7 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
+          sparse-checkout: |
+            .github/**
+          sparse-checkout-cone-mode: false
       - id: matrix
         name: Calculate matrix
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -79,7 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: true
+          sparse-checkout: |
+            .github/**
+          sparse-checkout-cone-mode: false
       - id: matrix
         name: Calculate matrix
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -106,6 +116,7 @@ jobs:
       flavors_matrix: ${{ needs.trustedboot_flavors_matrix.outputs.flavors_matrix }}
       run_id: ${{ needs.workflow_data.outputs.run_id }}
       with_certs: true
+      compatibility_flags: ${{ inputs.compatibility_flags }}
     secrets:
       aws_region: ${{ secrets.AWS_REGION }}
       aws_role: ${{ secrets.AWS_IAM_ROLE }}
@@ -123,6 +134,7 @@ jobs:
       flavors_matrix: ${{ needs.trustedboot_flavors_matrix.outputs.flavors_matrix }}
       run_id: ${{ needs.workflow_data.outputs.run_id }}
       with_certs: true
+      compatibility_flags: ${{ inputs.compatibility_flags }}
     secrets:
       aws_region: ${{ secrets.AWS_CN_REGION }}
       aws_role: ${{ secrets.AWS_CN_IAM_ROLE }}
@@ -139,6 +151,7 @@ jobs:
       version: ${{ needs.workflow_data.outputs.version }}
       flavors_matrix: ${{ needs.non_trustedboot_flavors_matrix.outputs.flavors_matrix }}
       run_id: ${{ needs.workflow_data.outputs.run_id }}
+      compatibility_flags: ${{ inputs.compatibility_flags }}
     secrets:
       aws_region: ${{ secrets.AWS_REGION }}
       aws_role: ${{ secrets.AWS_IAM_ROLE }}
@@ -155,6 +168,7 @@ jobs:
       version: ${{ needs.workflow_data.outputs.version }}
       flavors_matrix: ${{ needs.non_trustedboot_flavors_matrix.outputs.flavors_matrix }}
       run_id: ${{ needs.workflow_data.outputs.run_id }}
+      compatibility_flags: ${{ inputs.compatibility_flags }}
     secrets:
       aws_region: ${{ secrets.AWS_CN_REGION }}
       aws_role: ${{ secrets.AWS_CN_IAM_ROLE }}

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -17,6 +17,10 @@ on:
       with_certs:
         type: boolean
         default: false
+      compatibility_flags:
+        description: "Flags to activate compatibility modes"
+        type: string
+        default: ""
     secrets:
       aws_role:
         required: true
@@ -26,6 +30,8 @@ on:
         required: true
       aws_s3_bucket:
         required: true
+env:
+  GL_COMPATIBILITY_FLAGS: ${{ inputs.compatibility_flags }}
 jobs:
   upload_to_s3:
     name: upload to S3
@@ -43,8 +49,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(inputs.flavors_matrix) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: ${{ contains(inputs.compatibility_flags, "full_checkout") }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.commit_id }}
           submodules: true
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
@@ -54,18 +62,14 @@ jobs:
           role-session-name: ${{ secrets.aws_session }}
           aws-region: ${{ secrets.aws_region }}
           role-duration-seconds: 14400 # 4 hours
-      - name: Set flavor version reference
-        run: |
-          echo "${{ inputs.commit_id }}" | tee COMMIT
-          echo "${{ inputs.version }}" | tee VERSION
-      - name: Set CNAME
-        run: |
-          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} cname)" | tee -a "$GITHUB_ENV"
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
         with:
           name: build-${{ matrix.flavor }}-${{ matrix.arch }}
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
+      - name: Set CNAME
+        run: |
+          echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }}-${{ matrix.arch }} --release-file "${{ matrix.flavor }}-${{ matrix.arch }}-*.release" cname)" | tee -a "$GITHUB_ENV"
       - name: Load test artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes use of the release file if applicable to publish to ghcr.io and S3 without checkout of repositories. If this fails for whatever reason add generic compatibility flags to change default behavior.

Add the compatibility flag:
- `full_checkout` to checkout the current GitHub referenced branch including submodules.

**Which issue(s) this PR fixes**:
Closes #2950
Closes #2955
Closes #3039
Closes #3944
Related #3620
Related #4239

**Special notes for your reviewer**:
As no test environment for publishing exist the workflow changes are theoretically working but need testing on the next execution.