### PR TITLE
fix: publish to gardenlinux-fips

### DIFF
--- a/.github/workflows/publish_oci_containers.yml
+++ b/.github/workflows/publish_oci_containers.yml
@@ -91,7 +91,7 @@ jobs:
           - flavor: "container-pythonDev"
             subpath: "/container-python-dev"
           - flavor: "container-sslfips"
-            subpath: "/gardenlinux-fips"
+            subpath: "-fips"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Publish to gardenlinux-fips and not gardenlinux/gardenlinux-fips

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #