### PR TITLE
 docs: rework flavor, cname and related terms after ADR0034 and ADR0035, add links to feature references, dark and light mode images

### DIFF
--- a/docs/explanation/flavors.md
+++ b/docs/explanation/flavors.md
@@ -34,8 +34,9 @@ Imagine needing to create images for:
 
 The combinatorial explosion of possibilities would be impossible to manage if each image variant required a complete, independent definition. The flavor system addresses this by separating concerns into three dimensions:
 
-1. **[Target](#target-abstraction)** - The platform or environment (e.g., aws, azure, baremetal)
-2. **[Features](#feature-based-design)** - Capabilities and configurations (e.g., gardener, \_prod, \_usi)
+1. **[Platform features](/explanation/features#feature-types)** - The deployment target (e.g., [`aws`](/reference/features/aws), [`azure`](/reference/features/azure), [`baremetal`](/reference/features/baremetal))
+2. **[Element features](/explanation/features#feature-types)** - Functional components (e.g., [`gardener`](/reference/features/gardener), [`cis`](/reference/features/cis))
+3. **[Flag features](/explanation/features#feature-types)** - Lightweight modifiers (e.g., [`_prod`](/reference/features/_prod), [`_fips`](/reference/features/_fips), [`_usi`](/reference/features/_usi))
 
 This compositional approach allows Garden Linux to generate many unique flavor variants from the simple YAML definitions in [`flavors.yaml`](/reference/flavors.md).
 

--- a/docs/explanation/os-releases.md
+++ b/docs/explanation/os-releases.md
@@ -64,7 +64,7 @@ These specialized formats ensure optimal performance and integration with each p
 
 ### The CNAME system
 
-Every artifact receives a canonical name (CNAME) that serves as its unique identifier throughout the pipeline. The CNAME format encodes all essential information:
+For the full naming hierarchy, worked example, and the `/etc/os-release` keys written by the builder, see [Canonical Names in Flavors Reference](/reference/flavors#canonical-names) and [Feature resolution in `/etc/os-release`](/reference/features/#feature-resolution-in-etcos-release).
 
 ```
 {target}-{features}-{arch}-{version}-{commit}

--- a/docs/explanation/use-cases.md
+++ b/docs/explanation/use-cases.md
@@ -96,7 +96,7 @@ flavors is in the [Flavor Matrix](/reference/flavor-matrix).
 For organizations needing to run Gardener-managed Kubernetes on physical
 hardware, Garden Linux integrates with [IronCore](https://ironcore.dev) to
 provision bare-metal worker nodes via the Cluster API. This use case combines
-the `capi` (Cluster API) feature with the `baremetal` platform to enable PXE
+the [`capi`](/reference/features/capi) (Cluster API) feature with the [`baremetal`](/reference/features/baremetal) platform to enable PXE
 boot, ignition-based provisioning, and full hardware lifecycle management. It is
 designed for large-scale on-premises or edge deployments where control plane and
 worker nodes run on dedicated servers without a hypervisor layer.
@@ -213,7 +213,7 @@ include [cloud-init for initialization](/how-to/installation/post-install.html#m
 
 Deploy directly to physical servers by writing a raw disk image (`.raw`) to the
 target drive or via PXE network boot. This environment gives complete hardware
-control with no hypervisor overhead. The `baremetal` platform includes drivers
+control with no hypervisor overhead. The [`baremetal`](/reference/features/baremetal) platform includes drivers
 for common server hardware and supports UEFI and legacy BIOS boot modes. Use
 cases include data-center infrastructure nodes, edge appliances, and
 single-tenant hardware.

--- a/docs/how-to/choosing-flavors.md
+++ b/docs/how-to/choosing-flavors.md
@@ -28,10 +28,20 @@ github_target_path: docs/how-to/choosing-flavors.md
 
 # Choosing Flavors
 
-A Garden Linux [flavor](/explanation/flavors) is a pre-composed combination of
-a **platform target** (e.g. `aws`, `baremetal`) and one or more **features**
-(e.g. `gardener`, `_prod`, `_fips`). The flavor name encodes both:
-`<platform>-<feature1>_<feature2>` (e.g. `aws-gardener_prod`).
+A Garden Linux flavor is a specific build variant identified by a **canonical
+name (cname)** combined with a target architecture. Under
+[ADR 0035](/reference/adr/0035-cname-flavor-artifact-naming):
+
+- **cname** — the feature encoding only, canonically sorted (e.g.
+  `aws-gardener_prod`). See [Canonical Names](/reference/flavors#canonical-names).
+- **flavor** — `{cname}-{arch}` (e.g. `aws-gardener_prod-amd64`).
+
+The cname is assembled from three feature types defined in
+[ADR 0034](/reference/adr/0034-feature-terminology): exactly one **platform**
+feature (e.g. [`aws`](/reference/features/aws)), zero or more **element** features (e.g. [`gardener`](/reference/features/gardener)), and
+zero or more **flag** features (e.g. [`_prod`](/reference/features/_prod)). In `aws-gardener_prod`, `aws` is
+the platform feature, `gardener` is an element feature, and `_prod` is a flag
+feature.
 
 This guide walks you through selecting the right flavor in four steps. For
 background on how flavors work, see [Flavors](/explanation/flavors). For the

--- a/docs/how-to/installation/ignition.md
+++ b/docs/how-to/installation/ignition.md
@@ -36,13 +36,13 @@ Ignition runs only once during the first boot (`ignition.firstboot=1`). After co
 
 ## When to Use Ignition
 
-Use Ignition for bare-metal and PXE deployments. The `_pxe` feature includes the `_ignite` feature, which provides Ignition support during the initramfs stage.
+Use Ignition for bare-metal and PXE deployments. The [`_pxe`](/reference/features/_pxe) feature includes the [`_ignite`](/reference/features/_ignite) feature, which provides Ignition support during the initramfs stage.
 
 For cloud platform deployments (AWS, Azure, GCP, OpenStack), use [cloud-init](/how-to/installation/cloud-init.md) instead, as these platforms integrate with cloud-init natively.
 
 ## Prerequisites
 
-- Garden Linux build with the `_ignite` feature (automatically included with `_pxe`)
+- Garden Linux build with the [`_ignite`](/reference/features/_ignite) feature (automatically included with [`_pxe`](/reference/features/_pxe))
 - [Butane](https://github.com/coreos/butane) (optional but recommended, for translating YAML to JSON)
 
 ## Configuration format and basic structure

--- a/docs/how-to/installation/on-premises/index.md
+++ b/docs/how-to/installation/on-premises/index.md
@@ -34,7 +34,7 @@ For a complete step-by-step first-boot tutorial, see:
 :::
 
 ::: info Building Custom Images
-Garden Linux on-premises images require building with appropriate features (`_iso`, `_pxe`, `metal`, etc.). See [Building Images](/how-to/building-images.md) for build system documentation, or [Getting Images](/how-to/getting-images.md) for pre-built images.
+Garden Linux on-premises images require building with appropriate features ([`_iso`](/reference/features/_iso), [`_pxe`](/reference/features/_pxe), [`metal`](/reference/features/metal), etc.). See [Building Images](/how-to/building-images.md) for build system documentation, or [Getting Images](/how-to/getting-images.md) for pre-built images.
 :::
 
 <SectionIndex />

--- a/docs/how-to/installation/on-premises/pxe-boot.md
+++ b/docs/how-to/installation/on-premises/pxe-boot.md
@@ -148,9 +148,9 @@ The [`_pxe`](/reference/features/_pxe) feature provides the core PXE boot capabi
 
 | Build Command | Features | Use Case |
 |---------------|----------|----------|
-| `./build baremetal-gardener_prod_pxe` | `_pxe` | Live boot only (ephemeral, runs from RAM) |
-| `./build baremetal-gardener_prod_pxe_install` | `_pxe`, `_install` | Manual or Ignition-triggered installation |
-| `./build baremetal-gardener_prod_pxe_autoinstall` | `_pxe`, `_autoinstall` | Automatic installation to first disk |
+| `./build baremetal-gardener_prod_pxe` | [`_pxe`](/reference/features/_pxe) | Live boot only (ephemeral, runs from RAM) |
+| `./build baremetal-gardener_prod_pxe_install` | [`_pxe`](/reference/features/_pxe), [`_install`](/reference/features/_install) | Manual or Ignition-triggered installation |
+| `./build baremetal-gardener_prod_pxe_autoinstall` | [`_pxe`](/reference/features/_pxe), [`_autoinstall`](/reference/features/_autoinstall) | Automatic installation to first disk |
 
 The [`_autoinstall`](/reference/features/_autoinstall) feature includes [`_install`](/reference/features/_install), so you get both automatic detection and the ability to manually run the installer.
 
@@ -279,8 +279,8 @@ For additional Ignition configuration examples including network configuration, 
 Garden Linux PXE images require the [`_install`](/reference/features/_install) or [`_autoinstall`](/reference/features/_autoinstall) feature for disk installation. The [`_pxe`](/reference/features/_pxe) feature alone provides only live boot capability.
 
 To enable disk installation, build with one of:
-- `_pxe` + `_install` — Manual or Ignition-triggered installation
-- `_pxe` + `_autoinstall` — Automatic installation (includes `_install`)
+- [`_pxe`](/reference/features/_pxe) + [`_install`](/reference/features/_install) — Manual or Ignition-triggered installation
+- [`_pxe`](/reference/features/_pxe) + [`_autoinstall`](/reference/features/_autoinstall) — Automatic installation (includes `_install`)
 
 When [`_install`](/reference/features/_install) is included, `/opt/install/install.sh` is available and can be used in three ways:
 
@@ -359,7 +359,7 @@ passwd:
 
 - **`systemd.units.install.service`** — Systemd service that triggers installation on first boot
 - **`Environment="GL_INSTALL_TARGET=/dev/sda"`** — Specifies the target disk for installation (change to match your disk: `/dev/sda`, `/dev/nvme0n1`, etc.)
-- **`ExecStart=/opt/install/install.sh`** — Calls the built-in installer (provided by `_install` feature)
+- **`ExecStart=/opt/install/install.sh`** — Calls the built-in installer (provided by [`_install`](/reference/features/_install) feature)
 - **`passwd.users`** — User accounts to create on the installed system
 - **`ConditionFirstBoot=yes`** — Ensures installation only runs once
 
@@ -369,7 +369,7 @@ NVMe drives use the naming pattern `/dev/nvme0n1`, `/dev/nvme1n1`, etc. Virtio d
 
 #### Customizing the installation
 
-The built-in installer (`/opt/install/install.sh` from the `_install` feature) uses default configurations that can be customized:
+The built-in installer (`/opt/install/install.sh` from the [`_install`](/reference/features/_install) feature) uses default configurations that can be customized:
 
 **Default partition layout** (`/opt/install/install.part`):
 ```
@@ -621,7 +621,7 @@ System configuration tasks:
 
 ### Installation fails or does not start
 
-**For `_autoinstall` images:**
+**For [`_autoinstall`](/reference/features/_autoinstall) images:**
 - **Check gl-autoinstall.service logs**:
   ```bash
   journalctl -u gl-autoinstall.service
@@ -676,7 +676,7 @@ The test script automatically:
 4. Boots QEMU via network boot using iPXE
 5. Runs the test suite on the live system
 
-### Test PXE Installation with `_autoinstall` Feature
+### Test PXE Installation with [`_autoinstall`](/reference/features/_autoinstall) Feature
 
 To test PXE boot + installation to disk, build the image with the [`_autoinstall`](/reference/features/_autoinstall) feature:
 

--- a/docs/reference/adr/0034-feature-terminology.md
+++ b/docs/reference/adr/0034-feature-terminology.md
@@ -16,7 +16,7 @@ Accepted
 
 ## Context
 
-Garden Linux images are assembled from composable units called *features*. The main Garden Linux repository, `python-gardenlinux-lib`, and downstream tooling all use the terms *feature*, *platform*, *element*, and *flag*, but without a shared, written definition. This has led to inconsistencies — most notably in how `platform` is understood (a feature sub-type in the build system, a cloud provider name in publishing tooling, and an OCI image spec concept in update tooling) and in what the `GARDENLINUX_PLATFORM` and `GARDENLINUX_FEATURES_PLATFORMS` keys in `/etc/os-release` mean.
+Garden Linux images are assembled from composable units called _features_. The main Garden Linux repository, `python-gardenlinux-lib`, and downstream tooling all use the terms _feature_, _platform_, _element_, and _flag_, but without a shared, written definition. This has led to inconsistencies — most notably in how `platform` is understood (a feature sub-type in the build system, a cloud provider name in publishing tooling, and an OCI image spec concept in update tooling) and in what the `GARDENLINUX_PLATFORM` and `GARDENLINUX_FEATURES_PLATFORMS` keys in `/etc/os-release` mean.
 
 This ADR establishes shared definitions for these terms.
 
@@ -59,13 +59,13 @@ The **feature set** of a build is the complete set of features present after DAG
 
 The build process writes the following keys into `/etc/os-release`:
 
-| Key | Content |
-|---|---|
-| `GARDENLINUX_FEATURES` | Comma-separated list of all features in the resolved feature set |
-| `GARDENLINUX_FEATURES_PLATFORMS` | Comma-separated list of all features of type `platform` |
-| `GARDENLINUX_FEATURES_ELEMENTS` | Comma-separated list of all features of type `element` |
-| `GARDENLINUX_FEATURES_FLAGS` | Comma-separated list of all features of type `flag` |
-| `GARDENLINUX_PLATFORM` | The single authoritative platform identifier for this image |
+| Key                              | Content                                                          |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `GARDENLINUX_FEATURES`           | Comma-separated list of all features in the resolved feature set |
+| `GARDENLINUX_FEATURES_PLATFORMS` | Comma-separated list of all features of type `platform`          |
+| `GARDENLINUX_FEATURES_ELEMENTS`  | Comma-separated list of all features of type `element`           |
+| `GARDENLINUX_FEATURES_FLAGS`     | Comma-separated list of all features of type `flag`              |
+| `GARDENLINUX_PLATFORM`           | The single authoritative platform identifier for this image      |
 
 `GARDENLINUX_PLATFORM` is derived from `GARDENLINUX_FEATURES_PLATFORMS` as follows: if exactly one platform feature is present, `GARDENLINUX_PLATFORM` is set to that feature's name. If more than one platform feature is present (frankenstein build), `GARDENLINUX_PLATFORM` is set to the literal string `frankenstein`.
 

--- a/docs/reference/adr/0035-cname-flavor-artifact-naming.md
+++ b/docs/reference/adr/0035-cname-flavor-artifact-naming.md
@@ -52,10 +52,11 @@ The minimal features are sorted by **lexicographical topological order** with a 
 The cname string is assembled from the sorted minimal features as follows: features are concatenated with `-` as separator, except that flag features (which begin with `_`) are joined directly to the preceding component without a leading `-`. This encoding is reversible: given a cname, the minimal feature set can be recovered by replacing every occurrence of `_` with `-_` and splitting on `-`.
 
 Examples:
+
 - Features `{aws, gardener, _prod}` where `aws` is the platform, `gardener` the element, `_prod` the flag → cname = `aws-gardener_prod`
 - Features `{container}` → cname = `container`
 
-The word *canonical* is fitting: the cname is the canonical way to represent a particular set of features in their minimal, consistently-sorted form. It identifies *what* is being built, independent of where or when. Two builds with the same cname are builds of the same feature set.
+The word _canonical_ is fitting: the cname is the canonical way to represent a particular set of features in their minimal, consistently-sorted form. It identifies _what_ is being built, independent of where or when. Two builds with the same cname are builds of the same feature set.
 
 ### 2. Flavor
 
@@ -93,11 +94,11 @@ The artifact base name is the prefix of every file produced under `.build/` by t
 
 ### 6. Summary table
 
-| Term | Format | Example |
-|---|---|---|
-| **cname** | `{feature-encoding}` | `aws-gardener_prod` |
-| **flavor** | `{cname}-{arch}` | `aws-gardener_prod-amd64` |
-| **versioned flavor** | `{cname}-{arch}-{version}` | `aws-gardener_prod-amd64-1877.3` |
+| Term                   | Format                                    | Example                                   |
+| ---------------------- | ----------------------------------------- | ----------------------------------------- |
+| **cname**              | `{feature-encoding}`                      | `aws-gardener_prod`                       |
+| **flavor**             | `{cname}-{arch}`                          | `aws-gardener_prod-amd64`                 |
+| **versioned flavor**   | `{cname}-{arch}-{version}`                | `aws-gardener_prod-amd64-1877.3`          |
 | **artifact base name** | `{cname}-{arch}-{version}-{short_commit}` | `aws-gardener_prod-amd64-1877.3-a1b2c3d4` |
 
 ## Consequences

--- a/docs/reference/flavors.md
+++ b/docs/reference/flavors.md
@@ -127,7 +127,7 @@ Each Garden Linux build is identified by a four-level naming hierarchy defined i
 
 **flavor** qualifies the cname with a target architecture. This is the stable identifier used in `flavors.yaml` entries, CI job naming, and as the argument to the `./build` script.
 
-**versioned flavor** qualifies the flavor with a version. The version is never passed on the `./build` command line — it is resolved internally from the `VERSION` file via `./get_version`.
+**versioned flavor** qualifies the flavor with a version. The version can optionally be passed on the `./build` command line or is resolved internally from the `VERSION` file via `./get_version`.
 
 **artifact base name** qualifies the versioned flavor with a short commit hash. It is the prefix of every file produced under `.build/` and the key used for S3 artifact storage.
 

--- a/docs/reference/flavors.md
+++ b/docs/reference/flavors.md
@@ -116,18 +116,14 @@ Flavors with `publish: false` are still available as GitHub workflow artifacts f
 
 Each Garden Linux build is identified by a four-level naming hierarchy defined in [ADR 0035](/reference/adr/0035-cname-flavor-artifact-naming):
 
-| Term | Format | Example |
-|---|---|---|
-| **cname** | `{feature-encoding}` | `aws-gardener_prod` |
-| **flavor** | `{cname}-{arch}` | `aws-gardener_prod-amd64` |
-| **versioned flavor** | `{cname}-{arch}-{version}` | `aws-gardener_prod-amd64-2150.1.0` |
+| Term                   | Format                                    | Example                                    |
+| ---------------------- | ----------------------------------------- | ------------------------------------------ |
+| **cname**              | `{feature-encoding}`                      | `aws-gardener_prod`                        |
+| **flavor**             | `{cname}-{arch}`                          | `aws-gardener_prod-amd64`                  |
+| **versioned flavor**   | `{cname}-{arch}-{version}`                | `aws-gardener_prod-amd64-2150.1.0`         |
 | **artifact base name** | `{cname}-{arch}-{version}-{short_commit}` | `aws-gardener_prod-amd64-2150.1.0-abc1234` |
 
 **cname** (canonical name) encodes only the feature set — no architecture, version, or commit. It is the minimal, canonically-sorted representation of the features selected for a build.
-
-:::note
-ADR 0035 specifies that `GARDENLINUX_CNAME` in `/etc/os-release` will contain exactly the cname once the migration is complete. Currently it contains the versioned flavor (`{cname}-{arch}-{version}`).
-:::
 
 **flavor** qualifies the cname with a target architecture. This is the stable identifier used in `flavors.yaml` entries, CI job naming, and as the argument to the `./build` script.
 
@@ -144,7 +140,7 @@ For example, `aws-gardener_prod_fips` is assembled from:
 - [`gardener`](/reference/features/gardener) — an element, joined with `-` → `aws-gardener`
 - [`_prod`](/reference/features/_prod) — a flag, appended directly (no `-`) → `aws-gardener_prod`
 - [`_fips`](/reference/features/_fips) — a flag, appended directly (no `-`) → `aws-gardener_prod_fips`
-:::
+  :::
 
 **Worked example** for [`aws`](/reference/features/aws) (platform), [`gardener`](/reference/features/gardener) (element), [`_prod`](/reference/features/_prod) (flag) features on `amd64` at version `2150.1.0` with commit `abc1234`:
 

--- a/docs/reference/flavors.md
+++ b/docs/reference/flavors.md
@@ -114,7 +114,50 @@ Flavors with `publish: false` are still available as GitHub workflow artifacts f
 
 ## Feature List
 
-A complete list of all available features can be looked up in the [Features Reference](/reference/features/)
+Each Garden Linux build is identified by a four-level naming hierarchy defined in [ADR 0035](/reference/adr/0035-cname-flavor-artifact-naming):
+
+| Term | Format | Example |
+|---|---|---|
+| **cname** | `{feature-encoding}` | `aws-gardener_prod` |
+| **flavor** | `{cname}-{arch}` | `aws-gardener_prod-amd64` |
+| **versioned flavor** | `{cname}-{arch}-{version}` | `aws-gardener_prod-amd64-2150.1.0` |
+| **artifact base name** | `{cname}-{arch}-{version}-{short_commit}` | `aws-gardener_prod-amd64-2150.1.0-abc1234` |
+
+**cname** (canonical name) encodes only the feature set — no architecture, version, or commit. It is the minimal, canonically-sorted representation of the features selected for a build.
+
+:::note
+ADR 0035 specifies that `GARDENLINUX_CNAME` in `/etc/os-release` will contain exactly the cname once the migration is complete. Currently it contains the versioned flavor (`{cname}-{arch}-{version}`).
+:::
+
+**flavor** qualifies the cname with a target architecture. This is the stable identifier used in `flavors.yaml` entries, CI job naming, and as the argument to the `./build` script.
+
+**versioned flavor** qualifies the flavor with a version. The version is never passed on the `./build` command line — it is resolved internally from the `VERSION` file via `./get_version`.
+
+**artifact base name** qualifies the versioned flavor with a short commit hash. It is the prefix of every file produced under `.build/` and the key used for S3 artifact storage.
+
+:::info Feature name encoding in the cname
+Features are concatenated with `-` as separator. Flag features (whose names begin with `_`) are joined directly to the preceding component without a leading `-`.
+
+For example, `aws-gardener_prod_fips` is assembled from:
+
+- [`aws`](/reference/features/aws) — the platform feature
+- [`gardener`](/reference/features/gardener) — an element, joined with `-` → `aws-gardener`
+- [`_prod`](/reference/features/_prod) — a flag, appended directly (no `-`) → `aws-gardener_prod`
+- [`_fips`](/reference/features/_fips) — a flag, appended directly (no `-`) → `aws-gardener_prod_fips`
+:::
+
+**Worked example** for [`aws`](/reference/features/aws) (platform), [`gardener`](/reference/features/gardener) (element), [`_prod`](/reference/features/_prod) (flag) features on `amd64` at version `2150.1.0` with commit `abc1234`:
+
+1. **cname** = `aws-gardener_prod` (feature encoding only)
+1. **flavor** = `aws-gardener_prod-amd64` (cname + arch)
+1. **versioned flavor** = `aws-gardener_prod-amd64-2150.1.0` (flavor + version; resolved internally by `./build`)
+1. **artifact base name** = `aws-gardener_prod-amd64-2150.1.0-abc1234` (versioned flavor + short commit; prefix for all output files)
+
+:::info `today` as a version
+The version is never specified on the `./build` command line. It is read from the `VERSION` file in the repository root via `./get_version`. On `main`, `VERSION` contains `today`, so the literal string `today` is used as the version. On a release branch, `VERSION` contains the full semver for that branch (e.g. `2150.5.0`), and `get_version` returns it as-is. Builds with version `today` are development builds and are not intended for distribution.
+:::
+
+For the authoritative specification of cname construction, sorting, and minimisation, see [ADR 0035](/reference/adr/0035-cname-flavor-artifact-naming). For the feature type definitions (`platform`, `element`, `flag`) see [ADR 0034](/reference/adr/0034-feature-terminology).
 
 ## gl-flavors-parse Tool
 

--- a/features/_bfpxe/README.md
+++ b/features/_bfpxe/README.md
@@ -18,5 +18,5 @@ only bluefield pxe build is done (with squashfs)
 |---|---|
 |type|flag|
 |artifact|None|
-|included_features|_ignite|
+|included_features|[`_ignite`](/reference/features/_ignite)|
 |excluded_features|None|

--- a/features/_fips/README.md
+++ b/features/_fips/README.md
@@ -27,5 +27,5 @@ We have several tests executed.
 |---|---|
 |type|flag|
 |artifact|None|
-|included_features|base|
+|included_features|[`base`](/reference/features/base)|
 |excluded_features|None|

--- a/features/_oci/README.md
+++ b/features/_oci/README.md
@@ -251,5 +251,5 @@ This feature does not support unit tests.
 |---|---|
 |type|flag|
 |artifact|`.oci.tar.xz`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/_prod/README.md
+++ b/features/_prod/README.md
@@ -23,5 +23,5 @@ This feature does not support unit tests.
 |---|---|
 |type|flag|
 |artifact|None|
-|included_features|_nopkg,_readonly|
+|included_features|[`_nopkg`](/reference/features/_nopkg), [`_readonly`](/reference/features/_readonly)|
 |excluded_features|None|

--- a/features/_slim/README.md
+++ b/features/_slim/README.md
@@ -23,5 +23,5 @@ This feature does not support unit tests.
 |---|---|
 |type|flag|
 |artifact|None|
-|included_features|server|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/_usi/README.md
+++ b/features/_usi/README.md
@@ -18,5 +18,5 @@ boot using a UKI with embedded EROFS root disk
 |---|---|
 |type|flag|
 |artifact|None|
-|included_features|_nocrypt, _unsigned|
-|excluded_features|_legacy|
+|included_features|[`_nocrypt`](/reference/features/_nocrypt), [`_unsigned`](/reference/features/_unsigned)|
+|excluded_features|[`_legacy`](/reference/features/_legacy)|

--- a/features/ali/README.md
+++ b/features/ali/README.md
@@ -26,5 +26,5 @@ This platform feature supports unit testing and is based on the `ali` fixture to
 |---|---|
 |type|platform|
 |artifact|`.raw`,`.qcow2`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/aws/README.md
+++ b/features/aws/README.md
@@ -26,5 +26,5 @@ This platform feature supports unit testing and is based on the `aws` fixture to
 |---|---|
 |type|platform|
 |artifact|`.raw`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/azure/README.md
+++ b/features/azure/README.md
@@ -26,5 +26,5 @@ This platform feature supports unit testing and is based on the `azure` fixture 
 |---|---|
 |type|platform|
 |artifact|`.raw`, `.vhd`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/baremetal/README.md
+++ b/features/baremetal/README.md
@@ -24,5 +24,5 @@ This platform feature supports unit testing and is based on the `metal` fixture 
 |---|---|
 |type|platform|
 |artifact|`.raw`,`.qcow2`|
-|included_features|`cloud`|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/base/README.md
+++ b/features/base/README.md
@@ -25,5 +25,5 @@ Representing the base layer for Garden Linux requires many additional unit tests
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|`_slim`|
+|included_features|[`_slim`](/reference/features/_slim)|
 |excluded_features|None|

--- a/features/checkbox/README.md
+++ b/features/checkbox/README.md
@@ -18,5 +18,5 @@ checkbox HW Test Kit
 |---|---|
 |type|flag|
 |artifact|None|
-|included_features|_iso|
-|excluded_features|sap, firewall, log, _selinux, _ignite|
+|included_features|[`_iso`](/reference/features/_iso)|
+|excluded_features|[`sap`](/reference/features/sap), [`firewall`](/reference/features/firewall), [`log`](/reference/features/log), [`_selinux`](/reference/features/_selinux), [`_ignite`](/reference/features/_ignite)|

--- a/features/chost/README.md
+++ b/features/chost/README.md
@@ -29,5 +29,5 @@ buildkit
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|server|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/cis/README.md
+++ b/features/cis/README.md
@@ -34,5 +34,5 @@ Additional tests can be be included by placing an executable script nn [test/che
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|`aide`, `cisAudit`, `cisModprobe`, `cisOS`, `cisPackages`, `cisPartition`, `cisSshd`, `cisSysctl`, `clamav`, `firewall`|
-|excluded_features|`fedramp`|
+|included_features|[`aide`](/reference/features/aide), [`cisAudit`](/reference/features/cisAudit), [`cisModprobe`](/reference/features/cisModprobe), [`cisOS`](/reference/features/cisOS), [`cisPackages`](/reference/features/cisPackages), [`cisPartition`](/reference/features/cisPartition), [`cisSshd`](/reference/features/cisSshd), [`cisSysctl`](/reference/features/cisSysctl), [`clamav`](/reference/features/clamav), [`firewall`](/reference/features/firewall)|
+|excluded_features|[`fedramp`](/reference/features/fedramp)|

--- a/features/cisAudit/README.md
+++ b/features/cisAudit/README.md
@@ -24,5 +24,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cisModprobe/README.md
+++ b/features/cisModprobe/README.md
@@ -35,5 +35,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cisOS/README.md
+++ b/features/cisOS/README.md
@@ -24,5 +24,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cisPackages/README.md
+++ b/features/cisPackages/README.md
@@ -30,5 +30,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cisPartition/README.md
+++ b/features/cisPartition/README.md
@@ -42,5 +42,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cisSshd/README.md
+++ b/features/cisSshd/README.md
@@ -24,5 +24,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cisSysctl/README.md
+++ b/features/cisSysctl/README.md
@@ -25,5 +25,5 @@ Unit tests are only supported by its parent feature `cis`. See also [../cis/READ
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|cis|
+|included_features|[`cis`](/reference/features/cis)|
 |excluded_features|None|

--- a/features/cloud/README.md
+++ b/features/cloud/README.md
@@ -13,7 +13,7 @@ This feature adjusts Garden Linux for cloud functionality with cloud kernel, boo
 </website-feature>
 
 ### Features
-All hyperscaler & cloud platforms (e.g. `ali`, `azure`, `vmware`, `openstack`, etc.) are based on this `cloud` feature. Garden Linux artifacts with cloud functionality are highly optimized for cloud/hyperscaler environments by running on ARM64 or AMD64 hardware platforms including optimized kernel and boot options.
+All hyperscaler & cloud platforms (e.g. [`ali`](/reference/features/ali), [`azure`](/reference/features/azure), [`vmware`](/reference/features/vmware), [`openstack`](/reference/features/openstack), etc.) are based on this `cloud` feature. Garden Linux artifacts with cloud functionality are highly optimized for cloud/hyperscaler environments by running on ARM64 or AMD64 hardware platforms including optimized kernel and boot options.
 
 ### Unit testing
 this feature supports unit tests and ensures that all required packages are present, an autologout is configured, PAM faillock is active and the wireguard kernel module is activated.
@@ -23,5 +23,5 @@ this feature supports unit tests and ensures that all required packages are pres
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|server|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/container/README.md
+++ b/features/container/README.md
@@ -31,5 +31,5 @@ Testing of specific units can be avoided by placing the `non_container` fixture.
 |---|---|
 |type|platform|
 |artifact|`.tar.gz`|
-|included_features|base|
+|included_features|[`base`](/reference/features/base)|
 |excluded_features|None|

--- a/features/fedramp/README.md
+++ b/features/fedramp/README.md
@@ -13,7 +13,7 @@ This features adjusts Garden Linux to be compliant to the requirements of Fedram
 </website-feature>
 
 ### Features
-This `fedramp` feature represents a meta feature that includes multiple sub features like `aide` or `firewall`. Working with sub features provides an easy overview, adjustment and administration for each sub feature. While only including all sub features full fills the needed requirements for FedRAMP, it is in an operators decision to adjust sub features to his needs. This allows changes to be as near as possible to FedRAMP, even it may not fit the FedRAMP requirements. This feature includes further subfeatures.
+This `fedramp` feature represents a meta feature that includes multiple sub features like [`aide`](/reference/features/aide) or [`firewall`](/reference/features/firewall). Working with sub features provides an easy overview, adjustment and administration for each sub feature. While only including all sub features full fills the needed requirements for FedRAMP, it is in an operators decision to adjust sub features to his needs. This allows changes to be as near as possible to FedRAMP, even it may not fit the FedRAMP requirements. This feature includes further subfeatures.
 
 ### Unit testing
 The FedRAMP unit test is based on a simple [simple shell script](tests/test.sh) and is executed by a `PyTest` wrapper. This tests will be proceeded for artifacts that are built with the `fedramp` feature and will validate all options, whether a sub feature is included or not.
@@ -23,5 +23,5 @@ The FedRAMP unit test is based on a simple [simple shell script](tests/test.sh) 
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|aide,clamav,firewall|
+|included_features|[`aide`](/reference/features/aide), [`clamav`](/reference/features/clamav), [`firewall`](/reference/features/firewall)|
 |excluded_features|None|

--- a/features/gardener/README.md
+++ b/features/gardener/README.md
@@ -14,10 +14,10 @@ As Garden Linux is the Container Node OS for Gardener, that's also where the "Ga
 ### Features
 The `gardener` feature adjusts Garden Linux to fulfil the `gardener.cloud` requirements:
 - installs package `containerd`
-  - This is a duplicate of the ContainerHost (chost) feature, but as `containerd` is a fundamental requirement of Gardener it is also included in this feature
+  - This is a duplicate of the ContainerHost ([`chost`](/reference/features/chost)) feature, but as `containerd` is a fundamental requirement of Gardener it is also included in this feature
 - By default, systemd unit files for `containerd` are disabled and will be enabled by Gardener itself.
 - Installs default requirements for Gardener / Kubernetes `apparmor`, `ethtool`, `ipvsadm`, `socat`, `ebtables`
-  - This is very similar to the KubernetesHost (khost) feature of GardenLinux itself but adapted to Gardener needs
+  - This is very similar to the KubernetesHost ([`khost`](/reference/features/khost)) feature of GardenLinux itself but adapted to Gardener needs
 - Installs filesystem clients `btrfs-progs`, `xfsprogs`, `nfs-common`, `cifs-utils` to support common Gardener remote file system needs
 - Installs standard tools like `jq`, `curl` and `netcat` as needed by Gardener
 
@@ -45,5 +45,5 @@ Unit tests are supported for this feature and will ensure that the groups are co
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|server|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/gcp/README.md
+++ b/features/gcp/README.md
@@ -42,5 +42,5 @@ This platform feature supports unit testing and is based on the `gcp` fixture to
 |---|---|
 |type|platform|
 |artifact|`.raw`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/gdch/README.md
+++ b/features/gdch/README.md
@@ -18,5 +18,5 @@ Google Distributed Cloud Hosted (gdch environment)
 |---|---|
 |type|platform|
 |artifact|.raw|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/iscsi/README.md
+++ b/features/iscsi/README.md
@@ -20,5 +20,5 @@ The `iscsi` feature allows the usage of iscsi target and initiator within Garden
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|multipath|
+|included_features|[`multipath`](/reference/features/multipath)|
 |excluded_features|None|

--- a/features/khost/README.md
+++ b/features/khost/README.md
@@ -9,7 +9,7 @@ github_target_path: docs/reference/features/khost.md
 ## Feature: khost
 ### Description
 <website-feature>
-The vhost feature adjusts Garden Linux to support running Kubernetes (vanilla) workloads.
+The `khost` feature adjusts Garden Linux to support running Kubernetes (vanilla) workloads.
 </website-feature>
 
 ### Features
@@ -23,5 +23,5 @@ Unit tests will ensure that the needed packages are present as well as the `kubl
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|`chost`|
+|included_features|[`chost`](/reference/features/chost)|
 |excluded_features|None|

--- a/features/kvm/README.md
+++ b/features/kvm/README.md
@@ -24,5 +24,5 @@ Next to this, `kvm` fixture is the base platform to perform local unit tests tha
 |---|---|
 |type|platform|
 |artifact|`.raw`,`.qcow2`|
-|included_features|`server`|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/metal/README.md
+++ b/features/metal/README.md
@@ -24,5 +24,5 @@ This platform feature supports unit testing and is based on the `metal` fixture 
 |---|---|
 |type|platform|
 |artifact|`.raw`,`.qcow2`|
-|included_features|`cloud`|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/multipath/README.md
+++ b/features/multipath/README.md
@@ -14,12 +14,12 @@ This feature installs multipath
 
 ### Features
 This feature installs multipath and creates a config file for it.
-Multipath is needed by iscsi as well as nvme over tcp .
+Multipath is needed by [`iscsi`](/reference/features/iscsi) as well as nvme over tcp.
 
 ### Meta
 |||
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|server|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/nvme/README.md
+++ b/features/nvme/README.md
@@ -20,5 +20,5 @@ This feature installs nvm-cli as well as a systemd unit that creates /etc/nvme/h
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|multipath|
+|included_features|[`multipath`](/reference/features/multipath)|
 |excluded_features|None|

--- a/features/openstackCloud/README.md
+++ b/features/openstackCloud/README.md
@@ -25,5 +25,5 @@ This platform feature supports unit testing and is based on the `openstackccee` 
 |---|---|
 |type|platform|
 |artifact|`.raw`,`.qcow2`, `.vmdk`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|

--- a/features/pythonDev/README.md
+++ b/features/pythonDev/README.md
@@ -24,5 +24,5 @@ For production, we recommend using a [multistage build with bare-python](https:/
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|python|
+|included_features|[`python`](/reference/features/python)|
 |excluded_features|None|

--- a/features/sapmachine/README.md
+++ b/features/sapmachine/README.md
@@ -18,5 +18,5 @@ SapMachine - An OpenJDK release maintained and supported by SAP
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|_curl|
+|included_features|[`_curl`](/reference/features/_curl)|
 |excluded_features|None|

--- a/features/server/README.md
+++ b/features/server/README.md
@@ -24,5 +24,5 @@ This features support unit testing and validates the installed packages, sshd co
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|`base`, `ssh`,`_selinux`|
+|included_features|[`base`](/reference/features/base), [`ssh`](/reference/features/ssh), [`_selinux`](/reference/features/_selinux)|
 |excluded_features|None|

--- a/features/ssh/README.md
+++ b/features/ssh/README.md
@@ -15,8 +15,8 @@ This ssh layer adds the OpenSSH server with sshguard.
 ### Features
 This ssh layer adds the OpenSSH server with sshguard.
 
-Sshguard uses `nftables` which is installed and managed by the [`firewall`](../firewall/) feature.
-If the `firewall` feature is excluded, but `iptables` is available, sshguard will use `iptables`.
+Sshguard uses `nftables` which is installed and managed by the [`firewall`](/reference/features/firewall) feature.
+If the [`firewall`](/reference/features/firewall) feature is excluded, but `iptables` is available, sshguard will use `iptables`.
 If neither are available, sshguard is disabled.
 
 #### Configs
@@ -32,5 +32,5 @@ This feature supports unit tests that will validate the correct configuration of
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|`firewall`|
+|included_features|[`firewall`](/reference/features/firewall)|
 |excluded_features|None|

--- a/features/stigDev/README.md
+++ b/features/stigDev/README.md
@@ -18,5 +18,5 @@ github_target_path: docs/reference/features/stigDev.md
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|stig|
+|included_features|[`stig`](/reference/features/stig)|
 |excluded_features|None|

--- a/features/vhost/README.md
+++ b/features/vhost/README.md
@@ -23,5 +23,5 @@ To be fully compliant these unit tests validate the extended capabilities on `gs
 |---|---|
 |type|element|
 |artifact|None|
-|included_features|server|
+|included_features|[`server`](/reference/features/server)|
 |excluded_features|None|

--- a/features/vmware/README.md
+++ b/features/vmware/README.md
@@ -28,5 +28,5 @@ This platform feature supports unit testing and is based on the `chroot` and `kv
 |---|---|
 |type|platform|
 |artifact|`.vmdk`,`.ova`|
-|included_features|cloud|
+|included_features|[`cloud`](/reference/features/cloud)|
 |excluded_features|None|


### PR DESCRIPTION
**What this PR does / why we need it**:

- docs: rework flavor, cname and related terms after ADR0034 and ADR0035
- add links to feature references
- dark and light mode images
- extend glossary

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4600
