### PR TITLE
Add test_disastig_00154.py to prevent program execution local policies

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -1,0 +1,276 @@
+import os
+
+import pytest
+from plugins.dpkg import Dpkg
+from plugins.file import File
+from plugins.find import Find
+from plugins.shell import ShellRunner
+from plugins.systemd import Systemd
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify directory permissions")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+def test_tmp_exists(file: File):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /tmp exists on the system.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert file.exists("/tmp"), "stigcompliance: /tmp does not exist"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify directory permissions")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+def test_tmp_is_directory(file: File):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /tmp is a directory.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert file.is_dir("/tmp"), "stigcompliance: /tmp is not a directory"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify directory permissions")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+def test_tmp_has_sticky_bit(file: File):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /tmp is world-writable with sticky bit set.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert file.has_permissions(
+        "/tmp", "rwxrwxrwt"
+    ), f"stigcompliance: /tmp is not world-writable with sticky bit (got {file.get_mode('/tmp')})"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify directory permissions")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+def test_var_tmp_exists(file: File):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /var/tmp exists on the system.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert file.exists("/var/tmp"), "stigcompliance: /var/tmp does not exist"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify directory permissions")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+def test_var_tmp_is_directory(file: File):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /var/tmp is a directory.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert file.is_dir("/var/tmp"), "stigcompliance: /var/tmp is not a directory"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify directory permissions")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+def test_var_tmp_has_sticky_bit(file: File):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /var/tmp is world-writable with sticky bit set.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert file.has_permissions(
+        "/var/tmp", "rwxrwxrwt"
+    ), f"stigcompliance: /var/tmp is not world-writable with sticky bit (got {file.get_mode('/var/tmp')})"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+@pytest.mark.root(reason="required to verify execution restrictions")
+def test_tmp_mount_exists(shell: ShellRunner):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /tmp has a mount entry.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    mount_output = shell("mount", capture_output=True).stdout or ""
+    matching = [line for line in mount_output.splitlines() if " /tmp " in line]
+    assert matching, "stigcompliance: /tmp mount entry not found"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+@pytest.mark.root(reason="required to verify execution restrictions")
+def test_tmp_mounted_noexec(shell: ShellRunner):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /tmp is mounted with noexec.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    mount_output = shell("mount", capture_output=True).stdout or ""
+    matching = [line for line in mount_output.splitlines() if " /tmp " in line]
+    assert any(
+        "noexec" in line for line in matching
+    ), "stigcompliance: /tmp is not mounted with noexec"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+@pytest.mark.root(reason="required to verify execution restrictions")
+def test_var_tmp_mount_exists(shell: ShellRunner):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /var/tmp has a mount entry.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    mount_output = shell("mount", capture_output=True).stdout or ""
+    matching = [line for line in mount_output.splitlines() if " /var/tmp " in line]
+    assert matching, "stigcompliance: /var/tmp mount entry not found"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem inspection")
+@pytest.mark.root(reason="required to verify execution restrictions")
+def test_var_tmp_mounted_noexec(shell: ShellRunner):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that /var/tmp is mounted with noexec.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    mount_output = shell("mount", capture_output=True).stdout or ""
+    matching = [line for line in mount_output.splitlines() if " /var/tmp " in line]
+    assert any(
+        "noexec" in line for line in matching
+    ), "stigcompliance: /var/tmp is not mounted with noexec"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires LSM subsystem")
+@pytest.mark.root(reason="required to read kernel security state")
+def test_lsm_execution_control_present(lsm):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that a Linux Security Module capable of enforcing
+    execution control (AppArmor or SELinux) is active on the system.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    enforcement_lsms = {"apparmor", "selinux"}
+    assert enforcement_lsms.intersection(set(lsm)), (
+        f"stigcompliance: no execution-control LSM (AppArmor or SELinux) is active — "
+        f"active LSMs: {lsm}"
+    )
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires LSM subsystem")
+@pytest.mark.root(reason="required to check AppArmor enforcement status")
+def test_apparmor_is_active(systemd: Systemd, dpkg: Dpkg):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that the AppArmor service is active on the system.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    if not dpkg.package_is_installed("apparmor"):
+        pytest.skip("AppArmor not installed — skipping enforcement check")
+
+    assert systemd.is_active(
+        "apparmor"
+    ), "stigcompliance: AppArmor is installed but the apparmor service is not active"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires LSM subsystem")
+@pytest.mark.root(reason="required to check AppArmor enforcement status")
+def test_apparmor_is_enabled(systemd: Systemd, dpkg: Dpkg):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that the AppArmor service is enabled to survive reboots.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    if not dpkg.package_is_installed("apparmor"):
+        pytest.skip("AppArmor not installed — skipping enforcement check")
+
+    assert systemd.is_enabled(
+        "apparmor"
+    ), "stigcompliance: AppArmor is installed but the apparmor service is not enabled"
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires LSM subsystem")
+@pytest.mark.root(reason="required to check AppArmor enforcement status")
+def test_apparmor_has_enforce_mode_profiles(shell: ShellRunner, dpkg: Dpkg):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that AppArmor has profiles loaded in enforce mode
+    so that execution policies are actively enforced.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    if not dpkg.package_is_installed("apparmor"):
+        pytest.skip("AppArmor not installed — skipping enforcement check")
+
+    status = shell("apparmor_status", capture_output=True, ignore_exit_code=True)
+    assert (
+        "enforce mode" in status.stdout
+        or "profiles are in enforce mode" in status.stdout
+    ), (
+        "stigcompliance: AppArmor has no profiles in enforce mode — "
+        "program execution policies are not being enforced"
+    )
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem")
+@pytest.mark.root(reason="required to inspect filesystem for executable files")
+def test_no_executable_files_in_tmp(find: Find):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test scans /tmp for executable files, which should not be present
+    on a properly hardened system with noexec enforcement.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    find.same_mnt_only = True
+    find.root_paths = ["/tmp"]
+    find.entry_type = "files"
+
+    executables = [f for f in find if os.access(f, os.X_OK)]
+
+    assert (
+        not executables
+    ), "stigcompliance: executable files found in /tmp: " + ", ".join(executables)
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem")
+@pytest.mark.root(reason="required to inspect filesystem for executable files")
+def test_no_executable_files_in_var_tmp(find: Find):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test scans /var/tmp for executable files, which should not be present
+    on a properly hardened system with noexec enforcement.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    find.same_mnt_only = True
+    find.root_paths = ["/var/tmp"]
+    find.entry_type = "files"
+
+    executables = [f for f in find if os.access(f, os.X_OK)]
+
+    assert (
+        not executables
+    ), "stigcompliance: executable files found in /var/tmp: " + ", ".join(executables)

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -52,8 +52,12 @@ def test_var_tmp_mounted_noexec(shell: ShellRunner):
         capture_output=True,
         ignore_exit_code=True,
     )
