### PR TITLE
feat: remove migration frontmatter as migration is done

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -12,9 +12,6 @@ related_topics:
   - /reference/testing/developing-tests.md
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/contributing/testing.md

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -3,10 +3,6 @@ title: "Architecture"
 description: 1524-Meters View of Garden Linux
 order: 10
 github_target_path: "docs/explanation/architecture.md"
-migration_status: "new"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4632"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/architecture.md

--- a/docs/explanation/boot-modes.md
+++ b/docs/explanation/boot-modes.md
@@ -8,11 +8,6 @@ related_topics:
   - /how-to/secure-boot
   - /how-to/building-images
   - /how-to/installation/on-premises/disk-layout
-migration_status: "done"
-migration_source: "docs/legacy/boot_modes.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4630"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/boot-modes.md

--- a/docs/explanation/compliance-frameworks.md
+++ b/docs/explanation/compliance-frameworks.md
@@ -1,9 +1,5 @@
 ---
 title: "Compliance Frameworks"
-migration_status: "new"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4636"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/compliance.md

--- a/docs/explanation/container-base-image.md
+++ b/docs/explanation/container-base-image.md
@@ -7,11 +7,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_source: "01_developers/bare_container.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4626"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/container-base-image.md

--- a/docs/explanation/flavors.md
+++ b/docs/explanation/flavors.md
@@ -8,10 +8,6 @@ related_topics:
   - /explanation/release-hierarchy.md
   - /reference/flavor-matrix.md
   - /explanation/github-workflows.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4600"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/flavors.md

--- a/docs/explanation/os-releases.md
+++ b/docs/explanation/os-releases.md
@@ -11,10 +11,6 @@ related_topics:
   - /how-to/releases/os-releases.md
   - /explanation/repo-infrastructure.md
   - /explanation/github-workflows.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/os-releases.md

--- a/docs/explanation/release-hierarchy.md
+++ b/docs/explanation/release-hierarchy.md
@@ -12,10 +12,6 @@ related_topics:
   - /how-to/releases/apt-repos.md
   - /how-to/releases/os-releases.md
   - /reference/releases/release-lifecycle
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/release-hierarchy.md

--- a/docs/explanation/secure-boot.md
+++ b/docs/explanation/secure-boot.md
@@ -13,11 +13,6 @@ related_topics:
   - /how-to/secure-boot
   - /how-to/building-images
   - /reference/adr/0005-secure-boot-keys-glci
-migration_status: "done"
-migration_source: "docs/legacy/boot_modes.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4630"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/secure-boot.md

--- a/docs/explanation/security-posture.md
+++ b/docs/explanation/security-posture.md
@@ -1,9 +1,5 @@
 ---
 title: "Security Posture"
-migration_status: "new"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4634"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/security-posture.md

--- a/docs/explanation/semver.md
+++ b/docs/explanation/semver.md
@@ -12,10 +12,6 @@ related_topics:
   - /how-to/releases/apt-repos.md
   - /how-to/releases/os-releases.md
   - /reference/releases/release-lifecycle
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/semver.md

--- a/docs/explanation/testing/test-framework-architecture.md
+++ b/docs/explanation/testing/test-framework-architecture.md
@@ -12,10 +12,6 @@ related_topics:
   - /reference/testing/developing-tests.md
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_source: "tests/DEVELOPER.md, tests/README.md"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/testing/test-framework-architecture.md

--- a/docs/explanation/testing/test-organization.md
+++ b/docs/explanation/testing/test-organization.md
@@ -12,9 +12,6 @@ related_topics:
   - /reference/testing/developing-tests.md
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/testing/test-organization.md

--- a/docs/explanation/use-cases.md
+++ b/docs/explanation/use-cases.md
@@ -9,10 +9,6 @@ related_topics:
   - /how-to/building-images
   - /reference/releases/release-lifecycle
   - /reference/flavor-matrix
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4635"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/explanation/use-cases.md

--- a/docs/how-to/choosing-flavors.md
+++ b/docs/how-to/choosing-flavors.md
@@ -14,10 +14,6 @@ related_topics:
   - /reference/flavors
   - /how-to/building-images
   - /how-to/getting-images
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4624"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/choosing-flavors.md

--- a/docs/how-to/container-base-image/bare.md
+++ b/docs/how-to/container-base-image/bare.md
@@ -6,11 +6,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_source: "01_developers/bare_container.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4626"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/container-base-image/bare.md

--- a/docs/how-to/container-base-image/full.md
+++ b/docs/how-to/container-base-image/full.md
@@ -6,11 +6,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_source: "01_developers/bare_container.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4626"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/container-base-image/full.md

--- a/docs/how-to/container-base-image/index.md
+++ b/docs/how-to/container-base-image/index.md
@@ -6,11 +6,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_source: "01_developers/bare_container.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4626"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/container-base-image/index.md

