### PR TITLE
fix: pythonDev tests, remove libm.so.6

### DIFF
--- a/tests/integration/runtime/test_pythonDev.py
+++ b/tests/integration/runtime/test_pythonDev.py
@@ -28,7 +28,6 @@ dependencies = {
         "/required_libs_test/usr/lib/aarch64-linux-gnu",
         "/required_libs_test/usr/lib/aarch64-linux-gnu/libpthread.so.0",
         "/required_libs_test/usr/lib/aarch64-linux-gnu/libc.so.6",
-        "/required_libs_test/usr/lib/aarch64-linux-gnu/libm.so.6",
         "/required_libs_test/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
     },
     "amd64": {
@@ -38,7 +37,6 @@ dependencies = {
         "/required_libs_test/usr/lib/x86_64-linux-gnu",
         "/required_libs_test/usr/lib/x86_64-linux-gnu/libpthread.so.0",
         "/required_libs_test/usr/lib/x86_64-linux-gnu/libc.so.6",
-        "/required_libs_test/usr/lib/x86_64-linux-gnu/libm.so.6",
         "/required_libs_test/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
     },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the test_python_export_libs for the python dev container that breaks the nightly.

**Which issue(s) this PR fixes**:
Fixes #5160