### PR TITLE
Mark the Security ID to all test_disastig pytests with V-ID

### DIFF
--- a/tests/integration/security/compliance/test_disastig_00005.py
+++ b/tests/integration/security/compliance/test_disastig_00005.py
@@ -12,6 +12,7 @@ invalid logon attempts by a user during a 15-minute time period.
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-auth"], indirect=["pam_config"]
 )
+@pytest.mark.security_id(203594)
 @pytest.mark.feature("disaSTIGmedium")
 def test_stig_common_auth_pam_faillock(pam_config):
 

--- a/tests/integration/security/compliance/test_disastig_00008.py
+++ b/tests/integration/security/compliance/test_disastig_00008.py
@@ -13,5 +13,6 @@ for all accounts and/or account types. A hard maxlogins limit in
 @pytest.mark.feature(
     "disaSTIGlow", reason="maxlogins limit is configured by disaSTIGlow"
 )
+@pytest.mark.security_id(203597)
 def test_limits_conf_maxlogins_is_10(parse_file) -> None:
     assert "* hard maxlogins 10" in parse_file.lines("/etc/security/limits.conf")

--- a/tests/integration/security/compliance/test_disastig_00009.py
+++ b/tests/integration/security/compliance/test_disastig_00009.py
@@ -9,6 +9,7 @@ procedures.
 """
 
 
+@pytest.mark.security_id(203598)
 @pytest.mark.feature("not container and not lima and not gardener and not baremetal")
 @pytest.mark.root(reason="required to verify PAM authentication enforcement")
 def test_session_lock_requires_reauthentication(lsm):

--- a/tests/integration/security/compliance/test_disastig_00013.py
+++ b/tests/integration/security/compliance/test_disastig_00013.py
@@ -9,6 +9,7 @@ Verify the operating system monitors remote access methods.
 """
 
 
+@pytest.mark.security_id(203602)
 @pytest.mark.booted(reason="requires running sshguard")
 @pytest.mark.feature("ssh")
 def test_sshguard_is_enabled(systemd):
@@ -23,6 +24,7 @@ def test_sshguard_is_enabled(systemd):
 @pytest.mark.hypervisor(
     "not qemu", reason="a started sshguard prevents running the testsuite"
 )
+@pytest.mark.security_id(203602)
 def test_sshguard_is_active(systemd):
     """
     sshguard blocks and logs IP addresses that brute-force ssh access
@@ -30,6 +32,7 @@ def test_sshguard_is_active(systemd):
     assert systemd.is_active("sshguard")
 
 
+@pytest.mark.security_id(203602)
 @pytest.mark.feature("ssh")
 def test_sshguard_journal_reading_is_configured(parse_file):
     """
@@ -40,6 +43,7 @@ def test_sshguard_journal_reading_is_configured(parse_file):
     assert "journalctl" in config["LOGREADER"]
 
 
+@pytest.mark.security_id(203602)
 @pytest.mark.booted(reason="requires running journald")
 @pytest.mark.feature("ssh")
 def test_sshguard_can_log_to_journald_dev_log_is_managed_by_journald(file):
@@ -58,6 +62,7 @@ def test_sshguard_can_log_to_journald_dev_log_is_managed_by_journald(file):
     "disaSTIGmedium",
     reason="auth log routing to /var/log/secure is configured by disaSTIGmedium",
 )
+@pytest.mark.security_id(203602)
 def test_rsyslog_logs_auth_to_secure(parse_file) -> None:
     """Verify auth/authpriv logging to /var/log/secure in rsyslog (SRG-OS-000032-GPOS-00013)."""
     assert re.compile(r"auth.*/var/log/secure") in parse_file.lines(

--- a/tests/integration/security/compliance/test_disastig_00014.py
+++ b/tests/integration/security/compliance/test_disastig_00014.py
@@ -8,5 +8,6 @@ confidentiality of remote access sessions.
 """
 
 
+@pytest.mark.security_id(203603)
 def test_disastig_00014():
     pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00015.py
+++ b/tests/integration/security/compliance/test_disastig_00015.py
@@ -8,6 +8,7 @@ establish what type of events occurred.
 """
 
 
+@pytest.mark.security_id(203604)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")
@@ -20,6 +21,7 @@ def test_audit_event_generated(shell):
     assert result.stdout.strip() != "", "stigcompliance: no audit events captured"
 
 
+@pytest.mark.security_id(203604)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00016.py
+++ b/tests/integration/security/compliance/test_disastig_00016.py
@@ -8,6 +8,7 @@ establish when (date and time) the events occurred.
 """
 
 
+@pytest.mark.security_id(203605)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00017.py
+++ b/tests/integration/security/compliance/test_disastig_00017.py
@@ -8,6 +8,7 @@ establish where the events occurred.
 """
 
 
+@pytest.mark.security_id(203606)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00018.py
+++ b/tests/integration/security/compliance/test_disastig_00018.py
@@ -8,6 +8,7 @@ establish the source of the events.
 """
 
 
+@pytest.mark.security_id(203607)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00019.py
+++ b/tests/integration/security/compliance/test_disastig_00019.py
@@ -8,6 +8,7 @@ establish the outcome of the events.
 """
 
 
+@pytest.mark.security_id(203608)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00020.py
+++ b/tests/integration/security/compliance/test_disastig_00020.py
@@ -8,6 +8,7 @@ recording of privileged commands.
 """
 
 
+@pytest.mark.security_id(203609)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00021.py
+++ b/tests/integration/security/compliance/test_disastig_00021.py
@@ -8,6 +8,7 @@ identities of group account users.
 """
 
 
+@pytest.mark.security_id(203610)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00022.py
+++ b/tests/integration/security/compliance/test_disastig_00022.py
@@ -8,6 +8,7 @@ of an audit processing failure.
 """
 
 
+@pytest.mark.security_id(203611)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00024.py
+++ b/tests/integration/security/compliance/test_disastig_00024.py
@@ -12,6 +12,7 @@ analyze audit records from multiple components within the system.
 AUDITD_CONF = "/etc/audit/auditd.conf"
 
 
+@pytest.mark.security_id(203613)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.root(reason="required to read audit configuration")
 def test_audit_log_retention_config(parse_file):
@@ -30,6 +31,7 @@ def test_audit_log_retention_config(parse_file):
     ), "stigcompliance: space_left_action not configured"
 
 
+@pytest.mark.security_id(203613)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit configuration and logs")

--- a/tests/integration/security/compliance/test_disastig_00025.py
+++ b/tests/integration/security/compliance/test_disastig_00025.py
@@ -8,6 +8,7 @@ events of interest based upon all audit fields within audit records.
 """
 
 
+@pytest.mark.security_id(203614)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")
@@ -19,6 +20,7 @@ def test_audit_filter_by_uid(shell):
     ), "stigcompliance: unable to filter audit records by user identity (uid)"
 
 
+@pytest.mark.security_id(203614)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")
@@ -30,6 +32,7 @@ def test_audit_filter_returns_structured_output(shell):
     ), "stigcompliance: audit filtering does not return structured audit records"
 
 
+@pytest.mark.security_id(203614)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")
@@ -46,6 +49,7 @@ def test_audit_filter_by_event_type(shell):
     ), "stigcompliance: unable to filter audit records by event type"
 
 
+@pytest.mark.security_id(203614)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit logs")
@@ -62,6 +66,7 @@ def test_audit_filter_by_command(shell):
     ), "stigcompliance: unable to filter audit records by command"
 
 
+@pytest.mark.security_id(203614)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit configuration and logs")

--- a/tests/integration/security/compliance/test_disastig_00026.py
+++ b/tests/integration/security/compliance/test_disastig_00026.py
@@ -10,6 +10,7 @@ for audit records.
 """
 
 
+@pytest.mark.security_id(203615)
 @pytest.mark.feature("stig")
 @pytest.mark.booted(reason="requires audit subsystem running")
 @pytest.mark.root(reason="required to generate and read audit logs")
@@ -23,6 +24,7 @@ def test_audit_records_have_valid_timestamps(shell):
     ), "stigcompliance: audit records do not contain valid timestamps"
 
 
+@pytest.mark.security_id(203615)
 @pytest.mark.feature("stig")
 @pytest.mark.booted(reason="requires audit subsystem running")
 @pytest.mark.root(reason="required to generate and read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00027.py
+++ b/tests/integration/security/compliance/test_disastig_00027.py
@@ -11,6 +11,7 @@ AUDIT_LOG_DIR = "/var/log/audit"
 AUDIT_LOG_FILE = "/var/log/audit/audit.log"
 
 
+@pytest.mark.security_id(203616)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
@@ -22,6 +23,7 @@ def test_audit_log_directory_permissions_restricted(file):
         ), f"stigcompliance: audit log directory {AUDIT_LOG_DIR} permissions are not restricted"
 
 
+@pytest.mark.security_id(203616)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")
@@ -33,6 +35,7 @@ def test_audit_log_file_permissions_restricted(file):
         ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} permissions are not restricted"
 
 
+@pytest.mark.security_id(203616)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires audit subsystem")

--- a/tests/integration/security/compliance/test_disastig_00028.py
+++ b/tests/integration/security/compliance/test_disastig_00028.py
@@ -8,5 +8,6 @@ modification.
 """
 
 
