### PR TITLE
feat(disaSTIGmedium): configure audit subsystem for DISA STIG CAT II compliance

### DIFF
--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -31,10 +31,3 @@ chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chown root:root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000278-GPOS-00108/
-# (managed via file.include/etc/aide/aide.conf)
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000363-GPOS-00150/
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000447-GPOS-00201/
-# (managed via file.include/etc/default/aide)

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+set -x
+
+# =============================================================================
+# Audit (CAT II)
+# =============================================================================
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000122-GPOS-00063/
+systemctl enable auditd.service
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
+chmod 0600 /var/log/audit
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
+chown root:root -R /var/log/audit
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
+sed -i '/^log_group/D' /etc/audit/auditd.conf
+sed -i /^log_file/a'log_group = root' /etc/audit/auditd.conf
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000059-GPOS-00029/
+chmod -R g-w,o-rwx /var/log/audit
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
+chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
+chown root:root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000278-GPOS-00108/
+cat <<AIDE_EOF > "/etc/aide/aide.conf"
+# Audit Tools
+/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
+AIDE_EOF
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000363-GPOS-00150/
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000447-GPOS-00201/
+echo 'SILENTREPORTS=no' > /etc/default/aide

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -11,6 +11,14 @@ set -x
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000122-GPOS-00063/
 systemctl enable auditd.service
 
+# GL-TESTCOV-disaSTIGmedium-service-aide-init-enable
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000445-GPOS-00199/
+systemctl enable aide-init.service
+
+# GL-TESTCOV-disaSTIGmedium-service-aide-check-timer-enable
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000445-GPOS-00199/
+systemctl enable aide-check.timer
+
 # GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
 chmod 0600 /var/log/audit

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -15,7 +15,6 @@ systemctl enable auditd.service
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
 chmod 0600 /var/log/audit
 
-# GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
 chown root:root -R /var/log/audit
 
@@ -24,7 +23,6 @@ chown root:root -R /var/log/audit
 sed -i '/^log_group/D' /etc/audit/auditd.conf
 sed -i /^log_file/a'log_group = root' /etc/audit/auditd.conf
 
-# GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000059-GPOS-00029/
 chmod -R g-w,o-rwx /var/log/audit
 

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -28,11 +28,9 @@ sed -i /^log_file/a'log_group = root' /etc/audit/auditd.conf
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000059-GPOS-00029/
 chmod -R g-w,o-rwx /var/log/audit
 
-# GL-TESTCOV-disaSTIGmedium-config-audit-rules-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 
-# GL-TESTCOV-disaSTIGmedium-config-audit-rules-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chown root:root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -32,20 +32,9 @@ chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chown root:root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 
-# GL-TESTCOV-disaSTIGmedium-config-aide-audit-tools
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000278-GPOS-00108/
-cat <<AIDE_EOF > "/etc/aide/aide.conf"
-# Audit Tools
-/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
-/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
-/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
-/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
-/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
-/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512
-/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
-AIDE_EOF
+# (managed via file.include/etc/aide/aide.conf)
 
-# GL-TESTCOV-disaSTIGmedium-config-aide-silent-reports
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000363-GPOS-00150/
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000447-GPOS-00201/
-echo 'SILENTREPORTS=no' > /etc/default/aide
+# (managed via file.include/etc/default/aide)

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -7,28 +7,36 @@ set -x
 # Audit (CAT II)
 # =============================================================================
 
+# GL-TESTCOV-disaSTIGmedium-service-auditd-enable
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000122-GPOS-00063/
 systemctl enable auditd.service
 
+# GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
 chmod 0600 /var/log/audit
 
+# GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
 chown root:root -R /var/log/audit
 
+# GL-TESTCOV-disaSTIGmedium-config-audit-auditd-conf
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000057-GPOS-00027/
 sed -i '/^log_group/D' /etc/audit/auditd.conf
 sed -i /^log_file/a'log_group = root' /etc/audit/auditd.conf
 
+# GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000059-GPOS-00029/
 chmod -R g-w,o-rwx /var/log/audit
 
+# GL-TESTCOV-disaSTIGmedium-config-audit-rules-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 
+# GL-TESTCOV-disaSTIGmedium-config-audit-rules-permissions
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chown root:root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 
+# GL-TESTCOV-disaSTIGmedium-config-aide-audit-tools
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000278-GPOS-00108/
 cat <<AIDE_EOF > "/etc/aide/aide.conf"
 # Audit Tools
@@ -41,6 +49,7 @@ cat <<AIDE_EOF > "/etc/aide/aide.conf"
 /sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
 AIDE_EOF
 
