### PR TITLE
fix: use different region for ali tests

### DIFF
--- a/tests/util/tf/modules/ali/variables.tf
+++ b/tests/util/tf/modules/ali/variables.tf
@@ -66,7 +66,7 @@ variable "provider_vars" {
   description = "Ali specific settings"
 
   type = object({
-    region             = optional(string, "eu-west-1")
+    region             = optional(string, "eu-central-1")
     instance_type      = optional(string)
     boot_mode          = optional(string)
     net_cidr           = optional(string, "10.0.0.0/16")


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: use different region for ali tests

https://github.com/gardenlinux/gardenlinux/pull/4752 changed the machine type but this is not available in eu-west-1a. It is available in eu-central-1a, though.