+@pytest.mark.security_id(203617)
 def test_disastig_00028():
     pytest.skip(reason="covered by test_disastig_00027.py")

--- a/tests/integration/security/compliance/test_disastig_00029.py
+++ b/tests/integration/security/compliance/test_disastig_00029.py
@@ -8,5 +8,6 @@ deletion.
 """
 
 
+@pytest.mark.security_id(203618)
 def test_disastig_00029():
     pytest.skip(reason="covered by test_disastig_00027.py")

--- a/tests/integration/security/compliance/test_disastig_00031.py
+++ b/tests/integration/security/compliance/test_disastig_00031.py
@@ -8,27 +8,33 @@ DoD-defined auditable events for all operating system components.
 """
 
 
+@pytest.mark.security_id(203619)
 def test_audit_modify_delete_privileges():
     pytest.skip(reason="covered by test_disastig_00210.py")
 
 
+@pytest.mark.security_id(203619)
 def test_audit_modify_delete_security_objects():
     pytest.skip(reason="covered by test_disastig_00212.py")
 
 
+@pytest.mark.security_id(203619)
 def test_audit_modify_delete_security_levels():
     pytest.skip(reason="covered by test_disastig_00211.py")
 
 
+@pytest.mark.security_id(203619)
 def test_audit_user_access():
     pytest.skip(reason="covered by test_disastig_00220.py")
 
 
+@pytest.mark.security_id(203619)
 def test_audit_user_accounts_management():
     pytest.skip(
         reason="covered by test_disastig_00089.py,  test_disastig_00090.py, test_disastig_00091.py"
     )
 
 
+@pytest.mark.security_id(203619)
 def test_audit_kernel_module_load_unload():
     pytest.skip(reason="covered by test_disastig_00222.py")

--- a/tests/integration/security/compliance/test_disastig_00038.py
+++ b/tests/integration/security/compliance/test_disastig_00038.py
@@ -15,6 +15,7 @@ PWQUALITY_CONF = "/etc/security/pwquality.conf"
 @pytest.mark.feature(
     "disaSTIGlow", reason="password quality lcredit is configured by disaSTIGlow"
 )
+@pytest.mark.security_id(203626)
 def test_pwquality_conf_lcredit_is_minus_1(parse_file) -> None:
     """Verify lcredit=-1 in pwquality.conf (SRG-OS-000070-GPOS-00038)."""
     config = parse_file.parse(PWQUALITY_CONF, format="keyval")

--- a/tests/integration/security/compliance/test_disastig_00040.py
+++ b/tests/integration/security/compliance/test_disastig_00040.py
@@ -8,5 +8,6 @@ number of characters when passwords are changed.
 """
 
 
+@pytest.mark.security_id(203628)
 def test_disastig_00040():
     pytest.skip(reason="covered by test_disastig_00046.py")

--- a/tests/integration/security/compliance/test_disastig_00041.py
+++ b/tests/integration/security/compliance/test_disastig_00041.py
@@ -7,6 +7,7 @@ Verify the operating system stores only encrypted representations of passwords.
 """
 
 
+@pytest.mark.security_id(203629)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires booted system")
 @pytest.mark.root(reason="required for passwd checks")
@@ -16,6 +17,7 @@ def test_passwd_does_not_store_passwords(passwd_entries):
     ), "stigcompliance: plaintext password found in /etc/passwd"
 
 
+@pytest.mark.security_id(203629)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires booted system")
 @pytest.mark.root(reason="required for passwd checks")
@@ -27,6 +29,7 @@ def test_shadow_passwords_are_hashed(shadow_entries):
     ), "stigcompliance: non-hashed password detected in /etc/shadow"
 
 
+@pytest.mark.security_id(203629)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires booted system")
 @pytest.mark.root(reason="required for passwd checks")

--- a/tests/integration/security/compliance/test_disastig_00046.py
+++ b/tests/integration/security/compliance/test_disastig_00046.py
@@ -12,6 +12,7 @@ Verify the operating system enforces a minimum 15-character password length.
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
 )
+@pytest.mark.security_id(203634)
 def test_common_password_passwdqc_pam_faillock(pam_config):
     results = pam_config.find_entries(
         type_="password",

--- a/tests/integration/security/compliance/test_disastig_00047.py
+++ b/tests/integration/security/compliance/test_disastig_00047.py
@@ -17,6 +17,7 @@ PAM_FILES = [
 ]
 
 
+@pytest.mark.security_id(203635)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires authentication stack")
 @pytest.mark.root(reason="required for pam.d checks")
@@ -31,6 +32,7 @@ def test_authentication_uses_valid_pam_modules(file: File, parse_file: ParseFile
     ), "stigcompliance: no valid PAM authentication modules found"
 
 
+@pytest.mark.security_id(203635)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires authentication stack")
 @pytest.mark.root(reason="required for pam.d checks")

--- a/tests/integration/security/compliance/test_disastig_00050.py
+++ b/tests/integration/security/compliance/test_disastig_00050.py
@@ -22,6 +22,7 @@ FORBIDDEN_SERVICES = [
 @pytest.mark.feature(
     "not container and not gardener and not lima and not capi and not baremetal"
 )
+@pytest.mark.security_id(203638)
 @pytest.mark.booted(reason="requires booted system")
 @pytest.mark.root(reason="requires audit operations")
 @pytest.mark.skip(reason="no way of currently testing this")

--- a/tests/integration/security/compliance/test_disastig_00056.py
+++ b/tests/integration/security/compliance/test_disastig_00056.py
@@ -13,6 +13,7 @@ escalation mechanisms instead.
 @pytest.mark.feature(
     "disaSTIGmedium", reason="root account locking is enforced by disaSTIGmedium"
 )
+@pytest.mark.security_id(203644)
 @pytest.mark.root(reason="requires root to read shadow password status")
 def test_root_account_is_locked(shell) -> None:
     """Verify root account is locked (field 2 of passwd --status output is 'L')."""

--- a/tests/integration/security/compliance/test_disastig_00060.py
+++ b/tests/integration/security/compliance/test_disastig_00060.py
@@ -15,6 +15,7 @@ USERADD_DEFAULTS = "/etc/default/useradd"
 @pytest.mark.feature(
     "disaSTIGmedium", reason="account inactivity timeout is set by disaSTIGmedium"
 )
+@pytest.mark.security_id(203648)
 def test_useradd_inactive_is_35(parse_file) -> None:
     """Verify INACTIVE in /etc/default/useradd is 35 (SRG-OS-000118-GPOS-00060)."""
     config = parse_file.parse(USERADD_DEFAULTS, format="keyval")

--- a/tests/integration/security/compliance/test_disastig_00061.py
+++ b/tests/integration/security/compliance/test_disastig_00061.py
@@ -9,5 +9,6 @@ standards, and guidance for authentication to a cryptographic module.
 """
 
 
+@pytest.mark.security_id(203649)
 def test_disastig_00061():
     pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00063.py
+++ b/tests/integration/security/compliance/test_disastig_00063.py
@@ -10,6 +10,7 @@ supports on-demand reporting requirements.
 """
 
 
+@pytest.mark.security_id(203651)
 @pytest.mark.feature("log")
 def test_audit_reporting_tools_installed():
     tools = ["aureport", "ausearch"]
@@ -22,6 +23,7 @@ def test_audit_reporting_tools_installed():
 @pytest.mark.root(
     "Audit reporting requires root privileges to open /var/log/audit/audit.log"
 )
+@pytest.mark.security_id(203651)
 def test_audit_reporting_execution(shell):
     result = shell("aureport --summary", capture_output=True, ignore_exit_code=True)
 

--- a/tests/integration/security/compliance/test_disastig_00067.py
+++ b/tests/integration/security/compliance/test_disastig_00067.py
@@ -23,6 +23,7 @@ SETUID_BINARIES_ALLOWLIST = {
 }
 
 
+@pytest.mark.security_id(203655)
 def test_only_root_user_has_uid_zero():
     adm_users = [u.pw_name for u in pwd.getpwall() if u.pw_uid == 0]
     assert adm_users == [
@@ -30,6 +31,7 @@ def test_only_root_user_has_uid_zero():
     ], f"only root user should have uid 0, instead {adm_users} found"
 
 
+@pytest.mark.security_id(203655)
 @pytest.mark.feature("not lima")
 def test_only_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries):
     if exposed_setuid_binaries:
@@ -39,6 +41,7 @@ def test_only_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries)
         ), f"unexpected setuid binaries with too broad exec permissions: {exposed_setuid_binaries=} {diff=}"
 
 
