### PR TITLE
fix: update google-guest-agent service name to google-guest-agent-manager

### DIFF
--- a/tests/integration/core/test_services.py
+++ b/tests/integration/core/test_services.py
@@ -351,19 +351,19 @@ def test_firewall_nftables_service_active(systemd: Systemd):
 @pytest.mark.feature("gcp")
 @pytest.mark.booted(reason="Requires systemd")
 def test_gcp_google_guest_agent_service_enabled(systemd: Systemd):
-    """Test that google-guest-agent.service is enabled"""
-    assert systemd.is_enabled("google-guest-agent.service")
+    """Test that google-guest-agent-manager.service is enabled"""
+    assert systemd.is_enabled("google-guest-agent-manager.service")
 
 
 @pytest.mark.testcov(["GL-TESTCOV-gcp-service-google-guest-agent-enable"])
 @pytest.mark.feature("gcp")
 @pytest.mark.booted(reason="Requires systemd")
 @pytest.mark.hypervisor(
-    "not qemu", reason="google-guest-agent.service crashes if run in qemu"
+    "not qemu", reason="google-guest-agent-manager.service crashes if run in qemu"
 )
 def test_gcp_google_guest_agent_service_active(systemd: Systemd):
-    """Test that google-guest-agent.service is active"""
-    assert systemd.is_active("google-guest-agent.service")
+    """Test that google-guest-agent-manager.service is active"""
+    assert systemd.is_active("google-guest-agent-manager.service")
 
 
 @pytest.mark.testcov(["GL-TESTCOV-gcp-service-no-irqbalance"])


### PR DESCRIPTION
**What this PR does / why we need it**:
Nightly is broken after `google-guest-agent` was updated — the service was renamed from `google-guest-agent.service` to `google-guest-agent-manager.service`. Updates the test to use the new service name.

**Which issue(s) this PR fixes**:
Fixes #4879 #4884