### PR TITLE
fix: explicitly pull in openssh-client

### DIFF
--- a/features/ssh/pkg.include
+++ b/features/ssh/pkg.include
@@ -1,5 +1,6 @@
 # GL-TESTCOV-ssh-service-ssh-enable
 openssh-server
+openssh-client
 # GL-TESTCOV-ssh-service-sshguard-enable
 sshguard
 python3-systemd


### PR DESCRIPTION
**What this PR does / why we need it**:
The _openssh-client_ should be explicitly installed. In Debian, future versions of _openssh-server_ no longer pull in the client as a dependency.

**Which issue(s) this PR fixes**:
Fixes #