### PR TITLE
replace obsolete feature("stig") with feature("disaSTIGmedium") in test_disastig_* files

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00089.py
+++ b/tests/integration/security/compliance/test_disastig_00089.py
@@ -12,7 +12,7 @@ Verify the operating system automatically audits account removal actions.
 """
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 def test_audit_calling_user_group_related_utilities(audit_rule):
     for bin in [
         "/usr/sbin/visudo",

--- a/tests/integration/security/compliance/test_disastig_00098.py
+++ b/tests/integration/security/compliance/test_disastig_00098.py
@@ -38,7 +38,7 @@ def test_audit_log_directory_protected(file):
     )
 
 
-@pytest.mark.feature("stig or cis")
+@pytest.mark.feature("disaSTIGmedium or cis")
 @pytest.mark.booted(reason="audit protection requires booted system")
 @pytest.mark.root(reason="required to inspect audit log ownership")
 def test_audit_log_files_protected(file):

--- a/tests/integration/security/compliance/test_disastig_00173.py
+++ b/tests/integration/security/compliance/test_disastig_00173.py
@@ -2,7 +2,7 @@ import pytest
 from plugins.dpkg import Dpkg
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires SSH runtime configuration")
 @pytest.mark.root(reason="requires access to SSH configuration")
 def test_ssh_strong_macs_present(sshd, dpkg: Dpkg):
@@ -36,7 +36,7 @@ def test_ssh_strong_macs_present(sshd, dpkg: Dpkg):
     ), "stigcompliance: no strong MAC algorithms configured for SSH integrity protection"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires SSH runtime configuration")
 @pytest.mark.root(reason="requires access to SSH configuration")
 def test_ssh_weak_macs_not_present(sshd):

--- a/tests/integration/security/compliance/test_disastig_00218.py
+++ b/tests/integration/security/compliance/test_disastig_00218.py
@@ -21,7 +21,7 @@ def concurrent_login_environment(shell: ShellRunner):
     shell(f"rm -f {OUTPUT_FILE} {JOURNAL_FILE} {TIME_FILE}")
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires kernel logging")
 @pytest.mark.root(reason="required to generate audit events")
 def test_audit_concurrent_logins(shell: ShellRunner, concurrent_login_environment):

--- a/tests/integration/security/compliance/test_disastig_00222.py
+++ b/tests/integration/security/compliance/test_disastig_00222.py
@@ -3,7 +3,7 @@ from plugins.audit import AuditRule
 from plugins.parse_file import ParseFile
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="audit subsystem required")
 @pytest.mark.root(reason="requires access to audit rules")
 def test_audit_kernel_module_rules_present(parse_file: ParseFile):

--- a/tests/integration/security/compliance/test_disastig_auditd.py
+++ b/tests/integration/security/compliance/test_disastig_auditd.py
@@ -411,7 +411,7 @@ def test_audit_record_filtering_capability(shell: ShellRunner):
         ), f"stigcompliance: audit filtering failed for command: {cmd}"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem running")
 @pytest.mark.root(reason="required to generate and read audit logs")
 def test_audit_records_have_valid_timestamps(shell: ShellRunner):
@@ -430,7 +430,7 @@ def test_audit_records_have_valid_timestamps(shell: ShellRunner):
     ), "stigcompliance: audit records do not contain valid timestamps"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem running")
 @pytest.mark.root(reason="required to generate and read audit logs")
 def test_system_time_status_available(shell: ShellRunner):
@@ -450,7 +450,7 @@ AUDIT_LOG_DIR = "/var/log/audit"
 AUDIT_LOG_FILE = "/var/log/audit/audit.log"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
 @pytest.mark.root(reason="required to inspect audit log permissions")
 def test_audit_log_directory_permissions_restricted(file: File):
@@ -471,7 +471,7 @@ def test_audit_log_directory_permissions_restricted(file: File):
         ), f"stigcompliance: audit log directory {AUDIT_LOG_DIR} permissions are not restricted"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
 @pytest.mark.root(reason="required to inspect audit log permissions")
 def test_audit_log_file_permissions_restricted(file: File):
@@ -491,7 +491,7 @@ def test_audit_log_file_permissions_restricted(file: File):
         ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} permissions are not restricted"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
 @pytest.mark.root(reason="required to inspect audit log ownership")
 def test_audit_log_owned_by_root(file: File):


### PR DESCRIPTION
## What this PR does / why we need it
Update minor compliance test files (`test_disastig_0005`, `_00098`, `_00173`, `_00218`, `_00222`, `_0072`, `_0089`, `test_password_hashes`) to reference the new `disaSTIGmedium`/`disaSTIGlow` feature names.
Make features/stig working + make a flavor of it for test framework

## Which issue(s) this PR fixes
Fixes gardenlinux/security#373