### PR TITLE
Add test_disastig_00057.py for validating SSHD presence

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00057.py
+++ b/tests/integration/security/compliance/test_disastig_00057.py
@@ -1,11 +1,10 @@
 import pytest
-from plugins.sshd import Sshd
 
 
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires sshd effective configuration")
 @pytest.mark.root(reason="required to inspect ssh configuration")
-def test_ssh_available_for_network_access(sshd: Sshd):
+def test_ssh_available_for_network_access(sshd):
     """
     As per DISA STIG compliance requirement, the operating system must implement
     replay-resistant authentication mechanisms for network access to privileged accounts.


### PR DESCRIPTION
**What this PR does / why we need it**:
As per DISA STIG compliance requirement, the operating system must implement
replay-resistant authentication mechanisms for network access to privileged accounts.
This test verifies that SSH (a replay-resistant authentication mechanism)
is available for network access.
Ref: SRG-OS-000112-GPOS-00057

**Which issue(s) this PR fixes**:
Fixes [234](https://github.com/gardenlinux/security/issues/234)