### PR TITLE
Fix/try to fix pip fixture to clean up dependencies

### DIFF
--- a/tests/handlers/pip.py
+++ b/tests/handlers/pip.py
@@ -12,6 +12,7 @@ def pip_requests(shell: ShellRunner):
         capture_output=True,
     )
     package_dir = out.stdout.strip("\n")
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_before_install")
 
     restore_backup = False
     if os.path.isdir(package_dir):
@@ -23,9 +24,13 @@ def pip_requests(shell: ShellRunner):
     os.mkdir(package_dir)
 
     shell("/bin/pip3 install requests --break-system-packages --no-cache-dir")
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_after_install")
 
     yield package_dir
-
+    
+    shell("for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall $dep"; done 
+ done")
+    shell("rm /tmp/pip_freeze_before_install /tmp/pip_freeze_after_install")
     shutil.rmtree(package_dir)
     if restore_backup:
         shutil.move(package_dir + ".backup", package_dir)

--- a/tests/handlers/pip.py
+++ b/tests/handlers/pip.py
@@ -21,12 +21,16 @@ def pip_requests(shell: ShellRunner):
 
     os.mkdir(package_dir)
 
-    shell("/bin/pip3 install --break-system-packages --no-cache-dir --root-user-action=ignore requests")
+    shell(
+        "/bin/pip3 install --break-system-packages --no-cache-dir --root-user-action=ignore requests"
+    )
     shell("/bin/pip3 freeze >> /tmp/pip_freeze_after_install")
 
     yield package_dir
-    
-    shell("for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall -y --break-system-packages $dep; done")
+
+    shell(
+        "for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall -y --break-system-packages $dep; done"
+    )
     shell("rm /tmp/pip_freeze_before_install /tmp/pip_freeze_after_install")
     shutil.rmtree(package_dir)
     if restore_backup:

--- a/tests/handlers/pip.py
+++ b/tests/handlers/pip.py
@@ -19,21 +19,15 @@ def pip_requests(shell: ShellRunner):
         restore_backup = True
         shutil.move(package_dir, package_dir + ".backup")
 
-    delete_normalizer = not os.path.isfile("/usr/local/bin/normalizer")
-
     os.mkdir(package_dir)
 
-    shell("/bin/pip3 install requests --break-system-packages --no-cache-dir")
+    shell("/bin/pip3 install --break-system-packages --no-cache-dir --root-user-action=ignore requests")
     shell("/bin/pip3 freeze >> /tmp/pip_freeze_after_install")
 
     yield package_dir
     
-    shell("for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall $dep"; done 
- done")
+    shell("for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall -y --break-system-packages $dep; done")
     shell("rm /tmp/pip_freeze_before_install /tmp/pip_freeze_after_install")
     shutil.rmtree(package_dir)
     if restore_backup:
         shutil.move(package_dir + ".backup", package_dir)
-
-    if delete_normalizer:
-        os.remove("/usr/local/bin/normalizer")


### PR DESCRIPTION
**What this PR does / why we need it**:
Nightly is broken due to sysdiff test failure

the test failed because since recently the idna package, a dependency of requests, places the file idna venv/bin/idna OR if no venv is used in /usr/local/bin/idna . While the fixture backs the python package dir and up and restores it, it does not carefully deinstall packages that were installed as dependencies for requests but removes the package dir. This didn't work in that case as the binary was places outside of the package dir. This change implements a more proper cleanup.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4868

