### PR TITLE
removed accidental space in a regex

### DIFF
--- a/tests/plugins/audit.py
+++ b/tests/plugins/audit.py
@@ -83,7 +83,7 @@ class AuditRule:
             (
                 -F\s*perm=(\S+)
                 |
-                -p\s *
+                -p\s*
                 (\S+)
             )
             """,


### PR DESCRIPTION
**What this PR does / why we need it**: hotfix for an accidental space char in a regex in test framework audit plugin code