+# GL-TESTCOV-disaSTIGmedium-config-aide-silent-reports
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000363-GPOS-00150/
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000447-GPOS-00201/
 echo 'SILENTREPORTS=no' > /etc/default/aide

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -1,4 +1,6 @@
 markers:
+  "etc/aide/aide.conf":
+  - "GL-TESTCOV-disaSTIGmedium-config-aide-audit-tools"
   "etc/audit/rules.d/30-disaSTIG.rules":
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules"
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-30-disaSTIG-rules"
@@ -8,5 +10,7 @@ markers:
   - "GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit"
   "etc/sudoers.d/disaSTIG-sudo-log":
   - "GL-TESTCOV-disaSTIGmedium-config-sudoers-sudo-log"
+  "etc/default/aide":
+  - "GL-TESTCOV-disaSTIGmedium-config-aide-silent-reports"
   "etc/systemd/system/audit-rules.service.d/override.conf":
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -1,0 +1,6 @@
+markers:
+  "etc/audit/rules.d/30-disaSTIG.rules":
+  - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules"
+  - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-30-disaSTIG-rules"
+  "etc/kernel/cmdline.d/90-audit.cfg":
+  - "GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit"

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -2,5 +2,9 @@ markers:
   "etc/audit/rules.d/30-disaSTIG.rules":
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules"
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-30-disaSTIG-rules"
+  "etc/audit/rules.d/90-finalize.rules":
+  - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-90-finalize-rules"
   "etc/kernel/cmdline.d/90-audit.cfg":
   - "GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit"
+  "etc/systemd/system/audit-rules.service.d/override.conf":
+  - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -6,5 +6,7 @@ markers:
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-90-finalize-rules"
   "etc/kernel/cmdline.d/90-audit.cfg":
   - "GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit"
+  "etc/sudoers.d/disaSTIG-sudo-log":
+  - "GL-TESTCOV-disaSTIGmedium-config-sudoers-sudo-log"
   "etc/systemd/system/audit-rules.service.d/override.conf":
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"

--- a/features/disaSTIGmedium/file.include/etc/aide/aide.conf
+++ b/features/disaSTIGmedium/file.include/etc/aide/aide.conf
@@ -1,0 +1,8 @@
+# Audit Tools
+/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -1,0 +1,156 @@
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-ssh
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-ssh
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-w /var/log/tallylog -p wa -k logins
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-w /var/log/faillog -p wa -k logins
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-w /var/log/lastlog -p wa -k logins
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=-1 -k perm_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-passwd
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+# REMOVED (binary often missing in minimal OS)
+#-a always,exit -F path=/sbin/unix_update -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-unix-update
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=-1 -k module_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F arch=b64 -S init_module,finit_module -F auid>=1000 -F auid!=-1 -k module_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-pam_timestamp_check
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-crontab
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-usermod
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-chage
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-gpasswd
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
+-w /etc/passwd -p wa -k usergroup_modification
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
+-w /etc/group -p wa -k usergroup_modification
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000477-GPOS-00222/
+-w /usr/sbin/fdisk -p x -k fdisk
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
+-w /etc/shadow -p wa -k usergroup_modification
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
+-w /etc/gshadow -p wa -k usergroup_modification
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
+-w /etc/security/opasswd -p wa -k usergroup_modification
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000468-GPOS-00212/
+# Note: rmdir syscall does not exist on arm64; unlinkat covers directory removal
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=-1 -k delete
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000472-GPOS-00217/
+-w /var/run/utmp -p wa -k logins
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000472-GPOS-00217/
+-w /var/log/btmp -p wa -k logins
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000472-GPOS-00217/
+-w /var/log/wtmp -p wa -k logins
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000477-GPOS-00222/
+-w /sbin/modprobe -p x -k modules
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000477-GPOS-00222/
+-w /bin/kmod -p x -k modules
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-chfn
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-priv_change
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+# REMOVED: mount/umount binary-path rules covered by SAP 70-privileged-special.rules (mount/umount2 syscall audit)
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+# REMOVED: mount/umount binary-path rules covered by SAP 70-privileged-special.rules (mount/umount2 syscall audit)
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm_mod
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000326-GPOS-00126/
+# REMOVED: execve uid!=euid covered by SAP 70-privilege-escalation.rules (execve euid=0 audit)
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000392-GPOS-00172/
+-w /var/log/sudo.log -p wa -k maintenance
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+# Note: fchown/lchown do not exist as separate syscalls on arm64; covered by chown/fchownat
+-a always,exit -F arch=b64 -S chown,fchownat -F auid>=1000 -F auid!=-1 -k perm_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+# Note: fchmod does not exist as a separate syscall on arm64; covered by chmod/fchmodat
+-a always,exit -F arch=b64 -S chmod,fchmodat -F auid>=1000 -F auid!=-1 -k perm_chng
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+# Note: open and creat syscalls do not exist on arm64; use openat/openat2 instead
+-a always,exit -F arch=b64 -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm_access
+
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+
+# Ref: SRG-OS-000239-GPOS-00089
+-a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=-1 -k account_mod
+-w /usr/sbin/visudo -p x -k privileged-usermgmt
+-w /usr/sbin/chgpasswd -p x -k privileged-usermgmt
+-w /usr/sbin/chpasswd -p x -k privileged-usermgmt
+-w /usr/sbin/groupadd -p x -k privileged-usermgmt
+-w /usr/sbin/groupdel -p x -k privileged-usermgmt
+-w /usr/sbin/groupmod -p x -k privileged-usermgmt
+-w /usr/sbin/grpconv -p x -k privileged-usermgmt
+-w /usr/sbin/grpunconv -p x -k privileged-usermgmt
+-w /usr/sbin/newusers -p x -k privileged-usermgmt
+-w /usr/sbin/pwconv -p x -k privileged-usermgmt
+-w /usr/sbin/pwunconv -p x -k privileged-usermgmt
+-w /usr/sbin/shadowconfig -p x -k privileged-usermgmt
+-w /usr/sbin/useradd -p x -k privileged-usermgmt
+-w /usr/sbin/userdel -p x -k privileged-usermgmt
+-w /usr/sbin/vipw -p x -k privileged-usermgmt
+-w /usr/sbin/vigr -p x -k privileged-usermgmt
+
+# Ref: SRG-OS-000392-GPOS-00172
+-a always,exit -F arch=b64 -S execve,execveat -F auid>=1000 -F auid!=-1 -k exec

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -17,7 +17,7 @@
 -w /var/log/lastlog -p wa -k logins
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k newgrp
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
@@ -26,7 +26,7 @@
 -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=-1 -k passwd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -S delete_module -F auid>=1000 -F auid!=-1 -k kernel-module
