### PR TITLE
test: update test_disastig_0046.py for disaSTIG feature restructure

### DIFF
--- a/tests/integration/security/compliance/test_disastig_0046.py
+++ b/tests/integration/security/compliance/test_disastig_0046.py
@@ -2,9 +2,6 @@ import pytest
 
 
 @pytest.mark.feature("disaSTIGmedium")
-@pytest.mark.parametrize(
-    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
-)
 def test_common_password_passwdqc_pam_faillock(pam_config):
     """
     Requirements of SRG-OS-000078-GPOS-00046, SRG-OS-000072-GPOS-00040

--- a/tests/integration/security/compliance/test_disastig_0046.py
+++ b/tests/integration/security/compliance/test_disastig_0046.py
@@ -2,7 +2,9 @@ import pytest
 
 
 @pytest.mark.feature("disaSTIGmedium")
-@pytest.mark.parametrize("pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
 def test_common_password_passwdqc_pam_faillock(pam_config):
     """
     Requirements of SRG-OS-000078-GPOS-00046, SRG-OS-000072-GPOS-00040

--- a/tests/integration/security/compliance/test_disastig_0046.py
+++ b/tests/integration/security/compliance/test_disastig_0046.py
@@ -1,7 +1,8 @@
 import pytest
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.parametrize("pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"])
 def test_common_password_passwdqc_pam_faillock(pam_config):
     """
     Requirements of SRG-OS-000078-GPOS-00046, SRG-OS-000072-GPOS-00040


### PR DESCRIPTION
## What this PR does / why we need it
Update `test_disastig_0046.py` to reference the new `disaSTIGmedium`/`disaSTIGlow` feature names.
Make features/stig working + make a flavor of it for test framework

## Which issue(s) this PR fixes
Fixes gardenlinux/security#373