### PR TITLE
Fix `type` definition of `release_id` in `.github/workflows/upload_to_github_release.yml`

### DIFF
--- a/.github/workflows/upload_to_github_release.yml
+++ b/.github/workflows/upload_to_github_release.yml
@@ -15,8 +15,8 @@ on:
         type: string
         required: true
       release_id:
-        type: boolean
-        default: false
+        type: string
+        required: true
       compatibility_flags:
         description: 'Flags to activate compatibility modes'
         type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
This Pr fixes a wrong `type` definition of `release_id` in `.github/workflows/upload_to_github_release.yml`.