--- a/docs/how-to/getting-images.md
+++ b/docs/how-to/getting-images.md
@@ -8,10 +8,6 @@ related_topics:
   - /reference/flavor-matrix
   - /reference/releases/maintained-releases
   - /how-to/building-images
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4625"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/getting-images.md

--- a/docs/how-to/installation/cloud-init.md
+++ b/docs/how-to/installation/cloud-init.md
@@ -9,10 +9,6 @@ related_topics:
   - /how-to/installation/cloud/openstack.md
   - /how-to/installation/post-install.md
   - /how-to/installation/ignition.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/cloud-init.md

--- a/docs/how-to/installation/cloud/aws.md
+++ b/docs/how-to/installation/cloud/aws.md
@@ -3,10 +3,6 @@ title: "Install on AWS"
 related_topics:
   - /tutorials/cloud/first-boot-aws.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/cloud/aws.md

--- a/docs/how-to/installation/cloud/azure.md
+++ b/docs/how-to/installation/cloud/azure.md
@@ -3,10 +3,6 @@ title: "Install on Azure"
 related_topics:
   - /tutorials/cloud/first-boot-azure.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/cloud/azure.md

--- a/docs/how-to/installation/cloud/gcp.md
+++ b/docs/how-to/installation/cloud/gcp.md
@@ -3,10 +3,6 @@ title: "Install on GCP"
 related_topics:
   - /tutorials/cloud/first-boot-gcp.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/cloud/gcp.md

--- a/docs/how-to/installation/cloud/index.md
+++ b/docs/how-to/installation/cloud/index.md
@@ -4,10 +4,6 @@ order: 1
 related_topics:
   - /tutorials/cloud/index.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/cloud/index.md

--- a/docs/how-to/installation/cloud/openstack.md
+++ b/docs/how-to/installation/cloud/openstack.md
@@ -3,10 +3,6 @@ title: "Install on OpenStack"
 related_topics:
   - /tutorials/cloud/first-boot-openstack.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/cloud/openstack.md

--- a/docs/how-to/installation/container/index.md
+++ b/docs/how-to/installation/container/index.md
@@ -7,10 +7,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/container/index.md

--- a/docs/how-to/installation/ignition.md
+++ b/docs/how-to/installation/ignition.md
@@ -7,10 +7,6 @@ related_topics:
   - /how-to/installation/on-premises/iso.md
   - /how-to/installation/post-install.md
   - /how-to/installation/cloud-init.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/ignition.md

--- a/docs/how-to/installation/index.md
+++ b/docs/how-to/installation/index.md
@@ -8,10 +8,6 @@ related_topics:
   - /how-to/installation/post-install.md
   - /how-to/installation/cloud-init.md
   - /how-to/installation/ignition.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/index.md

--- a/docs/how-to/installation/local/index.md
+++ b/docs/how-to/installation/local/index.md
@@ -4,10 +4,6 @@ order: 3
 related_topics:
   - /tutorials/local/index.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/local/index.md

--- a/docs/how-to/installation/local/kvm.md
+++ b/docs/how-to/installation/local/kvm.md
@@ -3,10 +3,6 @@ title: "Install Locally Using KVM"
 related_topics:
   - /tutorials/local/first-boot-kvm.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/local/kvm.md

--- a/docs/how-to/installation/local/lima.md
+++ b/docs/how-to/installation/local/lima.md
@@ -4,11 +4,6 @@ description: "How to install Garden Linux on Lima"
 related_topics:
   - /tutorials/local/first-boot-lima.md
   - /how-to/installation/post-install.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_source: "02_operators/lima-vm.md,02_operators/local-k8s-lima.md"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/local/lima.md

--- a/docs/how-to/installation/on-premises/index.md
+++ b/docs/how-to/installation/on-premises/index.md
@@ -12,10 +12,6 @@ related_topics:
   - /how-to/building-images.md
   - /how-to/getting-images.md
   - /explanation/boot-modes.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/on-premises/index.md

--- a/docs/how-to/installation/on-premises/iso.md
+++ b/docs/how-to/installation/on-premises/iso.md
@@ -8,10 +8,6 @@ related_topics:
   - /how-to/installation/on-premises/pxe-boot.md
   - /how-to/building-images.md
   - /explanation/boot-modes.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/on-premises/iso.md

--- a/docs/how-to/installation/on-premises/pxe-boot.md
+++ b/docs/how-to/installation/on-premises/pxe-boot.md
@@ -9,11 +9,6 @@ related_topics:
   - /how-to/installation/on-premises/iso.md
   - /how-to/building-images.md
   - /explanation/boot-modes.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_source: "02_operators/deployment/ipxe-install.md"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/on-premises/pxe-boot.md

