### PR TITLE
Ensure `flavors.yaml` is checked out for `gl-gh-release` execution

### DIFF
--- a/.github/workflows/manual_gh_release_page.yml
+++ b/.github/workflows/manual_gh_release_page.yml
@@ -127,6 +127,12 @@ jobs:
       actions: write
     environment: oidc_aws_s3_upload
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.workflow_data.outputs.commit_id }}
+          sparse-checkout: |
+            flavors.yaml
+          sparse-checkout-cone-mode: false
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@19c1b24c01faab81a7fe24713748dd172d00904a # pin@0.10.16
       - name: Configure AWS credentials


### PR DESCRIPTION
**What this PR does / why we need it**:
While technically unnecessary `gl-gh-release` requires the existance of the `flavors.yaml` in a checked out Git repository to identify the artifact base names for downloading S3 metadata. This PR brings this file back.