+@pytest.mark.security_id(203655)
 @pytest.mark.feature("lima")
 def test_only_lima_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries):
     if exposed_setuid_binaries:

--- a/tests/integration/security/compliance/test_disastig_00068.py
+++ b/tests/integration/security/compliance/test_disastig_00068.py
@@ -8,5 +8,6 @@ functions.
 """
 
 
+@pytest.mark.security_id(203656)
 def test_disastig_00068():
     pytest.skip(reason="covered by test_disastig_00067.py")

--- a/tests/integration/security/compliance/test_disastig_00069.py
+++ b/tests/integration/security/compliance/test_disastig_00069.py
@@ -10,6 +10,7 @@ transfer via shared system resources.
 
 
 # -- temporary files
+@pytest.mark.security_id(203657)
 @pytest.mark.feature("not _selinux")
 @pytest.mark.booted(reason="Mounts are present on a booted system")
 def test_tmp_mount_is_configured_securely(mount):
@@ -23,6 +24,7 @@ def test_tmp_mount_is_configured_securely(mount):
     ), f"Missing /tmp mount options: {missing_mount_options}"
 
 
+@pytest.mark.security_id(203657)
 @pytest.mark.feature("_selinux")
 @pytest.mark.booted(reason="Mounts are present on a booted system")
 def test_tmp_mount_is_configured_securely_and_with_selinux(mount):
@@ -36,12 +38,14 @@ def test_tmp_mount_is_configured_securely_and_with_selinux(mount):
     ), f"Missing /tmp mount options: {missing_mount_options}"
 
 
+@pytest.mark.security_id(203657)
 def test_temp_directores_are_world_writable_and_have_sticky_bit_set(file):
     for dir in ["/tmp", "/var/tmp"]:
         assert file.is_dir(dir)
         assert file.has_mode(dir, "1777")
 
 
+@pytest.mark.security_id(203657)
 @pytest.mark.booted(reason="Systemd should be running")
 def test_systemd_tmpfiles_configuration_is_sane(shell):
     result = shell("systemd-tmpfiles --cat-config", capture_output=True)
@@ -53,12 +57,14 @@ def test_systemd_tmpfiles_configuration_is_sane(shell):
 
 
 # -- coredumps
+@pytest.mark.security_id(203657)
 @pytest.mark.feature("disaSTIGmedium")
 def test_suid_binaries_cannot_create_coredumps(sysctl):
     assert sysctl["fs.suid_dumpable"] == 0
 
 
 # -- memory
+@pytest.mark.security_id(203657)
 @pytest.mark.feature("disaSTIGmedium")
 def test_kernel_randomizes_virtual_memory_addresses(sysctl):
     assert sysctl["kernel.randomize_va_space"] == 2
@@ -68,6 +74,7 @@ def test_kernel_randomizes_virtual_memory_addresses(sysctl):
 @pytest.mark.feature(
     "disaSTIGlow", reason="sysctl hardening config is deployed by disaSTIGlow"
 )
+@pytest.mark.security_id(203657)
 def test_sysctl_disastig_low_conf_exists(file) -> None:
     """Verify /etc/sysctl.d/99-disaSTIG.conf exists for disaSTIGlow (SRG-OS-000138-GPOS-00069)."""
     assert file.exists(

--- a/tests/integration/security/compliance/test_disastig_00071.py
+++ b/tests/integration/security/compliance/test_disastig_00071.py
@@ -15,6 +15,7 @@ SYSCTL_DISASTIG = "/etc/sysctl.d/99-disaSTIG.conf"
 @pytest.mark.feature(
     "disaSTIGmedium", reason="sysctl hardening config is deployed by disaSTIGmedium"
 )
+@pytest.mark.security_id(203658)
 def test_sysctl_disastig_conf_exists(file) -> None:
     """Verify /etc/sysctl.d/99-disaSTIG.conf exists (SRG-OS-000142-GPOS-00071)."""
     assert file.exists(

--- a/tests/integration/security/compliance/test_disastig_00072.py
+++ b/tests/integration/security/compliance/test_disastig_00072.py
@@ -15,6 +15,7 @@ documented and validated mission requirements.
 @pytest.mark.testcov(
     ["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-clientalivecountmax"]
 )
+@pytest.mark.security_id(203659)
 @pytest.mark.feature("disaSTIGmedium")
 def test_terminate_ssh_session_after_inactivity_period(parse_file):
     config = parse_file.parse("/etc/ssh/sshd_config", format="spacedelim")

--- a/tests/integration/security/compliance/test_disastig_00083.py
+++ b/tests/integration/security/compliance/test_disastig_00083.py
@@ -14,6 +14,7 @@ VAR_LOG = "/var/log"
 @pytest.mark.feature(
     "disaSTIGmedium", reason="log directory permissions are hardened by disaSTIGmedium"
 )
+@pytest.mark.security_id(203663)
 def test_var_log_has_755_permissions(file) -> None:
     """Verify /var/log directory has permissions 755 (SRG-OS-000205-GPOS-00083)."""
     assert file.has_permissions(

--- a/tests/integration/security/compliance/test_disastig_00084.py
+++ b/tests/integration/security/compliance/test_disastig_00084.py
@@ -7,6 +7,7 @@ Verify the operating system reveals error messages only to authorized users.
 """
 
 
+@pytest.mark.security_id(203664)
 @pytest.mark.feature("disaSTIGmedium")
 def test_systemd_journal_is_not_world_readable(file):
     assert file.is_owned_by_user("/var/log/journal", "root")

--- a/tests/integration/security/compliance/test_disastig_00089.py
+++ b/tests/integration/security/compliance/test_disastig_00089.py
@@ -7,6 +7,7 @@ Verify the operating system automatically audits account modification.
 """
 
 
+@pytest.mark.security_id(203666)
 @pytest.mark.feature("disaSTIGmedium")
 def test_audit_calling_user_group_related_utilities(audit_rule):
     for bin in [
@@ -38,6 +39,7 @@ def test_audit_calling_user_group_related_utilities(audit_rule):
         ), f"No audit rule found for {bin} binary calls"
 
 
+@pytest.mark.security_id(203666)
 def test_audit_rules_for_logging_attempts_to_delete_privileges():
     pytest.skip(
         reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"

--- a/tests/integration/security/compliance/test_disastig_00090.py
+++ b/tests/integration/security/compliance/test_disastig_00090.py
@@ -7,10 +7,12 @@ Verify the operating system automatically audits account disabling actions.
 """
 
 
+@pytest.mark.security_id(203667)
 def test_disastig_00090():
     pytest.skip(reason="covered by test_disastig_00089.py")
 
 
+@pytest.mark.security_id(203667)
 def test_audit_rules_for_logging_attempts_to_delete_privileges():
     pytest.skip(
         reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"

--- a/tests/integration/security/compliance/test_disastig_00091.py
+++ b/tests/integration/security/compliance/test_disastig_00091.py
@@ -7,10 +7,12 @@ Verify the operating system automatically audits account removal actions.
 """
 
 
+@pytest.mark.security_id(203668)
 def test_disastig_00091():
     pytest.skip(reason="covered by test_disastig_00089.py")
 
 
+@pytest.mark.security_id(203668)
 def test_audit_rules_for_logging_attempts_to_delete_privileges():
     pytest.skip(
         reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"

--- a/tests/integration/security/compliance/test_disastig_00095.py
+++ b/tests/integration/security/compliance/test_disastig_00095.py
@@ -5,6 +5,7 @@ from plugins.file import File
 from plugins.parse_file import ParseFile
 
 
+@pytest.mark.security_id(203670)
 @pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
 @pytest.mark.feature("disaSTIGmedium")
 def test_audit_cmdline_config_file_exists(file: File):
@@ -19,6 +20,7 @@ def test_audit_cmdline_config_file_exists(file: File):
     ), "stigcompliance: /etc/kernel/cmdline.d/90-audit.cfg must exist"
 
 
+@pytest.mark.security_id(203670)
 @pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
 @pytest.mark.feature("disaSTIGmedium")
 def test_audit_cmdline_config_file_content(parse_file: ParseFile):
@@ -34,6 +36,7 @@ def test_audit_cmdline_config_file_content(parse_file: ParseFile):
     ), "stigcompliance: /etc/kernel/cmdline.d/90-audit.cfg must contain audit=1"
 
 
+@pytest.mark.security_id(203670)
 @pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="kernel cmdline is only available on a booted system")

--- a/tests/integration/security/compliance/test_disastig_00096.py
+++ b/tests/integration/security/compliance/test_disastig_00096.py
@@ -10,6 +10,7 @@ establish the identity of any individual or process associated with the event.
 """
 
 
+@pytest.mark.security_id(203671)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit retention validation requires audit subsystem")
 @pytest.mark.root(reason="required to read audit configuration and logs")

--- a/tests/integration/security/compliance/test_disastig_00097.py
+++ b/tests/integration/security/compliance/test_disastig_00097.py
@@ -14,6 +14,7 @@ AUDIT_TOOL_PATHS = [
 ]
 
 
+@pytest.mark.security_id(203672)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")
@@ -25,6 +26,7 @@ def test_shadow_permissions(file):
     )
 
 
