### PR TITLE
Tell systemd-networkd to ignore foreign nexthops

### DIFF
--- a/features/server/file.include/etc/systemd/networkd.conf.d/00-gardenlinux-server.conf
+++ b/features/server/file.include/etc/systemd/networkd.conf.d/00-gardenlinux-server.conf
@@ -1,3 +1,4 @@
 [Network]
 ManageForeignRoutingPolicyRules=no
 ManageForeignRoutes=no
+ManageForeignNextHops=no


### PR DESCRIPTION
**What this PR does / why we need it**:

When using a BGP daemon like FRR it will create nexthops for its routes which networkd considers as foreign and thus deletes them whenever it runs. Similar to foreign routes and routing policies those should be ignored to improve the interoperability with routing daemons.

**Which issue(s) this PR fixes**:

Fixes n/a

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Improve interoperability between systemd-networkd and FRR
```
