### PR TITLE
Update nightly.yml and add timezone

### DIFF
--- a/.github/workflows/build_lima_yaml_container.yml
+++ b/.github/workflows/build_lima_yaml_container.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
+      timzone: 'UTC'
+
 jobs:
   lima_manifest_container:
     name: Build Container for lima manifest generation

--- a/.github/workflows/build_lima_yaml_container.yml
+++ b/.github/workflows/build_lima_yaml_container.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
-      timzone: 'UTC'
+      timzone: 'Europe/Berlin'
 
 jobs:
   lima_manifest_container:

--- a/.github/workflows/cloud_test_cleanup.yml
+++ b/.github/workflows/cloud_test_cleanup.yml
@@ -2,6 +2,8 @@ name: Cloud Test Cleanup
 on:
   schedule:
     - cron: "0 2 * * *" # Run daily at 2 AM UTC
+      timezone: "UTC"
+
   # manual trigger
   workflow_dispatch:
 jobs:

--- a/.github/workflows/cloud_test_cleanup.yml
+++ b/.github/workflows/cloud_test_cleanup.yml
@@ -1,8 +1,8 @@
 name: Cloud Test Cleanup
 on:
   schedule:
-    - cron: "0 2 * * *" # Run daily at 2 AM UTC
-      timezone: "UTC"
+    - cron: "0 4 * * *" # Run daily at 4 AM
+      timezone: "Europe/Berlin"
 
   # manual trigger
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,7 @@ concurrency:
 on:
   schedule:
     - cron: '0 4 * * *'
+      timezone: "Europe/Berlin"
 jobs:
   build:
     name: Build

--- a/.github/workflows/test_update_python_runtime.yml
+++ b/.github/workflows/test_update_python_runtime.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Run at 12:00 noon CEST (10:00 UTC)
     - cron: "0 10 * * *"
+      timzone: "UTC"
 
 jobs:
   update:

--- a/.github/workflows/test_update_python_runtime.yml
+++ b/.github/workflows/test_update_python_runtime.yml
@@ -3,9 +3,9 @@ name: Test - Update Python Runtime
 on:
   workflow_dispatch:
   schedule:
-    # Run at 12:00 noon CEST (10:00 UTC)
-    - cron: "0 10 * * *"
-      timzone: "UTC"
+    # Run at 12:00 noon CEST
+    - cron: "0 12 * * *"
+      timzone: "Europe/Berlin"
 
 jobs:
   update:


### PR DESCRIPTION
**What this PR does / why we need it**:
The schedule works, but it rarely seems to finish before our daily. If we want to have time to investigate before the meeting, we need to start earlier and I believe it will be the least confusing if we add a timezone.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onschedule