+@pytest.mark.security_id(203672)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")
@@ -36,6 +38,7 @@ def test_passwd_permissions_numeric(file):
     )
 
 
+@pytest.mark.security_id(203672)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")
@@ -47,6 +50,7 @@ def test_passwd_permissions_symbolic(file):
     )
 
 
+@pytest.mark.security_id(203672)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")
@@ -67,6 +71,7 @@ def test_audit_tools_permissions(file):
     )
 
 
+@pytest.mark.security_id(203672)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")

--- a/tests/integration/security/compliance/test_disastig_00098.py
+++ b/tests/integration/security/compliance/test_disastig_00098.py
@@ -12,6 +12,7 @@ modification.
 AUDIT_LOG_DIR = "/var/log/audit"
 
 
+@pytest.mark.security_id(203673)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit protection requires booted system")
 @pytest.mark.root(reason="required to inspect audit log ownership")
@@ -35,6 +36,7 @@ def test_audit_log_directory_protected(file):
     )
 
 
+@pytest.mark.security_id(203673)
 @pytest.mark.feature("disaSTIGmedium or cis")
 @pytest.mark.booted(reason="audit protection requires booted system")
 @pytest.mark.root(reason="required to inspect audit log ownership")

--- a/tests/integration/security/compliance/test_disastig_00099.py
+++ b/tests/integration/security/compliance/test_disastig_00099.py
@@ -16,6 +16,7 @@ AUDIT_TOOL_PATHS = [
 ]
 
 
+@pytest.mark.security_id(203674)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")

--- a/tests/integration/security/compliance/test_disastig_00100.py
+++ b/tests/integration/security/compliance/test_disastig_00100.py
@@ -48,11 +48,13 @@ def ld_library_paths():
     }
 
 
+@pytest.mark.security_id(203675)
 def test_no_unsolicited_lib_path_for_ldconfig(ld_library_paths):
     diff = ld_library_paths - ALLOWED_LIB_DIRS[platform.machine()]
     assert not diff, f"unexpected shared libraries lookup paths configured: {diff}"
 
 
+@pytest.mark.security_id(203675)
 @pytest.mark.feature("disaSTIGmedium")
 def test_lib_directories_are_only_root_writable(ld_library_paths, file):
     for lib_path in ld_library_paths:
@@ -61,6 +63,7 @@ def test_lib_directories_are_only_root_writable(ld_library_paths, file):
             assert file.has_permissions(lib_path, "rwxr-xr-x")
 
 
+@pytest.mark.security_id(203675)
 @pytest.mark.feature("disaSTIGmedium")
 def test_python_lib_directory_is_only_root_writable(file, dpkg):
     python_pkg = dpkg.collect_installed_packages().get_package("python3")
@@ -70,6 +73,7 @@ def test_python_lib_directory_is_only_root_writable(file, dpkg):
         assert file.has_permissions(dist_packages, "rwxr-xr-x")
 
 
+@pytest.mark.security_id(203675)
 def test_python_disallows_installing_packages_with_pip_on_system_level(dpkg, file):
     python_pkg = dpkg.collect_installed_packages().get_package("python3")
     if python_pkg:
@@ -79,6 +83,7 @@ def test_python_disallows_installing_packages_with_pip_on_system_level(dpkg, fil
         )
 
 
+@pytest.mark.security_id(203675)
 def test_only_root_can_install_deb_packages(file):
     assert file.get_owner("/var/lib/dpkg") == ("root", "root")
     assert file.has_permissions("/var/lib/dpkg", "rwxr-xr-x")

--- a/tests/integration/security/compliance/test_disastig_00103.py
+++ b/tests/integration/security/compliance/test_disastig_00103.py
@@ -9,6 +9,7 @@ necessary to return to operations with least disruption to mission processes.
 """
 
 
+@pytest.mark.security_id(203677)
 def test_disastig_00103():
     pytest.skip(
         reason="covered by core/test_services::test__kdump_kdump_tools_service_enabled, integration/boot/test_initrd::test_kdump_initrd_files"

--- a/tests/integration/security/compliance/test_disastig_00108.py
+++ b/tests/integration/security/compliance/test_disastig_00108.py
@@ -8,6 +8,7 @@ integrity of audit tools.
 """
 
 
+@pytest.mark.security_id(203682)
 @pytest.mark.booted(reason="Requires working networking")
 def test_auditd_is_not_tampered(dpkg, dpkg_checksums, shell):
     if not dpkg.package_is_installed("auditd"):

--- a/tests/integration/security/compliance/test_disastig_00109.py
+++ b/tests/integration/security/compliance/test_disastig_00109.py
@@ -13,5 +13,6 @@ shell sessions time out after 15 minutes of inactivity.
 @pytest.mark.feature(
     "disaSTIGmedium", reason="terminal timeout is configured by disaSTIGmedium"
 )
+@pytest.mark.security_id(203683)
 def test_terminal_tmout_profile_sets_tmout_900(parse_file) -> None:
     assert "TMOUT=900" in parse_file.lines("/etc/profile.d/99-terminal_tmout.sh")

--- a/tests/integration/security/compliance/test_disastig_00110.py
+++ b/tests/integration/security/compliance/test_disastig_00110.py
@@ -8,6 +8,7 @@ are no longer associated to a user.
 """
 
 
+@pytest.mark.security_id(263650)
 def test_disastig_00110():
     """
     pam_unix is responsible for account expiration enforcement

--- a/tests/integration/security/compliance/test_disastig_00125.py
+++ b/tests/integration/security/compliance/test_disastig_00125.py
@@ -9,6 +9,7 @@ implemented security safeguards/countermeasures.
 """
 
 
+@pytest.mark.security_id(203695)
 @pytest.mark.feature("disaSTIGhigh")
 def test_ctrl_alt_del_burst_is_disabled(parse_file):
     config = parse_file.parse("/etc/systemd/system.conf", format="keyval")

--- a/tests/integration/security/compliance/test_disastig_00126.py
+++ b/tests/integration/security/compliance/test_disastig_00126.py
@@ -8,5 +8,6 @@ privilege levels than users executing the software.
 """
 
 
+@pytest.mark.security_id(203696)
 def test_disastig_00126():
     pytest.skip(reason="covered by test_disastig_00067.py")

--- a/tests/integration/security/compliance/test_disastig_00128.py
+++ b/tests/integration/security/compliance/test_disastig_00128.py
@@ -9,6 +9,7 @@ in 15 minutes are made.
 """
 
 
+@pytest.mark.security_id(203698)
 @pytest.mark.feature("disaSTIGmedium")
 def test_user_locked_after_unsuccessful_logon_attempts(parse_file):
     config = parse_file.parse("/etc/security/faillock.conf", format="keyval")

--- a/tests/integration/security/compliance/test_disastig_00134.py
+++ b/tests/integration/security/compliance/test_disastig_00134.py
@@ -15,6 +15,7 @@ AUDITD_CONF = "/etc/audit/auditd.conf"
 @pytest.mark.feature(
     "disaSTIGlow", reason="auditd disk_full_action is configured by disaSTIGlow"
 )
+@pytest.mark.security_id(203702)
 def test_auditd_conf_disk_full_action_is_halt(parse_file) -> None:
     """Verify disk_full_action=halt in auditd.conf (SRG-OS-000343-GPOS-00134)."""
     config = parse_file.parse(AUDITD_CONF, format="keyval")

--- a/tests/integration/security/compliance/test_disastig_00136.py
+++ b/tests/integration/security/compliance/test_disastig_00136.py
@@ -9,7 +9,7 @@ supports on-demand audit review and analysis.
 """
 
 