@@ -41,31 +41,31 @@
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=-1 -k crontab
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-usermod
+-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=1000 -F auid!=-1 -k usermod
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-chage
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=-1 -k chage
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-gpasswd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=-1 -k gpasswd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
--w /etc/passwd -p wa -k usergroup_modification
+-w /etc/passwd -p wa -k usergroup-modification
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
--w /etc/group -p wa -k usergroup_modification
+-w /etc/group -p wa -k usergroup-modification
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000477-GPOS-00222/
 -w /usr/sbin/fdisk -p x -k fdisk
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
--w /etc/shadow -p wa -k usergroup_modification
+-w /etc/shadow -p wa -k usergroup-modification
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
--w /etc/gshadow -p wa -k usergroup_modification
+-w /etc/gshadow -p wa -k usergroup-modification
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
--w /etc/security/opasswd -p wa -k usergroup_modification
+-w /etc/security/opasswd -p wa -k usergroup-modification
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000468-GPOS-00212/
 # Note: rmdir syscall does not exist on arm64; unlinkat covers directory removal
@@ -107,10 +107,10 @@
 -a always,exit -S chmod,fchmodat -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k chsh
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k sudoedit
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: open and creat syscalls do not exist on arm64; use openat/openat2 instead
@@ -118,22 +118,22 @@
 -a always,exit -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm-access
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k sudo
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000239-GPOS-00089/
--w /usr/sbin/visudo -p x -k privileged-usermgmt
--w /usr/sbin/chgpasswd -p x -k privileged-usermgmt
--w /usr/sbin/chpasswd -p x -k privileged-usermgmt
--w /usr/sbin/groupadd -p x -k privileged-usermgmt
--w /usr/sbin/groupdel -p x -k privileged-usermgmt
--w /usr/sbin/groupmod -p x -k privileged-usermgmt
--w /usr/sbin/grpconv -p x -k privileged-usermgmt
--w /usr/sbin/grpunconv -p x -k privileged-usermgmt
--w /usr/sbin/newusers -p x -k privileged-usermgmt
--w /usr/sbin/pwconv -p x -k privileged-usermgmt
--w /usr/sbin/pwunconv -p x -k privileged-usermgmt
--w /usr/sbin/shadowconfig -p x -k privileged-usermgmt
--w /usr/sbin/useradd -p x -k privileged-usermgmt
--w /usr/sbin/userdel -p x -k privileged-usermgmt
--w /usr/sbin/vipw -p x -k privileged-usermgmt
--w /usr/sbin/vigr -p x -k privileged-usermgmt
+-w /usr/sbin/visudo -p x -k usermgmt
+-w /usr/sbin/chgpasswd -p x -k usermgmt
+-w /usr/sbin/chpasswd -p x -k usermgmt
+-w /usr/sbin/groupadd -p x -k usermgmt
+-w /usr/sbin/groupdel -p x -k usermgmt
+-w /usr/sbin/groupmod -p x -k usermgmt
+-w /usr/sbin/grpconv -p x -k usermgmt
+-w /usr/sbin/grpunconv -p x -k usermgmt
+-w /usr/sbin/newusers -p x -k usermgmt
+-w /usr/sbin/pwconv -p x -k usermgmt
+-w /usr/sbin/pwunconv -p x -k usermgmt
+-w /usr/sbin/shadowconfig -p x -k usermgmt
+-w /usr/sbin/useradd -p x -k usermgmt
+-w /usr/sbin/userdel -p x -k usermgmt
+-w /usr/sbin/vipw -p x -k usermgmt
+-w /usr/sbin/vigr -p x -k usermgmt

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -87,13 +87,13 @@
 -w /bin/kmod -p x -k modules
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k unprivileged-chfn
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k chfn
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=-1 -k priv-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm_mod
+-a always,exit -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm-mod
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000392-GPOS-00172/
 -w /var/log/sudo.log -p wa -k maintenance
