### PR TITLE
Remove non-existent output check in GH workflow `publish_oci_containers.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,6 @@ jobs:
     with:
       commit_id: ${{ needs.requirements.outputs.commit_id }}
       version: ${{ needs.requirements.outputs.version }}
-      prefix: ${{ inputs.prefix }}
   upload_flavor_version_data:
     needs: [requirements, flavors]
     name: Store flavor version data

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - name: Download test distribution artifact
+      - name: Download test distribution
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
           path: tests/.build

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -32,14 +32,10 @@ jobs:
           cd tests
           make -f util/build.makefile
           touch .build/.gh_artifact
-      - name: Upload test distribution artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v7.0.0
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
-          name: ${{ inputs.prefix }}test-distribution
           path: tests/.build
-          include-hidden-files: true
-          if-no-files-found: error
-          retention-days: 7
+          key: test-distribution-${{ github.run_id }}
 
   test_container:
     name: Build test containers
@@ -56,10 +52,10 @@ jobs:
         with:
           submodules: true
       - name: Download test distribution artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
-          name: ${{ inputs.prefix }}test-distribution
-          path: .build
+          path: tests/.build
+          key: test-distribution-${{ github.run_id }}
       - name: Set distribution version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
@@ -72,7 +68,7 @@ jobs:
           repo="ghcr.io/${{ github.repository_owner }}/test"
           version="$(cat VERSION)"
 
-          podman build --arch ${arch} --build-context dist_ctx=.build -t ${repo}:${arch}-${version} tests/util/container
+          podman build --arch ${arch} --build-context dist_ctx=tests/.build -t ${repo}:${arch}-${version} tests/util/container
           podman save --format oci-archive ${repo}:${arch}-${version} > tests_container_${arch}.oci
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v7.0.0
         with:

--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -379,15 +379,13 @@ jobs:
           merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
-      - if: ${{ steps.tests_containers.outputs.cache-hit == 'true' }}
-        name: Load OCI archives
+      - name: Load OCI archives
         run: |
           for oci in *.oci; do
             podman load -i "${oci}"
             rm -f "${oci}"
           done
-      - if: ${{ steps.tests_containers.outputs.cache-hit == 'true' }}
-        name: Publish tests images and manifest
+      - name: Publish tests images and manifest
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/test_flavor_chroot.yml
+++ b/.github/workflows/test_flavor_chroot.yml
@@ -32,7 +32,7 @@ jobs:
             VERSION
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
-      - name: Download test distribution artifact
+      - name: Download test distribution
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
           path: tests/.build

--- a/.github/workflows/test_flavor_chroot.yml
+++ b/.github/workflows/test_flavor_chroot.yml
@@ -33,10 +33,10 @@ jobs:
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
       - name: Download test distribution artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
-          name: test-distribution
           path: tests/.build
+          key: test-distribution-${{ github.run_id }}
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
       - name: Set CNAME

--- a/.github/workflows/test_flavor_cloud.yml
+++ b/.github/workflows/test_flavor_cloud.yml
@@ -73,10 +73,10 @@ jobs:
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
       - name: Download test distribution artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
-          name: test-distribution
           path: tests/.build
+          key: test-distribution-${{ github.run_id }}
       - name: Load certs artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:

--- a/.github/workflows/test_flavor_cloud.yml
+++ b/.github/workflows/test_flavor_cloud.yml
@@ -72,7 +72,7 @@ jobs:
             VERSION
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
-      - name: Download test distribution artifact
+      - name: Download test distribution
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
           path: tests/.build

--- a/.github/workflows/test_flavor_oci.yml
+++ b/.github/workflows/test_flavor_oci.yml
@@ -36,7 +36,7 @@ jobs:
             VERSION
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
-      - name: Download test distribution artifact
+      - name: Download test distribution
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
           path: tests/.build

--- a/.github/workflows/test_flavor_oci.yml
+++ b/.github/workflows/test_flavor_oci.yml
@@ -37,10 +37,10 @@ jobs:
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
       - name: Download test distribution artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
-          name: test-distribution
           path: tests/.build
+          key: test-distribution-${{ github.run_id }}
       - name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@3e2802f425fd877c5b632094fb6ce71f5334b567 # pin@0.10.20
       - name: Set CNAME

--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -38,10 +38,10 @@ jobs:
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
       - name: Download test distribution artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
-          name: test-distribution
           path: tests/.build
+          key: test-distribution-${{ github.run_id }}
       - name: Load certs artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:

--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -37,7 +37,7 @@ jobs:
             VERSION
           key: build-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.run_id }}
           fail-on-cache-miss: true
-      - name: Download test distribution artifact
+      - name: Download test distribution
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # pin@v5.0.4
         with:
           path: tests/.build


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a check originated from `actions/cache` but not applicable for `actions/download-artifact` used in `publish_oci_containers.yml`.

**Which issue(s) this PR fixes**:
Fixes #4903