### PR TITLE
adjust test_server.py for nightly fix after sudo package update

### DIFF
--- a/tests/integration/core/test_server.py
+++ b/tests/integration/core/test_server.py
@@ -266,9 +266,9 @@ def test_server_sudoers_keepssh_content(parse_file: ParseFile):
 
 @pytest.mark.feature("server")
 @pytest.mark.root
-def test_sudo_resets_user_environment(parse_file: ParseFile):
+def test_sudo_secure_path_is_set(parse_file: ParseFile):
     lines = parse_file.lines("/etc/sudoers")
-    assert "Defaults env_reset" in lines
+    assert "Defaults secure_path" in lines
 
 
 # =============================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:
nightly broken on 08-Jun due to package-sudo update to `1.9.17p2-6`

**Which issue(s) this PR fixes**:
Fixes #4910 

Change in upstream causing the issue: https://salsa.debian.org/sudo-team/sudo/-/commit/363f95083974fb2bd0242917d899111890d7d9c5
