### PR TITLE
Add test_disastig_00153.py to comply with InsecureRepo or AllowUnauth…

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00153.py
+++ b/tests/integration/security/compliance/test_disastig_00153.py
@@ -29,6 +29,9 @@ def test_package_signature_verification_enabled(parse_file: ParseFile, find: Fin
     for path in find:
         lines = parse_file.lines(path, ignore_missing=True)
 
+        if not lines:
+            continue
+
         assert (
             insecure_pattern_1 not in lines
         ), f"stigcompliance: AllowUnauthenticated enabled in {path}"


### PR DESCRIPTION
**What this PR does / why we need it**:
As per DISA STIG compliance requirement, the operating system must prevent the
installation of patches, service packs, device drivers, or operating system components
without verification they have been digitally signed using a certificate that is recognized
and approved by the organization.
Ref: SRG-OS-000366-GPOS-00153

**Which issue(s) this PR fixes**:
Fixes [307](https://github.com/gardenlinux/security/issues/307)
