### PR TITLE
tests: add /sbin/nologin to the list of nologin shells

### DIFF
--- a/tests/integration/core/test_users_groups.py
+++ b/tests/integration/core/test_users_groups.py
@@ -21,6 +21,7 @@ def test_service_accounts_have_nologin_shell(regular_user_uid_range):
             continue
         assert entry.pw_shell in [
             "/usr/sbin/nologin",
+            "/sbin/nologin",
             "/bin/false",
         ], f"User {entry.pw_name} has unexpected shell: {entry.pw_shell}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
_/sbin/nologin_ should also be part of the list of no login shells.