### PR TITLE
Add additional permissions to GH workflow `upload_to_github_release.yml`

### DIFF
--- a/.github/workflows/upload_to_github_release.yml
+++ b/.github/workflows/upload_to_github_release.yml
@@ -44,6 +44,8 @@ jobs:
       GL_ALLOW_MULTIPLE_PLATFORMS: "1"
     permissions:
       id-token: write
+      contents: write
+      actions: write
     environment: oidc_aws_s3_upload
     strategy:
       fail-fast: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional `permissions` previously defined in the parent workflow to upload GitHub release assets.