-    assert result.returncode == 0, "stigcompliance: /var/tmp is not a separate mountpoint"
-    assert "noexec" in result.stdout, "stigcompliance: /var/tmp is not mounted with noexec"
+    assert (
+        result.returncode == 0
+    ), "stigcompliance: /var/tmp is not a separate mountpoint"
+    assert (
+        "noexec" in result.stdout
+    ), "stigcompliance: /var/tmp is not mounted with noexec"
 
 
 @pytest.mark.feature("not container and not lima")
@@ -78,6 +82,6 @@ def test_apparmor_enforcing(shell: ShellRunner, dpkg):
     if result.returncode != 0:
         pytest.skip("apparmor_status not available")
 
-    assert "enforce" in result.stdout.lower(), (
-        "stigcompliance: AppArmor not enforcing execution policies"
-    )
+    assert (
+        "enforce" in result.stdout.lower()
+    ), "stigcompliance: AppArmor not enforcing execution policies"

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -1,110 +1,23 @@
 import pytest
-from plugins.capabilities import Capabilities
 from plugins.dpkg import Dpkg
-from plugins.file import File
-from plugins.find import Find
 from plugins.parse_file import ParseFile
 from plugins.shell import ShellRunner
-from plugins.sysctl import Sysctl
-from plugins.systemd import Systemd
 
 
 @pytest.mark.feature("not container and not lima")
