### PR TITLE
Rework SRG-OS-000096-GPOS-00050 adding safe ports learnt for diff flavors from CI/CD

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00050.py
+++ b/tests/integration/security/compliance/test_disastig_00050.py
@@ -11,7 +11,7 @@ FORBIDDEN_SERVICES = [
 ]
 
 
-@pytest.mark.feature("not container and not lima")
+@pytest.mark.feature("stig")
 @pytest.mark.booted(reason="requires booted system")
 @pytest.mark.root(reason="requires audit operations")
 @pytest.mark.modify(reason="required for DISA STIG check")
@@ -43,7 +43,7 @@ def test_ports_protocols_and_services_restricted(shell):
     ), f"stigcompliance: unauthorized ports open: {unauthorized_ports}"
 
 
-@pytest.mark.feature("not container")
+@pytest.mark.feature("stig")
 @pytest.mark.booted(reason="requires booted system")
 @pytest.mark.root(reason="requires audit operations")
 @pytest.mark.modify(reason="required for DISA STIG check")


### PR DESCRIPTION
**What this PR does / why we need it**:
safe ports for diff flavors for STIG-00050
[SRG-OS-000096-GPOS-00050](https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000096-GPOS-00050/)

**Which issue(s) this PR fixes**:
Fixes #4498 [227](https://github.com/gardenlinux/security/issues/227)

SAFE_PORTS determined from all flavors including gardener and other flavors consolidated by failing them: 2601, 111, 2616, 3260, 2623, 39397
