### PR TITLE
fix: replace bare except with except Exception in DataSourceVMwareGuestInfo

### DIFF
--- a/features/vmware/file.include/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py
+++ b/features/vmware/file.include/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py
@@ -418,7 +418,7 @@ def load(data):
         return {}
     try:
         return json.loads(data)
-    except:
+    except Exception:
         return safeyaml.load(data)
 
 
@@ -574,7 +574,7 @@ def is_valid_ip_addr(val):
             addr = ipaddress.ip_address(val)
         except ipaddress.AddressValueError:
             addr = ipaddress.ip_address(unicode(val))
-    except:
+    except Exception:
         return False
     if addr.is_link_local or addr.is_loopback or addr.is_unspecified:
         return False


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in `DataSourceVMwareGuestInfo.py` (2 occurrences at lines 421 and 577).

Bare `except:` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` in addition to regular exceptions, which can mask critical signals. Since neither site re-raises, `except Exception:` is the correct replacement.

**Changes:**
```python
# Before (line 421)
    except:
        return safeyaml.load(data)

# After
    except Exception:
        return safeyaml.load(data)
```

```python
# Before (line 577)
    except:
        return False

# After
    except Exception:
        return False
```

## Testing
No behavior change for normal exceptions — style/correctness fix only.
Prevents accidentally catching `SystemExit` and `KeyboardInterrupt`.