-@pytest.mark.security_id(1447)
+@pytest.mark.security_id(203704)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="audit tools check requires booted system")
 @pytest.mark.root(reason="required to execute privileged tools")

--- a/tests/integration/security/compliance/test_disastig_00137.py
+++ b/tests/integration/security/compliance/test_disastig_00137.py
@@ -8,6 +8,7 @@ supports after-the-fact investigations of security incidents.
 """
 
 
+@pytest.mark.security_id(203705)
 @pytest.mark.feature("log")
 def test_disastig_00137():
     pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests/integration/security/compliance/test_disastig_00138.py
+++ b/tests/integration/security/compliance/test_disastig_00138.py
@@ -8,6 +8,7 @@ supports on-demand audit review and analysis.
 """
 
 
+@pytest.mark.security_id(203706)
 @pytest.mark.feature("log")
 def test_disastig_00138():
     pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests/integration/security/compliance/test_disastig_00139.py
+++ b/tests/integration/security/compliance/test_disastig_00139.py
@@ -8,6 +8,7 @@ supports on-demand reporting requirements.
 """
 
 
+@pytest.mark.security_id(203707)
 @pytest.mark.feature("log")
 def test_disastig_00139():
     pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests/integration/security/compliance/test_disastig_00140.py
+++ b/tests/integration/security/compliance/test_disastig_00140.py
@@ -8,5 +8,6 @@ supports after-the-fact investigations of security incidents.
 """
 
 
+@pytest.mark.security_id(203708)
 def test_disastig_00140():
     pytest.skip(reason="covered by test_disastig_00063.py")

--- a/tests/integration/security/compliance/test_disastig_00141.py
+++ b/tests/integration/security/compliance/test_disastig_00141.py
@@ -8,5 +8,6 @@ audit records when it provides an audit reduction capability.
 """
 
 
+@pytest.mark.security_id(203709)
 def test_disastig_00141():
     pytest.skip(reason="covered by test_disastig_00142.py")

--- a/tests/integration/security/compliance/test_disastig_00143.py
+++ b/tests/integration/security/compliance/test_disastig_00143.py
@@ -12,11 +12,13 @@ source.
 @pytest.mark.hypervisor(
     "gdch or microsoft", reason="Need PTP timesync sources to be reachable"
 )
+@pytest.mark.security_id(203711)
 @pytest.mark.booted(reason="requires running systemd")
 def test_time_sync_ptp_daemon_running(systemd):
     assert systemd.is_active("chrony")
 
 
+@pytest.mark.security_id(203711)
 @pytest.mark.hypervisor("not (azure or gdch)")
 @pytest.mark.booted(reason="requires running systemd")
 def test_time_sync_ntp_daemon_running(systemd):
@@ -27,11 +29,13 @@ def test_time_sync_ntp_daemon_running(systemd):
     "azure or gdch or google or microsoft",
     reason="Need NTP/PTP timesync sources to be reachable",
 )
+@pytest.mark.security_id(203711)
 @pytest.mark.booted(reason="requires running systemd")
 def test_time_is_actively_synced(timedatectl, shell):
     assert timedatectl.get_timesync_status().ntp_synchronized
 
 
+@pytest.mark.security_id(203711)
 @pytest.mark.booted(reason="requires running systemd")
 def test_time_is_synced_at_least_once_a_day(timedatectl):
     assert timedatectl.get_timesync_status().poll_interval_max < (24 * 60 * 60)

--- a/tests/integration/security/compliance/test_disastig_00144.py
+++ b/tests/integration/security/compliance/test_disastig_00144.py
@@ -9,5 +9,6 @@ second.
 """
 
 
+@pytest.mark.security_id(203712)
 def test_disastig_00144():
     pytest.skip(reason="covered by test_disastig_00143.py")

--- a/tests/integration/security/compliance/test_disastig_00145.py
+++ b/tests/integration/security/compliance/test_disastig_00145.py
@@ -10,6 +10,7 @@ minimum granularity of one second for a minimum degree of precision.
 """
 
 
+@pytest.mark.security_id(203713)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires audit subsystem running")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00146.py
+++ b/tests/integration/security/compliance/test_disastig_00146.py
@@ -9,6 +9,7 @@ mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).
 """
 
 
+@pytest.mark.security_id(203714)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires system time configuration")
 @pytest.mark.root(reason="required to verify time settings")

--- a/tests/integration/security/compliance/test_disastig_00149.py
+++ b/tests/integration/security/compliance/test_disastig_00149.py
@@ -20,6 +20,7 @@ PKG_BINARIES = [
 @pytest.mark.booted(
     reason="system must be booted to verify package manager permissions"
 )
+@pytest.mark.security_id(203716)
 def test_package_manager_requires_privileged_access(file: File):
     for path in PKG_BINARIES:
         if not file.exists(path):
@@ -47,6 +48,7 @@ PKG_DB_PATHS = [
 @pytest.mark.booted(
     reason="system must be booted to verify package database permissions"
 )
+@pytest.mark.security_id(203716)
 def test_package_database_protected(file: File):
     for path in PKG_DB_PATHS:
         if not file.exists(path):

--- a/tests/integration/security/compliance/test_disastig_00153.py
+++ b/tests/integration/security/compliance/test_disastig_00153.py
@@ -16,6 +16,7 @@ by the organization.
 APT_CONF_DIR = "/etc/apt/apt.conf.d"
 
 
+@pytest.mark.security_id(203720)
 @pytest.mark.feature("not container and not lima and not baremetal")
 @pytest.mark.root(reason="required to verify package signature enforcement")
 def test_package_signature_verification_enabled(parse_file: ParseFile, find: Find):

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.security_id(203721)
 @pytest.mark.feature("_selinux")
 @pytest.mark.booted(reason="requires booted system to verify LSM enforcement")
 @pytest.mark.root(reason="requires access to system security configuration")

--- a/tests/integration/security/compliance/test_disastig_00155.py
+++ b/tests/integration/security/compliance/test_disastig_00155.py
@@ -11,6 +11,7 @@ allow the execution of authorized software programs.
 @pytest.mark.feature(
     "not container and not gardener and not lima and not capi and not baremetal"
 )
+@pytest.mark.security_id(203722)
 @pytest.mark.booted(reason="requires booted system to verify LSM enforcement")
 @pytest.mark.root(reason="requires access to system security configuration")
 def test_deny_all_execution_mechanism_present(lsm):

--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -21,6 +21,7 @@ SUDOERS_WHEEL = "/etc/sudoers.d/wheel"
     "disaSTIGmedium and not _dev",
     reason="test runner injects NOPASSWD sudoers in _dev mode for SSH access",
 )
+@pytest.mark.security_id(203723)
 @pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
 def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
     nopasswd_pattern = re.compile(r"NOPASSWD", re.IGNORECASE)
@@ -41,6 +42,7 @@ def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
     "disaSTIGmedium and not _dev",
     reason="test runner injects NOPASSWD sudoers in _dev mode for SSH access",
 )
+@pytest.mark.security_id(203723)
 @pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
 def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
     noauthenticate_pattern = re.compile(r"!authenticate", re.IGNORECASE)
@@ -63,6 +65,7 @@ def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
 @pytest.mark.feature(
     "disaSTIGmedium", reason="sudoers wheel truncation is applied by disaSTIGmedium"
 )
+@pytest.mark.security_id(203723)
 def test_sudoers_wheel_file_exists(file) -> None:
     """Verify /etc/sudoers.d/wheel exists (created/truncated by disaSTIGmedium)."""
     assert file.exists(SUDOERS_WHEEL), f"stigcompliance: {SUDOERS_WHEEL} does not exist"
@@ -72,6 +75,7 @@ def test_sudoers_wheel_file_exists(file) -> None:
 @pytest.mark.feature(
     "disaSTIGmedium", reason="sudoers wheel truncation is applied by disaSTIGmedium"
 )
+@pytest.mark.security_id(203723)
 def test_sudoers_wheel_file_is_empty(file) -> None:
     """Verify /etc/sudoers.d/wheel is empty (disaSTIGmedium truncates it with echo -n)."""
     assert (

--- a/tests/integration/security/compliance/test_disastig_00170.py
+++ b/tests/integration/security/compliance/test_disastig_00170.py
@@ -12,6 +12,7 @@ new password upon account recovery for password-based authentication.
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-account"], indirect=["pam_config"]
 )
