### PR TITLE
Add features/disaSTIGDev — development variant of STIG compliance feature

### DIFF
--- a/features/_dev/exec.late
+++ b/features/_dev/exec.late
@@ -11,10 +11,3 @@ mkdir /home/dev/.ssh
 chmod -R 700 /home/dev/.ssh
 chown -R dev:dev /home/dev/.ssh
 find /home/dev -printf '%M %u:%g %p\n'
-
-# SSH key to login for ansible
-mkdir -p /home/user/.ssh
-echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC4OC9EXebOu9mOQHhnYFVGIZuEvAzAcOuePnPEtADwue0l4k+BV0+TWYIQRRtP/Lz7hoVB4+ujirmFdq933HtxVUP0Fy0/kzx3mHunZpUpq5JR4iRucQj0bNbYBpju47P5uRmCYjKOCajwBk1PXx88uLnoJm9Tq/2AR7znbwb2Gw==' >> /home/user/.ssh/authorized_keys
-chmod -R 700 /home/user/.ssh
-chown -R user:user /home/user/.ssh
-find /home/user -printf '%M %u:%g %p\n'

--- a/features/_dev/exec.late
+++ b/features/_dev/exec.late
@@ -11,3 +11,10 @@ mkdir /home/dev/.ssh
 chmod -R 700 /home/dev/.ssh
 chown -R dev:dev /home/dev/.ssh
 find /home/dev -printf '%M %u:%g %p\n'
+
+# SSH key to login for ansible
+mkdir -p /home/user/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC4OC9EXebOu9mOQHhnYFVGIZuEvAzAcOuePnPEtADwue0l4k+BV0+TWYIQRRtP/Lz7hoVB4+ujirmFdq933HtxVUP0Fy0/kzx3mHunZpUpq5JR4iRucQj0bNbYBpju47P5uRmCYjKOCajwBk1PXx88uLnoJm9Tq/2AR7znbwb2Gw==' >> /home/user/.ssh/authorized_keys
+chmod -R 700 /home/user/.ssh
+chown -R user:user /home/user/.ssh
+find /home/user -printf '%M %u:%g %p\n'

--- a/features/_dev/exec.late
+++ b/features/_dev/exec.late
@@ -11,3 +11,23 @@ mkdir /home/dev/.ssh
 chmod -R 700 /home/dev/.ssh
 chown -R dev:dev /home/dev/.ssh
 find /home/dev -printf '%M %u:%g %p\n'
+
+# GL-TESTCOV-_dev-config-user-stig-create
+useradd --user-group --create-home --shell=/usr/bin/bash --password="$(openssl passwd -6 user)" user
+
+chmod u+s /usr/bin/su
+chmod g+s /usr/bin/su
+chmod u+s /usr/bin/sudo
+chmod g+s /usr/bin/sudo
+
+systemctl enable ssh-keygen
+systemctl enable ssh
+
+chmod 0440 /etc/sudoers.d/user
+
+# SSH key to login for ansible
+mkdir -p /home/user/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC4OC9EXebOu9mOQHhnYFVGIZuEvAzAcOuePnPEtADwue0l4k+BV0+TWYIQRRtP/Lz7hoVB4+ujirmFdq933HtxVUP0Fy0/kzx3mHunZpUpq5JR4iRucQj0bNbYBpju47P5uRmCYjKOCajwBk1PXx88uLnoJm9Tq/2AR7znbwb2Gw==' >> /home/user/.ssh/authorized_keys
+chmod -R 700 /home/user/.ssh
+chown -R user:user /home/user/.ssh
+find /home/user -printf '%M %u:%g %p\n'

--- a/features/_dev/file.include/etc/sudoers.d/user
+++ b/features/_dev/file.include/etc/sudoers.d/user
@@ -1,0 +1,1 @@
+user ALL=(ALL:ALL) ALL

