### PR TITLE
Fix `flavors` in `flavors.yaml` for `azure` and `gcp`

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -132,7 +132,6 @@ targets:
         test: true
         test-platform: true
         publish: true
-    flavors:
       - features:
           - gardener
           - _prod
@@ -324,7 +323,6 @@ targets:
         test: true
         test-platform: true
         publish: true
-    flavors:
       - features:
           - gardener
           - _prod


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes key `flavors` defined twice for `azure` and `gcp` in `flavors.yaml` breaking building of some flavors.