@@ -114,8 +114,8 @@
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: open and creat syscalls do not exist on arm64; use openat/openat2 instead
--a always,exit -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k perm_access
--a always,exit -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm_access
+-a always,exit -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k perm-access
+-a always,exit -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm-access
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -1,8 +1,8 @@
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=-1 -k unprivileged-ssh
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=-1 -k ssh
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=-1 -k unprivileged-ssh
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=-1 -k ssh
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
@@ -29,16 +29,16 @@
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-passwd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -S delete_module -F auid>=1000 -F auid!=-1 -k module_chng
+-a always,exit -S delete_module -F auid>=1000 -F auid!=-1 -k kernel-module
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -S init_module,finit_module -F auid>=1000 -F auid!=-1 -k module_chng
+-a always,exit -S init_module,finit_module -F auid>=1000 -F auid!=-1 -k kernel-module
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-pam_timestamp_check
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=-1 -k pam-timestamp-check
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-crontab
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=-1 -k crontab
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-usermod

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -121,7 +121,6 @@
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000239-GPOS-00089/
--a always,exit -S execve -F auid>=1000 -F auid!=-1 -k account_mod
 -w /usr/sbin/visudo -p x -k privileged-usermgmt
 -w /usr/sbin/chgpasswd -p x -k privileged-usermgmt
 -w /usr/sbin/chpasswd -p x -k privileged-usermgmt
@@ -138,6 +137,3 @@
 -w /usr/sbin/userdel -p x -k privileged-usermgmt
 -w /usr/sbin/vipw -p x -k privileged-usermgmt
 -w /usr/sbin/vigr -p x -k privileged-usermgmt
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000392-GPOS-00172/
--a always,exit -S execve,execveat -F auid>=1000 -F auid!=-1 -k exec

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -1,11 +1,11 @@
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-ssh
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=-1 -k unprivileged-ssh
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-ssh
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=-1 -k unprivileged-ssh
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -w /var/log/tallylog -p wa -k logins
@@ -17,26 +17,22 @@
 -w /var/log/lastlog -p wa -k logins
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-passwd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
-# REMOVED (binary often missing in minimal OS)
-#-a always,exit -F path=/sbin/unix_update -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-unix-update
+-a always,exit -S delete_module -F auid>=1000 -F auid!=-1 -k module_chng
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=-1 -k module_chng
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F arch=b64 -S init_module,finit_module -F auid>=1000 -F auid!=-1 -k module_chng
+-a always,exit -S init_module,finit_module -F auid>=1000 -F auid!=-1 -k module_chng
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-pam_timestamp_check
@@ -73,7 +69,7 @@
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000468-GPOS-00212/
 # Note: rmdir syscall does not exist on arm64; unlinkat covers directory removal
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=-1 -k delete
+-a always,exit -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=-1 -k delete
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000472-GPOS-00217/
 -w /var/run/utmp -p wa -k logins
