### PR TITLE
feat(disaSTIGmedium): harden SSH daemon configuration for DISA STIG CAT II compliance

### DIFF
--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -39,3 +39,13 @@ chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
 
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000063-GPOS-00032/
 chown root:root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
+
+# =============================================================================
+# SSH Hardening (CAT II)
+# =============================================================================
+
+# GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-clientalivecountmax
+# V-238218: base sshd_config sets ClientAliveCountMax 0 before the Include directive,
+# so the drop-in cannot override it — patch the base file directly
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000126-GPOS-00066/
+sed -i 's/^ClientAliveCountMax.*/ClientAliveCountMax 1/' /etc/ssh/sshd_config

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -14,3 +14,5 @@ markers:
   - "GL-TESTCOV-disaSTIGmedium-config-aide-silent-reports"
   "etc/systemd/system/audit-rules.service.d/override.conf":
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"
+  "etc/ssh/sshd_config.d/50-disaSTIG.conf":
+  - "GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"

--- a/features/disaSTIGmedium/file.include/etc/ssh/sshd_config.d/50-disaSTIG.conf
+++ b/features/disaSTIGmedium/file.include/etc/ssh/sshd_config.d/50-disaSTIG.conf
@@ -1,0 +1,11 @@
+# DISA STIG CAT II (Medium) SSH hardening
+# These settings extend the base sshd_config with STIG-required values.
+
+# V-238217, V-238218: Approved ciphers only
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
+
+# V-238219: Approved MACs only
+MACs hmac-sha2-512,hmac-sha2-256
+
+# V-238220: Approved key exchange algorithms only
+KexAlgorithms diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp384,ecdh-sha2-nistp521


### PR DESCRIPTION
## Summary

- Adds \`/etc/ssh/sshd_config.d/50-disaSTIG.conf\` drop-in restricting Ciphers, MACs, and KexAlgorithms to STIG-approved values only
- \`exec.config\` patches \`ClientAliveCountMax 1\` directly in the base sshd_config — OpenSSH first-match semantics prevent the drop-in from overriding a directive already set before the \`Include\` directive

## Related PRs (part of the disaSTIGmedium feature split)

- **[PR 4771](https://github.com/gardenlinux/gardenlinux/pull/4771)**: Feature scaffold — \`info.yaml\`, \`pkg.include\`
- **[PR 4772](https://github.com/gardenlinux/gardenlinux/pull/4772)**: Audit hardening — audit rules, kernel cmdline, exec.config audit section
- **[PR 4773](https://github.com/gardenlinux/gardenlinux/pull/4773) (this)**: SSH hardening — sshd drop-in config, exec.config SSH section
- **[PR 4774](https://github.com/gardenlinux/gardenlinux/pull/4774)**: PAM hardening — pwquality, faillock, PAM stack
- **[PR 4775](https://github.com/gardenlinux/gardenlinux/pull/4775)**: OS hardening — sysctl, rsyslog, terminal timeout, filesystem permissions

## Fixes

Fixes gardenlinux/security#373
