### PR TITLE
Bump `python-gardenlinux-lib` to updated 0.10.16

### DIFF
--- a/.github/workflows/build_flavor.yml
+++ b/.github/workflows/build_flavor.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set build reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
@@ -73,7 +73,7 @@ jobs:
       - name: Build
         run: make ${{ inputs.flavor }}-${{ inputs.arch }}-build
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/build_flavors_matrix.yml
+++ b/.github/workflows/build_flavors_matrix.yml
@@ -31,7 +31,7 @@ jobs:
             flavors.yaml
           sparse-checkout-cone-mode: false
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - id: matrix
         name: Generate flavors matrix
         run: |

--- a/.github/workflows/build_kmodbuild_container.yml
+++ b/.github/workflows/build_kmodbuild_container.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ inputs.prefix }}build-container-${{ matrix.arch }}-${{ github.run_id }}
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
         name: Set CNAME
         run: |

--- a/.github/workflows/download_flavors_images.yml
+++ b/.github/workflows/download_flavors_images.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set image reference for S3
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -25,7 +25,7 @@ jobs:
   # Create new version in GLVD so it has the package list of the new release
   # This is needed for the automatic changelog generation
   glvd:
-    if: ${{ inputs.type }} == 'minor'
+    if: ${{ inputs.type == 'minor' }}
     name: Update GLVD distro list
     runs-on: ubuntu-latest
     env:
@@ -87,7 +87,7 @@ jobs:
       - name: install dependencies for generate_release_note.py script
         run: sudo apt-get update && sudo apt-get install -qy --no-install-recommends python3-boto3
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
@@ -125,7 +125,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
@@ -165,7 +165,7 @@ jobs:
           done
 
   tag_container_as_latest:
-    if: ${{ inputs.type }} == 'minor'
+    if: ${{ inputs.type == 'minor' }}
     uses: ./.github/workflows/tag_latest_container.yml
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -90,7 +90,7 @@ jobs:
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set CNAMEs
         run: |
           echo "CNAME_AMD64=$(gl-features-parse --cname ${{ matrix.flavor }}-amd64 cname)" | tee -a "$GITHUB_ENV"
@@ -257,7 +257,7 @@ jobs:
           role-session-name: ${{ secrets.aws_session }}
           aws-region: ${{ secrets.aws_region }}
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
@@ -326,7 +326,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set flavor version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT

--- a/.github/workflows/tag_latest_container.yml
+++ b/.github/workflows/tag_latest_container.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Tag manifest
         env:
           GL_CLI_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_flavor_chroot.yml
+++ b/.github/workflows/test_flavor_chroot.yml
@@ -38,7 +38,7 @@ jobs:
           name: test-distribution
           path: tests/.build
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test_flavor_cloud.yml
+++ b/.github/workflows/test_flavor_cloud.yml
@@ -83,7 +83,7 @@ jobs:
           name: certs
           path: cert/
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test_flavor_oci.yml
+++ b/.github/workflows/test_flavor_oci.yml
@@ -42,7 +42,7 @@ jobs:
           name: test-distribution
           path: tests/.build
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -48,7 +48,7 @@ jobs:
           name: certs
           path: cert/
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ inputs.flavor }}-${{ inputs.arch }} cname)" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/upload_to_s3.yml
+++ b/.github/workflows/upload_to_s3.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           submodules: true
       - name: Install python-gardenlinux-lib
-        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@2352ee1052c79ff0960182507d3472b19689fdf0 # pin@0.10.16
+        uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v4
         with:
           role-to-assume: ${{ secrets.aws_role }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps `python-gardenlinux-lib` to an updated tag of 0.10.16. This version fixes an issue with release notes being too large for the API.

**Which issue(s) this PR fixes**:
Fixes #4347