### PR TITLE
Update builder to include sbom creation.

### DIFF
--- a/build
+++ b/build
@@ -6,7 +6,7 @@ shopt -s nullglob
 exec 3>&1
 exec 1>&2
 
-container_image=ghcr.io/gardenlinux/builder:9d665fc86e72391a904f9646c849b43c0580d187
+container_image=ghcr.io/gardenlinux/builder:bd63099917c73e96e1285af793a14ac83617a147
 container_engine=podman
 target_dir=.build
 


### PR DESCRIPTION
On-behalf-of: SAP <b.ritter@sap.com>

**What this PR does / why we need it**:
Enables SBOM creation (CycloneDX) at image build time.

**Which issue(s) this PR fixes**:
Enables gardenlinux/glvd2#7 for all images created.

Updates the builder from to https://github.com/gardenlinux/builder/commit/bd63099917c73e96e1285af793a14ac83617a147.

The merge includes the changes since last update on November 6th, 2025: https://github.com/gardenlinux/builder/commits/main/?since=2025-11-07&until=2026-05-13

These include:
- Update of github actions/checkout to 6.0.2
- Update of github actions/upload-artifact to 6.0.0
- Update of github actions/download-artifact to 7.0.0
- Update of github redhat-plumbers-in-action/differential-shellcheck to 5.5.6
- https://github.com/gardenlinux/glvd/issues/189 (adds image.sourcemanifest)
- Documentation (Funding information and readme)
- One more verbose error message
- feat: dynamically solve all requirements.mod files (https://github.com/gardenlinux/builder/commit/17b7dc323189b17aa8293e7e049ee7f211b20809)