### PR TITLE
feat: add ci for docs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,12 +7,24 @@ on:
     branches:
       - main
     paths-ignore:
-      - "docs/**"
-      - "**/README.md"
+      - ".gitignore"
+      - ".github/docs*.yml"
+      - 'docs/**'
+      - 'features/*/README.md'
+      - 'features/*/info.yaml'
+      - 'flavors.yaml'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
   pull_request:
     paths-ignore:
+      - ".gitignore"
+      - ".github/docs*.yml"
       - 'docs/**'
-      - '**/README.md'
+      - 'features/*/README.md'
+      - 'features/*/info.yaml'
+      - 'flavors.yaml'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
 jobs:
   set_version:
     name: Set VERSION

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
       - 'features/*/README.md'
       - 'features/*/info.yaml'
-      - 'flavors.yaml'
       - 'CONTRIBUTING.md'
       - 'SECURITY.md'
   pull_request:
@@ -22,7 +21,6 @@ on:
       - 'docs/**'
       - 'features/*/README.md'
       - 'features/*/info.yaml'
-      - 'flavors.yaml'
       - 'CONTRIBUTING.md'
       - 'SECURITY.md'
 jobs:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,149 +21,42 @@ on:
       - 'SECURITY.md'
 
 jobs:
-  aggregate:
-    name: Aggregate documentation
+  docs-checks:
+    uses: gardenlinux/docs-ng/.github/workflows/docs-checks.yml@main
+    with:
+      override-repo: gardenlinux
+      override-ref: ${{ github.head_ref || github.ref_name }}
+      override-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+
+  notify-docs-ng:
+    name: Notify docs-ng
+    needs: [docs-checks]
     runs-on: ubuntu-24.04
+    if: success()
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          version: "10.28.0"
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+          repositories: docs-ng
 
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - name: Send repository dispatch to docs-ng
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          node-version: "22"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6.2.0
-        with:
-          python-version: "3.13"
-
-      - name: Aggregate docs
-        run: make -C docs aggregate
-        env:
-          DOCS_NG_REF: main
-
-      - name: Upload aggregated build directory
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: docs-ng-build
-          path: .docs-ng-build/
-          retention-days: 1
-          if-no-files-found: error
-          include-hidden-files: true
-
-  linkcheck:
-    name: Link check
-    needs: aggregate
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Download docs-ng build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: docs-ng-build
-          path: docs-ng-build
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: "10.28.0"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22"
-          cache: "pnpm"
-          cache-dependency-path: docs-ng-build/pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install
-        working-directory: docs-ng-build
-
-      # installing lychee is way easier using the gh action below
-      # - name: Run link check
-      #   run: make linkcheck
-      #   working-directory: docs-ng-build
-
-      - name: Run link check
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
-        with:
-          args: docs/**/*.md --config lychee.toml --root-dir "$(pwd)/docs/"
-          workingDirectory: docs-ng-build
-
-  spelling:
-    name: Spelling check
-    needs: aggregate
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Download docs-ng build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: docs-ng-build
-          path: docs-ng-build
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: "10.28.0"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22"
-          cache: "pnpm"
-          cache-dependency-path: docs-ng-build/pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: |
-          pnpm install
-          pip install git+https://github.com/gardenlinux/glrd.git@v4.1.0
-          pip install git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.10.20
-          pip install -r requirements.txt
-        working-directory: docs-ng-build
-
-      - name: Run spelling check
-        run: make spelling
-        working-directory: docs-ng-build
-
-  woke:
-    name: Inclusive language check
-    needs: aggregate
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Download docs-ng build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: docs-ng-build
-          path: docs-ng-build
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: "10.28.0"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22"
-          cache: "pnpm"
-          cache-dependency-path: docs-ng-build/pnpm-lock.yaml
-
-      - name: Install Go (for woke)
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: 'stable'
-          cache: false
-
-      - name: Install woke
-        run: go install github.com/get-woke/woke@latest
-
-      - name: Install dependencies
-        run: pnpm install
-        working-directory: docs-ng-build
-
-      - name: Run inclusive language check
-        run: |
-          export PATH=$PATH:$HOME/go/bin
-          make woke
-        working-directory: docs-ng-build
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'gardenlinux',
+              repo: 'docs-ng',
+              event_type: 'docs-pr',
+              client_payload: {
+                repo: 'gardenlinux',
+                pr_number: '${{ github.event.pull_request.number || '' }}',
+                commit_sha: '${{ github.event.pull_request.head.sha || github.sha }}',
+                ref: '${{ github.head_ref || github.ref_name }}',
+                event: '${{ github.event_name == 'push' && 'merged' || 'pr_success' }}'
+              }
+            });
+            core.info('Repository dispatch sent to docs-ng');

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,6 +3,7 @@ name: Documentation Quality Check
 on:
   pull_request:
     branches: [main, docs-ng]
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'docs/**'
       - 'features/*/README.md'