--- a/docs/how-to/installation/post-install.md
+++ b/docs/how-to/installation/post-install.md
@@ -2,10 +2,6 @@
 title: "Post Installation Steps"
 description: "Suggested First Steps after Installation"
 order: 7
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4623"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/installation/post-install.md

--- a/docs/how-to/releases/os-releases.md
+++ b/docs/how-to/releases/os-releases.md
@@ -12,10 +12,6 @@ related_topics:
   - /how-to/releases/apt-repos.md
   - /how-to/releases/os-releases.md
   - /reference/releases/release-lifecycle
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/releases/os-releases.md

--- a/docs/how-to/secure-boot.md
+++ b/docs/how-to/secure-boot.md
@@ -6,11 +6,6 @@ related_topics:
   - /explanation/secure-boot
   - /how-to/building-images
   - /reference/adr/0005-secure-boot-keys-glci
-migration_status: "done"
-migration_source: "docs/legacy/02_operators/deployment/aws-secureboot.md, docs/legacy/02_operators/deployment/gcp-secureboot.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4630"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/secure-boot.md

--- a/docs/how-to/testing/debug-tests.md
+++ b/docs/how-to/testing/debug-tests.md
@@ -12,10 +12,6 @@ related_topics:
   - /reference/testing/developing-tests.md
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_source: "tests/README.md, tests/DEVELOPER.md"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/testing/debug-tests.md

--- a/docs/how-to/testing/run-tests.md
+++ b/docs/how-to/testing/run-tests.md
@@ -13,9 +13,6 @@ related_topics:
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
   - /explanation/github-workflows.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/testing/run-tests.md

--- a/docs/how-to/testing/setup-test-environment.md
+++ b/docs/how-to/testing/setup-test-environment.md
@@ -12,9 +12,6 @@ related_topics:
   - /reference/testing/developing-tests.md
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/testing/setup-test-environment.md

--- a/docs/how-to/testing/test-in-cloud.md
+++ b/docs/how-to/testing/test-in-cloud.md
@@ -12,9 +12,6 @@ related_topics:
   - /reference/testing/developing-tests.md
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/testing/test-in-cloud.md

--- a/docs/reference/container-images.md
+++ b/docs/reference/container-images.md
@@ -5,11 +5,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_source: "01_developers/bare_container.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4626"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/container-images.md

--- a/docs/reference/flavor-matrix.md
+++ b/docs/reference/flavor-matrix.md
@@ -1,8 +1,6 @@
 ---
 title: "Flavor Matrix"
 description: "Complete matrix of Garden Linux flavors with their features and dependencies."
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/flavor-matrix.md

--- a/docs/reference/flavors.md
+++ b/docs/reference/flavors.md
@@ -5,10 +5,6 @@ related_topics:
   - /explanation/flavors.md
   - /explanation/os-releases.md
   - /reference/flavor-matrix.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4600"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/flavors.md

--- a/docs/reference/kernel.md
+++ b/docs/reference/kernel.md
@@ -3,11 +3,6 @@ title: "Garden Linux Kernel"
 description: Why we build the kernel the way we build it
 related_topics:
   - /how-to/kernel-builds.md
-migration_status: "done"
-migration_source: "00_introduction/kernel.md"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4629"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/kernel.md

--- a/docs/reference/releases/archived-releases.md
+++ b/docs/reference/releases/archived-releases.md
@@ -7,9 +7,6 @@ related_topics:
   - /reference/releases/archived-releases
   - /reference/releases/release-notes/
 order: 3
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4594
-migration_source: "00_introduction/release.md"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/src/aggregation/releases.py

--- a/docs/reference/releases/index.md
+++ b/docs/reference/releases/index.md
@@ -7,9 +7,6 @@ related_topics:
   - /reference/releases/maintained-releases
   - /reference/releases/archived-releases
   - /reference/releases/release-notes/
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4594
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/releases/index.md

--- a/docs/reference/releases/maintained-releases.md
+++ b/docs/reference/releases/maintained-releases.md
@@ -7,9 +7,6 @@ related_topics:
   - /reference/releases/archived-releases
   - /reference/releases/release-notes/
 order: 2
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4594
-migration_source: "00_introduction/release.md"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/src/aggregation/releases.py

--- a/docs/reference/releases/release-lifecycle.md
+++ b/docs/reference/releases/release-lifecycle.md
@@ -7,9 +7,6 @@ related_topics:
   - /reference/releases/maintained-releases
   - /reference/releases/archived-releases
   - /reference/releases/release-notes/
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4594
-migration_source: "00_introduction/release.md"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/releases/release-lifecycle.md

--- a/docs/reference/testing/developing-tests.md
+++ b/docs/reference/testing/developing-tests.md
@@ -13,9 +13,6 @@ related_topics:
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
 order: 1
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/testing/developing-tests.md

