### PR TITLE
fix(azure): disable cloud-init growpart/resizefs via drop-in config

### DIFF
--- a/features/azure/file.include/etc/cloud/cloud.cfg.d/02_azure_disable_resize.cfg
+++ b/features/azure/file.include/etc/cloud/cloud.cfg.d/02_azure_disable_resize.cfg
@@ -1,0 +1,8 @@
+## Azure: disable growpart and resizefs
+# Disk growth is handled by initramfs (growroot) before cloud-init runs.
+# Disabling these avoids a spurious resize2fs failure when the partition
+# is already at its target size, which would otherwise cause
+# cloud-init-main.service to exit with status 1.
+growpart:
+  mode: off
+resize_rootfs: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Alternative to #4891 using the proper cloud-init drop-in mechanism instead of grepping/modifying the base `cloud.cfg`.

On Azure, disk growth is handled by initramfs (`growroot`) before cloud-init runs. When the partition is already at its target size, `resize2fs /dev/sda3` fails and `cloud-init-main.service` exits with status 1, causing `test_no_failed_units` to fail.

**Why this approach is better than #4891:**
- Uses cloud-init's supported configuration keys (`resize_rootfs: false`, `growpart: mode: off`) in a drop-in file under `cloud.cfg.d/`
- Does not grep/modify the base `cloud.cfg` — robust against upstream package reformatting or indentation changes
- Minimal: only touches the two modules that caused the failure (no ntp change, which was not failing)

**Which issue(s) this PR fixes**:
Fixes #4890

See failing run: https://github.com/gardenlinux/gardenlinux/actions/runs/26457379685/attempts/1

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [ ] The code is appropriately tested (CI run on rel-2150 will verify)
- [x] Checked if the code needs to be backported to release branches of maintained versions