### PR TITLE
Revert "Always `fail-fast` on GH workflow tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,13 +173,14 @@ jobs:
                 core.setOutput(t.outMatrix, SKIP_MATRIX);
               }
             }
+  ## test-ng start
   test_flavors_chroot:
     needs: determine_test_settings
     name: Test chroot flavors
     uses: ./.github/workflows/test_flavor_chroot.yml
     if: ${{ needs.determine_test_settings.outputs.chroot_tests == 'true' }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{ fromJson(needs.determine_test_settings.outputs.chroot_test_flavors_matrix) }}
     with:
       arch: ${{ matrix.arch }}
@@ -224,13 +225,14 @@ jobs:
     uses: ./.github/workflows/test_flavor_oci.yml
     if: ${{ needs.determine_test_settings.outputs.oci_flavors_tests == 'true' }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{ fromJson(needs.determine_test_settings.outputs.oci_flavors_matrix) }}
     with:
       arch: ${{ matrix.arch }}
       flavor: ${{ matrix.flavor }}
     permissions:
       actions: write
+  ## test-ng end
   test_report:
     needs:
       - test_flavors_chroot


### PR DESCRIPTION
revert https://github.com/gardenlinux/gardenlinux/commit/7f00647fcafd37e9d04542a4ee0603800e065428

**Reason:** when the tests fail in the nightly it's incredibly useful to see directly if this is an isolated case of just one flavour or if multiple flavours are effected. The tests are running on free GitHub hosted runners, so we can run all tests to completion without worrying too much about the runner usage.