### PR TITLE
fix(tests): add testcov markers to audit log and lib tests

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00027.py
+++ b/tests/integration/security/compliance/test_disastig_00027.py
@@ -11,7 +11,8 @@ AUDIT_LOG_DIR = "/var/log/audit"
 AUDIT_LOG_FILE = "/var/log/audit/audit.log"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
 @pytest.mark.root(reason="required to inspect audit log permissions")
 def test_audit_log_directory_permissions_restricted(file):
@@ -21,7 +22,8 @@ def test_audit_log_directory_permissions_restricted(file):
         ), f"stigcompliance: audit log directory {AUDIT_LOG_DIR} permissions are not restricted"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
 @pytest.mark.root(reason="required to inspect audit log permissions")
 def test_audit_log_file_permissions_restricted(file):
@@ -31,7 +33,8 @@ def test_audit_log_file_permissions_restricted(file):
         ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} permissions are not restricted"
 
 
-@pytest.mark.feature("stig")
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
 @pytest.mark.root(reason="required to inspect audit log ownership")
 def test_audit_log_owned_by_root(file):

--- a/tests/integration/security/compliance/test_disastig_00100.py
+++ b/tests/integration/security/compliance/test_disastig_00100.py
@@ -53,6 +53,8 @@ def test_no_unsolicited_lib_path_for_ldconfig(ld_library_paths):
     assert not diff, f"unexpected shared libraries lookup paths configured: {diff}"
 
 
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-lib-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
 def test_lib_directories_are_only_root_writable(ld_library_paths, file):
     for lib_path in ld_library_paths:
         if file.exists(lib_path):
@@ -60,6 +62,8 @@ def test_lib_directories_are_only_root_writable(ld_library_paths, file):
             assert file.has_permissions(lib_path, "rwxr-xr-x")
 
 
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-lib-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
 def test_python_lib_directory_is_only_root_writable(file, dpkg):
     python_pkg = dpkg.collect_installed_packages().get_package("python3")
     if python_pkg:


### PR DESCRIPTION
## Summary
- `test_disastig_00027.py`: add `@pytest.mark.testcov` + `@pytest.mark.feature("disaSTIGmedium")` to 3 existing tests, covering `GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions` markers in PR #4772
- `test_disastig_00100.py`: add `@pytest.mark.testcov` + `@pytest.mark.feature("disaSTIGmedium")` to 2 existing lib tests, covering `GL-TESTCOV-disaSTIGmedium-config-lib-permissions` markers in PR #4775

No new test logic added — markers only.