### PR TITLE
Add test_disastig_00216.py and check for module 802.1q

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00216.py
+++ b/tests/integration/security/compliance/test_disastig_00216.py
@@ -34,4 +34,8 @@ def test_kernel_module_load_logged(kernel_module, shell):
 
     logs = (dmesg_result.stdout + journal_result.stdout).lower()
 
-    assert "802.1q" in logs, "stigcompliance: kernel module load event not logged"
+    expected = MODULE.replace("8021q", "802.1q")
+
+    assert (
+        expected in logs
+    ), f"stigcompliance: kernel module load event for {MODULE} not logged"


### PR DESCRIPTION
**What this PR does / why we need it**:
As per DISA STIG compliance requirement, the audit system must be configured to audit the loading and unloading of dynamic kernel modules.
Ref: SRG-OS-000471-GPOS-00216

**Which issue(s) this PR fixes**:
Fixes [171](https://github.com/gardenlinux/security/issues/171)