### PR TITLE
Use GL 2150.0.0 images in lima samples

### DIFF
--- a/docs/02_operators/lima-vm.md
+++ b/docs/02_operators/lima-vm.md
@@ -5,8 +5,6 @@ Lima makes use of existing vm solutions such as QEMU or Apple Virtualization, an
 
 Garden Linux provides pre-built images suitable for use with Lima, but you can also build your own images.
 
-Garden Linux images for Lima are published at https://images.gardenlinux.io
-
 ## How to use the pre-built image
 
 You need to have `podman` and `lima` installed.

--- a/features/lima/samples/gardenlinux-containerd.yaml
+++ b/features/lima/samples/gardenlinux-containerd.yaml
@@ -1,19 +1,20 @@
 os: Linux
 images:
-- location: "https://images.gardenlinux.io/gardenlinux-amd64-today.qcow2"
-  arch: "x86_64"
-- location: "https://images.gardenlinux.io/gardenlinux-arm64-today.qcow2"
-  arch: "aarch64"
+- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-amd64-2150.0.0-eb8696b9/lima-amd64-2150.0.0-eb8696b9.qcow2
+  arch: x86_64
+- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-arm64-2150.0.0-eb8696b9/lima-arm64-2150.0.0-eb8696b9.qcow2
+  arch: aarch64
 containerd:
   system: false
   user: false
-mountTypesUnsupported: [9p]
+mountTypesUnsupported:
+- 9p
 ssh:
   loadDotSSHPubKeys: true
   forwardAgent: true
 mounts:
-  - location: "~"
-    writable: false
+- location: '~'
+  writable: false
 
 provision:
 - mode: system

--- a/features/lima/samples/gardenlinux-rootless-podman.yaml
+++ b/features/lima/samples/gardenlinux-rootless-podman.yaml
@@ -1,19 +1,20 @@
 os: Linux
 images:
-- location: "https://images.gardenlinux.io/gardenlinux-amd64-today.qcow2"
-  arch: "x86_64"
-- location: "https://images.gardenlinux.io/gardenlinux-arm64-today.qcow2"
-  arch: "aarch64"
+- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-amd64-2150.0.0-eb8696b9/lima-amd64-2150.0.0-eb8696b9.qcow2
+  arch: x86_64
+- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-arm64-2150.0.0-eb8696b9/lima-arm64-2150.0.0-eb8696b9.qcow2
+  arch: aarch64
 containerd:
   system: false
   user: false
-mountTypesUnsupported: [9p]
+mountTypesUnsupported:
+- 9p
 ssh:
   loadDotSSHPubKeys: true
   forwardAgent: true
 mounts:
-  - location: "~"
-    writable: false
+- location: '~'
+  writable: false
 
 provision:
 - mode: system


### PR DESCRIPTION
The samples used the old publishing location of the images which is going to be removed.

Use 2150.0.0 as it is the latest supported major release

Tracks #4369