@@ -91,50 +87,41 @@
 -w /bin/kmod -p x -k modules
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-chfn
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k unprivileged-chfn
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-priv_change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
-# REMOVED: mount/umount binary-path rules covered by SAP 70-privileged-special.rules (mount/umount2 syscall audit)
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
-# REMOVED: mount/umount binary-path rules covered by SAP 70-privileged-special.rules (mount/umount2 syscall audit)
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm_mod
-
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000326-GPOS-00126/
-# REMOVED: execve uid!=euid covered by SAP 70-privilege-escalation.rules (execve euid=0 audit)
+-a always,exit -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm_mod
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000392-GPOS-00172/
 -w /var/log/sudo.log -p wa -k maintenance
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: fchown/lchown do not exist as separate syscalls on arm64; covered by chown/fchownat
--a always,exit -F arch=b64 -S chown,fchownat -F auid>=1000 -F auid!=-1 -k perm_chng
+-a always,exit -S chown,fchownat -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: fchmod does not exist as a separate syscall on arm64; covered by chmod/fchmodat
--a always,exit -F arch=b64 -S chmod,fchmodat -F auid>=1000 -F auid!=-1 -k perm_chng
+-a always,exit -S chmod,fchmodat -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: open and creat syscalls do not exist on arm64; use openat/openat2 instead
--a always,exit -F arch=b64 -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k perm_access
--a always,exit -F arch=b64 -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm_access
+-a always,exit -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k perm_access
+-a always,exit -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm_access
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k privileged-cmd
 
-# Ref: SRG-OS-000239-GPOS-00089
--a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=-1 -k account_mod
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000239-GPOS-00089/
+-a always,exit -S execve -F auid>=1000 -F auid!=-1 -k account_mod
 -w /usr/sbin/visudo -p x -k privileged-usermgmt
 -w /usr/sbin/chgpasswd -p x -k privileged-usermgmt
 -w /usr/sbin/chpasswd -p x -k privileged-usermgmt
@@ -152,5 +139,5 @@
 -w /usr/sbin/vipw -p x -k privileged-usermgmt
 -w /usr/sbin/vigr -p x -k privileged-usermgmt
 
-# Ref: SRG-OS-000392-GPOS-00172
--a always,exit -F arch=b64 -S execve,execveat -F auid>=1000 -F auid!=-1 -k exec
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000392-GPOS-00172/
+-a always,exit -S execve,execveat -F auid>=1000 -F auid!=-1 -k exec

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/30-disaSTIG.rules
@@ -17,7 +17,7 @@
 -w /var/log/lastlog -p wa -k logins
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k newgrp
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=-1 -k perm-change
@@ -44,10 +44,10 @@
 -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=1000 -F auid!=-1 -k usermod
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=-1 -k chage
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=-1 -k gpasswd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000004-GPOS-00004/
 -w /etc/passwd -p wa -k usergroup-modification
@@ -69,7 +69,7 @@
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000468-GPOS-00212/
 # Note: rmdir syscall does not exist on arm64; unlinkat covers directory removal
--a always,exit -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=-1 -k delete
+-a always,exit -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=-1 -k file-delete
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000472-GPOS-00217/
 -w /var/run/utmp -p wa -k logins
@@ -81,22 +81,22 @@
 -w /var/log/wtmp -p wa -k logins
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000477-GPOS-00222/
--w /sbin/modprobe -p x -k modules
+-w /sbin/modprobe -p x -k kernel-module
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000477-GPOS-00222/
--w /bin/kmod -p x -k modules
+-w /bin/kmod -p x -k kernel-module
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k chfn
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=-1 -k priv-change
+-a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=-1 -k perm-mod
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000392-GPOS-00172/
--w /var/log/sudo.log -p wa -k maintenance
+-w /var/log/sudo.log -p wa -k sudo
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: fchown/lchown do not exist as separate syscalls on arm64; covered by chown/fchownat
@@ -107,15 +107,15 @@
 -a always,exit -S chmod,fchmodat -F auid>=1000 -F auid!=-1 -k perm-change
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k chsh
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k sudoedit
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=-1 -k suid-binary
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 # Note: open and creat syscalls do not exist on arm64; use openat/openat2 instead
--a always,exit -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k perm-access
--a always,exit -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k perm-access
+-a always,exit -S openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k file-access
+-a always,exit -S openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k file-access
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000064-GPOS-00033/
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=-1 -k sudo

--- a/features/disaSTIGmedium/file.include/etc/audit/rules.d/90-finalize.rules
+++ b/features/disaSTIGmedium/file.include/etc/audit/rules.d/90-finalize.rules
@@ -1,0 +1,4 @@
+## Make the audit configuration immutable after all rules are loaded.
+## Changing rules will require a system reboot to take effect.
+## This satisfies STIG V-238298 / SRG-OS-000057-GPOS-00027.
+-e 2

--- a/features/disaSTIGmedium/file.include/etc/default/aide
+++ b/features/disaSTIGmedium/file.include/etc/default/aide
@@ -1,0 +1,1 @@
+SILENTREPORTS=no