+@pytest.mark.security_id(263654)
 def test_password_expiration_checking_pam_module_is_in_use(pam_config):
     """
     man 8 pam_unix:

--- a/tests/integration/security/compliance/test_disastig_00172.py
+++ b/tests/integration/security/compliance/test_disastig_00172.py
@@ -12,6 +12,7 @@ configuring sudo to log to a dedicated file.
 SUDO_LOG_CONFIG = "/etc/sudoers.d/disaSTIG-sudo-log"
 
 
+@pytest.mark.security_id(203735)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-sudo-log"])
 @pytest.mark.feature("disaSTIGmedium", reason="sudo log file required by DISA STIG")
 def test_sudo_logfile_configured(parse_file: ParseFile):

--- a/tests/integration/security/compliance/test_disastig_00173.py
+++ b/tests/integration/security/compliance/test_disastig_00173.py
@@ -10,6 +10,7 @@ nonlocal maintenance sessions.
 """
 
 
+@pytest.mark.security_id(203736)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires SSH runtime configuration")
@@ -36,6 +37,7 @@ def test_ssh_strong_macs_present(sshd, dpkg: Dpkg):
     ), "stigcompliance: no strong MAC algorithms configured for SSH integrity protection"
 
 
+@pytest.mark.security_id(203736)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires SSH runtime configuration")

--- a/tests/integration/security/compliance/test_disastig_00175.py
+++ b/tests/integration/security/compliance/test_disastig_00175.py
@@ -9,6 +9,7 @@ maintenance sessions.
 """
 
 
+@pytest.mark.security_id(203738)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires SSH runtime configuration")
 @pytest.mark.root(reason="requires access to SSH configuration")

--- a/tests/integration/security/compliance/test_disastig_00176.py
+++ b/tests/integration/security/compliance/test_disastig_00176.py
@@ -9,5 +9,6 @@ Orders, directives, policies, regulations, and standards.
 """
 
 
+@pytest.mark.security_id(203739)
 def test_disastig_00176():
     pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00180.py
+++ b/tests/integration/security/compliance/test_disastig_00180.py
@@ -2,6 +2,8 @@ import glob
 import re
 from os.path import exists
 
+import pytest
+
 """
 Ref: SRG-OS-000725-GPOS-00180
 
@@ -11,6 +13,7 @@ password-based authentication.
 """
 
 
+@pytest.mark.security_id(263655)
 def test_password_length_is_not_limited_in_pam_configs():
     search_str = r"^\s*password\s+requisite\s+pam_passwdqc.so\s+[^#]*max=\d+"
     pattern = re.compile(search_str)
@@ -26,6 +29,7 @@ def test_password_length_is_not_limited_in_pam_configs():
     assert not found, f"Password limit is set in {offender}"
 
 
+@pytest.mark.security_id(263655)
 def test_password_length_is_not_limited_in_passwdqc_config(parse_file):
     config = "/etc/passwdqc.conf"
     if not exists(config):

--- a/tests/integration/security/compliance/test_disastig_00186.py
+++ b/tests/integration/security/compliance/test_disastig_00186.py
@@ -9,6 +9,7 @@ rate-limiting measures on impacted network interfaces.
 """
 
 
+@pytest.mark.security_id(203747)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires running network stack")
 @pytest.mark.root(reason="requires access to sysctl parameters")
@@ -20,6 +21,7 @@ def test_icmp_rate_limiting_enabled(sysctl):
     ), f"stigcompliance: ICMP rate limiting not enabled (value={value})"
 
 
+@pytest.mark.security_id(203747)
 @pytest.mark.feature("not container")
 @pytest.mark.booted(reason="requires network stack")
 @pytest.mark.root(reason="requires access to sysctl parameters")

--- a/tests/integration/security/compliance/test_disastig_00187.py
+++ b/tests/integration/security/compliance/test_disastig_00187.py
@@ -9,6 +9,7 @@ transmitted information.
 """
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_telnet_service_disabled(systemd: Systemd):
@@ -17,6 +18,7 @@ def test_telnet_service_disabled(systemd: Systemd):
     ), "stigcompliance: insecure service telnet.service is enabled"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_telnet_service_active(systemd: Systemd):
@@ -25,6 +27,7 @@ def test_telnet_service_active(systemd: Systemd):
     ), "stigcompliance: insecure service telnet.service is active"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_rsh_service_disabled(systemd: Systemd):
@@ -33,6 +36,7 @@ def test_rsh_service_disabled(systemd: Systemd):
     ), "stigcompliance: insecure service rsh.service is enabled"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_rsh_service_active(systemd: Systemd):
@@ -41,6 +45,7 @@ def test_rsh_service_active(systemd: Systemd):
     ), "stigcompliance: insecure service rsh.service is active"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_rexec_service_disabled(systemd: Systemd):
@@ -49,6 +54,7 @@ def test_rexec_service_disabled(systemd: Systemd):
     ), "stigcompliance: insecure service rexec.service is enabled"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_rexec_service_active(systemd: Systemd):
@@ -57,6 +63,7 @@ def test_rexec_service_active(systemd: Systemd):
     ), "stigcompliance: insecure service rexec.service is active"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_rlogin_service_disabled(systemd: Systemd):
@@ -65,6 +72,7 @@ def test_rlogin_service_disabled(systemd: Systemd):
     ), "stigcompliance: insecure service rlogin.service is enabled"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_rlogin_service_active(systemd: Systemd):
@@ -73,6 +81,7 @@ def test_rlogin_service_active(systemd: Systemd):
     ), "stigcompliance: insecure service rlogin.service is active"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_vsftpd_service_disabled(systemd: Systemd):
@@ -81,6 +90,7 @@ def test_vsftpd_service_disabled(systemd: Systemd):
     ), "stigcompliance: insecure service vsftpd.service is enabled"
 
 
+@pytest.mark.security_id(203748)
 @pytest.mark.booted(reason="requires booted system to verify services")
 @pytest.mark.root(reason="required to inspect system services")
 def test_vsftpd_service_active(systemd: Systemd):

--- a/tests/integration/security/compliance/test_disastig_00188.py
+++ b/tests/integration/security/compliance/test_disastig_00188.py
@@ -13,6 +13,7 @@ safeguards, such as, at a minimum, a Protected Distribution System (PDS).
 """
 
 
+@pytest.mark.security_id(203749)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires sshd effective configuration")
@@ -25,6 +26,7 @@ def test_ssh_ciphers_are_strong(sshd: Sshd):
     ), "stigcompliance: weak cipher allowed in SSH configuration"
 
 
+@pytest.mark.security_id(203749)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires sshd effective configuration")
@@ -37,6 +39,7 @@ def test_ssh_macs_are_strong(sshd: Sshd):
     ), "stigcompliance: weak MAC allowed in SSH configuration"
 
 
+@pytest.mark.security_id(203749)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires sshd effective configuration")

--- a/tests/integration/security/compliance/test_disastig_00189.py
+++ b/tests/integration/security/compliance/test_disastig_00189.py
@@ -8,5 +8,6 @@ information during preparation for transmission.
 """
 
 
+@pytest.mark.security_id(203750)
 def test_disastig_00189():
     pytest.skip(reason="covered by test_disastig_00187.py")

--- a/tests/integration/security/compliance/test_disastig_00190.py
+++ b/tests/integration/security/compliance/test_disastig_00190.py
@@ -8,5 +8,6 @@ information during reception.
 """
 
 
+@pytest.mark.security_id(203751)
 def test_disastig_00190():
     pytest.skip(reason="covered by test_disastig_00187.py")

--- a/tests/integration/security/compliance/test_disastig_00191.py
+++ b/tests/integration/security/compliance/test_disastig_00191.py
@@ -8,6 +8,7 @@ reflects organizational and system objectives when invalid inputs are received.
 """
 
 
+@pytest.mark.security_id(203752)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="requires audit subsystem running")
 @pytest.mark.root(reason="required to read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00192.py
+++ b/tests/integration/security/compliance/test_disastig_00192.py
@@ -8,6 +8,7 @@ memory from unauthorized code execution.
 """
 
 
+@pytest.mark.security_id(203753)
 @pytest.mark.arch("amd64")
 def test_nx_bit_hardware_support():
     """
@@ -20,6 +21,7 @@ def test_nx_bit_hardware_support():
         ), "Finding: Hardware does not support or report the NX bit."
 
 
+@pytest.mark.security_id(203753)
 @pytest.mark.arch("amd64")
 def test_nx_not_disabled_at_boot(kernel_cmdline):
     """Verify the kernel has not been explicitly told to disable NX."""

