### PR TITLE
fix: ignore pcrlogin units in sysdiff for _trustedboot flavor

### DIFF
--- a/tests/plugins/sysdiff.py
+++ b/tests/plugins/sysdiff.py
@@ -72,6 +72,9 @@ IGNORED_SYSTEMD_PATTERNS = [
     # runs periodically
     "gce-workload-cert-refresh.service",
     "gce-workload-cert-refresh.timer",
+    # _trustedboot: pcrlogin activates dynamically during boot/test session
+    "systemd-pcrlogin@*.service",
+    "system-systemd*pcrlogin.slice",
 ]
 
 # Units to wait for before taking a snapshot (unit_name: expected_sub_state)


### PR DESCRIPTION
What this PR does / why we need it:
fix broken nightly due to new systemd pcrlogin (new kernel)

Which issue(s) this PR fixes:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4968