### PR TITLE
Fix version patch number in GH workflow `tag_latest_container.yml`

### DIFF
--- a/.github/workflows/tag_latest_container.yml
+++ b/.github/workflows/tag_latest_container.yml
@@ -32,7 +32,7 @@ jobs:
           is_latest="${{ inputs.is_latest }}"
 
           version_major=$(echo $version | cut -d'.' -f 1)
-          version_patch=$(echo $version | cut -d'.' -f 2)
+          version_patch=$(echo $version | cut -d'.' -f 3)
 
           container=ghcr.io/${{ github.repository }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the extraction of the version patch number in GitHub workflow `.github/workflows/tag_latest_container.yml`.

**Which issue(s) this PR fixes**:
Related #4513