--- a/tests/integration/security/compliance/test_disastig_00194.py
+++ b/tests/integration/security/compliance/test_disastig_00194.py
@@ -1,3 +1,5 @@
+import pytest
+
 """
 Ref: SRG-OS-000437-GPOS-00194
 
@@ -6,6 +8,7 @@ versions have been installed.
 """
 
 
+@pytest.mark.security_id(203755)
 def test_no_residual_software_components(shell):
     """
     If a package is in 'rc' state, it means the package was

--- a/tests/integration/security/compliance/test_disastig_00199.py
+++ b/tests/integration/security/compliance/test_disastig_00199.py
@@ -8,18 +8,21 @@ functions.
 """
 
 
+@pytest.mark.security_id(203756)
 @pytest.mark.feature("log")
 @pytest.mark.booted("Needs working systemd")
 def test_auditd_service_active(systemd):
     assert systemd.is_active("auditd")
 
 
+@pytest.mark.security_id(203756)
 @pytest.mark.feature("log")
 @pytest.mark.booted("Needs working systemd")
 def test_systemd_configured_to_restart_auditd_service(systemd):
     assert systemd.get_unit_properties("auditd")["Restart"] != "no"
 
 
+@pytest.mark.security_id(203756)
 @pytest.mark.feature("_selinux")
 def test_selinux_enabled(lsm):
     assert "selinux" in lsm
@@ -29,6 +32,7 @@ def test_selinux_enabled(lsm):
 @pytest.mark.feature(
     "disaSTIGmedium", reason="aide-init.service is enabled by disaSTIGmedium"
 )
+@pytest.mark.security_id(203756)
 @pytest.mark.booted(reason="requires systemd to query unit enable state")
 def test_aide_init_service_is_enabled(systemd) -> None:
     """Verify aide-init.service is enabled (SRG-OS-000445-GPOS-00199)."""
@@ -41,6 +45,7 @@ def test_aide_init_service_is_enabled(systemd) -> None:
 @pytest.mark.feature(
     "disaSTIGmedium", reason="aide-check.timer is enabled by disaSTIGmedium"
 )
+@pytest.mark.security_id(203756)
 @pytest.mark.booted(reason="requires systemd to query unit enable state")
 def test_aide_check_timer_is_enabled(systemd) -> None:
     """Verify aide-check.timer is enabled (SRG-OS-000445-GPOS-00199)."""

--- a/tests/integration/security/compliance/test_disastig_00203.py
+++ b/tests/integration/security/compliance/test_disastig_00203.py
@@ -8,5 +8,6 @@ successful/unsuccessful attempts to access security objects occur.
 """
 
 
+@pytest.mark.security_id(203759)
 def test_disastig_00203():
     pytest.skip(reason="covered by test_disastig_00089.py")

--- a/tests/integration/security/compliance/test_disastig_00205.py
+++ b/tests/integration/security/compliance/test_disastig_00205.py
@@ -9,5 +9,6 @@ classification levels) occur.
 """
 
 
+@pytest.mark.security_id(203760)
 def test_disastig_00205():
     pytest.skip(reason="covered by test_disastig_00210.py")

--- a/tests/integration/security/compliance/test_disastig_00206.py
+++ b/tests/integration/security/compliance/test_disastig_00206.py
@@ -8,5 +8,6 @@ successful/unsuccessful attempts to modify privileges occur.
 """
 
 
+@pytest.mark.security_id(203761)
 def test_disastig_00206():
     pytest.skip(reason="covered by test_disastig_00210.py")

--- a/tests/integration/security/compliance/test_disastig_00207.py
+++ b/tests/integration/security/compliance/test_disastig_00207.py
@@ -8,5 +8,6 @@ successful/unsuccessful attempts to modify security objects occur.
 """
 
 
+@pytest.mark.security_id(203762)
 def test_disastig_00207():
     pytest.skip(reason="covered by test_disastig_00211.py")

--- a/tests/integration/security/compliance/test_disastig_00209.py
+++ b/tests/integration/security/compliance/test_disastig_00209.py
@@ -16,6 +16,7 @@ classification levels) occur.
 PRIV_ESC_RULE_FILE = "/etc/audit/rules.d/70-privilege-escalation.rules"
 
 
+@pytest.mark.security_id(203763)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
 @pytest.mark.root(reason="required to inspect audit config")
@@ -25,6 +26,7 @@ def test_setreuid_rule_file_exists(file: File):
     ), f"stigcompliance: {PRIV_ESC_RULE_FILE} does not exist"
 
 
+@pytest.mark.security_id(203763)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
 @pytest.mark.root(reason="required to inspect audit config")
@@ -36,6 +38,7 @@ def test_setreuid_rule_contains_syscall(parse_file: ParseFile):
     ), "stigcompliance: setreuid audit rule not configured"
 
 
+@pytest.mark.security_id(203763)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
 @pytest.mark.root(reason="required to query audit rules")
@@ -51,6 +54,7 @@ def test_setreuid_rule_loaded(shell: ShellRunner, parse: type[Parse]):
     ), "stigcompliance: setreuid audit rule not loaded in kernel"
 
 
+@pytest.mark.security_id(203763)
 @pytest.mark.feature("not container and not lima")
 @pytest.mark.booted(reason="audit event validation requires audit subsystem")
 @pytest.mark.root(reason="required to trigger syscall and read audit logs")

--- a/tests/integration/security/compliance/test_disastig_00210.py
+++ b/tests/integration/security/compliance/test_disastig_00210.py
@@ -22,6 +22,7 @@ def sudoers_edit():
     os.remove("/etc/sudoers.bak")
 
 
+@pytest.mark.security_id(203764)
 @pytest.mark.feature("not lima")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
 @pytest.mark.root(reason="required to query audit logs")
@@ -32,6 +33,7 @@ def test_audit_rules_for_logging_attempts_to_delete_privileges(audit_rule):
         ), f"stigcompliance: writing to or changing metadata of /etc/{file} should be audited"
 
 
+@pytest.mark.security_id(203764)
 @pytest.mark.skip("not implemented")
 @pytest.mark.feature("not lima")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
@@ -42,6 +44,7 @@ def test_audit_rules_for_files_capabilities_removal(audit_rule):
     ), "stigcompliance: setcap syscall audit rule is not configured"
 
 
+@pytest.mark.security_id(203764)
 @pytest.mark.feature("_selinux")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
 def test_audit_rules_for_selinux_policies_changes(audit_rule):
@@ -50,6 +53,7 @@ def test_audit_rules_for_selinux_policies_changes(audit_rule):
     ), "stigcompliance: changes of selinux configuration files should be audited"
 
 
+@pytest.mark.security_id(203764)
 @pytest.mark.feature("not lima")
 @pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
 @pytest.mark.root(reason="required to query audit logs")
