### PR TITLE
chore: update to python3.14

### DIFF
--- a/docs/01_developers/bare_container.md
+++ b/docs/01_developers/bare_container.md
@@ -52,7 +52,7 @@ Their development is streamlined by the [unbase_oci](https://github.com/gardenli
   RUN exportLibs.py
   
   FROM ghcr.io/gardenlinux/gardenlinux/bare-python:1877.9
-  COPY --from=packages /usr/local/lib/python3.13/dist-packages/ /usr/local/lib/python3.13/dist-packages/
+  COPY --from=packages /usr/local/lib/python3.14/dist-packages/ /usr/local/lib/python3.14/dist-packages/
   COPY --from=packages /required_libs /
   
   COPY main.py /
@@ -129,7 +129,7 @@ $ dust -n 32 -w 64 -r /mnt
  52M └─┬ mnt                        │████████████████████ │ 100%
  52M   └─┬ usr                      │████████████████████ │ 100%
  43M     ├─┬ lib                    │█████████████████░░░ │  82%
- 28M     │ ├─┬ python3.13           │███████████▒▒▒▒▒▒░░░ │  55%
+ 28M     │ ├─┬ python3.14           │███████████▒▒▒▒▒▒░░░ │  55%
 5.2M     │ │ ├── lib-dynload        │██▓▓▓▓▓▓▓▓▓▒▒▒▒▒▒░░░ │  10%
 5.2M     │ │ ├── __pycache__        │██▓▓▓▓▓▓▓▓▓▒▒▒▒▒▒░░░ │  10%
 2.4M     │ │ ├─┬ encodings          │█▓▓▓▓▓▓▓▓▓▓▒▒▒▒▒▒░░░ │   5%
@@ -155,7 +155,7 @@ $ dust -n 32 -w 64 -r /mnt
 708K     │   ├── libzstd.so.1.5.7   │█▓▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒░░░ │   1%
 580K     │   └── libm.so.6          │█▓▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒░░░ │   1%
 7.0M     ├─┬ bin                    │███░░░░░░░░░░░░░░░░░ │  13%
-6.9M     │ └── python3.13           │███░░░░░░░░░░░░░░░░░ │  13%
+6.9M     │ └── python3.14           │███░░░░░░░░░░░░░░░░░ │  13%
 2.4M     └─┬ share                  │█░░░░░░░░░░░░░░░░░░░ │   5%
 1.9M       └─┬ zoneinfo             │█░░░░░░░░░░░░░░░░░░░ │   4%
 572K         └── America            │█░░░░░░░░░░░░░░░░░░░ │   1%

--- a/features/pythonDev/pkg.include
+++ b/features/pythonDev/pkg.include
@@ -1,3 +1,3 @@
 python3-pip
-python3.13-venv
+python3.14-venv
 vim

--- a/tests/integration/runtime/test_pythonDev.py
+++ b/tests/integration/runtime/test_pythonDev.py
@@ -16,8 +16,8 @@ def test_python_environment_is_installed(shell: ShellRunner):
         "python3-pip"
     ), "python3-pip package is not installed"
     assert dpkg.package_is_installed(
-        "python3.13-venv"
-    ), "python3.13-venv package is not installed"
+        "python3.14-venv"
+    ), "python3.14-venv package is not installed"
 
 
 dependencies = {


### PR DESCRIPTION
**What this PR does / why we need it**:

chore: update to python3.14