--- a/features/disaSTIGmedium/file.include/etc/kernel/cmdline.d/90-audit.cfg
+++ b/features/disaSTIGmedium/file.include/etc/kernel/cmdline.d/90-audit.cfg
@@ -1,0 +1,2 @@
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000254-GPOS-00095/
+CMDLINE_LINUX="$CMDLINE_LINUX audit=1"

--- a/features/disaSTIGmedium/file.include/etc/sudoers.d/disaSTIG-sudo-log
+++ b/features/disaSTIGmedium/file.include/etc/sudoers.d/disaSTIG-sudo-log
@@ -1,0 +1,1 @@
+Defaults logfile=/var/log/sudo.log

--- a/features/disaSTIGmedium/file.include/etc/systemd/system/audit-rules.service.d/override.conf
+++ b/features/disaSTIGmedium/file.include/etc/systemd/system/audit-rules.service.d/override.conf
@@ -1,0 +1,10 @@
+[Service]
+ExecStart=
+ExecStart=/bin/sh -c '\
+    /sbin/augenrules --load; rc=$?; \
+    if [ $rc -ne 0 ]; then \
+        if /sbin/auditctl -s 2>/dev/null | grep -Eq "enabled[[:space:]]+2|locked[[:space:]]+2"; then \
+            exit 0; \
+        fi; \
+        exit $rc; \
+    fi'

--- a/features/stig/file.include.markers.yaml
+++ b/features/stig/file.include.markers.yaml
@@ -1,22 +1,8 @@
 markers:
-  "etc/apt/apt.conf.d/01-vendor-Ubuntu":
-  - "GL-TESTCOV-stig-config-apt-vendor-ubuntu"
-  "etc/audit/auditd.conf":
-  - "GL-TESTCOV-stig-config-audit-auditd-conf"
-  "etc/audit/rules.d/stig.rules":
-  - "GL-TESTCOV-stig-config-audit-rules-d-stig-rules"
-  "etc/kernel/cmdline.d/90-audit.cfg":
-  - "GL-TESTCOV-stig-config-kernel-cmdline-audit"
   "etc/modprobe.d/disabled_usb.conf":
   - "GL-TESTCOV-stig-config-modprobe-usb-disable"
   "etc/rsyslog.d/50-default.conf":
   - "GL-TESTCOV-stig-config-rsyslog-default"
-  "etc/security/faillock.conf":
-  - "GL-TESTCOV-stig-config-security-faillock"
-  "etc/security/limits.conf":
-  - "GL-TESTCOV-stig-config-security-limits"
-  "etc/security/pwquality.conf":
-  - "GL-TESTCOV-stig-config-security-pwquality"
   "etc/sysctl.d/99-stig.conf":
   - "GL-TESTCOV-stig-config-sysctl-stig"
   "usr/share/pam-configs/garden-stig":

--- a/tests/integration/security/compliance/test_disastig_00172.py
+++ b/tests/integration/security/compliance/test_disastig_00172.py
@@ -1,0 +1,21 @@
+import pytest
+from plugins.parse_file import ParseFile
+
+"""
+Ref: SRG-OS-000392-GPOS-00172
+
+Verify the operating system generates audit records for all activities
+performed during nonlocal maintenance and diagnostic sessions by
+configuring sudo to log to a dedicated file.
+"""
+
+SUDO_LOG_CONFIG = "/etc/sudoers.d/disaSTIG-sudo-log"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-sudo-log"])
+@pytest.mark.feature("disaSTIGmedium", reason="sudo log file required by DISA STIG")
+def test_sudo_logfile_configured(parse_file: ParseFile):
+    lines = parse_file.lines(SUDO_LOG_CONFIG)
+    assert (
+        "Defaults logfile=/var/log/sudo.log" in lines
+    ), "stigcompliance: sudo is not configured to log to /var/log/sudo.log"

--- a/tests/integration/security/compliance/test_stig.py
+++ b/tests/integration/security/compliance/test_stig.py
@@ -3,140 +3,6 @@ from plugins.file import File
 from plugins.kernel_module import KernelModule
 from plugins.parse_file import ParseFile
 
