### PR TITLE
tests: feat: return error code in coverage reporting

### DIFF
--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -70,7 +70,7 @@ jobs:
           python-version: "3.13"
 
       - name: Run coverage
-        run: make -f tests/dev.makefile coverage || true
+        run: make -f tests/dev.makefile coverage
 
       - name: Generate Coverage Report
         uses: gardenlinux/pytest-multi-results-action@8fc9cd734e3bfac0057ca43d70cd561b5f4d52bb

--- a/tests/util/coverage.py
+++ b/tests/util/coverage.py
@@ -860,6 +860,14 @@ def generate_junit_xml_report(
     """
     Generate a JUnit XML report compatible with pytest and CI/CD systems.
 
+    The report uses a single <testsuite> element (with a <properties> section
+    containing a Suite property) so that pytest-multi-results-action can parse
+    metadata correctly without triggering a metadata-parsing-error.
+
+    Test cases use classname to distinguish sections:
+    - coverage.features   — one testcase per feature (pass/skip/fail)
+    - coverage.validation — duplicate detection and orphaned ID checks
+
     Args:
         markers_by_feature: Dict mapping feature names to their markers
         found_markers: Set of markers found in test files
@@ -873,74 +881,52 @@ def generate_junit_xml_report(
     """
     stats = calculate_coverage_stats(markers_by_feature, found_markers)
 
-    # Create root testsuites element
-    testsuites = ET.Element("testsuites")
-    testsuites.set("name", "marker Coverage")
     timestamp = datetime.now().isoformat()
-    testsuites.set("timestamp", timestamp)
 
-    # Testsuite 1: Feature Coverage
-    total_tests = len(markers_by_feature) + len(
-        all_features - set(markers_by_feature.keys())
-    )
-    failures = len(stats["untested_by_feature"])
-    skipped = len(all_features - set(markers_by_feature.keys()))
+    # --- Collect all testcases ---
 
-    suite1 = ET.SubElement(testsuites, "testsuite")
-    suite1.set("name", "Feature Coverage")
-    suite1.set("tests", str(total_tests))
-    suite1.set("failures", str(failures))
-    suite1.set("errors", "0")
-    suite1.set("skipped", str(skipped))
-    suite1.set("timestamp", timestamp)
-
-    # Add test cases for each feature
+    # Section 1: Feature Coverage testcases
+    feature_testcases: List[ET.Element] = []
+    feature_failures = 0
+    feature_skipped = 0
     for feature in sorted(all_features):
-        testcase = ET.SubElement(suite1, "testcase")
-        testcase.set("name", feature)
-        testcase.set("classname", "coverage.features")
-
+        tc = ET.Element("testcase")
+        tc.set("name", feature)
+        tc.set("classname", "coverage.features")
         if feature not in markers_by_feature:
-            # Feature has no markers - skip
-            skipped_elem = ET.SubElement(testcase, "skipped")
+            skipped_elem = ET.SubElement(tc, "skipped")
             skipped_elem.set("message", "No markers defined")
+            feature_skipped += 1
         elif feature in stats["untested_by_feature"]:
-            # Feature has untested IDs - failure
             untested = stats["untested_by_feature"][feature]
-            failure = ET.SubElement(testcase, "failure")
+            failure = ET.SubElement(tc, "failure")
             failure.set("message", f"{len(untested)} untested marker(s)")
             failure.set("type", "UntestedSettingIDs")
             failure.text = "Untested IDs:\n" + "\n".join(
                 f"  - {sid}" for sid in untested
             )
+            feature_failures += 1
+        feature_testcases.append(tc)
 
-    # Testsuite 2: Duplicate Detection
-    dup_failures = len(within_feature_dupes) + (1 if across_feature_dupes else 0)
-    suite2 = ET.SubElement(testsuites, "testsuite")
-    suite2.set("name", "Duplicate Detection")
-    suite2.set("tests", "1")
-    suite2.set("failures", str(dup_failures))
-    suite2.set("errors", "0")
-    suite2.set("skipped", "0")
-    suite2.set("timestamp", timestamp)
-
-    # Test for within-feature duplicates
+    # Section 2: Duplicate Detection testcases
+    dup_testcases: List[ET.Element] = []
+    dup_failures = 0
     if within_feature_dupes:
         for feature, dupes in within_feature_dupes.items():
-            testcase = ET.SubElement(suite2, "testcase")
-            testcase.set("name", f"no_duplicate_ids_within_{feature}")
-            testcase.set("classname", "coverage.validation")
-            failure = ET.SubElement(testcase, "failure")
+            tc = ET.Element("testcase")
+            tc.set("name", f"no_duplicate_ids_within_{feature}")
+            tc.set("classname", "coverage.validation")
+            failure = ET.SubElement(tc, "failure")
             failure.set("message", f"{len(dupes)} duplicate marker(s) in {feature}")
             failure.set("type", "DuplicateSettingIDs")
             failure.text = "Duplicate IDs:\n" + "\n".join(f"  - {sid}" for sid in dupes)
-
-    # Test for across-feature duplicates
+            dup_failures += 1
+            dup_testcases.append(tc)
     if across_feature_dupes:
-        testcase = ET.SubElement(suite2, "testcase")
-        testcase.set("name", "no_duplicate_ids_across_features")
-        testcase.set("classname", "coverage.validation")
-        failure = ET.SubElement(testcase, "failure")
+        tc = ET.Element("testcase")
+        tc.set("name", "no_duplicate_ids_across_features")
+        tc.set("classname", "coverage.validation")
+        failure = ET.SubElement(tc, "failure")
         failure.set(
             "message",
             f"{len(across_feature_dupes)} marker(s) duplicated across features",
@@ -950,33 +936,57 @@ def generate_junit_xml_report(
         for sid, features in sorted(across_feature_dupes.items()):
             dup_details.append(f"  - {sid}: {', '.join(features)}")
         failure.text = "Duplicated across features:\n" + "\n".join(dup_details)
-
+        dup_failures += 1
+        dup_testcases.append(tc)
     if not within_feature_dupes and not across_feature_dupes:
-        testcase = ET.SubElement(suite2, "testcase")
-        testcase.set("name", "no_duplicate_markers")
-        testcase.set("classname", "coverage.validation")
+        tc = ET.Element("testcase")
+        tc.set("name", "no_duplicate_markers")
+        tc.set("classname", "coverage.validation")
+        dup_testcases.append(tc)
 
-    # Testsuite 3: Orphaned IDs Detection
+    # Section 3: Orphaned IDs testcase
     orphaned_count = len(stats["orphaned_ids"])
-    suite3 = ET.SubElement(testsuites, "testsuite")
-    suite3.set("name", "Orphaned IDs Detection")
-    suite3.set("tests", "1")
-    suite3.set("failures", "1" if orphaned_count > 0 else "0")
-    suite3.set("errors", "0")
-    suite3.set("skipped", "0")
-    suite3.set("timestamp", timestamp)
-
-    testcase = ET.SubElement(suite3, "testcase")
-    testcase.set("name", "no_orphaned_markers")
-    testcase.set("classname", "coverage.validation")
-
+    orphaned_tc = ET.Element("testcase")
+    orphaned_tc.set("name", "no_orphaned_markers")
+    orphaned_tc.set("classname", "coverage.validation")
+    orphaned_failures = 0
     if orphaned_count > 0:
-        failure = ET.SubElement(testcase, "failure")
+        failure = ET.SubElement(orphaned_tc, "failure")
         failure.set("message", f"{orphaned_count} orphaned marker(s)")
         failure.set("type", "OrphanedSettingIDs")
         failure.text = "IDs in tests but not in features:\n" + "\n".join(
             f"  - {sid}" for sid in sorted(stats["orphaned_ids"])
         )
+        orphaned_failures = 1
+
+    all_testcases = feature_testcases + dup_testcases + [orphaned_tc]
+    total_tests = len(all_testcases)
+    total_failures = feature_failures + dup_failures + orphaned_failures
+
+    # --- Build XML tree ---
+
+    testsuites = ET.Element("testsuites")
+    testsuites.set("name", "marker Coverage")
+    testsuites.set("timestamp", timestamp)
+
+    # Single testsuite with <properties> so pytest-multi-results-action can
+    # extract metadata without triggering a metadata-parsing-error.
+    suite = ET.SubElement(testsuites, "testsuite")
+    suite.set("name", "Coverage Report")
+    suite.set("tests", str(total_tests))
+    suite.set("failures", str(total_failures))
+    suite.set("errors", "0")
+    suite.set("skipped", str(feature_skipped))
+    suite.set("time", "0.0")
+    suite.set("timestamp", timestamp)
+
+    properties = ET.SubElement(suite, "properties")
+    prop = ET.SubElement(properties, "property")
+    prop.set("name", "Suite")
+    prop.set("value", "Coverage Report")
+
+    for tc in all_testcases:
+        suite.append(tc)
 
     # Write to file if specified
     if output_file:

--- a/tests/util/tests/test_coverage.py
+++ b/tests/util/tests/test_coverage.py
@@ -625,7 +625,7 @@ class TestJunitXmlReport:
     """Tests for generate_junit_xml_report function."""
 
     def test_xml_structure_is_valid(self):
-        """Should generate valid XML structure."""
+        """Should generate valid XML with a single testsuite and properties."""
         markers_by_feature = {"feature1": ["GL-TESTCOV-001"]}
         found_markers = {"GL-TESTCOV-001"}
         all_features = {"feature1"}
@@ -638,8 +638,21 @@ class TestJunitXmlReport:
         assert xml_root.get("name") == "marker Coverage"
         assert xml_root.get("timestamp") is not None
 
-    def test_includes_all_test_suites(self):
-        """Should include Feature Coverage, Duplicate Detection, and Orphaned IDs suites."""
+        # Should have exactly one testsuite
+        suites = list(xml_root)
+        assert len(suites) == 1
+        suite = suites[0]
+        assert suite.get("name") == "Coverage Report"
+        assert suite.get("time") == "0.0"
+
+        # Should have a <properties> element with Suite property
+        props_elem = suite.find("properties")
+        assert props_elem is not None
+        prop_list = props_elem.findall("property")
+        assert any(p.get("name") == "Suite" for p in prop_list)
+
+    def test_includes_all_sections_as_testcases(self):
+        """Should include feature, duplicate, and orphan testcases in single suite."""
         markers_by_feature = {"feature1": ["GL-TESTCOV-001"]}
         found_markers = {"GL-TESTCOV-001"}
         all_features = {"feature1"}
@@ -648,14 +661,21 @@ class TestJunitXmlReport:
             markers_by_feature, found_markers, all_features, {}, {}
         )
 
-        suites = list(xml_root)
-        assert len(suites) == 3
-        assert suites[0].get("name") == "Feature Coverage"
-        assert suites[1].get("name") == "Duplicate Detection"
-        assert suites[2].get("name") == "Orphaned IDs Detection"
+        suite = list(xml_root)[0]
+        testcases = suite.findall("testcase")
+
+        # Should have feature testcase(s) + no_duplicate_markers + no_orphaned_markers
+        classnames = [tc.get("classname") for tc in testcases]
+        assert "coverage.features" in classnames
+        assert "coverage.validation" in classnames
+
+        names = [tc.get("name") for tc in testcases]
+        assert "feature1" in names
+        assert "no_duplicate_markers" in names
+        assert "no_orphaned_markers" in names
 
     def test_handles_failures_correctly(self):
-        """Should mark failures for untested and duplicate IDs."""
+        """Should mark failures for untested markers in the single suite."""
         markers_by_feature = {"feature1": ["GL-TESTCOV-001", "GL-TESTCOV-002"]}
         found_markers = {"GL-TESTCOV-001"}  # GL-TESTCOV-002 is untested
         all_features = {"feature1"}
@@ -664,12 +684,17 @@ class TestJunitXmlReport:
             markers_by_feature, found_markers, all_features, {}, {}
         )
 
-        # Check Feature Coverage suite has failures
-        feature_suite = list(xml_root)[0]
-        assert int(feature_suite.get("failures", "0")) > 0
+        suite = list(xml_root)[0]
+        assert int(suite.get("failures", "0")) > 0
+
+        # The feature1 testcase should have a failure element
+        feature_tc = next(
+            tc for tc in suite.findall("testcase") if tc.get("name") == "feature1"
+        )
+        assert feature_tc.find("failure") is not None
 
     def test_reports_duplicates_in_xml(self):
-        """Should include duplicate detection failures in XML."""
+        """Should include duplicate detection failure testcase in XML."""
         markers_by_feature = {"feature1": ["GL-TESTCOV-001"]}
         found_markers = set()
         all_features = {"feature1"}
@@ -684,11 +709,18 @@ class TestJunitXmlReport:
             across_dupes,
         )
 
