### PR TITLE
Fix/fips gnu tls generate hmac

### DIFF
--- a/features/_fips/exec.config
+++ b/features/_fips/exec.config
@@ -56,6 +56,7 @@ sha512hmac -c /boot/.vmlinuz-"$KERNEL".hmac
 # GnuTLS
 # We have an issue that the lib's are different at times in the build environment and we have to
 # re-compute the hmac manually to ensure consistency.
+rm /usr/lib/`uname -m`-linux-gnu/.libgnutls.so.30.hmac
 cat <<EOF > /usr/lib/`uname -m`-linux-gnu/.libgnutls.so.30.hmac
 [global]
 format-version = 1
@@ -64,11 +65,11 @@ path = `dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1`
 hmac =$(cat `dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 [libhogweed.so.6]
 path = `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1`
-hmac = $(cat `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1` /usr/lib/aarch64-linux-gnu/libhogweed.so.6.11  | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+hmac =$(cat `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 [libnettle.so.8]
 path = `dpkg -L libnettle8t64 |grep libnettle.so|head -n1`
-hmac = $(cat `dpkg -L libnettle8t64 |grep libnettle.so|head -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+hmac =$(cat `dpkg -L libnettle8t64 |grep libnettle.so|head -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 [libgmp.so.10]
 path = `dpkg -L libgmp10 |grep libgmp.so |head -n1`
-hmac = $(cat `dpkg -L libgmp10 |grep libgmp.so |head -n1`| openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+hmac =$(cat `dpkg -L libgmp10 |grep libgmp.so |head -n1`| openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 EOF

--- a/features/_fips/exec.config
+++ b/features/_fips/exec.config
@@ -56,20 +56,21 @@ sha512hmac -c /boot/.vmlinuz-"$KERNEL".hmac
 # GnuTLS
 # We have an issue that the lib's are different at times in the build environment and we have to
 # re-compute the hmac manually to ensure consistency.
-rm /usr/lib/`uname -m`-linux-gnu/.libgnutls.so.30.hmac
-cat <<EOF > /usr/lib/`uname -m`-linux-gnu/.libgnutls.so.30.hmac
+rm "/usr/lib/$(uname -m)-linux-gnu/.libgnutls.so.30.hmac"
+# shellcheck disable=SC2046
+cat <<EOF > "/usr/lib/$(uname -m)-linux-gnu/.libgnutls.so.30.hmac"
 [global]
 format-version = 1
 [libgnutls.so.30]
-path = `dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1`
-hmac =$(cat `dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+path = $(dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1)
+hmac =$(cat $(dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1) | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 [libhogweed.so.6]
-path = `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1`
-hmac =$(cat `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+path = $(dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1)
+hmac =$(cat $(dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1) | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 [libnettle.so.8]
-path = `dpkg -L libnettle8t64 |grep libnettle.so|head -n1`
-hmac =$(cat `dpkg -L libnettle8t64 |grep libnettle.so|head -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+path = $(dpkg -L libnettle8t64 |grep libnettle.so|head -n1)
+hmac =$(cat $(dpkg -L libnettle8t64 |grep libnettle.so|head -n1) | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 [libgmp.so.10]
-path = `dpkg -L libgmp10 |grep libgmp.so |head -n1`
-hmac =$(cat `dpkg -L libgmp10 |grep libgmp.so |head -n1`| openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+path = $(dpkg -L libgmp10 |grep libgmp.so |head -n1)
+hmac =$(cat $(dpkg -L libgmp10 |grep libgmp.so |head -n1)| openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
 EOF

--- a/features/_fips/exec.config
+++ b/features/_fips/exec.config
@@ -50,3 +50,25 @@ echo "Ciphers aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ct
 KERNEL=$(ls /boot/vmlinuz-*|cut -d "-" -f2-4)
 sha512hmac /boot/vmlinuz-"$KERNEL"  > /boot/.vmlinuz-"$KERNEL".hmac
 sha512hmac -c /boot/.vmlinuz-"$KERNEL".hmac
+
+
+
+# GnuTLS
+# We have an issue that the lib's are different at times in the build environment and we have to
+# re-compute the hmac manually to ensure consistency.
+cat <<EOF > /usr/lib/`uname -m`-linux-gnu/.libgnutls.so.30.hmac
+[global]
+format-version = 1
+[libgnutls.so.30]
+path = `dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1`
+hmac =$(cat `dpkg -L libgnutls30t64 |grep libgnutls.so |tail -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+[libhogweed.so.6]
+path = `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1`
+hmac = $(cat `dpkg -L libhogweed6t64 | grep 'libhogweed.so' |head -n1` /usr/lib/aarch64-linux-gnu/libhogweed.so.6.11  | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+[libnettle.so.8]
+path = `dpkg -L libnettle8t64 |grep libnettle.so|head -n1`
+hmac = $(cat `dpkg -L libnettle8t64 |grep libnettle.so|head -n1` | openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+[libgmp.so.10]
+path = `dpkg -L libgmp10 |grep libgmp.so |head -n1`
+hmac = $(cat `dpkg -L libgmp10 |grep libgmp.so |head -n1`| openssl dgst -sha256 -hmac orboDeJITITejsirpADONivirpUkvarP |cut -d '=' -f2)
+EOF


### PR DESCRIPTION
In this PR, we compute the HMAC of the dependency of GnuTLS manually. This is necessary since Debian has published a change to one of GnuTLS's dependencies that wasn't open-sourced yet. 

The main problem is that the build environment in which GnuTLS is built remains fairly static and computes the HMAC for the dependency at build-time. However, when one of the underlying dependencies is changed the HMAC test will fail. In the past, this could have been addressed by rebuilding the GnuTLS package. Since the packages from the build environment would be in the nightly. 

With this change, we will compute it every time we build. This ensures that the HMAC is computed for the libraries that are present to make it independent of the package built environment. 

 