### PR TITLE
ssh key lower for openssh 10.4 compatibility

### DIFF
--- a/tests/plugins/sshd.py
+++ b/tests/plugins/sshd.py
@@ -18,6 +18,7 @@ class Sshd:
             parts = line.split(maxsplit=1)
             if len(parts) == 2:
                 key, value = parts
+                key = str.casefold(key)
                 # If key already exists, convert to set and append
                 if key in self._sshd_config:
                     if isinstance(self._sshd_config[key], set):
@@ -27,7 +28,7 @@ class Sshd:
                 else:
                     self._sshd_config[key] = value
             elif len(parts) == 1:
-                key = parts[0]
+                key = str.casefold(parts[0])
                 self._sshd_config[key] = None
 
     def get_config(self) -> dict:

--- a/tests/plugins/sshd.py
+++ b/tests/plugins/sshd.py
@@ -18,7 +18,7 @@ class Sshd:
             parts = line.split(maxsplit=1)
             if len(parts) == 2:
                 key, value = parts
-                key = str.casefold(key)
+                key = key.lower()
                 # If key already exists, convert to set and append
                 if key in self._sshd_config:
                     if isinstance(self._sshd_config[key], set):
@@ -28,14 +28,14 @@ class Sshd:
                 else:
                     self._sshd_config[key] = value
             elif len(parts) == 1:
-                key = str.casefold(parts[0])
+                key = parts[0].lower()
                 self._sshd_config[key] = None
 
     def get_config(self) -> dict:
         return self._sshd_config
 
     def get_config_section(self, key: str) -> str | set | None:
-        return self._sshd_config.get(str.casefold(key))
+        return self._sshd_config.get(key.lower())
 
 
 @pytest.fixture


### PR DESCRIPTION
**What this PR does / why we need it**:
As openssh is apt_src (Debian Snapshot) and backport (rel-2150) is via Salsa, an `openssh` compatibility issue is discovered in 10.4p1-1 with our `tests/plugins/sshd.py`

**Which issue(s) this PR fixes**:
Fixes #5033 