### PR TITLE
suppress stdout for diki verbose

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, List, Optional
 
 import pytest
 
@@ -20,11 +21,11 @@ for plugin in pytest_plugins:
     pytest.register_assert_rewrite(plugin)
 
 
-def pytest_assertrepr_compare(op, left, right):
+def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[str]]:
     if op == "in" and isinstance(right, str) and len(right) > 200:
         return [
             f"Assertion failed: '{left}' not found in comparison string.",
-            f"Comparison string (truncated): {right[:200]}...",
+            f"Comparison string (truncated): {right[:500]}...",
         ]
     return None
 


### PR DESCRIPTION
Adds pytest_assertrepr_compare hook in conftest.py to truncate large strings in assertion failure output, preventing ausearch stdout from flooding diki reports. Simplifies test_disastig_00022.py with regex. Ref: PR 5051 commit 7251d96f