### PR TITLE
Use archives to pack logs and secureboot certificates as well

### DIFF
--- a/.github/workflows/tag_latest_container.yml
+++ b/.github/workflows/tag_latest_container.yml
@@ -40,6 +40,12 @@ jobs:
           echo "Tagging as ${version_major}"
           gl-oci push-index-tags --index "${container}" --index-tag "${version}" --tag "${version_major}"
 
+          # Tag the patch release version
+          if [ -z "${version_patch}" ]; then
+            echo "Tagging as ${version}.0"
+            gl-oci push-index-tags --index "${container}" --index-tag "${version}" --tag "${version}.0"
+          fi
+
           # Tag latest only if requested
           if [ "${is_latest}" == "true" ]; then
             echo "Tagging as latest"

--- a/.github/workflows/upload_to_github_release.yml
+++ b/.github/workflows/upload_to_github_release.yml
@@ -77,10 +77,11 @@ jobs:
       - name: Load test artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
-          pattern: "*-test-${{ env.CNAME }}"
+          pattern: "*-+(test|testng)-${{ env.CNAME }}"
           merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
+          path: log/
       - if: ${{ inputs.with_certs }}
         name: Load certs artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
@@ -97,20 +98,19 @@ jobs:
           xz "$CNAME.tar"
           mv "$CNAME.tar.xz" "$CNAME/"
 
-          # upload test logs separately (if they exist)
-          log_suffixes="chroot.test.log chroot.test.xml cloud.test.log cloud.test.xml oci.test.log oci.test.xml qemu.test.log qemu.test.xml platform.test.log platform.test.xml"
-
-          for suffix in $log_suffixes; do
-            mv "$CNAME.$suffix" "$CNAME"
-          done
+          tar -C "log" -cJf "$CNAME/$CNAME.logs.tar.xz" .
 
           # Certificates if "with_certs"
           if [ -d "cert" ]; then
+            mkdir release_cert
+
             pushd cert
             for file in "secureboot."*; do
-              mv "$file" "../$CNAME/$CNAME.$file"
+              mv "$file" "../release_cert/$CNAME.$file"
             done
             popd
+
+            tar -C "release_cert" -cJf "$CNAME/$CNAME.certs.tar.xz" .
           fi
       - name: Upload to release
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:
With additional log formats added to `rel-1877` we are getting closer to GitHub release page limits for files (<= 1000). Therefore pack logs and secureboot certificates to archives.