### PR TITLE
Add idna package to the venv to be excluded from sysdiff tests

### DIFF
--- a/features/pythonDev/exec.config
+++ b/features/pythonDev/exec.config
@@ -9,7 +9,7 @@ python3 -m venv venv
 
 # shellcheck source=/dev/null
 source venv/bin/activate
-pip install pyelftools
+pip install pyelftools idna
 deactivate
 
 cd ..


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR is needed to allow the nightly to finish again without errors, the sysdiff test was failing related to the idna python package

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4868