-@pytest.mark.root(reason="required to verify directory permissions")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-def test_tmp_exists(file: File):
+@pytest.mark.booted(reason="requires LSM subsystem")
+@pytest.mark.root(reason="required to inspect execution control mechanisms")
+def test_execution_control_lsm_present(lsm):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp exists on the system.
+    This test verifies that a Linux Security Module (AppArmor or SELinux)
+    capable of enforcing execution control is present.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    assert file.exists("/tmp"), "stigcompliance: /tmp does not exist"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.root(reason="required to verify directory permissions")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-def test_tmp_is_directory(file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp is a directory.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    assert file.is_dir("/tmp"), "stigcompliance: /tmp is not a directory"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.root(reason="required to verify directory permissions")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-def test_tmp_has_sticky_bit(file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp is world-writable with sticky bit set.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    assert file.has_permissions(
-        "/tmp", "rwxrwxrwt"
-    ), f"stigcompliance: /tmp is not world-writable with sticky bit (got {file.get_mode('/tmp')})"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.root(reason="required to verify directory permissions")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-def test_var_tmp_exists(file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp exists on the system.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    assert file.exists("/var/tmp"), "stigcompliance: /var/tmp does not exist"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.root(reason="required to verify directory permissions")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-def test_var_tmp_is_directory(file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp is a directory.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    assert file.is_dir("/var/tmp"), "stigcompliance: /var/tmp is not a directory"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.root(reason="required to verify directory permissions")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-def test_var_tmp_has_sticky_bit(file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp is world-writable with sticky bit set.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    assert file.has_permissions(
-        "/var/tmp", "rwxrwxrwt"
-    ), f"stigcompliance: /var/tmp is not world-writable with sticky bit (got {file.get_mode('/var/tmp')})"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-@pytest.mark.root(reason="required to verify execution restrictions")
-def test_tmp_mount_exists(parse_file: ParseFile):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp has a mount entry in /proc/mounts.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    lines = parse_file.lines("/proc/mounts", format="spacedelim")
-    assert any(
-        "/tmp" in str(line) for line in lines
-    ), "stigcompliance: /tmp mount entry not found in /proc/mounts"
+    assert (
+        "apparmor" in lsm or "selinux" in lsm
+    ), f"stigcompliance: no execution control mechanism present (active LSMs: {lsm})"
 
 
 @pytest.mark.feature("not container and not lima")
@@ -114,29 +27,14 @@ def test_tmp_mounted_noexec(parse_file: ParseFile):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp is mounted with noexec in /proc/mounts.
+    This test verifies that /tmp is mounted with noexec.
     Ref: SRG-OS-000368-GPOS-00154
     """
     lines = parse_file.lines("/proc/mounts", format="spacedelim")
-    assert any(
-        "/tmp" in str(line) and "noexec" in str(line) for line in lines
+
+    assert (
+        "/tmp" in lines and "noexec" in lines
     ), "stigcompliance: /tmp is not mounted with noexec"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-@pytest.mark.root(reason="required to verify execution restrictions")
-def test_var_tmp_mount_exists(parse_file: ParseFile):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp has a mount entry in /proc/mounts.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    lines = parse_file.lines("/proc/mounts", format="spacedelim")
-    assert any(
-        "/var/tmp" in str(line) for line in lines
-    ), "stigcompliance: /var/tmp mount entry not found in /proc/mounts"
 
 
 @pytest.mark.feature("not container and not lima")
@@ -146,170 +44,32 @@ def test_var_tmp_mounted_noexec(parse_file: ParseFile):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp is mounted with noexec in /proc/mounts.
+    This test verifies that /var/tmp is mounted with noexec.
     Ref: SRG-OS-000368-GPOS-00154
     """
     lines = parse_file.lines("/proc/mounts", format="spacedelim")
-    assert any(
-        "/var/tmp" in str(line) and "noexec" in str(line) for line in lines
+
+    assert (
+        "/var/tmp" in lines and "noexec" in lines
     ), "stigcompliance: /var/tmp is not mounted with noexec"
 
 
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires LSM subsystem")
-@pytest.mark.root(reason="required to read kernel security state")
-def test_lsm_execution_control_present(lsm):
+@pytest.mark.root(reason="required to verify enforcement state")
+def test_apparmor_enforcing(shell: ShellRunner, dpkg: Dpkg):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that a Linux Security Module capable of enforcing
-    execution control (AppArmor or SELinux) is active on the system.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    enforcement_lsms = {"apparmor", "selinux"}
-    assert enforcement_lsms.intersection(set(lsm)), (
-        f"stigcompliance: no execution-control LSM (AppArmor or SELinux) is active — "
-        f"active LSMs: {lsm}"
-    )
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires LSM subsystem")
-@pytest.mark.root(reason="required to check AppArmor enforcement status")
-def test_apparmor_is_active(systemd: Systemd, dpkg: Dpkg):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that the AppArmor service is active on the system.
+    This test verifies that AppArmor is enforcing execution policies when present.
     Ref: SRG-OS-000368-GPOS-00154
     """
     if not dpkg.package_is_installed("apparmor"):
-        pytest.skip("AppArmor not installed — skipping enforcement check")
-
-    assert systemd.is_active(
-        "apparmor"
-    ), "stigcompliance: AppArmor is installed but the apparmor service is not active"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires LSM subsystem")
-@pytest.mark.root(reason="required to check AppArmor enforcement status")
-def test_apparmor_is_enabled(systemd: Systemd, dpkg: Dpkg):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that the AppArmor service is enabled to survive reboots.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    if not dpkg.package_is_installed("apparmor"):
-        pytest.skip("AppArmor not installed — skipping enforcement check")
-
-    assert systemd.is_enabled(
-        "apparmor"
-    ), "stigcompliance: AppArmor is installed but the apparmor service is not enabled"
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires LSM subsystem")
-@pytest.mark.root(reason="required to check AppArmor enforcement status")
-def test_apparmor_has_enforce_mode_profiles(shell: ShellRunner, dpkg: Dpkg):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that AppArmor has profiles loaded in enforce mode
-    so that execution policies are actively enforced.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    if not dpkg.package_is_installed("apparmor"):
-        pytest.skip("AppArmor not installed — skipping enforcement check")
+        pytest.skip("AppArmor not installed")
 
     status = shell("apparmor_status", capture_output=True, ignore_exit_code=True)
+
     assert (
         "enforce mode" in status.stdout
         or "profiles are in enforce mode" in status.stdout
-    ), (
-        "stigcompliance: AppArmor has no profiles in enforce mode — "
-        "program execution policies are not being enforced"
-    )
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires mounted filesystem")
-@pytest.mark.root(reason="required to inspect filesystem for executable files")
-def test_no_executable_files_in_tmp(find: Find, file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test scans /tmp for executable files, which should not be present
-    on a properly hardened system with noexec enforcement.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    find.same_mnt_only = True
-    find.root_paths = ["/tmp"]
-    find.entry_type = "files"
-
-    executables = [f for f in find if file.is_executable(f)]
-
-    assert (
-        not executables
-    ), "stigcompliance: executable files found in /tmp: " + ", ".join(executables)
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires mounted filesystem")
-@pytest.mark.root(reason="required to inspect filesystem for executable files")
-def test_no_executable_files_in_var_tmp(find: Find, file: File):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test scans /var/tmp for executable files, which should not be present
-    on a properly hardened system with noexec enforcement.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    find.same_mnt_only = True
-    find.root_paths = ["/var/tmp"]
-    find.entry_type = "files"
-
-    executables = [f for f in find if file.is_executable(f)]
-
-    assert (
-        not executables
-    ), "stigcompliance: executable files found in /var/tmp: " + ", ".join(executables)
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires /proc/sys kernel parameters")
-@pytest.mark.root(reason="required to read kernel sysctl parameters")
-def test_aslr_enabled(sysctl: Sysctl):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that Address Space Layout Randomization (ASLR) is fully
-    enabled (kernel.randomize_va_space=2) to prevent exploitation of executed
-    programs through memory layout prediction.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    assert sysctl["kernel.randomize_va_space"] == 2, (
-        f"stigcompliance: ASLR is not fully enabled — "
-        f"kernel.randomize_va_space={sysctl['kernel.randomize_va_space']} (expected 2)"
-    )
-
-
-@pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires mounted filesystem")
-@pytest.mark.root(reason="required to inspect file capabilities")
-def test_no_capabilities_on_files_in_tmp(capabilities: Capabilities):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that no files in /tmp have elevated Linux capabilities
-    set, which could allow bypassing execution control policies.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    tmp_caps = [entry for entry in capabilities.get() if entry.startswith("/tmp/")]
-
-    assert (
-        not tmp_caps
-    ), "stigcompliance: files in /tmp have elevated capabilities: " + ", ".join(
-        tmp_caps
-    )
+    ), "stigcompliance: AppArmor not enforcing execution policies"

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -38,29 +38,6 @@ def test_tmp_mounted_noexec(shell: ShellRunner):
 
 
 @pytest.mark.feature("not container and not lima")
-@pytest.mark.booted(reason="requires mounted filesystem inspection")
-@pytest.mark.root(reason="required to verify execution restrictions")
-def test_var_tmp_mounted_noexec(shell: ShellRunner):
-    """
-    As per DISA STIG requirement, the operating system must prevent program
-    execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp is mounted with noexec.
-    Ref: SRG-OS-000368-GPOS-00154
-    """
-    result = shell(
-        "findmnt --noheadings -o OPTIONS -T /var/tmp",
-        capture_output=True,
-        ignore_exit_code=True,
-    )
-    assert (
-        result.returncode == 0
-    ), "stigcompliance: /var/tmp is not a separate mountpoint"
-    assert (
-        "noexec" in result.stdout
-    ), "stigcompliance: /var/tmp is not mounted with noexec"
-
-
-@pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires LSM subsystem")
 @pytest.mark.root(reason="required to verify enforcement state")
 def test_apparmor_enforcing(shell: ShellRunner, dpkg):

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -37,7 +37,7 @@ def test_tmp_mounted_noexec(parse_file: ParseFile):
     ), "stigcompliance: /tmp is not mounted with noexec"
 
 
-@pytest.mark.feature("not container and not lima")
+@pytest.mark.feature("stig")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
 def test_var_tmp_mounted_noexec(parse_file: ParseFile):

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -1,10 +1,11 @@
-import os
-
 import pytest
+from plugins.capabilities import Capabilities
 from plugins.dpkg import Dpkg
 from plugins.file import File
 from plugins.find import Find
+from plugins.parse_file import ParseFile
 from plugins.shell import ShellRunner
+from plugins.sysctl import Sysctl
 from plugins.systemd import Systemd
 
 
@@ -93,64 +94,64 @@ def test_var_tmp_has_sticky_bit(file: File):
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
-def test_tmp_mount_exists(shell: ShellRunner):
+def test_tmp_mount_exists(parse_file: ParseFile):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp has a mount entry.
+    This test verifies that /tmp has a mount entry in /proc/mounts.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    mount_output = shell("mount", capture_output=True).stdout or ""
-    matching = [line for line in mount_output.splitlines() if " /tmp " in line]
-    assert matching, "stigcompliance: /tmp mount entry not found"
+    lines = parse_file.lines("/proc/mounts", format="spacedelim")
+    assert any(
+        "/tmp" in str(line) for line in lines
+    ), "stigcompliance: /tmp mount entry not found in /proc/mounts"
 
 
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
-def test_tmp_mounted_noexec(shell: ShellRunner):
+def test_tmp_mounted_noexec(parse_file: ParseFile):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /tmp is mounted with noexec.
+    This test verifies that /tmp is mounted with noexec in /proc/mounts.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    mount_output = shell("mount", capture_output=True).stdout or ""
-    matching = [line for line in mount_output.splitlines() if " /tmp " in line]
+    lines = parse_file.lines("/proc/mounts", format="spacedelim")
     assert any(
-        "noexec" in line for line in matching
+        "/tmp" in str(line) and "noexec" in str(line) for line in lines
     ), "stigcompliance: /tmp is not mounted with noexec"
 
 
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
-def test_var_tmp_mount_exists(shell: ShellRunner):
+def test_var_tmp_mount_exists(parse_file: ParseFile):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp has a mount entry.
+    This test verifies that /var/tmp has a mount entry in /proc/mounts.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    mount_output = shell("mount", capture_output=True).stdout or ""
-    matching = [line for line in mount_output.splitlines() if " /var/tmp " in line]
-    assert matching, "stigcompliance: /var/tmp mount entry not found"
+    lines = parse_file.lines("/proc/mounts", format="spacedelim")
+    assert any(
+        "/var/tmp" in str(line) for line in lines
+    ), "stigcompliance: /var/tmp mount entry not found in /proc/mounts"
 
 
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
-def test_var_tmp_mounted_noexec(shell: ShellRunner):
+def test_var_tmp_mounted_noexec(parse_file: ParseFile):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
-    This test verifies that /var/tmp is mounted with noexec.
+    This test verifies that /var/tmp is mounted with noexec in /proc/mounts.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    mount_output = shell("mount", capture_output=True).stdout or ""
-    matching = [line for line in mount_output.splitlines() if " /var/tmp " in line]
+    lines = parse_file.lines("/proc/mounts", format="spacedelim")
     assert any(
-        "noexec" in line for line in matching
+        "/var/tmp" in str(line) and "noexec" in str(line) for line in lines
     ), "stigcompliance: /var/tmp is not mounted with noexec"
 
 
@@ -235,7 +236,7 @@ def test_apparmor_has_enforce_mode_profiles(shell: ShellRunner, dpkg: Dpkg):
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem")
 @pytest.mark.root(reason="required to inspect filesystem for executable files")
-def test_no_executable_files_in_tmp(find: Find):
+def test_no_executable_files_in_tmp(find: Find, file: File):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
@@ -247,7 +248,7 @@ def test_no_executable_files_in_tmp(find: Find):
     find.root_paths = ["/tmp"]
     find.entry_type = "files"
 
-    executables = [f for f in find if os.access(f, os.X_OK)]
+    executables = [f for f in find if file.is_executable(f)]
 
     assert (
         not executables
@@ -257,7 +258,7 @@ def test_no_executable_files_in_tmp(find: Find):
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem")
 @pytest.mark.root(reason="required to inspect filesystem for executable files")
-def test_no_executable_files_in_var_tmp(find: Find):
+def test_no_executable_files_in_var_tmp(find: Find, file: File):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
@@ -269,8 +270,46 @@ def test_no_executable_files_in_var_tmp(find: Find):
     find.root_paths = ["/var/tmp"]
     find.entry_type = "files"
 
-    executables = [f for f in find if os.access(f, os.X_OK)]
+    executables = [f for f in find if file.is_executable(f)]
 
     assert (
         not executables
     ), "stigcompliance: executable files found in /var/tmp: " + ", ".join(executables)
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires /proc/sys kernel parameters")
+@pytest.mark.root(reason="required to read kernel sysctl parameters")
+def test_aslr_enabled(sysctl: Sysctl):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that Address Space Layout Randomization (ASLR) is fully
+    enabled (kernel.randomize_va_space=2) to prevent exploitation of executed
+    programs through memory layout prediction.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    assert sysctl["kernel.randomize_va_space"] == 2, (
+        f"stigcompliance: ASLR is not fully enabled — "
+        f"kernel.randomize_va_space={sysctl['kernel.randomize_va_space']} (expected 2)"
+    )
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires mounted filesystem")
+@pytest.mark.root(reason="required to inspect file capabilities")
+def test_no_capabilities_on_files_in_tmp(capabilities: Capabilities):
+    """
+    As per DISA STIG requirement, the operating system must prevent program
+    execution in accordance with local policies regarding software program usage.
+    This test verifies that no files in /tmp have elevated Linux capabilities
+    set, which could allow bypassing execution control policies.
+    Ref: SRG-OS-000368-GPOS-00154
+    """
+    tmp_caps = [entry for entry in capabilities.get() if entry.startswith("/tmp/")]
+
+    assert (
+        not tmp_caps
+    ), "stigcompliance: files in /tmp have elevated capabilities: " + ", ".join(
+        tmp_caps
+    )

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -1,6 +1,4 @@
 import pytest
-from plugins.dpkg import Dpkg
-from plugins.parse_file import ParseFile
 from plugins.shell import ShellRunner
 
 
@@ -23,41 +21,45 @@ def test_execution_control_lsm_present(lsm):
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
-def test_tmp_mounted_noexec(parse_file: ParseFile):
+def test_tmp_mounted_noexec(shell: ShellRunner):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
     This test verifies that /tmp is mounted with noexec.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    lines = parse_file.lines("/proc/mounts", format="spacedelim")
+    result = shell(
+        "findmnt --noheadings -o OPTIONS -T /tmp",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+    assert result.returncode == 0, "stigcompliance: /tmp is not a separate mountpoint"
+    assert "noexec" in result.stdout, "stigcompliance: /tmp is not mounted with noexec"
 
-    assert (
-        "/tmp" in lines and "noexec" in lines
-    ), "stigcompliance: /tmp is not mounted with noexec"
 
-
-@pytest.mark.feature("stig")
+@pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires mounted filesystem inspection")
 @pytest.mark.root(reason="required to verify execution restrictions")
-def test_var_tmp_mounted_noexec(parse_file: ParseFile):
+def test_var_tmp_mounted_noexec(shell: ShellRunner):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
     This test verifies that /var/tmp is mounted with noexec.
     Ref: SRG-OS-000368-GPOS-00154
     """
-    lines = parse_file.lines("/proc/mounts", format="spacedelim")
-
-    assert (
-        "/var/tmp" in lines and "noexec" in lines
-    ), "stigcompliance: /var/tmp is not mounted with noexec"
+    result = shell(
+        "findmnt --noheadings -o OPTIONS -T /var/tmp",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+    assert result.returncode == 0, "stigcompliance: /var/tmp is not a separate mountpoint"
+    assert "noexec" in result.stdout, "stigcompliance: /var/tmp is not mounted with noexec"
 
 
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires LSM subsystem")
 @pytest.mark.root(reason="required to verify enforcement state")
-def test_apparmor_enforcing(shell: ShellRunner, dpkg: Dpkg):
+def test_apparmor_enforcing(shell: ShellRunner, dpkg):
     """
     As per DISA STIG requirement, the operating system must prevent program
     execution in accordance with local policies regarding software program usage.
@@ -67,9 +69,15 @@ def test_apparmor_enforcing(shell: ShellRunner, dpkg: Dpkg):
     if not dpkg.package_is_installed("apparmor"):
         pytest.skip("AppArmor not installed")
 
-    status = shell("apparmor_status", capture_output=True, ignore_exit_code=True)
+    result = shell(
+        "apparmor_status",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
 
-    assert (
-        "enforce mode" in status.stdout
-        or "profiles are in enforce mode" in status.stdout
-    ), "stigcompliance: AppArmor not enforcing execution policies"
+    if result.returncode != 0:
+        pytest.skip("apparmor_status not available")
+
+    assert "enforce" in result.stdout.lower(), (
+        "stigcompliance: AppArmor not enforcing execution policies"
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:
As per DISA STIG requirement, the operating system must prevent program
execution in accordance with local policies regarding software program usage.
Ref: SRG-OS-000368-GPOS-00154

**Which issue(s) this PR fixes**:
Fixes [308](https://github.com/gardenlinux/security/issues/308)