--- a/docs/reference/testing/test-cli.md
+++ b/docs/reference/testing/test-cli.md
@@ -13,9 +13,6 @@ related_topics:
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
 order: 3
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/testing/test-cli.md

--- a/docs/reference/testing/test-coverage-markers.md
+++ b/docs/reference/testing/test-coverage-markers.md
@@ -13,10 +13,6 @@ related_topics:
   - /reference/testing/test-coverage-markers.md
   - /reference/testing/test-cli.md
 order: 2
-migration_status: "done"
-migration_issue: https://github.com/gardenlinux/gardenlinux/issues/4748
-migration_source: "tests/DEVELOPER-TESTCOV.md"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/reference/testing/test-coverage-markers.md

--- a/docs/tutorials/cloud/first-boot-aws.md
+++ b/docs/tutorials/cloud/first-boot-aws.md
@@ -5,10 +5,6 @@ category: "tutorials"
 tags: ["tutorial", "aws", "cloud", "beginner"]
 related_topics:
   - /how-to/installation/cloud/aws.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/cloud/first-boot-aws.md

--- a/docs/tutorials/cloud/first-boot-azure.md
+++ b/docs/tutorials/cloud/first-boot-azure.md
@@ -5,10 +5,6 @@ category: "tutorials"
 tags: ["tutorial", "azure", "cloud", "beginner"]
 related_topics:
   - /how-to/installation/cloud/azure.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/cloud/first-boot-azure.md

--- a/docs/tutorials/cloud/first-boot-gcp.md
+++ b/docs/tutorials/cloud/first-boot-gcp.md
@@ -5,10 +5,6 @@ category: "tutorials"
 tags: ["tutorial", "gcp", "cloud", "beginner"]
 related_topics:
   - /how-to/installation/cloud/gcp.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/cloud/first-boot-gcp.md

--- a/docs/tutorials/cloud/first-boot-openstack.md
+++ b/docs/tutorials/cloud/first-boot-openstack.md
@@ -5,10 +5,6 @@ category: "tutorials"
 tags: ["tutorial", "openstack", "cloud", "beginner"]
 related_topics:
   - /how-to/installation/cloud/openstack.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/cloud/first-boot-openstack.md

--- a/docs/tutorials/cloud/index.md
+++ b/docs/tutorials/cloud/index.md
@@ -2,10 +2,6 @@
 title: Cloud Tutorials
 description: Deploy Garden Linux to cloud providers
 order: 2
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/cloud/index.md

--- a/docs/tutorials/container/first-boot-oci.md
+++ b/docs/tutorials/container/first-boot-oci.md
@@ -7,10 +7,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/container/first-boot-oci.md

--- a/docs/tutorials/container/index.md
+++ b/docs/tutorials/container/index.md
@@ -7,10 +7,6 @@ related_topics:
   - /how-to/container-base-image/bare.md
   - /how-to/container-base-image/full.md
   - /reference/container-images.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/container/index.md

--- a/docs/tutorials/local/first-boot-kvm.md
+++ b/docs/tutorials/local/first-boot-kvm.md
@@ -5,10 +5,6 @@ category: "tutorials"
 tags: ["tutorial", "kvm", "qemu", "virtualization", "beginner"]
 related_topics:
   - /how-to/installation/local/lima.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/local/first-boot-kvm.md

--- a/docs/tutorials/local/first-boot-lima.md
+++ b/docs/tutorials/local/first-boot-lima.md
@@ -5,10 +5,6 @@ category: "tutorials"
 tags: ["tutorial", "lima", "virtualization", "beginner"]
 related_topics:
   - /how-to/installation/local/lima.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/local/first-boot-lima.md

--- a/docs/tutorials/local/index.md
+++ b/docs/tutorials/local/index.md
@@ -2,10 +2,6 @@
 title: Local Tutorials
 description: Run Garden Linux on your workstation with virtualization
 order: 1
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/local/index.md

--- a/docs/tutorials/on-premises/first-boot-bare-metal.md
+++ b/docs/tutorials/on-premises/first-boot-bare-metal.md
@@ -9,10 +9,6 @@ related_topics:
   - /how-to/installation/post-install.md
   - /how-to/building-images.md
   - /how-to/getting-images.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/on-premises/first-boot-bare-metal.md

--- a/docs/tutorials/on-premises/index.md
+++ b/docs/tutorials/on-premises/index.md
@@ -2,10 +2,6 @@
 title: On-Premises Tutorials
 description: Deploy Garden Linux on physical hardware
 order: 4
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4595"
-migration_stakeholder: "@tmang0ld, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/tutorials/on-premises/index.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardenlinux/gardenlinux/issues/4332 we used migration markers in the frontmatter to track the migration status. These can now be removed as the documentation system is live.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5048
