### PR TITLE
Append test_disastig_auditd.py for SRG-OS-000392-GPOS-00172

### DIFF
--- a/tests/integration/security/compliance/test_disastig_auditd.py
+++ b/tests/integration/security/compliance/test_disastig_auditd.py
@@ -532,8 +532,8 @@ def test_audit_timestamp_granularity(shell: ShellRunner):
 
 
 @pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="audit subsystem must be active")
-@pytest.mark.root(reason="required to inspect audit rules and logs")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to read audit logs")
 def test_audit_nonlocal_maintenance_sessions(audit_rule: AuditRule, shell: ShellRunner):
     """
     As per DISA STIG compliance requirement, the operating system must audit all


### PR DESCRIPTION
**What this PR does / why we need it**:
As per DISA STIG compliance requirement, the operating system must audit all
activities performed during nonlocal maintenance and diagnostic sessions.
This test verifies that command execution syscalls (execve and execveat) are
audited and that corresponding audit records are generated.
Ref: SRG-OS-000392-GPOS-00172

**Which issue(s) this PR fixes**:
Fixes [320](https://github.com/gardenlinux/security/issues/320)