### PR TITLE
Docs: Fix broken image links in ipxe guide

### DIFF
--- a/docs/02_operators/deployment/ipxe-install.md
+++ b/docs/02_operators/deployment/ipxe-install.md
@@ -5,11 +5,11 @@ The installation procedure runs in a live version of Garden Linux. For this the 
 
 The installation procedure itself consists of copying the live instance to a specified disk while installing an appropriate bootloader. The system then switches directly into the installed OS. Here is an overview:
 
-<img src="../.media/firstboot.svg">
+<img src="../../.media/firstboot.svg">
 
 The installation process is not invoked on every boot of the system but only on firstboot. Just before completing the installer disables the dracut module responsible for livebooting and removes the installer. On UEFI systems also the boot order is changed so that subsequent boots go straight to GardenLinux.
 
-<img src="../.media/subsboots.svg">
+<img src="../../.media/subsboots.svg">
 
 #### disk layout & format
 The targeted disk will have two partitions. The first partition is created to be *ESP (Efi System Partition)* compatible and serve the bootloaders (see *bootloader installation*). Garden Linux will install its rootfs to the second partition with ext4 format.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two broken links for schematics for the `ipxe` install guide.

**Which issue(s) this PR fixes**:
Tacks #4329

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
