### PR TITLE
Fix reference to `CNAME` in `.github/workflows/publish_oci_containers.yml`

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -90,8 +90,7 @@ jobs:
           - flavor: "container-pythonDev"
             subpath: "/container-python-dev"
     steps:
-      - if: ${{ contains(inputs.compatibility_flags, 'full_checkout') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.commit_id }}
           submodules: true
@@ -333,8 +332,7 @@ jobs:
       matrix: ${{ fromJson(inputs.flavors_matrix) }}
       max-parallel: 1
     steps:
-      - if: ${{ contains(inputs.compatibility_flags, 'full_checkout') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.commit_id }}
           submodules: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes access to at this stage not yet defined `CNAME` in `.github/workflows/publish_oci_containers.yml`.

**Which issue(s) this PR fixes**:
Related #4444