--- a/features/disaSTIGDev/exec.late
+++ b/features/disaSTIGDev/exec.late
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+set -x
+
+# On purpose, create a user with a known password.
+useradd --user-group --create-home --shell=/usr/bin/bash --password="$(openssl passwd -6 user)" user
+
+chmod u+s /usr/bin/su
+chmod g+s /usr/bin/su
+chmod u+s /usr/bin/sudo
+chmod g+s /usr/bin/sudo
+
+systemctl enable ssh-keygen
+systemctl enable ssh
+
+chmod 0440 /etc/sudoers.d/user
+
+# SSH key to login for ansible
+mkdir -p /home/user/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC4OC9EXebOu9mOQHhnYFVGIZuEvAzAcOuePnPEtADwue0l4k+BV0+TWYIQRRtP/Lz7hoVB4+ujirmFdq933HtxVUP0Fy0/kzx3mHunZpUpq5JR4iRucQj0bNbYBpju47P5uRmCYjKOCajwBk1PXx88uLnoJm9Tq/2AR7znbwb2Gw==' >> /home/user/.ssh/authorized_keys
+chmod -R 700 /home/user/.ssh
+chown -R user:user /home/user/.ssh
+find /home/user -printf '%M %u:%g %p\n'

--- a/features/disaSTIGDev/exec.late
+++ b/features/disaSTIGDev/exec.late
@@ -15,3 +15,10 @@ systemctl enable ssh-keygen
 systemctl enable ssh
 
 chmod 0440 /etc/sudoers.d/user
+
+# SSH key to login for ansible
+mkdir -p /home/user/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC4OC9EXebOu9mOQHhnYFVGIZuEvAzAcOuePnPEtADwue0l4k+BV0+TWYIQRRtP/Lz7hoVB4+ujirmFdq933HtxVUP0Fy0/kzx3mHunZpUpq5JR4iRucQj0bNbYBpju47P5uRmCYjKOCajwBk1PXx88uLnoJm9Tq/2AR7znbwb2Gw==' >> /home/user/.ssh/authorized_keys
+chmod -R 700 /home/user/.ssh
+chown -R user:user /home/user/.ssh
+find /home/user -printf '%M %u:%g %p\n'

--- a/features/disaSTIGDev/exec.late
+++ b/features/disaSTIGDev/exec.late
@@ -15,10 +15,3 @@ systemctl enable ssh-keygen
 systemctl enable ssh
 
 chmod 0440 /etc/sudoers.d/user
-
-# SSH key to login for ansible
-mkdir -p /home/user/.ssh
-echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQC4OC9EXebOu9mOQHhnYFVGIZuEvAzAcOuePnPEtADwue0l4k+BV0+TWYIQRRtP/Lz7hoVB4+ujirmFdq933HtxVUP0Fy0/kzx3mHunZpUpq5JR4iRucQj0bNbYBpju47P5uRmCYjKOCajwBk1PXx88uLnoJm9Tq/2AR7znbwb2Gw==' >> /home/user/.ssh/authorized_keys
-chmod -R 700 /home/user/.ssh
-chown -R user:user /home/user/.ssh
-find /home/user -printf '%M %u:%g %p\n'

--- a/features/disaSTIGDev/file.include/etc/sudoers.d/user
+++ b/features/disaSTIGDev/file.include/etc/sudoers.d/user
@@ -1,0 +1,1 @@
+user ALL=(ALL:ALL) ALL

--- a/features/disaSTIGDev/file.include/usr/lib/tmpfiles.d/gardenlinux-tests-dev.conf
+++ b/features/disaSTIGDev/file.include/usr/lib/tmpfiles.d/gardenlinux-tests-dev.conf
@@ -1,0 +1,3 @@
+# Create /run/gardenlinux-tests-dev owned by the gardenlinux user at boot
+# so that the dev test workflow (--dev) can sync tests without requiring sudo.
+d /run/gardenlinux-tests-dev 0755 gardenlinux gardenlinux -

--- a/features/disaSTIGDev/info.yaml
+++ b/features/disaSTIGDev/info.yaml
@@ -1,0 +1,6 @@
+description: |
+  disaSTIG Development/Debugging Setup. Never enable for production images. Will set known passwords for users.
+type: element
+features:
+  include:
+    - disaSTIGmedium

--- a/features/disaSTIGDev/pkg.include
+++ b/features/disaSTIGDev/pkg.include
@@ -1,0 +1,1 @@
+openssh-server


### PR DESCRIPTION
## What this PR does / why we need it
Add `disaSTIGDev` feature — development-time STIG compliance configurations including sudoers, pkg, and exec configurations.
Make features/stig working + make a flavor of it for test framework

## Which issue(s) this PR fixes
Fixes gardenlinux/security#373