### PR TITLE
fix: explicitly pull in openssh-client

### DIFF
--- a/features/ssh/pkg.include
+++ b/features/ssh/pkg.include
@@ -1,3 +1,4 @@
 openssh-server
+openssh-client
 sshguard
 python3-systemd


### PR DESCRIPTION
**What this PR does / why we need it**:
The _openssh-server_ version that got pulled in with 2150.7.0 is no longer automatically installing the client when the ssh server is being installed, so unfortunately the 2150.7.0 release is missing the ssh client for flavors that use the ssh feature (if not explicitly installing it in other features)

**Which issue(s) this PR fixes**:
Fixes #