### PR TITLE
Adding binutils to include objdump for dracut

### DIFF
--- a/features/_fips/pkg.include
+++ b/features/_fips/pkg.include
@@ -4,3 +4,4 @@ libgnutls28-dev
 gnutls-bin
 libgcrypt20
 libkcapi1-hmac
+binutils


### PR DESCRIPTION
Fix missing packages that break FIPS test in dracut.  