### PR TITLE
fix: ignore pcrlogin units in sysdiff for _trustedboot flavor

### DIFF
--- a/tests/plugins/sysdiff.py
+++ b/tests/plugins/sysdiff.py
@@ -72,6 +72,9 @@ IGNORED_SYSTEMD_PATTERNS = [
     # runs periodically
     "gce-workload-cert-refresh.service",
     "gce-workload-cert-refresh.timer",
+    # _trustedboot: pcrlogin activates dynamically during boot/test session
+    "systemd-pcrlogin@*.service",
+    "system-systemd*pcrlogin.slice",
 ]
 
 # Units to wait for before taking a snapshot (unit_name: expected_sub_state)


### PR DESCRIPTION
## Summary

- `systemd-pcrlogin@*.service` and its associated slice activate dynamically during the test session on `_trustedboot` images
- This is expected TPM2/PCR behavior — not caused by any specific test
- Nightly has been failing on all `*_tpm2_trustedboot` QEMU flavors since 2026-06-30 due to sysdiff detecting this as an unexpected state change
- Fix: add them to `IGNORED_SYSTEMD_PATTERNS` in `sysdiff.py`, same pattern as other dynamic units (sysstat, kubelet, pcrlogin etc.)

## Test plan
- [ ] CI passes for `*_tpm2_trustedboot` QEMU flavors (sysdiff no longer flags pcrlogin units)