@@ -22,6 +23,8 @@ on:
 
 jobs:
   docs-checks:
+    # Skip checks on closed PRs (only need the notification)
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     uses: gardenlinux/docs-ng/.github/workflows/docs-checks.yml@main
     with:
       override-repo: gardenlinux
@@ -32,7 +35,13 @@ jobs:
     name: Notify docs-ng
     needs: [docs-checks]
     runs-on: ubuntu-24.04
-    if: success()
+    # Run after checks pass, OR immediately for merged PRs (skip checks on merge)
+    if: |
+      always() &&
+      (
+        (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) ||
+        (needs.docs-checks.result == 'success')
+      )
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -47,16 +56,35 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const isMergedPR = context.eventName === 'pull_request' &&
+                               context.payload.action === 'closed' &&
+                               context.payload.pull_request.merged === true;
+            const isPush = context.eventName === 'push';
+
+            // For merged PRs, use the base branch (the branch it was merged into)
+            // For push events, use the branch being pushed to
+            // For open PRs, use the head branch
+            let ref;
+            if (isMergedPR) {
+              ref = context.payload.pull_request.base.ref;
+            } else if (isPush) {
+              ref = context.ref.replace('refs/heads/', '');
+            } else {
+              ref = context.payload.pull_request?.head?.ref || context.ref;
+            }
+
             await github.rest.repos.createDispatchEvent({
               owner: 'gardenlinux',
               repo: 'docs-ng',
               event_type: 'docs-pr',
               client_payload: {
                 repo: 'gardenlinux',
-                pr_number: '${{ github.event.pull_request.number || '' }}',
-                commit_sha: '${{ github.event.pull_request.head.sha || github.sha }}',
-                ref: '${{ github.head_ref || github.ref_name }}',
-                event: '${{ github.event_name == 'push' && 'merged' || 'pr_success' }}'
+                pr_number: `${context.payload.pull_request?.number || ''}`,
+                commit_sha: isMergedPR
+                  ? context.payload.pull_request.merge_commit_sha
+                  : (context.payload.pull_request?.head?.sha || context.sha),
+                ref: ref,
+                event: (isMergedPR || isPush) ? 'merged' : 'pr_success'
               }
             });
             core.info('Repository dispatch sent to docs-ng');

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,169 @@
+name: Documentation Quality Check
+
+on:
+  pull_request:
+    branches: [main, docs-ng]
+    paths:
+      - 'docs/**'
+      - 'features/*/README.md'
+      - 'features/*/info.yaml'
+      - 'flavors.yaml'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+  push:
+    branches: [main, docs-ng]
+    paths:
+      - 'docs/**'
+      - 'features/*/README.md'
+      - 'features/*/info.yaml'
+      - 'flavors.yaml'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+
+jobs:
+  aggregate:
+    name: Aggregate documentation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: "10.28.0"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Aggregate docs
+        run: make -C docs aggregate
+        env:
+          DOCS_NG_REF: main
+
+      - name: Upload aggregated build directory
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: docs-ng-build
+          path: .docs-ng-build/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
+
+  linkcheck:
+    name: Link check
+    needs: aggregate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download docs-ng build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: docs-ng-build
+          path: docs-ng-build
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: "10.28.0"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: docs-ng-build/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+        working-directory: docs-ng-build
+
+      # installing lychee is way easier using the gh action below
+      # - name: Run link check
+      #   run: make linkcheck
+      #   working-directory: docs-ng-build
+
+      - name: Run link check
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: docs/**/*.md --config lychee.toml --root-dir "$(pwd)/docs/"
+          workingDirectory: docs-ng-build
+
+  spelling:
+    name: Spelling check
+    needs: aggregate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download docs-ng build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: docs-ng-build
+          path: docs-ng-build
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: "10.28.0"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: docs-ng-build/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: |
+          pnpm install
+          pip install git+https://github.com/gardenlinux/glrd.git@v4.1.0
+          pip install git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.10.20
+          pip install -r requirements.txt
+        working-directory: docs-ng-build
+
+      - name: Run spelling check
+        run: make spelling
+        working-directory: docs-ng-build
+
+  woke:
+    name: Inclusive language check
+    needs: aggregate
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download docs-ng build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: docs-ng-build
+          path: docs-ng-build
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: "10.28.0"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: docs-ng-build/pnpm-lock.yaml
+
+      - name: Install Go (for woke)
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - name: Install woke
+        run: go install github.com/get-woke/woke@latest
+
+      - name: Install dependencies
+        run: pnpm install
+        working-directory: docs-ng-build
+
+      - name: Run inclusive language check
+        run: |
+          export PATH=$PATH:$HOME/go/bin
+          make woke
+        working-directory: docs-ng-build

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ COMMIT
 VERSION
 edk2/
 **/*-internal.md
+# docs-ng build directory (created by docs/Makefile)
+/.docs-ng-build/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# The docs-ng build directory lives at the repo root (.docs-ng-build/),
+# not here — see the root .gitignore.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -126,7 +126,7 @@ dev:
 	cd "$(BUILD_DIR)" && pnpm run docs:dev
 
 # ---------------------------------------------------------------------------
-# Building the complete documenation
+# Building the complete documentation
 # ---------------------------------------------------------------------------
 
 build: aggregate

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,143 @@
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -euo pipefail -c
+
+# ---------------------------------------------------------------------------
+# Configuration — all variables can be overridden from the environment
+# ---------------------------------------------------------------------------
+
+# docs-ng repository to clone
+DOCS_NG_REPO    ?= https://github.com/gardenlinux/docs-ng.git
+# Branch / tag of docs-ng to use
+DOCS_NG_REF     ?= main
+# This repo's name as it appears in docs-ng's repos-config.json
+REPO_NAME       ?= gardenlinux
+# Absolute path to the root of THIS repository (parent of docs/)
+LOCAL_DOCS_PATH ?= $(abspath $(CURDIR)/..)
+
+# Build directory: cloned docs-ng lives at the repo root (NOT inside docs/,
+# to avoid the aggregator picking it up when copying the docs/ tree)
+BUILD_DIR := $(abspath $(CURDIR)/../.docs-ng-build)
+
+# Sentinel file that marks a completed setup
+SETUP_SENTINEL := $(BUILD_DIR)/.setup-done
+
+# ---------------------------------------------------------------------------
+
+.PHONY: help setup aggregate aggregate-repo check linkcheck spelling woke clean
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "Garden Linux Documentation CI"
+	@echo ""
+	@echo "Usage:  make [TARGET] [VAR=value ...]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  aggregate      Clone docs-ng and aggregate documentation from local repo"
+	@echo "  aggregate-repo Aggregate documentation from local repo only"
+	@echo "  check          Run all quality checks  (aggregate + linkcheck + spelling + woke)"
+	@echo "  linkcheck      Check links with lychee"
+	@echo "  spelling       Check spelling with codespell"
+	@echo "  woke           Check inclusive language with woke"
+	@echo "  setup          Clone docs-ng and install dependencies (runs automatically)"
+	@echo "  clean          Remove the build directory"
+	@echo ""
+	@echo "Configuration variables (override via environment or make VAR=value):"
+	@printf "  %-20s %s\n" "DOCS_NG_REPO"    "$(DOCS_NG_REPO)"
+	@printf "  %-20s %s\n" "DOCS_NG_REF"     "$(DOCS_NG_REF)"
+	@printf "  %-20s %s\n" "REPO_NAME"       "$(REPO_NAME)"
+	@printf "  %-20s %s\n" "LOCAL_DOCS_PATH" "$(LOCAL_DOCS_PATH)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make check"
+	@echo "  make check DOCS_NG_REF=feature/my-branch"
+	@echo "  make linkcheck"
+	@echo "  make clean && make check"
+
+# ---------------------------------------------------------------------------
+# Setup: clone docs-ng and install all dependencies
+# ---------------------------------------------------------------------------
+
+setup: $(SETUP_SENTINEL)
+
+$(SETUP_SENTINEL):
+	@echo "==> Cloning docs-ng ($(DOCS_NG_REPO)@$(DOCS_NG_REF)) into $(BUILD_DIR)..."
+	rm -rf "$(BUILD_DIR)"
+	git clone --depth 1 --branch "$(DOCS_NG_REF)" "$(DOCS_NG_REPO)" "$(BUILD_DIR)"
+	@echo "==> Installing Node.js dependencies..."
+	cd "$(BUILD_DIR)" && pnpm install
+	@echo "==> Installing Python dependencies..."
+	cd "$(BUILD_DIR)" && pip install -r requirements.txt
+	cd "$(BUILD_DIR)" && pip install git+https://github.com/gardenlinux/glrd.git@v4.1.0
+	cd "$(BUILD_DIR)" && pip install git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.10.20
+	touch "$@"
+	@echo "==> Setup complete."
+
+# ---------------------------------------------------------------------------
+# Aggregate: patch repos-config.json to point at local repo, then aggregate
+# ---------------------------------------------------------------------------
+
+aggregate: setup
+	@echo "==> Patching repos-config.json for repo '$(REPO_NAME)' -> file://$(LOCAL_DOCS_PATH)"
+	@python3 -c "\
+import json, sys; \
+config_path = '$(BUILD_DIR)/repos-config.json'; \
+config = json.load(open(config_path)); \
+repos = [r for r in config['repos'] if r['name'] == '$(REPO_NAME)']; \
+(sys.exit('ERROR: repo $(REPO_NAME) not found in repos-config.json')) if not repos else None; \
+repos[0].update({'url': 'file://$(LOCAL_DOCS_PATH)', 'ref': 'HEAD'}); \
+repos[0].pop('commit', None); \
+json.dump(config, open(config_path, 'w'), indent=2); \
+print('Patched $(REPO_NAME): url=file://$(LOCAL_DOCS_PATH), ref=HEAD'); \
+"
+	@echo "==> Running aggregation..."
+	cd "$(BUILD_DIR)" && python3 src/aggregate.py
+	@echo "==> Aggregation complete."
+
+aggregate-repo: setup
+	@echo "==> Aggregating documentation for local repositroy '$(REPO_NAME)'"
+	cd "$(BUILD_DIR)" && python3 src/aggregate.py --repo $(REPO_NAME)
+
+# ---------------------------------------------------------------------------
+# Quality checks
+# ---------------------------------------------------------------------------
+
+check: linkcheck spelling woke
+	@echo "==> All quality checks passed."
+
+linkcheck:
+	@echo "==> Running link check..."
+	cd "$(BUILD_DIR)" && pnpm run docs:linkcheck
+
+spelling:
+	@echo "==> Running spelling check..."
+	cd "$(BUILD_DIR)" && pnpm run docs:spelling
+
+woke:
+	@echo "==> Running inclusive language check..."
+	cd "$(BUILD_DIR)" && pnpm run docs:woke
+
+# ---------------------------------------------------------------------------
+# Run a development server
+# ---------------------------------------------------------------------------
+
+dev:
+	@echo "==> Running link check..."
+	cd "$(BUILD_DIR)" && pnpm run docs:dev
+
+# ---------------------------------------------------------------------------
+# Building the complete documenation
+# ---------------------------------------------------------------------------
+
+build: aggregate
+	@echo "==> Running link check..."
+	cd "$(BUILD_DIR)" && pnpm run docs:build
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+clean:
+	@echo "==> Removing build directory $(BUILD_DIR)..."
+	rm -rf "$(BUILD_DIR)"
+	@echo "==> Clean complete."


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: add ci for docs

This adds a CI for the new documentation hub that can be run locally and by github actions.
It uses the same checks as https://github.com/gardenlinux/docs-ng (https://github.com/gardenlinux/docs-ng/blob/07c93e83e37e22afaf0463ee1b7f3c61160d0ea5/.github/workflows/docs-checks.yml), running the aggregate with the ref/commit from the PR and running the checks.
It dispatches the https://github.com/gardenlinux/docs-ng/blob/07c93e83e37e22afaf0463ee1b7f3c61160d0ea5/.github/workflows/docs-pr.yml workflow so a PR is created/updated in the docs-ng repository.
