### PR TITLE
fix: run the nightly and test cleanup job earlier

### DIFF
--- a/.github/workflows/cloud_test_cleanup.yml
+++ b/.github/workflows/cloud_test_cleanup.yml
@@ -1,7 +1,7 @@
 name: Cloud Test Cleanup
 on:
   schedule:
-    - cron: "0 4 * * *" # Run daily at 4 AM UTC
+    - cron: "0 2 * * *" # Run daily at 2 AM UTC
   # manual trigger
   workflow_dispatch:
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ concurrency:
   cancel-in-progress: true
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 4 * * *'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
**What this PR does / why we need it**:
The _cloud test cleanup_ and the _nightly_ should run earlier. Because of the daylight saving time, every day when we have our internal meetings the nightly is still running. 
