### PR TITLE
fix(azure): cloud-init - Skip growpart, resize, and ntp step

### DIFF
--- a/features/azure/exec.config
+++ b/features/azure/exec.config
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# GL-TESTCOV-azure-config-cloud-no-growpart
+# GL-TESTCOV-azure-config-cloud-no-resizefs
+# GL-TESTCOV-azure-config-cloud-no-ntp
+# growpart is done in initramfs, growroot by systemd
+mv /etc/cloud/cloud.cfg /etc/cloud/cloud.cfg.bak
+cat /etc/cloud/cloud.cfg.bak | grep -v "^ - growpart$" | grep -v "^ - resizefs$" | grep -v "^ - ntp$" >/etc/cloud/cloud.cfg
+rm /etc/cloud/cloud.cfg.bak
+
 # GL-TESTCOV-azure-config-cloud-network-config-disable
 # disable cloud-init network configuration
-echo -e "network:\n  config: disabled\n" >>/etc/cloud/cloud.cfg.d/00_azure.cfg
+echo -e "network:\n  config: disabled\n" >> /etc/cloud/cloud.cfg.d/00_azure.cfg


### PR DESCRIPTION
**What this PR does / why we need it**:
Caused issues with a failing test while building `2150.4.0`.

See: https://github.com/gardenlinux/gardenlinux/actions/runs/26457379685/attempts/1

**Which issue(s) this PR fixes**:
Fixes #4890

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)