### PR TITLE
Reduce the compression level of `xz` to increase GitHub workflow throughput

### DIFF
--- a/.github/workflows/upload_to_github_release.yml
+++ b/.github/workflows/upload_to_github_release.yml
@@ -96,7 +96,7 @@ jobs:
           mkdir -p "$CNAME"
 
           gunzip "$CNAME.tar.gz"
-          xz "$CNAME.tar"
+          xz -1 "$CNAME.tar"
           mv "$CNAME.tar.xz" "$CNAME/"
 
           tar -C "log" -cJf "$CNAME/$CNAME.logs.tar.xz" .


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces the compression level of `xz` to increase GitHub workflow throughput. This is due to `xz` default compression level of `6` which is too high for the content we have in our tar artifacts anyway.

**Which issue(s) this PR fixes**:
Fixes: #4744 