### PR TITLE
fix: use correct data disk type on ali tests

### DIFF
--- a/tests/util/tf/modules/ali/disks.tf
+++ b/tests/util/tf/modules/ali/disks.tf
@@ -11,7 +11,7 @@ resource "terraform_data" "test_disk_hash" {
 }
 
 resource "alicloud_oss_bucket" "images" {
-  count = var.existing_root_disk != "" ? 0 : 1
+  count = 1
 
   bucket = local.bucket_name
 
@@ -36,7 +36,7 @@ resource "terraform_data" "pause_1_second" {
 }
 
 resource "alicloud_oss_bucket_public_access_block" "no_public_access" {
-  count = var.existing_root_disk != "" ? 0 : 1
+  count = 1
 
   bucket = alicloud_oss_bucket.images[0].bucket
 

--- a/tests/util/tf/modules/ali/vm.tf
+++ b/tests/util/tf/modules/ali/vm.tf
@@ -39,7 +39,7 @@ resource "alicloud_instance" "instance" {
 
   data_disks {
     size = 20
-    category = "cloud_efficiency"
+    category = "cloud_auto"
     delete_with_instance = true
     snapshot_id = data.alicloud_ecs_snapshots.image_test.snapshots.0.id
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: use correct data disk type on ali tests

https://github.com/gardenlinux/gardenlinux/pull/4752 changed the machine type but this is not available in eu-west-1a. It is available in eu-central-1a, though.
https://github.com/gardenlinux/gardenlinux/pull/4758 changed the region but the data disk type is not available there
