### PR TITLE
Add _fips for arm64 and amd on ali

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -18,6 +18,24 @@ targets:
         test: false
         test-platform: false
         publish: false
+      - features:
+          - gardener
+          - _prod
+          - _fips
+        arch: amd64
+        build: true
+        test: true
+        test-platform: true
+        publish: true
+      - features:
+          - gardener
+          - _prod
+          - _fips
+        arch: arm64
+        build: false
+        test: false
+        test-platform: false
+        publish: false
   - name: aws
     category: public-cloud
     flavors:


### PR DESCRIPTION
Add `_fips` to Ali, but without support for `_usi`. 


Releates: https://github.com/gardenlinux/gardenlinux/issues/3703
