### PR TITLE
Remove IDNA from the pythonDev image again

### DIFF
--- a/features/pythonDev/exec.config
+++ b/features/pythonDev/exec.config
@@ -9,7 +9,7 @@ python3 -m venv venv
 
 # shellcheck source=/dev/null
 source venv/bin/activate
-pip install pyelftools idna
+pip install pyelftools
 deactivate
 
 cd ..


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the explicitly installed idna package again to hopefully make the pythonDev test pass

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4868
