### PR TITLE
Add bare kvm flavor

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -456,6 +456,20 @@ targets:
     category: hypervisor
     flavors:
       - features:
+          - _prod
+        arch: amd64
+        build: true
+        test: true
+        test-platform: false
+        publish: true
+      - features:
+          - _prod
+        arch: arm64
+        build: true
+        test: true
+        test-platform: false
+        publish: true
+      - features:
           - gardener
           - _prod
         arch: amd64


### PR DESCRIPTION
**What this PR does / why we need it**: Publish a non-gardener KVM image for general purpose VMs.

**Which issue(s) this PR fixes**:
n/a

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**: as discussed with @gehoern 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Publish bare KVM cloud images
```
