### PR TITLE
Fix validation if GitHub workflow matrices are empty

### DIFF
--- a/.github/workflows/github.mjs
+++ b/.github/workflows/github.mjs
@@ -40,7 +40,7 @@ export function excludeFlavorsMatrix(matrixA, matrixB) {
 }
 
 export function isMatrixEmpty(matrix) {
-    return (matrix == "" || matrix == `{"include":[]}`);
+    return (!Object.keys(matrix).includes('include') || matrix['include'].length < 1);
 }
 
 export function getGHCRRepositoryFromTarget(target) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
               const matrix = gitHubLib.intersectFlavorsMatrix(t.inputMatrix, t.supported);
               const isEnabled = !gitHubLib.isMatrixEmpty(matrix);
               core.setOutput(t.outTests, isEnabled);
-              console.log(`${t.key}: ${isEnabled ? 'enabled' : 'disabled'} (${isEnabled ? matrix.length : 0} flavors)`);
+              console.log(`${t.key}: ${isEnabled ? 'enabled' : 'disabled'} (${isEnabled ? matrix['include'].length : 0} flavors)`);
 
               if (isEnabled) {
                 core.setOutput(t.outMatrix, matrix);


### PR DESCRIPTION
**What this PR does / why we need it**:
After analyzing a `matrix must define at least one vector` issue in `rel-1877` an bug was identified affecting `main` as well for executing GitHub workflow `manual_tests.yml`. This PR fixes that bug.