### PR TITLE
re-enable inactivity-disabled (not intentional ones) workflows in package repos daily

### DIFF
--- a/.github/workflows/enable_disabled_workflows.yml
+++ b/.github/workflows/enable_disabled_workflows.yml
@@ -1,0 +1,64 @@
+name: Re-enable inactivity-disabled workflows in package repos
+
+on:
+  schedule:
+    - cron: '17 5 * * *'  # daily at 05:17 UTC
+  workflow_dispatch:        # allow manual trigger
+
+jobs:
+  enable-disabled-workflows:
+    name: Re-enable inactivity-disabled workflows
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Re-enable workflows disabled due to inactivity
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.WORKFLOW_ENABLE_PAT }}
+          script: |
+            let page = 1;
+            const repos = [];
+
+            // Collect all package-* repos in the gardenlinux org
+            while (true) {
+              const { data } = await github.rest.repos.listForOrg({
+                org: 'gardenlinux',
+                type: 'public',
+                per_page: 100,
+                page,
+              });
+              if (data.length === 0) break;
+              repos.push(...data.filter(r => r.name.startsWith('package-')));
+              page++;
+            }
+
+            core.info(`Found ${repos.length} package-* repos`);
+
+            let totalEnabled = 0;
+
+            for (const repo of repos) {
+              const { data: { workflows } } = await github.rest.actions.listRepoWorkflows({
+                owner: 'gardenlinux',
+                repo: repo.name,
+                per_page: 100,
+              });
+
+              const disabled = workflows.filter(w => w.state === 'disabled_inactivity');
+
+              for (const workflow of disabled) {
+                core.info(`Re-enabling ${repo.name} / ${workflow.name}`);
+                await github.rest.actions.enableWorkflow({
+                  owner: 'gardenlinux',
+                  repo: repo.name,
+                  workflow_id: workflow.id,
+                });
+                totalEnabled++;
+              }
+            }
+
+            if (totalEnabled === 0) {
+              core.info('No workflows were disabled due to inactivity — nothing to do.');
+            } else {
+              core.info(`Re-enabled ${totalEnabled} workflow(s) across package-* repos.`);
+            }

--- a/.github/workflows/enable_disabled_workflows.yml
+++ b/.github/workflows/enable_disabled_workflows.yml
@@ -2,8 +2,11 @@ name: Re-enable inactivity-disabled workflows in package repos
 
 on:
   schedule:
-    - cron: '0 1 * * *'  # daily at 01:00 UTC
-  workflow_dispatch:        # allow manual trigger
+    - cron: '0 1 * * *'  # Run daily at 01:00 UTC
+      timezone: "Europe/Berlin"
+
+  # triggered manually
+  workflow_dispatch:
     inputs:
       dry_run:
         description: 'Dry run — log what would be re-enabled without making changes'
@@ -18,14 +21,17 @@ jobs:
       actions: write
     steps:
       - name: Re-enable workflows disabled due to inactivity
+        # WORKFLOW_ENABLE_PAT must be a PAT with 'workflow' scope — required because
+        # github.token is scoped to this repo only and cannot write to package-* repos
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.WORKFLOW_ENABLE_PAT }}
           script: |
+            const dryRun = ${{ inputs.dry_run == 'true' }};
             let page = 1;
             const repos = [];
 
-            // Collect all package-* repos in the gardenlinux org
+            // Collect active (non-archived, non-disabled) package-* repos
             while (true) {
               const { data } = await github.rest.repos.listForOrg({
                 org: 'gardenlinux',
@@ -38,7 +44,7 @@ jobs:
               page++;
             }
 
-            core.info(`Found ${repos.length} package-* repos`);
+            core.info(`Found ${repos.length} active package-* repos`);
 
             let totalEnabled = 0;
 
@@ -49,10 +55,8 @@ jobs:
                 per_page: 100,
               });
 
