### PR TITLE
feat(disaSTIGmedium): enforce PAM password quality and account lockout for DISA STIG CAT II

### DIFF
--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -16,3 +16,7 @@ markers:
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"
   "etc/ssh/sshd_config.d/50-disaSTIG.conf":
   - "GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"
+  "etc/security/pwquality.conf":
+  - "GL-TESTCOV-disaSTIGmedium-config-security-pwquality"
+  "usr/share/pam-configs/garden-disaSTIG":
+  - "GL-TESTCOV-disaSTIGmedium-config-pam-garden-disaSTIG"

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -16,6 +16,12 @@ markers:
   - "GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"
   "etc/ssh/sshd_config.d/50-disaSTIG.conf":
   - "GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"
+  "etc/pam.d/common-account":
+  - "GL-TESTCOV-disaSTIGmedium-config-pam-common-account"
+  "etc/pam.d/common-auth":
+  - "GL-TESTCOV-disaSTIGmedium-config-pam-common-auth"
+  "etc/pam.d/common-password":
+  - "GL-TESTCOV-disaSTIGmedium-config-pam-common-password"
   "etc/security/pwquality.conf":
   - "GL-TESTCOV-disaSTIGmedium-config-security-pwquality"
   "usr/share/pam-configs/garden-disaSTIG":

--- a/features/disaSTIGmedium/file.include/etc/pam.d/common-account
+++ b/features/disaSTIGmedium/file.include/etc/pam.d/common-account
@@ -1,0 +1,4 @@
+account required pam_faillock.so
+account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
+account	requisite			pam_deny.so
+account	required			pam_permit.so

--- a/features/disaSTIGmedium/file.include/etc/pam.d/common-auth
+++ b/features/disaSTIGmedium/file.include/etc/pam.d/common-auth
@@ -1,0 +1,4 @@
+auth required pam_faillock.so onerr=fail audit silent deny=3 unlock_time=900
+auth	[success=1 default=ignore]	pam_unix.so nullok
+auth	requisite			pam_deny.so
+auth	required			pam_permit.so

--- a/features/disaSTIGmedium/file.include/etc/pam.d/common-password
+++ b/features/disaSTIGmedium/file.include/etc/pam.d/common-password
@@ -1,0 +1,6 @@
+password    required        pam_passwdqc.so min=disabled,disabled,15,15,8 passphrase=4 match=7 similar=deny retry=5
+password    required        pam_pwhistory.so use_authtok remember=5 retry=5
+
+password    [success=1 default=ignore]      pam_unix.so obscure yescrypt
+password    requisite                       pam_deny.so
+password    required                        pam_permit.so

--- a/features/disaSTIGmedium/file.include/etc/security/pwquality.conf
+++ b/features/disaSTIGmedium/file.include/etc/security/pwquality.conf
@@ -1,0 +1,6 @@
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00225/
+dictcheck=1
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000078-GPOS-00046/
+minlen=15
+# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00225/
+enforcing = 1

--- a/features/disaSTIGmedium/file.include/usr/share/pam-configs/garden-disaSTIG
+++ b/features/disaSTIGmedium/file.include/usr/share/pam-configs/garden-disaSTIG
@@ -1,0 +1,13 @@
+Name: Garden Linux disaSTIG compliance
+Default: yes
+Priority: 1
+Auth-Type: Primary
+Auth:
+    required                            pam_faildelay.so delay=4000000
+Account-Type: Primary
+Account:
+    required                            pam_faillock.so
+Password:
+    [success=1 default=ignore]          pam_unix.so obscure sha512 shadow remember=5 rounds=5000
+Session:
+    required                            pam_lastlog.so showfailed

--- a/features/disaSTIGmedium/pkg.include
+++ b/features/disaSTIGmedium/pkg.include
@@ -1,4 +1,3 @@
 aide
 aide-common
-# GL-TESTCOV-disaSTIGmedium-service-auditd-enable
 auditd


### PR DESCRIPTION
## Summary

- Adds \`pwquality.conf\`: minimum password length 15, dictionary check enabled, enforcing mode
- Adds \`garden-disaSTIG\` pam-config: faillock account lockout, 4-second login delay, SHA512 password hashing with 5000 rounds, session lastlog
- PAM stack overrides: \`common-auth\` (faillock deny=3 unlock_time=900), \`common-account\` (faillock check), \`common-password\` (passwdqc complexity + pwhistory remember=5)

## Related PRs (part of the disaSTIGmedium feature split)

- **[PR 4771](https://github.com/gardenlinux/gardenlinux/pull/4771)**: Feature scaffold — \`info.yaml\`, \`pkg.include\`
- **[PR 4772](https://github.com/gardenlinux/gardenlinux/pull/4772)**: Audit hardening — audit rules, kernel cmdline, exec.config audit section
- **[PR 4773](https://github.com/gardenlinux/gardenlinux/pull/4773)**: SSH hardening — sshd drop-in config, exec.config SSH section
- **[PR 4774](https://github.com/gardenlinux/gardenlinux/pull/4774) (this)**: PAM hardening — pwquality, faillock, PAM stack
- **[PR 4775](https://github.com/gardenlinux/gardenlinux/pull/4775)**: OS hardening — sysctl, rsyslog, terminal timeout, filesystem permissions

## Fixes

Fixes gardenlinux/security#373
