### PR TITLE
Fix the short sha commit when ./build lima locally

### DIFF
--- a/features/lima/exec.config
+++ b/features/lima/exec.config
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-cat << EOF > /builder/.build/"$BUILDER_CNAME"-"$BUILDER_COMMIT".lima.yaml
+SHORT_COMMIT="${BUILDER_COMMIT:0:8}"
+
+cat << EOF > /builder/.build/"$BUILDER_CNAME"-"$SHORT_COMMIT".lima.yaml
 os: Linux
 images:
-  - location: ./$BUILDER_CNAME-$BUILDER_COMMIT.qcow2
+  - location: ./$BUILDER_CNAME-$SHORT_COMMIT.qcow2
 
 containerd:
   system: false
@@ -17,6 +19,3 @@ mounts:
     writable: false
 mountTypesUnsupported: [9p]
 EOF
-
-
-


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the image output string in`.build/lima-<ARCH>-<COMMIT-SHA>.yaml` and its image name in this lima yaml.

for instance:
From 
`.build/lima-arm64-today-bf20885a7ae48efd51192b9955bc829f6a6f9fa3.lima.yaml` to 
`.build/lima-arm64-today-bf20885a.lima.yaml`

And the image.location from 
```
images:
  - location: ./lima-arm64-today-bf20885a7ae48efd51192b9955bc829f6a6f9fa3.qcow2
```
to 
```
images:
  - location: ./lima-arm64-today-bf20885a.qcow2
```

**Which issue(s) this PR fixes**:
Fixes #

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [ ] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
category: bugfix
target_group: user|operator|developer
```