@@ -65,6 +69,7 @@ def test_audit_rules_for_logging_attempts_to_modify_apparmor_policies(audit_rule
 @pytest.mark.modify(
     reason="changing /etc/sudoers file to check if audit works on a running system"
 )
+@pytest.mark.security_id(203764)
 @pytest.mark.root(reason="required to query audit logs")
 def test_attempt_to_delete_privileges_event_logged(audit_rule, shell, sudoers_edit):
     result = shell(

--- a/tests/integration/security/compliance/test_disastig_00211.py
+++ b/tests/integration/security/compliance/test_disastig_00211.py
@@ -8,11 +8,13 @@ successful/unsuccessful attempts to delete security levels occur.
 """
 
 
+@pytest.mark.security_id(203765)
 @pytest.mark.feature("disaSTIGmedium")
 def test_selinux_runtime_changes_are_audited(audit_rule):
     assert audit_rule(fs_watch_path="/sys/fs/selinux", access_types="wa")
 
 
+@pytest.mark.security_id(203765)
 @pytest.mark.feature("disaSTIGmedium")
 def test_changes_to_extended_file_attributes_are_audited(audit_rule):
     for sc in [

--- a/tests/integration/security/compliance/test_disastig_00212.py
+++ b/tests/integration/security/compliance/test_disastig_00212.py
@@ -8,6 +8,7 @@ successful/unsuccessful attempts to delete security objects occur.
 """
 
 
+@pytest.mark.security_id(203766)
 @pytest.mark.feature("disaSTIGmedium")
 def test_attempts_to_delete_are_audited(audit_rule):
     for syscall in ["unlink", "unlinkat", "rename", "renameat", "rmdir"]:

--- a/tests/integration/security/compliance/test_disastig_00215.py
+++ b/tests/integration/security/compliance/test_disastig_00215.py
@@ -8,6 +8,7 @@ or other system-level access.
 """
 
 
+@pytest.mark.security_id(203768)
 def test_disastig_00215():
     pytest.skip(
         reason="covered by test_disastig_00209.py, test_disastig_00210.py, test_disastig_00211.py test_disastig_00220.py test_disastig_00222.py"

--- a/tests/integration/security/compliance/test_disastig_00217.py
+++ b/tests/integration/security/compliance/test_disastig_00217.py
@@ -8,5 +8,6 @@ time for user access to the system.
 """
 
 
+@pytest.mark.security_id(203770)
 def test_disastig_00217():
     pytest.skip(reason="covered by test_disastig_00214.py")

--- a/tests/integration/security/compliance/test_disastig_00218.py
+++ b/tests/integration/security/compliance/test_disastig_00218.py
@@ -23,6 +23,7 @@ def concurrent_login_environment(shell: ShellRunner):
     shell(f"rm -f {OUTPUT_FILE} {JOURNAL_FILE} {TIME_FILE}")
 
 
+@pytest.mark.security_id(203771)
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires kernel logging")
 @pytest.mark.root(reason="required to generate audit events")

--- a/tests/integration/security/compliance/test_disastig_00220.py
+++ b/tests/integration/security/compliance/test_disastig_00220.py
@@ -7,6 +7,7 @@ Verify the operating system generates audit records for all direct access to the
 """
 
 
+@pytest.mark.security_id(203773)
 @pytest.mark.booted(reason="requires running systemd")
 def test_journald_should_not_store_logs_in_memory(systemd):
     """
@@ -17,6 +18,7 @@ def test_journald_should_not_store_logs_in_memory(systemd):
         assert result["Storage"] != "volatile"
 
 
+@pytest.mark.security_id(203773)
 @pytest.mark.feature("ssh")
 def test_sshd_log_level_is_set_to_verbose(parse_file):
     """
@@ -26,6 +28,7 @@ def test_sshd_log_level_is_set_to_verbose(parse_file):
     assert config["LogLevel"] == "VERBOSE"
 
 
+@pytest.mark.security_id(203773)
 @pytest.mark.feature("ssh")
 @pytest.mark.booted(reason="requires running systemd")
 def test_sshd_unit_is_journald_friendly(systemd):
@@ -45,6 +48,7 @@ def test_sshd_unit_is_journald_friendly(systemd):
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-session"], indirect=["pam_config"]
 )
+@pytest.mark.security_id(203773)
 def test_pam_unix_is_in_use(pam_config):
     """
     pam_unix is responsible for user sessions logging

--- a/tests/integration/security/compliance/test_disastig_00222.py
+++ b/tests/integration/security/compliance/test_disastig_00222.py
@@ -10,6 +10,7 @@ unload, and restart actions, and also for all program initiations.
 """
 
 
+@pytest.mark.security_id(203775)
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="audit subsystem required")
 @pytest.mark.root(reason="requires access to audit rules")

--- a/tests/integration/security/compliance/test_disastig_00223.py
+++ b/tests/integration/security/compliance/test_disastig_00223.py
@@ -11,5 +11,6 @@ Orders, directives, policies, regulations, and standards.
 """
 
 
+@pytest.mark.security_id(203776)
 def test_fips():
     pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00225.py
+++ b/tests/integration/security/compliance/test_disastig_00225.py
@@ -11,6 +11,7 @@ Verify the operating system prevents the use of dictionary words for passwords.
 @pytest.mark.parametrize(
     "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
 )
+@pytest.mark.security_id(203778)
 @pytest.mark.feature("disaSTIGmedium")
 def test_dictionary_passwords_are_forbidden(pam_config):
     """

--- a/tests/integration/security/compliance/test_disastig_00226.py
+++ b/tests/integration/security/compliance/test_disastig_00226.py
@@ -8,6 +8,7 @@ logon prompts following a failed logon attempt.
 """
 
 
+@pytest.mark.security_id(203779)
 @pytest.mark.parametrize("pam_config", ["/etc/pam.d/login"], indirect=["pam_config"])
 @pytest.mark.feature("disaSTIGmedium")
 def test_delay_is_enforced_after_failed_logins(pam_config):

--- a/tests/integration/security/compliance/test_disastig_00227.py
+++ b/tests/integration/security/compliance/test_disastig_00227.py
@@ -2,6 +2,7 @@ import pytest
 from plugins.sshd import Sshd
 
 
+@pytest.mark.security_id(203780)
 @pytest.mark.feature("disaSTIGmedium")
 @pytest.mark.booted(reason="requires SSH runtime configuration")
 @pytest.mark.root(reason="requires access to SSH configuration")

--- a/tests/integration/security/compliance/test_disastig_00228.py
+++ b/tests/integration/security/compliance/test_disastig_00228.py
@@ -10,15 +10,18 @@ users in such a way that the user can only read and modify their own files.
 """
 
 
+@pytest.mark.security_id(203781)
 def test_umask_is_restrictive_enough(parse_file):
     config = parse_file.parse("/etc/login.defs", format="spacedelim")
     assert config["UMASK"] == "027"
 
 
+@pytest.mark.security_id(203781)
 def test_skeleton_directory_is_not_world_writable(file):
     assert file.has_permissions("/etc/skel", "755")
 
 
+@pytest.mark.security_id(203781)
 def test_skeleton_files_are_not_world_writable(file):
     for f in glob.glob("/etc/skel/.*"):
         assert file.has_permissions(f, "640") or file.has_permissions(
@@ -26,6 +29,7 @@ def test_skeleton_files_are_not_world_writable(file):
         ), f"Wrong file permissions for {f}: {file.get_mode(f)}"
 
 
+@pytest.mark.security_id(203781)
 @pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-login-defs-umask"])
 @pytest.mark.feature("disaSTIGmedium", reason="077 umask is enforced by disaSTIGmedium")
 def test_login_defs_umask_is_077(parse_file) -> None:

--- a/tests/integration/security/compliance/test_disastig_00229.py
+++ b/tests/integration/security/compliance/test_disastig_00229.py
@@ -8,6 +8,7 @@ the system.
 """
 
 
+@pytest.mark.security_id(203782)
 @pytest.mark.booted(reason="Requires functioning systemd")
 def test_systemd_getty_autologin_is_not_enabled(systemd):
     for i in range(7):

--- a/tests/integration/security/compliance/test_disastig_00230.py
+++ b/tests/integration/security/compliance/test_disastig_00230.py
@@ -8,6 +8,7 @@ anchors in trust stores or certificate stores managed by the organization.
 """
 
 
+@pytest.mark.security_id(263659)
 @pytest.mark.feature("sap")
 def test_validate_fingerprint_of_SAP_CA_certificate(shell):
     cert_path = "/etc/ssl/certs/SAP_Global_Root_CA.pem"

--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -427,7 +427,7 @@ def test_kernel_has_fips_entry_in_procfs(parse_file: ParseFile):
     has been booted into FIPS mode.
     """
     lines = parse_file.lines("/proc/sys/crypto/fips_enabled")
-    assert "1" in lines, "Kernel was not booted in FIPS mode!"
+    assert "1" in lines, f"Kernel was not booted in FIPS mode!"
 
 
 @pytest.mark.feature("_fips")

--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -427,7 +427,7 @@ def test_kernel_has_fips_entry_in_procfs(parse_file: ParseFile):
     has been booted into FIPS mode.
     """
     lines = parse_file.lines("/proc/sys/crypto/fips_enabled")
-    assert "1" in lines, f"Kernel was not booted in FIPS mode!"
+    assert "1" in lines, "Kernel was not booted in FIPS mode!"
 
 
 @pytest.mark.feature("_fips")


### PR DESCRIPTION
**What this PR does / why we need it**:
Mark all the \`test_disastig_XXXXX.py\` with its respective \`security_id(Vulnerability-ID)\` as required by Gardener Unit

**Which issue(s) this PR fixes**:
Fixes #4902

**Related issues (gardenlinux/security)**:
gardenlinux/security#374 gardenlinux/security#375 gardenlinux/security#376 gardenlinux/security#377 gardenlinux/security#378 gardenlinux/security#379 gardenlinux/security#380 gardenlinux/security#381 gardenlinux/security#382 gardenlinux/security#383 gardenlinux/security#384 gardenlinux/security#385 gardenlinux/security#386 gardenlinux/security#387 gardenlinux/security#388 gardenlinux/security#389 gardenlinux/security#390 gardenlinux/security#391 gardenlinux/security#392 gardenlinux/security#393 gardenlinux/security#394 gardenlinux/security#395 gardenlinux/security#396 gardenlinux/security#397 gardenlinux/security#398 gardenlinux/security#399 gardenlinux/security#400 gardenlinux/security#402 gardenlinux/security#403