### PR TITLE
fix: wrong file path for sshd_config on GDCH

### DIFF
--- a/features/gdch/exec.config
+++ b/features/gdch/exec.config
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # set default timezone
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
-cat >>/etc/ssh/sshd_conf <<EOF
+cat >>/etc/ssh/sshd_config <<EOF
 
 # Needed for google oslogin
 AuthorizedKeysCommand /usr/libexec/google_authorized_keys


### PR DESCRIPTION
**What this PR does / why we need it**:

GDCH feature uses wrong sshd config filename for oslogin configuration statements.
An extension of what was fixed in https://github.com/gardenlinux/gardenlinux/pull/4390.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4335
