### PR TITLE
fix: use different machine type for ali tests

### DIFF
--- a/tests/util/tf/modules/ali/variables.tf
+++ b/tests/util/tf/modules/ali/variables.tf
@@ -33,7 +33,7 @@ variable "user_data_script_path" {
 variable "instance_type_amd64" {
   description = "Default instance type for amd64"
   type        = string
-  default     = "ecs.t6-c1m2.large"
+  default     = "ecs.u2a-c1m2.large"
 }
 
 variable "instance_type_arm64" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches the instance type for the Ali tests from a burstable instance to a universal instance family.