-        dup_suite = list(xml_root)[1]
-        assert int(dup_suite.get("failures", "0")) > 0
+        suite = list(xml_root)[0]
+        assert int(suite.get("failures", "0")) > 0
+
+        dup_tc = next(
+            tc
+            for tc in suite.findall("testcase")
+            if tc.get("name") == "no_duplicate_ids_within_feature1"
+        )
+        assert dup_tc.find("failure") is not None
 
     def test_reports_orphaned_ids(self):
-        """Should report orphaned IDs as failures."""
+        """Should report orphaned IDs as a failure testcase."""
         markers_by_feature = {"feature1": ["GL-TESTCOV-001"]}
         found_markers = {"GL-TESTCOV-001", "GL-TESTCOV-999"}  # 999 is orphaned
         all_features = {"feature1"}
@@ -697,8 +729,14 @@ class TestJunitXmlReport:
             markers_by_feature, found_markers, all_features, {}, {}
         )
 
-        orphaned_suite = list(xml_root)[2]
-        assert int(orphaned_suite.get("failures", "0")) == 1
+        suite = list(xml_root)[0]
+
+        orphaned_tc = next(
+            tc
+            for tc in suite.findall("testcase")
+            if tc.get("name") == "no_orphaned_markers"
+        )
+        assert orphaned_tc.find("failure") is not None
 
     @patch("pathlib.Path.mkdir")
     @patch("xml.etree.ElementTree.ElementTree.write")


### PR DESCRIPTION
**What this PR does / why we need it**:

- [tests: return error code in coverage reporting](https://github.com/gardenlinux/gardenlinux/commit/b3b3f206d31096966e9d7399a44ab94c359e493c)
  - In https://github.com/gardenlinux/gardenlinux/issues/4820 some untested/orphaned test markers slipped through.
- [tests: fix: coverage report returns single <testsuite>](https://github.com/gardenlinux/gardenlinux/commit/59c41bd4111ca9bac35a76c67b167567711594ab)
  - fix "Metadata could not be parsed from XML file" error that is related to multiple `<testsuite>` XML elements

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4820

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Notes for reviewers:**

The tests will fail until https://github.com/gardenlinux/gardenlinux/issues/4820 is resolved. This can be merged only after this is solved. After the merge, we can set the `Coverage` job as __Required__ to block PRs.

<img width="712" height="761" alt="image" src="https://github.com/user-attachments/assets/843893e4-0852-479e-b5e2-8b9197ad5fdc" />
