### PR TITLE
Repack assets archive for a GitHub release

### DIFF
--- a/.github/workflows/upload_to_github_release.yml
+++ b/.github/workflows/upload_to_github_release.yml
@@ -66,20 +66,20 @@ jobs:
       - name: Set CNAME
         run: |
           echo "CNAME=$(gl-features-parse --cname ${{ matrix.flavor }} --arch ${{ matrix.arch }} --version ${{ inputs.version }} --commit ${{ inputs.commit_id }} cname)" | tee -a "$GITHUB_ENV"
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           name: build-${{ matrix.flavor }}-${{ matrix.arch }}
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
       - name: Load test artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           pattern: "*-test-${{ env.CNAME }}"
           merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
       - name: Load certs artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # pin@v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           name: certs
           github-token: ${{ github.token }}
@@ -88,8 +88,10 @@ jobs:
       - name: Prepare upload artifacts
         run: |
           mkdir -p "$CNAME"
-          tar -C $CNAME -xzvf "$CNAME.tar.gz"
-          rm "$CNAME.tar.gz"
+
+          gunzip "$CNAME.tar.gz"
+          xz "$CNAME.tar"
+          mv "$CNAME.tar.xz" "$CNAME/"
 
           pushd cert
           for file in "secureboot."*; do


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR repacks the whole assets archive for a GitHub release instead of unpacking and pushing the content. Previously we unpacked but repacked it before uploading and while enhancing the workflow we started to unpack but handle all assets individually. This resulted in hitting the GitHub release limit `file_count limited to 1000 assets per release`.