### PR TITLE
Cherry-pick: Publish FIPS containers

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -90,32 +90,48 @@ jobs:
             subpath: ""
           - flavor: "container-pythonDev"
             subpath: "/container-python-dev"
+          - flavor: "container-sslfips"
+            subpath: "/gardenlinux-fips"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.commit_id }}
           submodules: true
-      - name: Install python-gardenlinux-lib
+      - id: build_container_cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # pin@v6.1.0
+        with:
+          path: |
+            COMMIT
+            VERSION
+          key: build-${{ matrix.flavor }}-amd64-${{ github.run_id }}
+          lookup-only: true
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        name: Install python-gardenlinux-lib
         uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@9aaf32aec5513e15a089fcfe12baf505299ffbb3 # pin@0.10.22
-      - name: Set container version reference
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        name: Set container version reference
         run: |
           echo "${{ inputs.commit_id }}" | tee COMMIT
           echo "${{ inputs.version }}" | tee VERSION
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           name: build-${{ matrix.flavor }}-amd64
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
         with:
           name: build-${{ matrix.flavor }}-arm64
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id }}
-      - name: Set CNAMEs
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        name: Set CNAMEs
         run: |
           echo "CNAME_AMD64=$(gl-features-parse --cname ${{ matrix.flavor }} --arch amd64 --version ${{ inputs.version }} --commit ${{ inputs.commit_id }} cname)" | tee -a "$GITHUB_ENV"
           echo "CNAME_ARM64=$(gl-features-parse --cname ${{ matrix.flavor }} --arch arm64 --version ${{ inputs.version }} --commit ${{ inputs.commit_id }} cname)" | tee -a "$GITHUB_ENV"
-      - name: Publish container images
+      - if: ${{ steps.build_container_cache.outputs.cache-hit == 'true' }}
+        name: Publish container images
         run: |
           if [ "${{ inputs.target }}" = "nightly" ]; then
             is_nightly=true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR works around mixed OCI container names for different flavors. It introduces a new `container-sslfips` flavor and it's target `ghcr.io/gardenlinux/gardenlinux-fips`. This is related to #2754 and may cause issues related to #4185.