-# =============================================================================
-# stig Feature - Security Technical Implementation Guide
-# =============================================================================
-
-
-@pytest.mark.testcov(
-    [
-        "GL-TESTCOV-stig-config-audit-auditd-conf",
-        "GL-TESTCOV-stig-config-audit-rules-d-stig-rules",
-    ]
-)
-@pytest.mark.feature("stig")
-def test_stig_audit_configs_exist(file: File):
-    """Test that STIG audit configurations exist"""
-    configs = [
-        "/etc/audit/auditd.conf",
-        "/etc/audit/rules.d/stig.rules",
-    ]
-    missing = [cfg for cfg in configs if not file.is_regular_file(cfg)]
-    assert not missing, f"Missing STIG audit configs: {', '.join(missing)}"
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-audit-auditd-conf"])
-@pytest.mark.feature("stig")
-def test_stig_audit_auditd_conf_content(parse_file: ParseFile):
-    """Test that STIG audit auditd.conf content exists"""
-    lines = parse_file.lines("/etc/audit/auditd.conf")
-    assert (
-        "space_left_action email" in lines
-    ), "auditd.conf should contain the correct content"
-    assert (
-        "space_left 250000" in lines
-    ), "auditd.conf should contain the correct content"
-    assert (
-        "action_mail_acct root@localhost" in lines
-    ), "auditd.conf should contain the correct content"
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-audit-rules-d-stig-rules"])
-@pytest.mark.feature("stig")
-def test_stig_audit_rules_d_stig_rules_content(parse_file: ParseFile):
-    """Test that STIG audit rules.d/stig.rules content exists"""
-    lines = parse_file.lines("/etc/audit/rules.d/stig.rules")
-    assert lines == [
-        "-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh",
-        "-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh",
-        "-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-w /var/log/tallylog -p wa -k logins",
-        "-w /var/log/faillog -p wa -k logins",
-        "-w /var/log/lastlog -p wa -k logins",
-        "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-        "-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd",
-        "-a always,exit -F path=/sbin/unix_update -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-unix-update",
-        "-a always,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=4294967295 -k module_chng",
-        "-a always,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=4294967295 -k module_chng",
-        "-a always,exit -F arch=b32 -S init_module,finit_module -F auid>=1000 -F auid!=4294967295 -k module_chng",
-        "-a always,exit -F arch=b64 -S init_module,finit_module -F auid>=1000 -F auid!=4294967295 -k module_chng",
-        "-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam_timestamp_check",
-        "-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-crontab",
-        "-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-usermod",
-        "-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-chage",
-        "-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-gpasswd",
-        "-w /etc/passwd -p wa -k usergroup_modification",
-        "-w /etc/group -p wa -k usergroup_modification",
-        "-w /usr/sbin/fdisk -p x -k fdisk",
-        "-w /etc/shadow -p wa -k usergroup_modification",
-        "-w /etc/gshadow -p wa -k usergroup_modification",
-        "-w /etc/security/opasswd -p wa -k usergroup_modification",
-        "-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat,rmdir -F auid>=1000 -F auid!=4294967295 -k delete",
-        "-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat,rmdir -F auid>=1000 -F auid!=4294967295 -k delete",
-        "-w /var/run/utmp -p wa -k logins",
-        "-w /var/log/btmp -p wa -k logins",
-        "-w /var/log/wtmp -p wa -k logins",
-        "-w /sbin/modprobe -p x -k modules",
-        "-w /bin/kmod -p x -k modules",
-        "-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-chfn",
-        "-a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change",
-        "-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh",
-        "-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh",
-        "-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-umount",
-        "-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount",
-        "-a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod",
-        "-a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod",
-        "-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod",
-        "-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod",
-        "-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=execpriv",
-        "-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=execpriv",
-        "-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=execpriv",
-        "-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=execpriv",
-        "-w /var/log/sudo.log -p wa -k maintenance",
-        "-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-        "-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-        "-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-        "-w /var/log/sudo.log -p wa -k maintenance",
-        "-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_chng",
-        "-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-        "-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-        "-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k perm_access",
-        "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k priv_cmd",
-    ]
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-kernel-cmdline-audit"])
-@pytest.mark.feature("stig")
-def test_stig_kernel_cmdline_audit_exists(file: File):
-    """Test that STIG audit kernel cmdline config exists"""
-    assert file.is_regular_file("/etc/kernel/cmdline.d/90-audit.cfg")
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-kernel-cmdline-audit"])
-@pytest.mark.feature("stig")
-def test_stig_kernel_cmdline_audit_content(parse_file: ParseFile):
-    """Test that STIG audit kernel cmdline config content exists"""
-    lines = parse_file.lines("/etc/kernel/cmdline.d/90-audit.cfg")
-    assert (
-        "audit=1" in lines
-    ), "kernel cmdline audit configuration should contain the correct content"
-
 
 @pytest.mark.testcov(["GL-TESTCOV-stig-config-modprobe-usb-disable"])
 @pytest.mark.feature("stig")
@@ -161,71 +27,15 @@ def test_stig_modprobe_disable_modules_not_loaded(kernel_module: KernelModule):
         ), f"Module {module} is loaded but should be deny listed"
 
 
