### PR TITLE
Update team list in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,6 @@ following volunteers:
 * Andre Russ, (**[@gehoern](https://github.com/gehoern)**)
 * Nikolas Kraetzschmar (**[@nkraetzschmar](https://github.com/nkraetzschmar/)**)
 * Stefan Catargiu (**[@5kt](https://github.com/5kt/)**)
-* Florian Wilhelm (**[@fwilhe](https://github.com/fwilhe/)**)
 
 
 ## Disclosures


### PR DESCRIPTION
**What this PR does / why we need it**:

Update team list in SECURITY.md
Removed Florian Wilhelm from the list of contributors.
