### PR TITLE
Tests/check that md5 is disabled

### DIFF
--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -3,6 +3,8 @@ import hmac
 import os
 from ctypes import CDLL, c_int, c_void_p
 from ctypes.util import find_library
+from hashlib import _hashlib # pyright: ignore
+from hashlib import md5 as MD5
 from hashlib import sha256 as SHA256
 from platform import machine as arch
 from typing import List
@@ -27,13 +29,7 @@ def test_that_md5_is_disabled_in_openssl_via_haslib():
     We try to load the MD5 constructor to see if OpenSSL disallows the usage of MD5.
     Fails when we have a vaild MD5 object in a Security senstive context.
     """
-    try:
-        MD5()
-    except hashlib._hashlib.UnsupportedDigestmodError:
-        assert True
-        return
-
-    assert False, "MD5 can be loaded!"
+    pytest.raises(_hashlib.UnsupportedDigestmodError, MD5)
 
 
 @pytest.mark.testcov(

--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -19,6 +19,7 @@ from plugins.shell import ShellRunner
 # _fips Feature
 # =============================================================================
 
+
 @pytest.mark.feature("_fips")
 def test_that_md5_is_disabled_in_openssl_via_haslib():
     """

--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -3,7 +3,7 @@ import hmac
 import os
 from ctypes import CDLL, c_int, c_void_p
 from ctypes.util import find_library
-from hashlib import _hashlib # pyright: ignore
+from hashlib import _hashlib  # pyright: ignore
 from hashlib import md5 as MD5
 from hashlib import sha256 as SHA256
 from platform import machine as arch

--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -19,6 +19,21 @@ from plugins.shell import ShellRunner
 # _fips Feature
 # =============================================================================
 
+@pytest.mark.feature("_fips")
+def test_that_md5_is_disabled_in_openssl_via_haslib():
+    """
+    Python's hashlib requires the systems OpenSSL to compute hash function.
+    We try to load the MD5 constructor to see if OpenSSL disallows the usage of MD5.
+    Fails when we have a vaild MD5 object in a Security senstive context.
+    """
+    try:
+        MD5()
+    except hashlib._hashlib.UnsupportedDigestmodError:
+        assert True
+        return
+
+    assert False, "MD5 can be loaded!"
+
 
 @pytest.mark.testcov(
     [


### PR DESCRIPTION
We have to ensure that MD5 isn't loaded. This test uses Python's `hashlib` to ensure that this isn't the case. Since it uses OpenSSL to load MD5. 