-@pytest.mark.testcov(
-    [
-        "GL-TESTCOV-stig-config-security-faillock",
-        "GL-TESTCOV-stig-config-security-limits",
-        "GL-TESTCOV-stig-config-security-pwquality",
-    ]
-)
-@pytest.mark.feature("stig")
-def test_stig_security_configs_exist(file: File):
-    """Test that STIG security configurations exist"""
-    configs = [
-        "/etc/security/faillock.conf",
-        "/etc/security/limits.conf",
-        "/etc/security/pwquality.conf",
-    ]
-    missing = [cfg for cfg in configs if not file.is_regular_file(cfg)]
-    assert not missing, f"Missing STIG security configs: {', '.join(missing)}"
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-security-faillock"])
-@pytest.mark.feature("stig")
-def test_stig_security_faillock_content(parse_file: ParseFile):
-    """Test that STIG security faillock configuration content exists"""
-    lines = parse_file.lines("/etc/security/faillock.conf")
-    assert "audit" in lines, "faillock configuration should contain the correct content"
-    assert (
-        "silent" in lines
-    ), "faillock configuration should contain the correct content"
-    assert (
-        "deny = 3" in lines
-    ), "faillock configuration should contain the correct content"
-    assert (
-        "fail_interval = 900" in lines
-    ), "faillock configuration should contain the correct content"
-    assert (
-        "unlock_time = 0" in lines
-    ), "faillock configuration should contain the correct content"
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-apt-vendor-ubuntu"])
-@pytest.mark.feature("stig")
-def test_stig_apt_vendor_ubuntu_exists(file: File):
-    """Test that STIG APT vendor config exists"""
-    assert file.exists("/etc/apt/apt.conf.d/01-vendor-ubuntu")
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-apt-vendor-ubuntu"])
-@pytest.mark.feature("stig")
-def test_stig_apt_vendor_ubuntu_content(parse_file: ParseFile):
-    """Test that STIG APT vendor config content exists"""
-    lines = parse_file.lines("/etc/apt/apt.conf.d/01-vendor-ubuntu")
-    assert (
-        'APT::Get::AllowUnauthenticated "false";' in lines
-    ), "APT vendor config should contain the correct content"
-
-
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-rsyslog-default"])
-@pytest.mark.feature("stig")
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-rsyslog-default"])
+@pytest.mark.feature("disaSTIGmedium")
 def test_stig_rsyslog_default_exists(file: File):
     """Test that STIG rsyslog default config exists"""
     assert file.is_regular_file("/etc/rsyslog.d/50-default.conf")
 
 
-@pytest.mark.testcov(["GL-TESTCOV-stig-config-rsyslog-default"])
-@pytest.mark.feature("stig")
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-rsyslog-default"])
+@pytest.mark.feature("disaSTIGmedium")
 def test_stig_rsyslog_default_content(parse_file: ParseFile):
     """Test that STIG rsyslog default config content exists"""
     lines = parse_file.lines("/etc/rsyslog.d/50-default.conf")


### PR DESCRIPTION
## Summary

- Adds audit rules (\`30-disaSTIG.rules\`) covering privileged command execution, user/group modifications, file deletions, login events, and module changes
- Adds \`90-finalize.rules\` to make audit configuration immutable (\`-e 2\`) after loading
- Adds kernel cmdline \`audit=1\` flag via \`90-audit.cfg\`
- Adds systemd \`audit-rules.service\` override to handle immutable ruleset gracefully (no failure if rules are locked)
- \`exec.config\` audit section: enables auditd, sets permissions on \`/var/log/audit\`, configures \`log_group=root\`, and sets up AIDE monitoring of audit tools

## Related PRs (part of the disaSTIGmedium feature split)

- **[PR 4771](https://github.com/gardenlinux/gardenlinux/pull/4771)**: Feature scaffold — \`info.yaml\`, \`pkg.include\`
- **[PR 4772](https://github.com/gardenlinux/gardenlinux/pull/4772) (this)**: Audit hardening — audit rules, kernel cmdline, exec.config audit section
- **[PR 4773](https://github.com/gardenlinux/gardenlinux/pull/4773)**: SSH hardening — sshd drop-in config, exec.config SSH section
- **[PR 4774](https://github.com/gardenlinux/gardenlinux/pull/4774)**: PAM hardening — pwquality, faillock, PAM stack
- **[PR 4775](https://github.com/gardenlinux/gardenlinux/pull/4775)**: OS hardening — sysctl, rsyslog, terminal timeout, filesystem permissions

## Fixes

Fixes gardenlinux/security#373
