### PR TITLE
fix: don't use hvf on macOS

### DIFF
--- a/tests/util/run_qemu.sh
+++ b/tests/util/run_qemu.sh
@@ -250,10 +250,6 @@ qemu_accel=tcg
 if [ "$arch" = "$native_arch" ]; then
 	if [ -w /dev/kvm ]; then
 		qemu_accel=kvm
-	elif [ "$(uname -s)" = Darwin ]; then
-		if [ "$(sysctl -n kern.hv_support)" = 1 ]; then
-			qemu_accel=hvf
-		fi
 	fi
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Using HVF does not correctly work in the test framework. With `qemu_cpu=cortex-a57` it runs into the error reported in the linked issue, with `qemu_cpu=host` the VM does come up, but the tests get stuck on

```
⚙️  Qemu environment quirks...
```

So for now it appears the best cause of action is to disable HVF and use emulation instead so that while slower it at least runs on macOS.

**Which issue(s) this PR fixes**:
Fixes #4894 
