### PR TITLE
fix: test: exclude gce-workload-cert-refresh.timer from sysdiff

### DIFF
--- a/tests/plugins/sysdiff.py
+++ b/tests/plugins/sysdiff.py
@@ -69,6 +69,9 @@ IGNORED_SYSTEMD_PATTERNS = [
     "user-runtime-dir@*.service",
     "user@*.service",
     "user-*.slice",
+    # runs periodically
+    "gce-workload-cert-refresh.service",
+    "gce-workload-cert-refresh.timer",
 ]
 
 # Units to wait for before taking a snapshot (unit_name: expected_sub_state)


### PR DESCRIPTION
**What this PR does / why we need it**:

Exclude gce-workload-cert-refresh.timer from sysdiff.

**Which issue(s) this PR fixes**:
Fixes #4585
