### PR TITLE
Call GitHub workflow `publish_s3.yml` from `manual_release.yml` as well

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -157,7 +157,7 @@ jobs:
     needs: upload_workflow_data
     if: ${{ inputs.publish }}
     name: Publish release to S3
-    uses: gardenlinux/gardenlinux/.github/workflows/publish.yml@main
+    uses: gardenlinux/gardenlinux/.github/workflows/publish_s3.yml@main
     with:
       run_id: ${{ github.run_id }}
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in `.github/workflows/manual_release.yml` calling `publish.yml` twice but not `publish_s3.yml` once as expected.