### PR TITLE
feat(disaSTIGmedium): introduce DISA STIG CAT II (Medium) compliance feature scaffold

### DIFF
--- a/features/disaSTIGmedium/info.yaml
+++ b/features/disaSTIGmedium/info.yaml
@@ -1,0 +1,5 @@
+description: "DISA STIG Compliance - CAT II (Medium Severity)"
+type: element
+features:
+ include:
+   - disaSTIGlow

--- a/features/disaSTIGmedium/pkg.include
+++ b/features/disaSTIGmedium/pkg.include
@@ -1,0 +1,4 @@
+aide
+aide-common
+# GL-TESTCOV-ssh-service-auditd-enable
+auditd

--- a/features/disaSTIGmedium/pkg.include
+++ b/features/disaSTIGmedium/pkg.include
@@ -1,4 +1,3 @@
 aide
 aide-common
-# GL-TESTCOV-ssh-service-auditd-enable
 auditd

--- a/features/disaSTIGmedium/pkg.include
+++ b/features/disaSTIGmedium/pkg.include
@@ -1,3 +1,4 @@
 aide
 aide-common
+# GL-TESTCOV-disaSTIGmedium-service-auditd-enable
 auditd


### PR DESCRIPTION
## Summary

- Adds \`disaSTIGmedium\` feature skeleton: \`info.yaml\` (feature metadata, includes \`disaSTIGlow\`) and \`pkg.include\` (aide, aide-common, auditd)
- This is the foundation for the \`disaSTIGmedium\` feature — subsequent PRs add audit, SSH, PAM, and OS hardening on top of this scaffold

## Related PRs (part of the disaSTIGmedium feature split)

- **[PR 4771](https://github.com/gardenlinux/gardenlinux/pull/4771) (this)**: Feature scaffold — \`info.yaml\`, \`pkg.include\`
- **[PR 4772](https://github.com/gardenlinux/gardenlinux/pull/4772)**: Audit hardening — audit rules, kernel cmdline, exec.config audit section
- **[PR 4773](https://github.com/gardenlinux/gardenlinux/pull/4773)**: SSH hardening — sshd drop-in config, exec.config SSH section
- **[PR 4774](https://github.com/gardenlinux/gardenlinux/pull/4774)**: PAM hardening — pwquality, faillock, PAM stack
- **[PR 4775](https://github.com/gardenlinux/gardenlinux/pull/4775)**: OS hardening — sysctl, rsyslog, terminal timeout, filesystem permissions

## Fixes

Fixes gardenlinux/security#373
