### PR TITLE
fix: Update test_python_export_libs (caused failure in nightly build)

### DIFF
--- a/tests/test_pythonDev.py
+++ b/tests/test_pythonDev.py
@@ -28,6 +28,7 @@ dependencies = {
         "/required_libs_test/usr/lib/aarch64-linux-gnu",
         "/required_libs_test/usr/lib/aarch64-linux-gnu/libpthread.so.0",
         "/required_libs_test/usr/lib/aarch64-linux-gnu/libc.so.6",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/libm.so.6",
         "/required_libs_test/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
     },
     "amd64": {
@@ -37,6 +38,7 @@ dependencies = {
         "/required_libs_test/usr/lib/x86_64-linux-gnu",
         "/required_libs_test/usr/lib/x86_64-linux-gnu/libpthread.so.0",
         "/required_libs_test/usr/lib/x86_64-linux-gnu/libc.so.6",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/libm.so.6",
         "/required_libs_test/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
     },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporary fix for the current nightly build issues. Adjust the test to now also expect _libm_ to be one of the shared libraries.

Needs a better solution in the future to avoid failures, because of changes in the python ecosystem.

**Which issue(s) this PR fixes**:
Temporary fix for #[4410](https://github.com/gardenlinux/gardenlinux/issues/4410)

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)