### PR TITLE
fix: disa_stig_version showing as None in diki JUnit XML reports

### DIFF
--- a/tests/plugins/security_id.py
+++ b/tests/plugins/security_id.py
@@ -2,6 +2,16 @@ from typing import List
 
 import pytest
 
+DISA_STIG_VERSION = "General Purpose Operating System STIG V3R2"
+
+
+def pytest_addoption(parser: pytest.Parser):
+    parser.addini(
+        "disa_stig_version",
+        default=DISA_STIG_VERSION,
+        help="DISA STIG profile version/revision string for diki integration.",
+    )
+
 
 def pytest_configure(config: pytest.Config):
     config.addinivalue_line(


### PR DESCRIPTION
## Summary

- Fixes `disa_stig_version` property showing as `None` in diki JUnit XML reports
- Root cause: `config.addini()` does not exist in pytest 9.x — ini options must be registered via `parser.addini()` in `pytest_addoption`
- Adds a hardcoded default (`"General Purpose Operating System STIG V3R2"`) so the value is always present even when `pytest.ini` is not included in the test distribution

## Changes

- `tests/plugins/security_id.py`: adds `pytest_addoption(parser)` hook using `parser.addini()` to register the `disa_stig_version` ini option with a default value; reads it in `pytest_collection_modifyitems` via `config.getini()`

## Test plan

- [ ] Verify diki report shows `disa_stig_version = "General Purpose Operating System STIG V3R2"` in `<properties>` for `test_disastig_*` tests
- [ ] Verify CI lint/test-utils passes (no `AttributeError: 'Config' object has no attribute 'addini'`)