### PR TITLE
Use 0666 for /dev/kvm for the qemu tests

### DIFF
--- a/.github/workflows/test_flavor_qemu.yml
+++ b/.github/workflows/test_flavor_qemu.yml
@@ -63,6 +63,12 @@ jobs:
           rm "$CNAME.tar.gz"
           tree .build
         # TODO: handle skipping better
+      - name: rw for KVM
+        # TODO: can we do this in a nicer way?
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Execute tests
         run: |
           if [ ! -e ".build/$CNAME.raw" ]; then

--- a/tests/util/run_qemu.sh
+++ b/tests/util/run_qemu.sh
@@ -153,11 +153,6 @@ else
 	qemu-img create -q -f qcow2 -F raw -b "$(realpath -- "$image")" "$tmpdir/disk.qcow" 4G
 fi
 
-console_device="/dev/ttyS0"
-if [ "$arch" = aarch64 ]; then
-	console_device="/dev/ttyAMA0"
-fi
-
 cat >"$tmpdir/fw_cfg-script.sh" <<EOF
 #!/usr/bin/env bash
 
@@ -180,7 +175,7 @@ fi
 cat >>"$tmpdir/fw_cfg-script.sh" <<EOF
 # Send all output to console so it appears on
 # the QEMU serial output (and thus in logs).
-exec >$console_device
+exec >/dev/console
 exec 2>&1
 
 echo "⚙️  Qemu environment quirks..."

--- a/tests/util/run_qemu.sh
+++ b/tests/util/run_qemu.sh
@@ -258,7 +258,8 @@ if ! ((skip_tests)); then
 		"--system-booted"
 		"--allow-system-modifications"
 	)
-	if [ "$qemu_accel" == "tcg" ]; then
+	# skip performance metrics when no acceleration is availale or being run in a github runner
+	if [[ "$qemu_accel" == "tcg" || (-v RUNNER_ENVIRONMENT && "$RUNNER_ENVIRONMENT" == github-hosted ) ]]; then
 		test_args+=("--skip-performance-metrics")
 	fi
 	if ((ssh)); then


### PR DESCRIPTION
**What this PR does / why we need it**:
Use 0666 permissions for /dev/kvm so that our qemu tests can use kvm acceleration. (nested virtualization is allowed on the runners[^1])

**Which issue(s) this PR fixes**:
Fixes #

[^1]: https://github.com/orgs/community/discussions/160591#discussioncomment-9018826
