### PR TITLE
Add support for publishing_group per ADR0037

### DIFF
--- a/features/_archgrouped/info.yaml
+++ b/features/_archgrouped/info.yaml
@@ -1,0 +1,2 @@
+description: "publish this build's architectures as one grouped multi-arch artifact"
+type: flag

--- a/features/_archgrouped/requirements.mod
+++ b/features/_archgrouped/requirements.mod
@@ -1,0 +1,1 @@
+requirements["publishing_group"]="${BUILDER_CNAME_BASE:-}"

--- a/features/container/image.oci
+++ b/features/container/image.oci
@@ -76,7 +76,10 @@ cat > index.json << EOF
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "digest": "sha256:$manifest_sha256",
-      "size": $manifest_size
+      "size": $manifest_size,
+      "annotations": {
+        "org.opencontainers.image.ref.name": "$BUILDER_CNAME_BASE-$BUILDER_ARCH"
+      }
     }
   ]
 }

--- a/features/container/info.yaml
+++ b/features/container/info.yaml
@@ -1,5 +1,6 @@
 description: "Container platform"
 type: platform
 features:
-  include: 
+  include:
     - base
+    - _archgrouped


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds publishing_group to implement ADR0037. It must be merged in lockstep with the builder change (https://github.com/gardenlinux/builder/pull/160). 

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for publishing_group
```