-              const disabled = workflows.filter(w => w.state === 'disabled_inactivity');
-
-              for (const workflow of disabled) {
-                if (context.payload.inputs?.dry_run === 'true') {
+              for (const workflow of workflows.filter(w => w.state === 'disabled_inactivity')) {
+                if (dryRun) {
                   core.info(`[DRY RUN] Would re-enable ${repo.name} / ${workflow.name}`);
                 } else {
                   core.info(`Re-enabling ${repo.name} / ${workflow.name}`);
@@ -69,6 +73,5 @@ jobs:
             if (totalEnabled === 0) {
               core.info('No workflows were disabled due to inactivity — nothing to do.');
             } else {
-              const mode = context.payload.inputs?.dry_run === 'true' ? '[DRY RUN] Would have re-enabled' : 'Re-enabled';
-              core.info(`${mode} ${totalEnabled} workflow(s) across package-* repos.`);
+              core.info(`${dryRun ? '[DRY RUN] Would have re-enabled' : 'Re-enabled'} ${totalEnabled} workflow(s) across package-* repos.`);
             }

--- a/.github/workflows/enable_disabled_workflows.yml
+++ b/.github/workflows/enable_disabled_workflows.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 1 * * *'  # daily at 01:00 UTC
   workflow_dispatch:        # allow manual trigger
+    inputs:
+      dry_run:
+        description: 'Dry run — log what would be re-enabled without making changes'
+        default: 'false'
+        type: boolean
 
 jobs:
   enable-disabled-workflows:
@@ -29,7 +34,7 @@ jobs:
                 page,
               });
               if (data.length === 0) break;
-              repos.push(...data.filter(r => r.name.startsWith('package-')));
+              repos.push(...data.filter(r => r.name.startsWith('package-') && !r.archived && !r.disabled));
               page++;
             }
 
@@ -47,12 +52,16 @@ jobs:
               const disabled = workflows.filter(w => w.state === 'disabled_inactivity');
 
               for (const workflow of disabled) {
-                core.info(`Re-enabling ${repo.name} / ${workflow.name}`);
-                await github.rest.actions.enableWorkflow({
-                  owner: 'gardenlinux',
-                  repo: repo.name,
-                  workflow_id: workflow.id,
-                });
+                if (context.payload.inputs?.dry_run === 'true') {
+                  core.info(`[DRY RUN] Would re-enable ${repo.name} / ${workflow.name}`);
+                } else {
+                  core.info(`Re-enabling ${repo.name} / ${workflow.name}`);
+                  await github.rest.actions.enableWorkflow({
+                    owner: 'gardenlinux',
+                    repo: repo.name,
+                    workflow_id: workflow.id,
+                  });
+                }
                 totalEnabled++;
               }
             }
@@ -60,5 +69,6 @@ jobs:
             if (totalEnabled === 0) {
               core.info('No workflows were disabled due to inactivity — nothing to do.');
             } else {
-              core.info(`Re-enabled ${totalEnabled} workflow(s) across package-* repos.`);
+              const mode = context.payload.inputs?.dry_run === 'true' ? '[DRY RUN] Would have re-enabled' : 'Re-enabled';
+              core.info(`${mode} ${totalEnabled} workflow(s) across package-* repos.`);
             }

--- a/.github/workflows/enable_disabled_workflows.yml
+++ b/.github/workflows/enable_disabled_workflows.yml
@@ -2,7 +2,7 @@ name: Re-enable inactivity-disabled workflows in package repos
 
 on:
   schedule:
-    - cron: '17 5 * * *'  # daily at 05:17 UTC
+    - cron: '0 1 * * *'  # daily at 01:00 UTC
   workflow_dispatch:        # allow manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary

GitHub automatically disables scheduled workflows after 60 days of repository inactivity. This affects all \`gardenlinux/package-*\` repos which run a nightly \`build.yml\` — they gets disabled 

**Note**: This change does not touch **intentionally** disabled repos as below:

```bash
  package-libyang2
  package-docker-machine
  package-neofetch
  package-ostree
  package-syslinux
  package-tar
  package-fail2ban
  package-uid-wrapper
  package-usr-is-merged
  package-dropbear-static
```




