### PR TITLE
fix: manually enable google-guest-agent in exec.config

### DIFF
--- a/features/gcp/exec.config
+++ b/features/gcp/exec.config
@@ -19,3 +19,6 @@ EOF
 
 # GL-TESTCOV-gcp-service-google-guest-agent-manager-mask
 systemctl mask google-guest-agent-manager.service
+
+# GL-TESTCOV-gcp-service-google-guest-agent-enable
+systemctl enable google-guest-agent.service

--- a/features/gcp/pkg.include
+++ b/features/gcp/pkg.include
@@ -2,6 +2,5 @@
 # cloud-init
 google-compute-engine-oslogin
 google-compute-engine
-# GL-TESTCOV-gcp-service-google-guest-agent-enable
 google-guest-agent
 nvme-cli


### PR DESCRIPTION
Fixes nightly by manually enabling `google-guest-agent.service` which no longer is enabled in the presets of the `google-guest-agent` package.

> [!NOTE]
> This is a temporary solution to fix the nightly until we further investigate the split of google-guest-agent into a manager and plugin architecture. Long term we should probably adopt the new variant and not stick on the now outdated `google-guest-agent.service`[^1]

[^1]: https://docs.cloud.google.com/compute/docs/images/guest-agent#backward-compatibility