### PR TITLE
Fix sources list file adaption in latest image

### DIFF
--- a/images/kmodbuild/Containerfile
+++ b/images/kmodbuild/Containerfile
@@ -7,8 +7,23 @@ FROM $base
 COPY --from=snapshot /etc/apt/sources.list /tmp/sources.list
 RUN grep '^deb ' /tmp/sources.list >> /etc/apt/sources.list && rm /tmp/sources.list
 
-RUN version="$(awk '/^URIs:.*https:\/\/packages\.gardenlinux\.io\/gardenlinux/ { found=1 } found && /^Suites:/ { print $2; exit }' /etc/apt/sources.list.d/gardenlinux.sources)" && \
+RUN version="$(awk ' \
+    /^$/ { \
+        if (found && suite) { print suite; exit } \
+        found=0; suite="" \
+    } \
+    /^URIs:.*https:\/\/packages\.gardenlinux\.io\/gardenlinux/ { found=1 } \
+    /^Suites:/ { suite=$2 } \
+    END { \
+        if (found && suite) { print suite } \
+    } \
+' /etc/apt/sources.list.d/gardenlinux.sources)" && \
+    if [ -z "$version" ]; then \
+        echo "Error: Could not determine Garden Linux version from sources"; \
+        exit 1; \
+    fi && \
     printf 'Package: *\nPin: release n=%s\nPin-Priority: 900\n' "$version" > /etc/apt/preferences.d/gardenlinux
+
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends \
 	build-essential \

--- a/images/kmodbuild/Containerfile
+++ b/images/kmodbuild/Containerfile
@@ -6,7 +6,10 @@ FROM $snapshot AS snapshot
 FROM $base
 COPY --from=snapshot /etc/apt/sources.list /tmp/sources.list
 RUN grep '^deb ' /tmp/sources.list >> /etc/apt/sources.list && rm /tmp/sources.list
-RUN version="$(awk '$2 == "https://packages.gardenlinux.io/gardenlinux" { print $3 }' /etc/apt/sources.list)" && printf 'Package: *\nPin: release n=%s\nPin-Priority: 900\n' "$version" > /etc/apt/preferences.d/gardenlinux
+
+RUN version="$(awk '/^URIs:.*https:\/\/packages\.gardenlinux\.io\/gardenlinux/ { found=1 } found && /^Suites:/ { print $2; exit }' /etc/apt/sources.list.d/gardenlinux.sources)" && \
+    printf 'Package: *\nPin: release n=%s\nPin-Priority: 900\n' "$version" > /etc/apt/preferences.d/gardenlinux
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends \
 	build-essential \
 	curl \


### PR DESCRIPTION
**What this PR does / why we need it**:
Nightly build fails since sources.list doesn't exist anymore
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardenlinux/gardenlinux/actions/runs/24329367219/job/71033160247
**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
