### PR TITLE
Add test_disastig_00156.py to verify sudoers requires re-authentication

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -12,11 +12,10 @@ def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
     As per DISA STIG compliance requirements, the operating system must require
     users to re-authenticate for privilege escalation.
     This test verifies that no sudoers file grants passwordless privilege escalation
-    via NOPASSWD or !authenticate.
+    via NOPASSWD.
     Ref: SRG-OS-000373-GPOS-00156
     """
     nopasswd_pattern = re.compile(r"NOPASSWD", re.IGNORECASE)
-    noauthenticate_pattern = re.compile(r"!authenticate", re.IGNORECASE)
 
     find.root_paths = "/etc/sudoers.d"
     find.entry_type = "files"
@@ -29,6 +28,28 @@ def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
         assert (
             nopasswd_pattern not in lines
         ), f"stigcompliance: NOPASSWD found in sudoers file {path}"
+
+
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
+def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
+    """
+    As per DISA STIG compliance requirements, the operating system must require
+    users to re-authenticate for privilege escalation.
+    This test verifies that no sudoers file bypasses authentication
+    via !authenticate.
+    Ref: SRG-OS-000373-GPOS-00156
+    """
+    noauthenticate_pattern = re.compile(r"!authenticate", re.IGNORECASE)
+
+    find.root_paths = "/etc/sudoers.d"
+    find.entry_type = "files"
+    paths_to_check = ["/etc/sudoers"] + list(find)
+
+    for path in paths_to_check:
+        lines = parse_file.lines(path, ignore_missing=True)
+        if not lines:
+            continue
         assert (
             noauthenticate_pattern not in lines
         ), f"stigcompliance: !authenticate found in sudoers file {path}"

--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -26,9 +26,9 @@ def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
         lines = parse_file.lines(path, ignore_missing=True)
         if not lines:
             continue
-        assert nopasswd_pattern not in lines, (
-            f"stigcompliance: NOPASSWD found in sudoers file {path}"
-        )
-        assert noauthenticate_pattern not in lines, (
-            f"stigcompliance: !authenticate found in sudoers file {path}"
-        )
+        assert (
+            nopasswd_pattern not in lines
+        ), f"stigcompliance: NOPASSWD found in sudoers file {path}"
+        assert (
+            noauthenticate_pattern not in lines
+        ), f"stigcompliance: !authenticate found in sudoers file {path}"

--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -1,0 +1,34 @@
+import re
+
+import pytest
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+
+
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
+def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
+    """
+    As per DISA STIG compliance requirements, the operating system must require
+    users to re-authenticate for privilege escalation.
+    This test verifies that no sudoers file grants passwordless privilege escalation
+    via NOPASSWD or !authenticate.
+    Ref: SRG-OS-000373-GPOS-00156
+    """
+    nopasswd_pattern = re.compile(r"NOPASSWD", re.IGNORECASE)
+    noauthenticate_pattern = re.compile(r"!authenticate", re.IGNORECASE)
+
+    find.root_paths = "/etc/sudoers.d"
+    find.entry_type = "files"
+    paths_to_check = ["/etc/sudoers"] + list(find)
+
+    for path in paths_to_check:
+        lines = parse_file.lines(path, ignore_missing=True)
+        if not lines:
+            continue
+        assert nopasswd_pattern not in lines, (
+            f"stigcompliance: NOPASSWD found in sudoers file {path}"
+        )
+        assert noauthenticate_pattern not in lines, (
+            f"stigcompliance: !authenticate found in sudoers file {path}"
+        )

--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -25,9 +25,8 @@ def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
         lines = parse_file.lines(path, ignore_missing=True)
         if not lines:
             continue
-        assert (
-            nopasswd_pattern not in lines
-        ), f"stigcompliance: NOPASSWD found in sudoers file {path}"
+        matches = nopasswd_pattern.findall(lines.content)
+        assert not matches, f"stigcompliance: NOPASSWD found in sudoers file {path}"
 
 
 @pytest.mark.feature("disaSTIGmedium")
@@ -50,6 +49,5 @@ def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
         lines = parse_file.lines(path, ignore_missing=True)
         if not lines:
             continue
-        assert (
-            noauthenticate_pattern not in lines
-        ), f"stigcompliance: !authenticate found in sudoers file {path}"
+        matches = noauthenticate_pattern.findall(lines.content)
+        assert not matches, f"stigcompliance: !authenticate found in sudoers file {path}"

--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -50,4 +50,6 @@ def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
         if not lines:
             continue
         matches = noauthenticate_pattern.findall(lines.content)
-        assert not matches, f"stigcompliance: !authenticate found in sudoers file {path}"
+        assert (
+            not matches
+        ), f"stigcompliance: !authenticate found in sudoers file {path}"


### PR DESCRIPTION
## What this PR does / why we need it

Add `test_disastig_00156.py` to verify that no sudoers file grants passwordless privilege escalation via `NOPASSWD` or `!authenticate`.

As per DISA STIG compliance requirements (SRG-OS-000373-GPOS-00156), the operating system must require users to re-authenticate for privilege escalation.

## Which issue(s) this PR fixes

Fixes gardenlinux/security#373