### PR TITLE
feat: backport DISA STIG compliance tests to rel-1877

### DIFF
--- a/tests-ng/handlers/audit_user.py
+++ b/tests-ng/handlers/audit_user.py
@@ -1,0 +1,16 @@
+import pytest
+from plugins.shell import ShellRunner
+
+TEST_USER = "audit_test_user"
+
+
+@pytest.fixture
+def audit_user(shell: ShellRunner):
+    shell(f"id {TEST_USER} || useradd -m -s /bin/sh {TEST_USER}")
+    yield TEST_USER
+    shell(f"pkill -9 -u {TEST_USER}", ignore_exit_code=True)
+    shell("sleep 1")
+    shell(f"userdel -r {TEST_USER}", ignore_exit_code=True)
+    shell(
+        "rm -f /etc/group- /etc/gshadow- /etc/passwd- /etc/shadow- /etc/subgid- /etc/subuid-"
+    )

--- a/tests-ng/handlers/pip.py
+++ b/tests-ng/handlers/pip.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.fixture
+def pip_requests(shell: ShellRunner):
+    out = shell(
+        '/bin/python3 -c "import site; print(site.getsitepackages()[0])"',
+        capture_output=True,
+    )
+    package_dir = out.stdout.strip("\n")
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_before_install")
+
+    restore_backup = False
+    if os.path.isdir(package_dir):
+        restore_backup = True
+        shutil.move(package_dir, package_dir + ".backup")
+
+    os.mkdir(package_dir)
+
+    shell(
+        "/bin/pip3 install --break-system-packages --no-cache-dir --root-user-action=ignore requests"
+    )
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_after_install")
+
+    yield package_dir
+
+    shell(
+        "for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall -y --break-system-packages $dep; done"
+    )
+    shell("rm /tmp/pip_freeze_before_install /tmp/pip_freeze_after_install")
+    shutil.rmtree(package_dir)
+    if restore_backup:
+        shutil.move(package_dir + ".backup", package_dir)

--- a/tests-ng/plugins/audit.py
+++ b/tests-ng/plugins/audit.py
@@ -1,0 +1,179 @@
+import itertools
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+from plugins.dpkg import Dpkg
+
+logger = logging.getLogger(__name__)
+
+
+class AuditRule:
+    def __init__(self):
+        if not Dpkg().package_is_installed("auditd"):
+            raise RuntimeError("auditd is not installed")
+        try:
+            result = subprocess.run(
+                ["auditctl", "-l"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except FileNotFoundError:
+            raise RuntimeError("auditctl not found in PATH")
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"auditctl failed (exit {exc.returncode})\n"
+                f"stderr: {exc.stderr.strip()}"
+            )
+        self.rules = self._parse(result.stdout.splitlines())
+
+    def _parse(self, auditctl_lines):
+        return [self._parse_line(line) for line in auditctl_lines]
+
+    def _parse_line(self, auditctl_line):
+        """
+        Split a line looking like this
+
+        -a exit,always -S open,unlink,rmdir -S truncate -F dir=/etc -F success=0
+
+        into a dict like this
+
+        {'-a': ['exit', 'always'],
+         '-S': ['open', 'unlink', 'rmdir', 'truncate'],
+         '-F': ['dir=/etc', 'success=0']}
+        """
+        result = {}
+        for key, value in itertools.batched(auditctl_line.split(), 2):
+            result.setdefault(key, []).extend(value.split(","))
+        return result
+
+    def _extract_paths(self, auditd_rule):
+        """
+        Return a list of file paths referred by -F path= or -F dir= arguments in the auditd rule.
+        """
+        return [
+            field.split("=")[1]
+            for field in auditd_rule["-F"]
+            if "path=" in field or "dir=" in field
+        ]
+
+    def _filter_by_rule_fields(self, rules, rule_fields):
+        if not rule_fields:
+            return rules
+        return [
+            rule
+            for rule_field in rule_fields
+            for rule in rules
+            if "-F" in rule.keys()
+            if rule_field in rule["-F"]
+        ]
+
+    def file_path_audit_rule(self, fs_watch_path, access_types):
+        logger.debug(
+            f"File path audit rule for {fs_watch_path} with access {access_types}"
+        )
+        file_path_rules = [
+            rule
+            for rule in self.rules
+            if "-w" in rule.keys()
+            if Path(fs_watch_path).is_relative_to(rule["-w"][0])  # pyright: ignore
+            if set(access_types).issubset(rule["-p"][0])
+        ]
+        if file_path_rules:
+            logger.debug(f"Matched file path rules: {file_path_rules}")
+            return True
+
+        file_syscall_rules = [
+            rule
+            for rule in self.rules
+            if "-F" in rule
+            if "path=" in rule["-F"] or "dir=" in rule["-F"]
+        ]
+        matching_file_syscall_rules = [
+            rule
+            for rule in file_syscall_rules
+            for path in self._extract_paths(rule)
+            if Path(fs_watch_path).is_relative_to(path)  # pyright: ignore
+            if set(access_types).issubset(rule["-p"][0])
+        ]
+        if matching_file_syscall_rules:
+            logger.debug(f"Matched file syscall rules: {matching_file_syscall_rules}")
+            return True
+        return False
+
+    def syscall_audit_rule(self, syscall, rule_fields):
+        logger.debug(f"Syscall audit rule for {syscall}")
+        matched_rules = [
+            rule for rule in self.rules if "-S" in rule.keys() if syscall in rule["-S"]
+        ]
+
+        filtered_rules = self._filter_by_rule_fields(matched_rules, rule_fields)
+
+        if filtered_rules:
+            logger.debug(f"Matched syscall rules: {filtered_rules}")
+            return True
+        return False
+
+    def binary_call_audit_rule(self, binary_path, rule_fields):
+        logger.debug(f"Binary call audit rule for {binary_path} | {rule_fields=}")
+        matched_rules = [
+            rule
+            for rule in self.rules
+            if "-S" in rule.keys()
+            if "-F" in rule.keys()
+            if "execve" in rule["-S"]
+            if f"exe={binary_path}" in rule["-F"]
+        ]
+
+        filtered_rules = self._filter_by_rule_fields(matched_rules, rule_fields)
+
+        if filtered_rules:
+            logger.debug(f"Matched binary call rules: {filtered_rules}")
+            return True
+        return False
+
+    def __call__(
+        self,
+        syscall=None,
+        access_types=None,
+        fs_watch_path=None,
+        binary_call=None,
+        rule_fields=[],
+    ):
+        logger.debug("In AuditRule.__call__")
+        if fs_watch_path and access_types:
+            return self.file_path_audit_rule(fs_watch_path, access_types)
+        if syscall:
+            return self.syscall_audit_rule(syscall, rule_fields)
+        if binary_call:
+            return self.binary_call_audit_rule(binary_call, rule_fields)
+
+
+@pytest.fixture
+def audit_rule():
+    """
+    Returns an object that, when called, returns an audit rule lookup function.
+    Said object calls a file path audit rule lookup function
+    if fs_watch_path and access_type arguments are not empty
+    or a syscall audit rule lookup function if syscall argument is not empty.
+
+    For a file path audit rule the lookup is successful (function return True)
+    if and only if there is at least one auditd rule that covers the provided fs_watch_path
+    and access_types' values. Given that auditd file path rules are recursive, a lookup for /etc/passwd
+    will be successful if there's a rule for /etc with matching access_types.
+
+    For a syscall audit rule the lookup is successful
+    if there is at least one auditd rule that concerns the syscall parameter's value.
+
+    For an audit rule that tracks when a certain binary is executed the lookup is successful
+    if a rule with 'execve' syscall and the provided binary path (binary_call argument) is found.
+
+    Examples:
+
+    assert audit_rule(fs_watch_path="/etc/passwd", access_types="wa")
+    assert audit_rule(syscall="setcap", rule_fields=["auid>=1000", "auid!=-1"])
+    assert audit_rule(binary_call="/usr/bin/passwd")
+    """
+    return AuditRule()

--- a/tests-ng/plugins/file.py
+++ b/tests-ng/plugins/file.py
@@ -1,4 +1,5 @@
 import grp
+import hashlib
 import os
 import pwd
 import stat
@@ -329,8 +330,118 @@ class File:
         """
         return self.get_user(path) == user and self.get_group(path) == group
 
+    def has_permissions(self, path: str | Path, permissions: str | int) -> bool:
+        """Check if a file has the specified permission mode.
 
-@pytest.fixture
+        This helper retrieves the current permission bits of the given path
+        and compares them with the expected permissions. The expected value
+        may be provided either as an octal **string** representation (e.g., ``"0644"``
+        or ``644``) or as a symbolic string (e.g., ``"rw-r--r--"``).
+
+        Args:
+        path: File path.
+        permissions: Expected permissions as either:
+            - an octal integer (e.g., ``644``),
+            - an octal string (e.g., ``"0644"``),
+            - a symbolic string (e.g., ``"rw-r--r--"``).
+
+        Returns:
+        bool: ``True`` if the file's permissions match the expected
+        permission mode, otherwise ``False``.
+
+        Raises:
+        FileNotFoundError: If the path does not exist.
+        PermissionError: If permission to access the path is denied.
+        ValueError: If the permission specification is invalid.
+        """
+        actual_mode = stat.S_IMODE(Path(path).stat().st_mode)
+        expected_mode = self._normalize_permissions(permissions)
+        return actual_mode == expected_mode
+
+    def _normalize_permissions(self, permissions: str | int) -> int:
+        """Normalize a permission specification to a numeric mode.
+
+        Converts a permission representation into the integer mode used by
+        the operating system.
+
+        Supported formats include:
+        - integer permission modes (e.g., ``644``), which are returned unchanged,
+        - octal strings (e.g., ``"0644"``),
+        - symbolic POSIX permission strings (e.g., ``"rwxr-x---"``).
+
+        Args:
+            permissions: Permission representation to normalize.
+
+        Returns:
+            int: Numeric permission mode suitable for comparison with
+            values returned by ``stat.S_IMODE``.
+
+        Raises:
+            ValueError: If the provided permission format is invalid or
+            contains unsupported characters.
+        """
+        if isinstance(permissions, int):
+            return permissions
+
+        if not isinstance(permissions, str):
+            raise ValueError("Permissions must be int or string")
+
+        permissions = permissions.strip()
+
+        if permissions.isdigit():
+            return int(permissions, 8)
+
+        if len(permissions) != 9:
+            raise ValueError(
+                "Symbolic permissions must be 9 characters (e.g., 'rwxr-x---')"
+            )
+
+        perm_map = {"r": 4, "w": 2, "x": 1, "-": 0}
+
+        mode = 0
+        special = 0
+
+        for idx in range(3):
+            chunk = permissions[idx * 3 : (idx + 1) * 3]
+            value = 0
+
+            for pos, char in enumerate(chunk):
+                if char in perm_map:
+                    value += perm_map[char]
+
+                elif pos == 2:
+                    if idx == 0 and char in ("s", "S"):
+                        special |= stat.S_ISUID
+                        if char == "s":
+                            value += 1
+
+                    elif idx == 1 and char in ("s", "S"):
+                        special |= stat.S_ISGID
+                        if char == "s":
+                            value += 1
+
+                    elif idx == 2 and char in ("t", "T"):
+                        special |= stat.S_ISVTX
+                        if char == "t":
+                            value += 1
+
+                    else:
+                        raise ValueError(f"Invalid permission character: {char}")
+
+                else:
+                    raise ValueError(f"Invalid permission character: {char}")
+
+            mode = (mode << 3) | value
+
+        return special | mode
+
+    def checksum(self, file_path):
+        with open(file_path, "rb") as fd:
+            md5sum = hashlib.md5(fd.read(), usedforsecurity=False).hexdigest()
+        return md5sum
+
+
+@pytest.fixture(scope="session")
 def file() -> File:
     """Fixture providing the ``File`` helper for file metadata operations."""
     return File()

--- a/tests-ng/plugins/parse.py
+++ b/tests-ng/plugins/parse.py
@@ -98,12 +98,21 @@ class Lines:
     def _check_string_literal(self, pattern: str) -> bool:
         """Check if a string literal exists in lines (with comment filtering)."""
         comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+        # Normalize the pattern as well to match normalized lines
+        normalized_pattern = re.sub(r"\s+", " ", pattern)
+
+        # Check if pattern starts with a comment character - if so, don't strip comments
+        pattern_is_comment = any(
+            pattern.lstrip().startswith(char) for char in comment_chars
+        )
 
         for line in self.content.splitlines():
-            line = _strip_comments_from_line(line, comment_chars)
+            # Only strip comments if the pattern itself is not a comment
+            if not pattern_is_comment:
+                line = _strip_comments_from_line(line, comment_chars)
             line = line.rstrip()
-            normalized = re.sub(r"\s+", " ", line)
-            if normalized.find(pattern) != -1:
+            normalized_line = re.sub(r"\s+", " ", line)
+            if normalized_line.find(normalized_pattern) != -1:
                 return True
         return False
 
@@ -165,6 +174,54 @@ class Lines:
                 f"Expected str, re.Pattern, or list of str."
             )
 
+    def __eq__(self, other: object) -> bool:
+        """Check if Lines content matches a list of expected lines exactly.
+
+        Args:
+            other: List of expected lines to compare against.
+
+        Returns:
+            bool: True if all lines match in order, False otherwise.
+        """
+        if not isinstance(other, list):
+            return NotImplemented
+
+        comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+
+        # Get actual lines from content, stripping full-line comments but keeping inline comments
+        actual_lines = []
+        for line in self.content.splitlines():
+            line = line.rstrip()
+            if not line:  # Skip empty lines
+                continue
+            # Skip lines that are purely comments (start with comment char after whitespace)
+            stripped = line.lstrip()
+            if comment_chars and any(
+                stripped.startswith(char) for char in comment_chars
+            ):
+                continue
+            actual_lines.append(line)
+
+        return actual_lines == other
+
+    def __repr__(self) -> str:
+        """Return representation of Lines for debugging."""
+        comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+
+        actual_lines = []
+        for line in self.content.splitlines():
+            line = line.rstrip()
+            if not line:  # Skip empty lines
+                continue
+            # Skip lines that are purely comments
+            stripped = line.lstrip()
+            if comment_chars and any(
+                stripped.startswith(char) for char in comment_chars
+            ):
+                continue
+            actual_lines.append(line)
+        return repr(actual_lines)
+
 
 @dataclass
 class Parse:
@@ -208,12 +265,16 @@ class Parse:
         """
         return cls(content, label)
 
-    def _parse_keyval(self, content: str) -> Dict[str, str]:
-        cfg = configparser.ConfigParser(allow_no_value=True)
-        cfg.optionxform = lambda optionstr: optionstr
+    def _parse_keyval(
+        self, content: str, forbid_duplicates: bool = False
+    ) -> Dict[str, str]:
+        cfg = configparser.ConfigParser(allow_no_value=True, strict=forbid_duplicates)
+        cfg.optionxform = lambda optionstr: optionstr  # type: ignore[assignment]
         wrapped = "[default]\n" + content
         cfg.read_file(StringIO(wrapped))
-        return dict(cfg.items("default")) if "default" in cfg else {}
+        result = dict(cfg.items("default")) if "default" in cfg else {}
+        # Strip quotes from values (both single and double quotes)
+        return {k: v.strip('"').strip("'") if v else v for k, v in result.items()}
 
     def _parse_spacedelim(self, content: str) -> Dict[str, str]:
         result = {}
@@ -229,6 +290,7 @@ class Parse:
 
     def _parse_ini(self, content: str) -> Dict[str, Any]:
         cfg = configparser.ConfigParser()
+        cfg.optionxform = str  # type: ignore[method-assign] # Preserve case of option names
         cfg.read_file(StringIO(content))
         return {section: dict(cfg[section]) for section in cfg.sections()}
 
@@ -255,11 +317,13 @@ class Parse:
             )
         return tomllib.loads(content)
 
-    def _parse_content(self, format: str, ignore_comments: bool = True) -> Any:
+    def _parse_content(
+        self, format: str, ignore_comments: bool = True, forbid_duplicates: bool = True
+    ) -> Any:
         fmt = format.lower()
         match fmt:
             case "keyval":
-                return self._parse_keyval(self.content)
+                return self._parse_keyval(self.content, forbid_duplicates)
             case "spacedelim":
                 return self._parse_spacedelim(self.content)
             case "ini":
@@ -276,13 +340,16 @@ class Parse:
                     f"Supported formats: {', '.join(SUPPORTED_FORMATS)}."
                 )
 
-    def parse(self, format: str, ignore_comments: bool = True) -> Any:
+    def parse(
+        self, format: str, ignore_comments: bool = True, forbid_duplicates: bool = True
+    ) -> Any:
         """Parse content and return data structure based on format.
 
 
         Args:
             format: One of the supported format identifiers (json, yaml, toml, ini, keyval).
             ignore_comments: (optional, default=True) If True, strip comments where applicable.
+            forbid_duplicates: If False, won't raise an exception if duplicate key (where applicable) is found.
 
         Returns:
             Parsed data structure (dict, list, etc.) based on format.
@@ -294,7 +361,7 @@ class Parse:
             >>> assert config["database"]["port"] == 5432
             >>> assert "missing" not in config["database"]
         """
-        return self._parse_content(format, ignore_comments)
+        return self._parse_content(format, ignore_comments, forbid_duplicates)
 
     def lines(
         self,

--- a/tests-ng/plugins/setting_ids.py
+++ b/tests-ng/plugins/setting_ids.py
@@ -1,0 +1,13 @@
+"""
+Plugin to register custom pytest marker for Garden Linux setting IDs.
+"""
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config):
+    """Register custom marker for Garden Linux setting IDs."""
+    config.addinivalue_line(
+        "markers",
+        "testcov(ids): Mark tests with Garden Linux setting IDs for traceability",
+    )

--- a/tests-ng/plugins/setuid_binaries.py
+++ b/tests-ng/plugins/setuid_binaries.py
@@ -1,0 +1,29 @@
+import os
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def exposed_setuid_binaries():
+    """
+    Returns a set of pathnames of root-owned binaries with setuid bit which are
+    also "others"-executable (i.e. binaries that give root privileges to every
+    user).
+    """
+    dirs = [
+        "/usr/sbin",
+        "/usr/bin",
+        "/usr/libexec",
+        "/usr/local/sbin",
+        "/usr/local/bin",
+    ]
+    return {
+        str(p)
+        for d in dirs
+        for root, _, files in os.walk(d)
+        for p in map(lambda n: pathlib.Path(root) / n, files)
+        if p.stat().st_uid == 0  # file belongs to root
+        and (m := p.stat().st_mode) & 0o4000  # set‑uid bit present
+        and ((m >> 3) & 0o111)  # “others” execute bit set
+    }

--- a/tests-ng/plugins/systemd.py
+++ b/tests-ng/plugins/systemd.py
@@ -2,12 +2,12 @@ import json
 import re
 import time
 from dataclasses import dataclass
-from os import system
 from typing import Tuple
 
 import pytest
 
 from .modify import allow_system_modifications
+from .parse import Parse
 from .shell import ShellRunner
 
 
@@ -143,6 +143,81 @@ class Systemd:
 
         return active
 
+    def is_inactive(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-active {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        inactive = result.stdout.strip() == "inactive"
+        if not inactive:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return inactive
+
+    def is_enabled(self, unit_name: str) -> bool:
+        """Check if a system-level systemd unit is enabled.
+
+        Note: This also returns True for 'static' units (units without [Install] section
+        that are enabled by default or pulled in by other units).
+        """
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        state = result.stdout.strip()
+        enabled = state in ("enabled", "static")
+        if not enabled:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return enabled
+
+    def is_disabled(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        disabled = result.stdout.strip() == "disabled"
+        if not disabled:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return disabled
+
+    def is_masked(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        state = result.stdout.strip()
+        masked = state in ("masked")
+        if not masked:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return masked
+
     def start_unit(self, unit_name: str):
         if not allow_system_modifications():
             pytest.skip(
@@ -192,6 +267,19 @@ class Systemd:
         )
         elapsed = time.time() - start_time
         return SystemRunningState(result.stdout.strip(), result.returncode, elapsed)
+
+    def get_unit_properties(self, service_name) -> dict:
+        result = self._shell(
+            cmd=f"systemctl show {service_name}.service",
+            capture_output=True,
+        )
+        return Parse.from_str(result.stdout).parse("keyval", forbid_duplicates=False)
+
+    def get_config(self, config_path) -> dict:
+        result = self._shell(
+            f"systemd-analyze cat-config {config_path}", capture_output=True
+        )
+        return Parse.from_str(result.stdout).parse("keyval", forbid_duplicates=False)
 
 
 @pytest.fixture

--- a/tests-ng/test_disastig_00005.py
+++ b/tests-ng/test_disastig_00005.py
@@ -1,0 +1,36 @@
+"""
+Ref: SRG-OS-000021-GPOS-00005
+
+Verify that the operating system enforces the limit of three consecutive invalid logon attempts by a user during a 15-minute time period.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-auth"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-auth"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203594)
+@pytest.mark.feature("disaSTIGmedium")
+def test_stig_common_auth_pam_faillock(pam_config):
+    """Verify pam_faillock is configured with deny=3 and unlock_time=900."""
+    results = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faillock.so",
+        arg_contains=["preauth", "silent", "audit", "deny=3", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Logins should be blocked for 15 minutes after 3 failed attempts (preauth check configured)"
+
+    pam_config.find_entries(
+        type_="auth",
+        control_contains="default=die",
+        module_contains="pam_faillock.so",
+        arg_contains=["authfail", "silent", "audit", "deny=3", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Control value of PAM Module pam_faillock.so must be set to required (postauth action configured)"

--- a/tests-ng/test_disastig_00008.py
+++ b/tests-ng/test_disastig_00008.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000027-GPOS-00008
+
+Verify the operating system limits the number of concurrent sessions to 10 for all accounts and/or account types. A hard maxlogins limit in /etc/security/limits.conf enforces this restriction.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-security-limits"])
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-limits-maxlogins"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="maxlogins limit is configured by disaSTIGlow"
+)
+@pytest.mark.security_id(203597)
+def test_limits_conf_maxlogins_is_10(parse_file) -> None:
+    """Verify /etc/security/limits.conf sets a hard maxlogins limit of 10."""
+    assert "* hard maxlogins 10" in parse_file.lines("/etc/security/limits.conf")

--- a/tests-ng/test_disastig_00009.py
+++ b/tests-ng/test_disastig_00009.py
@@ -1,0 +1,17 @@
+"""
+Ref: SRG-OS-000028-GPOS-00009
+
+Verify the operating system retains a user's session lock until that user reestablishes access using established identification and authentication procedures.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203598)
+@pytest.mark.feature("not container and not lima and not gardener and not baremetal")
+@pytest.mark.root(reason="required to verify PAM authentication enforcement")
+def test_session_lock_requires_reauthentication(lsm):
+    """Verify 'selinux' appears in the active LSM list."""
+    assert (
+        "selinux" in lsm
+    ), "stigcompliance: no LSM (AppArmor/SELinux) present to enforce session lock re-authentication"

--- a/tests-ng/test_disastig_00013.py
+++ b/tests-ng/test_disastig_00013.py
@@ -1,0 +1,58 @@
+"""
+Ref: SRG-OS-000032-GPOS-00013
+
+Verify the operating system monitors remote access methods.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203602)
+@pytest.mark.booted(reason="requires running sshguard")
+@pytest.mark.feature("ssh")
+def test_sshguard_is_enabled(systemd):
+    """Verify sshguard.service is enabled."""
+    assert systemd.is_enabled("sshguard")
+
+
+@pytest.mark.booted(reason="requires running sshguard")
+@pytest.mark.feature("ssh")
+@pytest.mark.hypervisor(
+    "not qemu", reason="a started sshguard prevents running the testsuite"
+)
+@pytest.mark.security_id(203602)
+def test_sshguard_is_active(systemd):
+    """Verify sshguard.service is active."""
+    assert systemd.is_active("sshguard")
+
+
+@pytest.mark.security_id(203602)
+@pytest.mark.feature("ssh")
+def test_sshguard_journal_reading_is_configured(parse_file):
+    """Verify /etc/sshguard/sshguard.conf sets LOGREADER to use journalctl."""
+    config = parse_file.parse("/etc/sshguard/sshguard.conf", format="keyval")
+    assert "LOGREADER" in config
+    assert "journalctl" in config["LOGREADER"]
+
+
+@pytest.mark.security_id(203602)
+@pytest.mark.booted(reason="requires running journald")
+@pytest.mark.feature("ssh")
+def test_sshguard_can_log_to_journald_dev_log_is_managed_by_journald(file):
+    """Verify /dev/log is a symlink to /run/systemd/journal/dev-log."""
+    assert file.is_symlink("/dev/log", "/run/systemd/journal/dev-log")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-rsyslog-default"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="auth log routing to /var/log/secure is configured by disaSTIGmedium",
+)
+@pytest.mark.security_id(203602)
+def test_rsyslog_logs_auth_to_secure(parse_file) -> None:
+    """Verify rsyslog 50-default.conf routes auth.* to /var/log/secure."""
+    assert re.compile(r"auth.*/var/log/secure") in parse_file.lines(
+        "/etc/rsyslog.d/50-default.conf"
+    )

--- a/tests-ng/test_disastig_00014.py
+++ b/tests-ng/test_disastig_00014.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000033-GPOS-00014
+
+Verify the operating system implements DoD-approved encryption to protect the confidentiality of remote access sessions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203603)
+def test_disastig_00014():
+    """Encryption for remote access sessions is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests-ng/test_disastig_00015.py
+++ b/tests-ng/test_disastig_00015.py
@@ -1,0 +1,37 @@
+"""
+Ref: SRG-OS-000037-GPOS-00015
+
+Verify the operating system produces audit records containing information to establish what type of events occurred.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203604)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_generated(shell):
+    """Verify ausearch -ts recent returns non-empty output."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    assert result.stdout.strip() != "", "stigcompliance: no audit events captured"
+
+
+@pytest.mark.security_id(203604)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_type(shell):
+    """Verify ausearch -ts recent output contains a 'type=' field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    assert (
+        "type=" in result.stdout
+    ), "stigcompliance: audit records do not contain event type information"

--- a/tests-ng/test_disastig_00016.py
+++ b/tests-ng/test_disastig_00016.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000038-GPOS-00016
+
+Verify the operating system produces audit records containing information to establish when (date and time) the events occurred.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203605)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_timestamp(shell):
+    """Verify ausearch -ts recent output contains 'time->' or 'audit(' timestamps."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "time->" in result.stdout or "audit(" in result.stdout
+    ), "stigcompliance: audit records do not contain timestamp information"

--- a/tests-ng/test_disastig_00017.py
+++ b/tests-ng/test_disastig_00017.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000039-GPOS-00017
+
+Verify the operating system produces audit records containing information to establish where the events occurred.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203606)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_location(shell):
+    """Verify ausearch -ts recent output contains a cwd=, name=, exe= or path= field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    assert (
+        "cwd=" in result.stdout
+        or "name=" in result.stdout
+        or "exe=" in result.stdout
+        or "path=" in result.stdout
+    ), "stigcompliance: audit records do not contain location (where) information"

--- a/tests-ng/test_disastig_00018.py
+++ b/tests-ng/test_disastig_00018.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000040-GPOS-00018
+
+Verify the operating system produces audit records containing information to establish the source of the events.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203607)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_source(shell):
+    """Verify ausearch -ts recent output contains an auid=, uid=, ses=, comm= or exe= field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "auid=" in result.stdout
+        or "uid=" in result.stdout
+        or "ses=" in result.stdout
+        or "comm=" in result.stdout
+        or "exe=" in result.stdout
+    ), "stigcompliance: audit records do not contain source information"

--- a/tests-ng/test_disastig_00019.py
+++ b/tests-ng/test_disastig_00019.py
@@ -1,0 +1,25 @@
+"""
+Ref: SRG-OS-000041-GPOS-00019
+
+Verify the operating system produces audit records containing information to establish the outcome of the events.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203608)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_full_record(shell):
+    """Verify ausearch -ts recent output contains a success=yes/no or res=success/failed field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "success=yes" in result.stdout
+        or "success=no" in result.stdout
+        or "res=success" in result.stdout
+        or "res=failed" in result.stdout
+    ), "stigcompliance: audit records do not contain outcome (success/failure) information"

--- a/tests-ng/test_disastig_00020.py
+++ b/tests-ng/test_disastig_00020.py
@@ -1,0 +1,24 @@
+"""
+Ref: SRG-OS-000042-GPOS-00020
+
+Verify the operating system generates audit records containing the full-text recording of privileged commands.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203609)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_full_text_recording(audit_rule, shell):
+    """Verify ausearch -ts recent output contains a type=EXECVE record with a0= or a proctitle= field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "type=EXECVE" in result.stdout and " a0=" in result.stdout
+    ) or "proctitle=" in result.stdout, (
+        "stigcompliance: audit records do not contain full-text command recording"
+    )

--- a/tests-ng/test_disastig_00021.py
+++ b/tests-ng/test_disastig_00021.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000042-GPOS-00021
+
+Verify the operating system produces audit records containing the individual identities of group account users.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203610)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_individual_identities(shell):
+    """Verify ausearch -ts recent output contains an a0=, a1= or a2= argument field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        " a0=" in result.stdout or " a1=" in result.stdout or " a2=" in result.stdout
+    ), "stigcompliance: audit records do not contain command argument details"

--- a/tests-ng/test_disastig_00022.py
+++ b/tests-ng/test_disastig_00022.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000043-GPOS-00022
+
+Verify the operating system alerts the ISSO and SA (at a minimum) in the event of an audit processing failure.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203611)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_audit_processing_failures(shell):
+    """Verify ausearch -ts recent output mentions 'audit' together with fail/error/lost=/backlog."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    match_found = bool(re.search(r"audit.*(fail|error|lost=|backlog)", result.stdout))
+    assert (
+        match_found
+    ), "stigcompliance: audit records do not indicate alerting or detection of audit processing failures"

--- a/tests-ng/test_disastig_00024.py
+++ b/tests-ng/test_disastig_00024.py
@@ -1,0 +1,52 @@
+"""
+Ref: SRG-OS-000051-GPOS-00024
+
+Verify the operating system provides the capability to centrally review and analyze audit records from multiple components within the system.
+"""
+
+import re
+
+import pytest
+
+AUDITD_CONF = "/etc/audit/auditd.conf"
+
+
+@pytest.mark.security_id(203613)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to read audit configuration")
+def test_audit_log_retention_config(parse_file):
+    """Verify auditd.conf defines max_log_file, num_logs and space_left_action."""
+    lines = parse_file.lines(AUDITD_CONF)
+
+    assert (
+        re.compile(r"max_log_file\s*=\s*\d+") in lines
+    ), "stigcompliance: max_log_file not configured properly"
+
+    assert (
+        re.compile(r"num_logs\s*=\s*\d+") in lines
+    ), "stigcompliance: num_logs not configured properly"
+
+    assert (
+        re.compile(r"space_left_action\s*=\s*\S+") in lines
+    ), "stigcompliance: space_left_action not configured"
+
+
+@pytest.mark.security_id(203613)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit configuration and logs")
+def test_audit_log_retention_availability(shell):
+    """Verify ausearch returns structured audit records (retention works)."""
+    result = shell("ausearch -ts recent", capture_output=True)
+
+    assert (
+        result.returncode == 0
+    ), "stigcompliance: ausearch failed, audit logs not retrievable"
+
+    output = result.stdout.strip()
+
+    assert output != "", "stigcompliance: no audit records found (retention failure)"
+
+    assert (
+        "type=" in output
+    ), "stigcompliance: audit records not in expected structured format"

--- a/tests-ng/test_disastig_00025.py
+++ b/tests-ng/test_disastig_00025.py
@@ -1,0 +1,89 @@
+"""
+Ref: SRG-OS-000054-GPOS-00025
+
+Verify the operating system provides the capability to filter audit records for events of interest based upon all audit fields within audit records.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_by_uid(shell):
+    """Verify ausearch -ua 0 succeeds (filter by user identity)."""
+    result = shell("ausearch -ua 0", capture_output=True)
+
+    assert (
+        result.returncode == 0
+    ), "stigcompliance: unable to filter audit records by user identity (uid)"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_returns_structured_output(shell):
+    """Verify ausearch -ua 0 output contains a 'type=' field."""
+    result = shell("ausearch -ua 0", capture_output=True)
+
+    assert (
+        "type=" in result.stdout or "type=" in result.stdout or "type=" in result.stdout
+    ), "stigcompliance: audit filtering does not return structured audit records"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_by_event_type(shell):
+    """Verify ausearch -ts recent -m USER_LOGIN runs (filter by event type)."""
+    result = shell(
+        "ausearch -ts recent -m USER_LOGIN",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    assert result.returncode in (
+        0,
+        1,
+    ), "stigcompliance: unable to filter audit records by event type"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_by_command(shell):
+    """Verify ausearch -ts recent -c id runs (filter by command name)."""
+    result = shell(
+        "ausearch -ts recent -c id",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    assert result.returncode in (
+        0,
+        1,
+    ), "stigcompliance: unable to filter audit records by command"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit configuration and logs")
+def test_audit_record_filtering_capability(shell):
+    """Verify ausearch supports filtering by -m, -ts, -ua, and -x flags."""
+    commands = [
+        "ausearch -m USER_LOGIN || true",  # event type
+        "ausearch -ts recent || true",  # time
+        "ausearch -ua 0 || true",  # user identity (root)
+        "ausearch -x /usr/bin/id || true",  # executable
+    ]
+
+    for cmd in commands:
+        result = shell(cmd, capture_output=True)
+        assert (
+            result.returncode == 0
+        ), f"stigcompliance: audit filtering failed for command: {cmd}"

--- a/tests-ng/test_disastig_00026.py
+++ b/tests-ng/test_disastig_00026.py
@@ -1,0 +1,34 @@
+"""
+Ref: SRG-OS-000055-GPOS-00026
+
+Verify the operating system uses internal system clocks to generate time stamps for audit records.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203615)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to generate and read audit logs")
+def test_audit_records_have_valid_timestamps(shell):
+    """Verify ausearch -ts recent output contains a 'time->' line in the expected date format."""
+    result = shell("ausearch -ts recent", capture_output=True)
+
+    timestamp_pattern = r"time->\w{3}\s+\w{3}\s+\d+\s+\d+:\d+:\d+\s+\d{4}"
+
+    match_found = bool(re.search(timestamp_pattern, result.stdout))
+    assert match_found, "stigcompliance: audit records do not contain valid timestamps"
+
+
+@pytest.mark.security_id(203615)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to generate and read audit logs")
+def test_system_time_status_available(shell):
+    """Verify timedatectl status exits 0."""
+    timedate = shell("timedatectl status", capture_output=True)
+
+    assert timedate.returncode == 0, "stigcompliance: unable to check time sync status"

--- a/tests-ng/test_disastig_00027.py
+++ b/tests-ng/test_disastig_00027.py
@@ -1,0 +1,49 @@
+"""
+Ref: SRG-OS-000057-GPOS-00027
+
+Verify the operating system protects audit information from unauthorized read access.
+"""
+
+import pytest
+
+AUDIT_LOG_DIR = "/var/log/audit"
+AUDIT_LOG_FILE = "/var/log/audit/audit.log"
+
+
+@pytest.mark.security_id(203616)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem")
+@pytest.mark.root(reason="required to inspect audit log permissions")
+def test_audit_log_directory_permissions_restricted(file):
+    """Verify audit log directory has restrictive permissions (rwx------)."""
+    if file.exists(AUDIT_LOG_DIR):
+        assert file.has_permissions(
+            AUDIT_LOG_DIR, "rwx------"
+        ), f"stigcompliance: audit log directory {AUDIT_LOG_DIR} permissions are not restricted"
+
+
+@pytest.mark.security_id(203616)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem")
+@pytest.mark.root(reason="required to inspect audit log permissions")
+def test_audit_log_file_permissions_restricted(file):
+    """Verify the audit log file has restrictive permissions (rw-------)."""
+    if file.exists(AUDIT_LOG_FILE):
+        assert file.has_permissions(
+            AUDIT_LOG_FILE, "rw-------"
+        ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} permissions are not restricted"
+
+
+@pytest.mark.security_id(203616)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem")
+@pytest.mark.root(reason="required to inspect audit log ownership")
+def test_audit_log_owned_by_root(file):
+    """Verify the audit log file is owned by root."""
+    if file.exists(AUDIT_LOG_FILE):
+        assert file.is_owned_by_user(
+            AUDIT_LOG_FILE, "root"
+        ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} is not owned by root"

--- a/tests-ng/test_disastig_00028.py
+++ b/tests-ng/test_disastig_00028.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000058-GPOS-00028
+
+Verify the operating system protects audit information from unauthorized modification.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203617)
+def test_disastig_00028():
+    """Audit information protection is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00027.py")

--- a/tests-ng/test_disastig_00029.py
+++ b/tests-ng/test_disastig_00029.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000059-GPOS-00029
+
+Verify the operating system protects audit information from unauthorized deletion.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203618)
+def test_disastig_00029():
+    """Protection of audit information from deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00027.py")

--- a/tests-ng/test_disastig_00031.py
+++ b/tests-ng/test_disastig_00031.py
@@ -1,0 +1,45 @@
+"""
+Ref: SRG-OS-000062-GPOS-00031
+
+Verify the operating system provides audit record generation capability for DoD-defined auditable events for all operating system components.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203619)
+def test_audit_modify_delete_privileges():
+    """Audit of privilege modification/deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00210.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_modify_delete_security_objects():
+    """Audit of security object modification/deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00212.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_modify_delete_security_levels():
+    """Audit of security level modification/deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00211.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_user_access():
+    """Audit of user access events is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00220.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_user_accounts_management():
+    """Audit of user account management is covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00089.py,  test_disastig_00090.py, test_disastig_00091.py"
+    )
+
+
+@pytest.mark.security_id(203619)
+def test_audit_kernel_module_load_unload():
+    """Audit of kernel module load/unload is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00222.py")

--- a/tests-ng/test_disastig_00038.py
+++ b/tests-ng/test_disastig_00038.py
@@ -1,0 +1,28 @@
+"""
+Ref: SRG-OS-000070-GPOS-00038
+
+Verify the operating system enforces password complexity by requiring at least one lowercase character. Setting lcredit=-1 in pwquality.conf mandates at least one lowercase letter in every new password.
+"""
+
+import pytest
+
+PWQUALITY_CONF = "/etc/security/pwquality.conf"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-disaSTIGlow-config-security-pwquality",
+        "GL-TESTCOV-disaSTIGmedium-config-security-pwquality",
+    ]
+)
+@pytest.mark.feature(
+    "disaSTIGlow or disaSTIGmedium",
+    reason="password quality lcredit is configured by disaSTIGlow and disaSTIGmedium",
+)
+@pytest.mark.security_id(203626)
+def test_pwquality_conf_lcredit_is_minus_1(parse_file) -> None:
+    """Verify lcredit=-1 in pwquality.conf (SRG-OS-000070-GPOS-00038)."""
+    config = parse_file.parse(PWQUALITY_CONF, format="keyval")
+    assert (
+        config["lcredit"] == "-1"
+    ), f"stigcompliance: lcredit in {PWQUALITY_CONF} is {config['lcredit']!r}, expected '-1'"

--- a/tests-ng/test_disastig_00040.py
+++ b/tests-ng/test_disastig_00040.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000072-GPOS-00040
+
+Verify the operating system requires the change of at least eight of the total number of characters when passwords are changed.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203628)
+def test_disastig_00040():
+    """Password character change requirement is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00046.py")

--- a/tests-ng/test_disastig_00041.py
+++ b/tests-ng/test_disastig_00041.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000073-GPOS-00041
+
+Verify the operating system stores only encrypted representations of passwords.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203629)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="required for passwd checks")
+def test_passwd_does_not_store_passwords(passwd_entries):
+    """Verify /etc/passwd contains no plaintext passwords."""
+    assert all(
+        entry.password in ("x", "*", "!") for entry in passwd_entries
+    ), "stigcompliance: plaintext password found in /etc/passwd"
+
+
+@pytest.mark.security_id(203629)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="required for passwd checks")
+def test_shadow_passwords_are_hashed(shadow_entries):
+    """Verify /etc/shadow entries are empty, locked, or hashed."""
+    assert all(
+        entry.encrypted_password == ""
+        or entry.encrypted_password.startswith(("!", "*", "$"))
+        for entry in shadow_entries
+    ), "stigcompliance: non-hashed password detected in /etc/shadow"
+
+
+@pytest.mark.security_id(203629)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="required for passwd checks")
+def test_shadow_uses_strong_hashing_algorithm(shadow_entries):
+    """Verify /etc/shadow uses strong hashing (yescrypt or sha512)."""
+    assert all(
+        entry.encrypted_password == ""
+        or entry.encrypted_password.startswith(("!", "*", "$y$", "$6$"))
+        for entry in shadow_entries
+    ), "stigcompliance: weak password hashing algorithm detected"

--- a/tests-ng/test_disastig_00046.py
+++ b/tests-ng/test_disastig_00046.py
@@ -1,0 +1,32 @@
+"""
+Ref: SRG-OS-000078-GPOS-00046
+
+Verify the operating system enforces a minimum 15-character password length.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-password"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203634)
+def test_common_password_passwdqc_pam_faillock(pam_config):
+    """Verify pam_passwdqc enforces password strength rules in common-password."""
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_passwdqc.so",
+        arg_contains=[
+            "min=disabled,disabled,15,15,8",
+            "passphrase=4",
+            "similar=deny",
+            "match=7",
+            "retry=5",
+        ],
+    )
+    assert (
+        len(results) == 1
+    ), "User password should conform to password strength requirements"

--- a/tests-ng/test_disastig_00047.py
+++ b/tests-ng/test_disastig_00047.py
@@ -1,0 +1,48 @@
+"""
+Ref: SRG-OS-000079-GPOS-00047
+
+Verify the operating system obscures feedback of authentication information during the authentication process to protect the information from possible exploitation/use by unauthorized individuals.
+"""
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+PAM_FILES = [
+    "/etc/pam.d/common-auth",
+    "/etc/pam.d/login",
+    "/etc/pam.d/sshd",
+]
+
+
+@pytest.mark.security_id(203635)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires authentication stack")
+@pytest.mark.root(reason="required for pam.d checks")
+def test_authentication_uses_valid_pam_modules(file: File, parse_file: ParseFile):
+    """Verify pam_unix or pam_sss is wired into the PAM auth stack."""
+    existing_pam_files = [p for p in PAM_FILES if file.exists(p)]
+
+    assert existing_pam_files, "stigcompliance: no PAM configuration files found"
+
+    assert any(
+        ("pam_unix.so" in parse_file.lines(p) or "pam_sss.so" in parse_file.lines(p))
+        for p in existing_pam_files
+    ), "stigcompliance: no valid PAM authentication modules found"
+
+
+@pytest.mark.security_id(203635)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires authentication stack")
+@pytest.mark.root(reason="required for pam.d checks")
+def test_authentication_no_insecure_echo(file: File, parse_file: ParseFile):
+    """Verify PAM configs do not enable insecure echo of authentication input."""
+    for pam_file in PAM_FILES:
+        if not file.exists(pam_file):
+            continue
+
+        lines = parse_file.lines(pam_file)
+
+        assert (
+            "echo" not in lines
+        ), f"stigcompliance: insecure echo option found in {pam_file}"

--- a/tests-ng/test_disastig_00050.py
+++ b/tests-ng/test_disastig_00050.py
@@ -1,0 +1,53 @@
+"""
+Ref: SRG-OS-000096-GPOS-00050
+
+Verify the operating system is configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.
+"""
+
+import pytest
+
+ALLOWED_PORTS = {22, 53}
+
+FORBIDDEN_SERVICES = [
+    "telnet.service",
+    "vsftpd.service",
+    "rsh.service",
+    "avahi-daemon.service",
+    "cups.service",
+]
+
+
+@pytest.mark.feature(
+    "not container and not gardener and not lima and not capi and not baremetal"
+)
+@pytest.mark.security_id(203638)
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="requires audit operations")
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_ports_protocols_and_services_restricted(shell, systemd):
+    """Verify only ports 22 and 53 listen and forbidden services (telnet, vsftpd, rsh, avahi-daemon, cups) are not running."""
+    result = shell("ss -tuln", capture_output=True)
+    assert result.returncode == 0, "stigcompliance: failed to list listening ports"
+
+    open_ports = set()
+    for line in result.stdout.splitlines():
+        if "LISTEN" in line:
+            port = line.split()[4].split(":")[-1]
+            if port.isdigit():
+                open_ports.add(int(port))
+
+    unauthorized_ports = open_ports - ALLOWED_PORTS
+
+    assert (
+        not unauthorized_ports
+    ), f"stigcompliance: unauthorized ports open: {unauthorized_ports}"
+
+    running_units = systemd.list_running_units()
+
+    running_names = {unit.unit for unit in running_units}
+
+    found_forbidden = [svc for svc in FORBIDDEN_SERVICES if svc in running_names]
+
+    assert (
+        not found_forbidden
+    ), f"stigcompliance: forbidden services running: {found_forbidden}"

--- a/tests-ng/test_disastig_00056.py
+++ b/tests-ng/test_disastig_00056.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000109-GPOS-00056
+
+Verify the operating system locks the root account. A locked root account prevents direct login as root, forcing administrators to use privilege escalation mechanisms instead.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-root-locked"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="root account locking is enforced by disaSTIGmedium"
+)
+@pytest.mark.security_id(203644)
+@pytest.mark.root(reason="requires root to read shadow password status")
+def test_root_account_is_locked(shell) -> None:
+    """Verify root account is locked (field 2 of passwd --status output is 'L')."""
+    result = shell("passwd --status root", capture_output=True, ignore_exit_code=True)
+    fields = result.stdout.split()
+    assert (
+        len(fields) >= 2 and fields[1] == "L"
+    ), f"stigcompliance: root account is not locked (passwd --status output: {result.stdout!r})"

--- a/tests-ng/test_disastig_00057.py
+++ b/tests-ng/test_disastig_00057.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000112-GPOS-00057
+
+Verify the operating system implements replay-resistant authentication mechanisms for network access to privileged accounts.
+"""
+
+import re
+
+import pytest
+from plugins.sshd import Sshd
+
+
+@pytest.mark.security_id(203645)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect SSH configuration")
+def test_ssh_kex_algorithms_are_replay_resistant(sshd: Sshd) -> None:
+    """Verify SSH KexAlgorithms exclude non-replay-resistant algorithms (diffie-hellman-group1-sha1, diffie-hellman-group14-sha1)."""
+    kex = sshd.get_config_section("kexalgorithms") or ""
+
+    match_found = bool(
+        re.search(
+            r"diffie-hellman-group1-sha1|diffie-hellman-group14-sha1",
+            str(kex),
+            re.IGNORECASE,
+        )
+    )
+    assert (
+        not match_found
+    ), "stigcompliance: SSH KexAlgorithms contain non-replay-resistant algorithms"
+
+
+@pytest.mark.security_id(203645)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect SSH configuration")
+def test_ssh_kex_includes_ecdh(sshd: Sshd) -> None:
+    """Verify SSH KexAlgorithms include an approved ECDH algorithm (ecdh-sha2-nistp384 or ecdh-sha2-nistp521)."""
+    kex = sshd.get_config_section("kexalgorithms") or ""
+
+    match_found = bool(re.search(r"ecdh-sha2-nistp(384|521)", str(kex), re.IGNORECASE))
+    assert match_found, "stigcompliance: no approved ECDH KexAlgorithm configured"

--- a/tests-ng/test_disastig_00060.py
+++ b/tests-ng/test_disastig_00060.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000118-GPOS-00060
+
+Verify the operating system disables accounts inactive for more than 35 days. Setting INACTIVE in /etc/default/useradd ensures new accounts inherit this policy automatically.
+"""
+
+import pytest
+
+USERADD_DEFAULTS = "/etc/default/useradd"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-useradd-inactive"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="account inactivity timeout is set by disaSTIGmedium"
+)
+@pytest.mark.security_id(203648)
+def test_useradd_inactive_is_35(parse_file) -> None:
+    """Verify INACTIVE in /etc/default/useradd is 35 (SRG-OS-000118-GPOS-00060)."""
+    config = parse_file.parse(USERADD_DEFAULTS, format="keyval")
+    assert (
+        config["INACTIVE"] == "35"
+    ), f"stigcompliance: INACTIVE in {USERADD_DEFAULTS} is {config['INACTIVE']!r}, expected '35'"

--- a/tests-ng/test_disastig_00061.py
+++ b/tests-ng/test_disastig_00061.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000120-GPOS-00061
+
+Verify the operating system uses mechanisms meeting the requirements of applicable federal laws, Executive orders, directives, policies, regulations, standards, and guidance for authentication to a cryptographic module.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203649)
+def test_disastig_00061():
+    """Cryptographic module authentication is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests-ng/test_disastig_00063.py
+++ b/tests-ng/test_disastig_00063.py
@@ -1,0 +1,33 @@
+"""
+Ref: SRG-OS-000122-GPOS-00063
+
+Verify the operating system provides an audit reduction capability that supports on-demand reporting requirements.
+"""
+
+import shutil
+
+import pytest
+
+
+@pytest.mark.security_id(203651)
+@pytest.mark.feature("log")
+def test_audit_reporting_tools_installed():
+    """Verify aureport and ausearch are installed."""
+    tools = ["aureport", "ausearch"]
+    for tool in tools:
+        path = shutil.which(tool)
+        assert path is not None, f"'{tool}' audit reporting utility is not installed"
+
+
+@pytest.mark.feature("log")
+@pytest.mark.root(
+    "Audit reporting requires root privileges to open /var/log/audit/audit.log"
+)
+@pytest.mark.security_id(203651)
+def test_audit_reporting_execution(shell):
+    """Verify aureport produces a usable summary."""
+    result = shell("aureport --summary", capture_output=True, ignore_exit_code=True)
+
+    assert (
+        "Summary" in result.stdout
+    ), f"'aureport' executed but returned an unexpected result: {result.stdout}"

--- a/tests-ng/test_disastig_00067.py
+++ b/tests-ng/test_disastig_00067.py
@@ -1,0 +1,55 @@
+"""
+Ref: SRG-OS-000132-GPOS-00067
+
+Verify the operating system separates user functionality (including user interface services) from operating system management functionality.
+"""
+
+import pwd
+
+import pytest
+
+SETUID_BINARIES_ALLOWLIST = {
+    "default": {
+        "/usr/bin/chfn",
+        "/usr/bin/chsh",
+        "/usr/bin/gpasswd",
+        "/usr/bin/passwd",
+        "/usr/bin/su",
+        "/usr/bin/sudo",
+        "/usr/bin/sudoedit",
+    },
+    "lima": {"/usr/bin/fusermount3", "/usr/bin/fusermount"},
+}
+
+
+@pytest.mark.security_id(203655)
+def test_only_root_user_has_uid_zero():
+    """Verify only the root account has UID 0."""
+    adm_users = [u.pw_name for u in pwd.getpwall() if u.pw_uid == 0]
+    assert adm_users == [
+        "root"
+    ], f"only root user should have uid 0, instead {adm_users} found"
+
+
+@pytest.mark.security_id(203655)
+@pytest.mark.feature("not lima")
+def test_only_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries):
+    """Verify only allowlisted setuid binaries are exposed."""
+    if exposed_setuid_binaries:
+        diff = exposed_setuid_binaries - SETUID_BINARIES_ALLOWLIST["default"]
+        assert (
+            not diff
+        ), f"unexpected setuid binaries with too broad exec permissions: {exposed_setuid_binaries=} {diff=}"
+
+
+@pytest.mark.security_id(203655)
+@pytest.mark.feature("lima")
+def test_only_lima_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries):
+    """Verify only allowlisted setuid binaries (incl. lima additions) are exposed."""
+    if exposed_setuid_binaries:
+        diff = exposed_setuid_binaries - (
+            SETUID_BINARIES_ALLOWLIST["default"] | SETUID_BINARIES_ALLOWLIST["lima"]
+        )
+        assert (
+            not diff
+        ), f"unexpected setuid binaries with too broad exec permissions: {exposed_setuid_binaries=} {diff=}"

--- a/tests-ng/test_disastig_00068.py
+++ b/tests-ng/test_disastig_00068.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000134-GPOS-00068
+
+Verify the operating system isolates security functions from nonsecurity functions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203656)
+def test_disastig_00068():
+    """Isolation of security from nonsecurity functions is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00067.py")

--- a/tests-ng/test_disastig_00069.py
+++ b/tests-ng/test_disastig_00069.py
@@ -1,0 +1,89 @@
+"""
+Ref: SRG-OS-000138-GPOS-00069
+
+Verify operating systems prevents unauthorized and unintended information transfer via shared system resources.
+"""
+
+import pytest
+from plugins.parse import Lines
+
+
+# -- temporary files
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("not _selinux")
+@pytest.mark.booted(reason="Mounts are present on a booted system")
+def test_tmp_mount_is_configured_securely(mount):
+    """Verify /tmp is mounted with nosuid."""
+    required_mount_options = {"nosuid"}
+
+    real_mount_options = mount("/tmp").options
+    missing_mount_options = required_mount_options - real_mount_options
+
+    assert (
+        not missing_mount_options
+    ), f"Missing /tmp mount options: {missing_mount_options}"
+
+
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="Mounts are present on a booted system")
+def test_tmp_mount_is_configured_securely_and_with_selinux(mount):
+    """Verify /tmp is mounted with nosuid and seclabel under SELinux."""
+    required_mount_options = {"nosuid", "seclabel"}
+
+    real_mount_options = mount("/tmp").options
+    missing_mount_options = required_mount_options - real_mount_options
+
+    assert (
+        not missing_mount_options
+    ), f"Missing /tmp mount options: {missing_mount_options}"
+
+
+@pytest.mark.security_id(203657)
+def test_temp_directores_are_world_writable_and_have_sticky_bit_set(file):
+    """Verify /tmp and /var/tmp are world-writable with sticky bit (1777)."""
+    for dir in ["/tmp", "/var/tmp"]:
+        assert file.is_dir(dir)
+        assert file.has_mode(dir, "1777")
+
+
+@pytest.mark.security_id(203657)
+@pytest.mark.booted(reason="Systemd should be running")
+def test_systemd_tmpfiles_configuration_is_sane(shell):
+    """Verify systemd-tmpfiles configures /tmp and /var/tmp with mode 1777."""
+    result = shell("systemd-tmpfiles --cat-config", capture_output=True)
+    for dir in ["/tmp", "/var/tmp"]:
+        lines = Lines(result.stdout, comment_char="#")
+        assert (
+            f"q {dir} 1777 root root" in lines
+        ), f"{dir} should be correctly configured in systemd-tmpfiles"
+
+
+# -- coredumps
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="sysctl values are only applied on a booted system")
+def test_suid_binaries_cannot_create_coredumps(sysctl):
+    """Verify fs.suid_dumpable is 0."""
+    assert sysctl["fs.suid_dumpable"] == 0
+
+
+# -- memory
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="sysctl values are only applied on a booted system")
+def test_kernel_randomizes_virtual_memory_addresses(sysctl):
+    """Verify kernel.randomize_va_space is set to 2 (full ASLR)."""
+    assert sysctl["kernel.randomize_va_space"] == 2
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-sysctl-disaSTIG"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="sysctl hardening config is deployed by disaSTIGlow"
+)
+@pytest.mark.security_id(203657)
+def test_sysctl_disastig_low_conf_exists(file) -> None:
+    """Verify /etc/sysctl.d/99-disaSTIG.conf exists for disaSTIGlow (SRG-OS-000138-GPOS-00069)."""
+    assert file.exists(
+        "/etc/sysctl.d/99-disaSTIG.conf"
+    ), "stigcompliance: /etc/sysctl.d/99-disaSTIG.conf does not exist"

--- a/tests-ng/test_disastig_00071.py
+++ b/tests-ng/test_disastig_00071.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000142-GPOS-00071
+
+Verify the operating system is configured to prevent unauthorized connection of devices. The disaSTIG sysctl configuration file must be present to ensure kernel parameter hardening is applied.
+"""
+
+import pytest
+
+SYSCTL_DISASTIG = "/etc/sysctl.d/99-disaSTIG.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sysctl-disaSTIG"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="sysctl hardening config is deployed by disaSTIGmedium"
+)
+@pytest.mark.security_id(203658)
+def test_sysctl_disastig_conf_exists(file) -> None:
+    """Verify /etc/sysctl.d/99-disaSTIG.conf exists (SRG-OS-000142-GPOS-00071)."""
+    assert file.exists(
+        SYSCTL_DISASTIG
+    ), f"stigcompliance: {SYSCTL_DISASTIG} does not exist"

--- a/tests-ng/test_disastig_00072.py
+++ b/tests-ng/test_disastig_00072.py
@@ -1,0 +1,19 @@
+"""
+Ref: SRG-OS-000163-GPOS-00072
+
+Verify the operating system terminates all network connections associated with a communications session at the end of the session, or as follows: for in-band management sessions (privileged sessions), the session must be terminated after 10 minutes of inactivity; and for user sessions (non-privileged session), the session must be terminated after 15 minutes of inactivity, except to fulfill documented and validated mission requirements.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-clientalivecountmax"]
+)
+@pytest.mark.security_id(203659)
+@pytest.mark.feature("disaSTIGmedium")
+def test_terminate_ssh_session_after_inactivity_period(parse_file):
+    """Verify sshd is set to disconnect after 600s of inactivity."""
+    config = parse_file.parse("/etc/ssh/sshd_config", format="spacedelim")
+    assert config["ClientAliveInterval"] == "600"
+    assert config["ClientAliveCountMax"] == "1"

--- a/tests-ng/test_disastig_00078.py
+++ b/tests-ng/test_disastig_00078.py
@@ -1,0 +1,16 @@
+"""
+Ref: SRG-OS-000184-GPOS-00078
+
+Verify the operating system fails to a secure state if system initialization fails, shutdown fails, or aborts fail.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sysctl-disaSTIG"])
+@pytest.mark.security_id(203664)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="sysctl values are only applied on a booted system")
+def test_kernel_dump_is_disabled(sysctl):
+    """Verify kernel.core_pattern routes core dumps to /bin/false."""
+    assert sysctl["kernel.core_pattern"] == "|/bin/false"

--- a/tests-ng/test_disastig_00083.py
+++ b/tests-ng/test_disastig_00083.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000205-GPOS-00083
+
+Verify the operating system defines proper permissions on the system log directory /var/log so that unauthorized users cannot access log data.
+"""
+
+import pytest
+
+VAR_LOG = "/var/log"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-var-log-file-permissions"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="log directory permissions are hardened by disaSTIGmedium"
+)
+@pytest.mark.security_id(203663)
+def test_var_log_has_755_permissions(file) -> None:
+    """Verify /var/log directory has permissions 755 (SRG-OS-000205-GPOS-00083)."""
+    assert file.has_permissions(
+        VAR_LOG, "rwxr-xr-x"
+    ), f"stigcompliance: {VAR_LOG} permissions are {file.get_mode(VAR_LOG)!r}, expected 0755"

--- a/tests-ng/test_disastig_00084.py
+++ b/tests-ng/test_disastig_00084.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000206-GPOS-00084
+
+Verify the operating system reveals error messages only to authorized users.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203664)
+@pytest.mark.feature("disaSTIGmedium")
+def test_systemd_journal_is_not_world_readable(file):
+    """Verify /var/log/journal is owned by root with mode rwxr-s---."""
+    assert file.is_owned_by_user("/var/log/journal", "root")
+    assert file.has_permissions("/var/log/journal", "rwxr-s---")

--- a/tests-ng/test_disastig_00089.py
+++ b/tests-ng/test_disastig_00089.py
@@ -1,0 +1,55 @@
+"""
+Ref: SRG-OS-000239-GPOS-00089
+
+Verify the operating system automatically audits account modification.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203666)
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-30-disaSTIG-rules",
+        "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules",
+    ]
+)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_audit_calling_user_group_related_utilities(audit_rule):
+    """Verify execution of user/group management binaries is audited."""
+    for bin in [
+        "/usr/sbin/visudo",
+        "/usr/sbin/chgpasswd",
+        "/usr/sbin/chpasswd",
+        "/usr/sbin/groupadd",
+        "/usr/sbin/groupdel",
+        "/usr/sbin/groupmod",
+        "/usr/sbin/grpconv",
+        "/usr/sbin/grpunconv",
+        "/usr/sbin/newusers",
+        "/usr/sbin/pwconv",
+        "/usr/sbin/pwunconv",
+        "/usr/sbin/shadowconfig",
+        "/usr/sbin/useradd",
+        "/usr/sbin/userdel",
+        "/usr/sbin/usermod",
+        "/usr/sbin/vipw",
+        "/usr/sbin/vigr",
+        "/usr/bin/chage",
+        "/usr/bin/chfn",
+        "/usr/bin/chsh",
+        "/usr/bin/gpasswd",
+        "/usr/bin/passwd",
+    ]:
+        assert audit_rule(
+            fs_watch_path=bin, access_types="x"
+        ), f"No audit rule found for {bin} execution"
+
+
+@pytest.mark.security_id(203666)
+def test_audit_rules_for_logging_attempts_to_delete_privileges():
+    """Audit rules for privilege deletion are covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"
+    )

--- a/tests-ng/test_disastig_00090.py
+++ b/tests-ng/test_disastig_00090.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000240-GPOS-00090
+
+Verify the operating system automatically audits account disabling actions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203667)
+def test_disastig_00090():
+    """Auditing of account disabling actions is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00089.py")
+
+
+@pytest.mark.security_id(203667)
+def test_audit_rules_for_logging_attempts_to_delete_privileges():
+    """Audit rules for privilege deletion are covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"
+    )

--- a/tests-ng/test_disastig_00091.py
+++ b/tests-ng/test_disastig_00091.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000241-GPOS-00091
+
+Verify the operating system automatically audits account removal actions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203668)
+def test_disastig_00091():
+    """Auditing of account removal actions is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00089.py")
+
+
+@pytest.mark.security_id(203668)
+def test_audit_rules_for_logging_attempts_to_delete_privileges():
+    """Audit rules for privilege deletion are covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"
+    )

--- a/tests-ng/test_disastig_00095.py
+++ b/tests-ng/test_disastig_00095.py
@@ -1,0 +1,43 @@
+"""
+Ref: SRG-OS-000254-GPOS-00095
+
+As per DISA STIG compliance requirements, the operating system must begin auditing sessions when the system starts up.
+"""
+
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+
+@pytest.mark.security_id(203670)
+@pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
+@pytest.mark.feature("disaSTIGmedium")
+def test_audit_cmdline_config_file_exists(file: File):
+    """Verify the audit kernel cmdline config file exists."""
+    assert file.is_regular_file(
+        "/etc/kernel/cmdline.d/90-audit.cfg"
+    ), "stigcompliance: /etc/kernel/cmdline.d/90-audit.cfg must exist"
+
+
+@pytest.mark.security_id(203670)
+@pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
+@pytest.mark.feature("disaSTIGmedium")
+def test_audit_cmdline_config_file_content(parse_file: ParseFile):
+    """Verify the audit kernel cmdline config contains audit=1."""
+    lines = parse_file.lines("/etc/kernel/cmdline.d/90-audit.cfg")
+    assert (
+        "audit=1" in lines
+    ), "stigcompliance: /etc/kernel/cmdline.d/90-audit.cfg must contain audit=1"
+
+
+@pytest.mark.security_id(203670)
+@pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="kernel cmdline is only available on a booted system")
+def test_audit_enabled_in_kernel_cmdline(kernel_cmdline: List[str]):
+    """Verify audit=1 is present in the runtime kernel cmdline."""
+    assert (
+        "audit=1" in kernel_cmdline
+    ), "stigcompliance: kernel must be booted with audit=1"

--- a/tests-ng/test_disastig_00096.py
+++ b/tests-ng/test_disastig_00096.py
@@ -1,0 +1,41 @@
+"""
+Ref: SRG-OS-000255-GPOS-00096
+
+Verify the operating system produces audit records containing information to establish the identity of any individual or process associated with the event.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203671)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit configuration and logs")
+def test_audit_records_contain_identity_information(shell):
+    """Verify audit records carry identity fields (auid, uid, pid, comm, exe)."""
+    result = shell(
+        "ausearch -ts recent",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    stdout = result.stdout or ""
+
+    identity_patterns = [
+        r"\bauid=\d+",
+        r"\buid=\d+",
+        r"\beuid=\d+",
+        r"\bpid=\d+",
+        r"\bcomm=",
+        r"\bexe=",
+    ]
+
+    missing = [
+        pattern for pattern in identity_patterns if not re.search(pattern, stdout)
+    ]
+
+    assert (
+        not missing
+    ), "stigcompliance: audit records missing identity fields: " + ", ".join(missing)

--- a/tests-ng/test_disastig_00097.py
+++ b/tests-ng/test_disastig_00097.py
@@ -1,0 +1,89 @@
+"""
+Ref: SRG-OS-000256-GPOS-00097
+
+Verify the operating system protects audit tools from unauthorized access.
+"""
+
+import pytest
+
+AUDIT_TOOL_PATHS = [
+    "/sbin/auditctl",
+    "/usr/sbin/auditctl",
+    "/usr/bin/last",
+    "/usr/bin/journalctl",
+]
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_shadow_permissions(file):
+    """Verify /etc/shadow has mode 0640."""
+    actual = file.get_mode("/etc/shadow")
+    assert file.has_permissions("/etc/shadow", "0640"), (
+        f"stigcompliance: incorrect permissions on /etc/shadow "
+        f"(expected 640, got {actual})"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_passwd_permissions_numeric(file):
+    """Verify /etc/passwd has numeric mode 0644."""
+    actual = file.get_mode("/etc/passwd")
+    assert file.has_permissions("/etc/passwd", "0644"), (
+        f"stigcompliance: incorrect permissions on /etc/passwd "
+        f"(expected 0644, got {actual})"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_passwd_permissions_symbolic(file):
+    """Verify /etc/passwd has symbolic mode rw-r--r--."""
+    actual = file.get_mode("/etc/passwd")
+    assert file.has_permissions("/etc/passwd", "rw-r--r--"), (
+        f"stigcompliance: incorrect symbolic permissions on /etc/passwd "
+        f"(expected rw-r--r--, got {actual})"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+def test_audit_tools_permissions(file):
+    """Verify auditctl, last and journalctl binaries have mode 755."""
+    invalid = []
+
+    for path in AUDIT_TOOL_PATHS:
+        if not file.exists(path):
+            continue
+
+        if not file.has_permissions(path, "755"):
+            invalid.append(f"{path} ({file.get_mode(path)})")
+
+    assert not invalid, (
+        "stigcompliance: audit tools must have 755: " f"{', '.join(invalid)}"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_sticky_bit_support(file, tmp_path):
+    """Verify a tmp directory chmod-ed to 1777 reports both 1777 and rwxrwxrwt."""
+    test_dir = tmp_path / "sticky_test"
+    test_dir.mkdir()
+    test_dir.chmod(0o1777)
+
+    assert file.has_permissions(test_dir, "1777")
+    assert file.has_permissions(test_dir, "rwxrwxrwt")

--- a/tests-ng/test_disastig_00098.py
+++ b/tests-ng/test_disastig_00098.py
@@ -1,0 +1,72 @@
+"""
+Ref: SRG-OS-000257-GPOS-00098
+
+Verify the operating system protects audit tools from unauthorized modification.
+"""
+
+from pathlib import Path
+
+import pytest
+
+AUDIT_LOG_DIR = "/var/log/audit"
+
+
+@pytest.mark.security_id(203673)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit protection requires booted system")
+@pytest.mark.root(reason="required to inspect audit log ownership")
+def test_audit_log_directory_protected(file):
+    """Verify /var/log/audit is owned by root with one of: rwx------, rwxr-x---, rwxr-----, rwx--x---."""
+    assert file.exists(AUDIT_LOG_DIR), f"stigcompliance: {AUDIT_LOG_DIR} does not exist"
+
+    assert file.is_owned_by_user(
+        AUDIT_LOG_DIR, "root"
+    ), f"stigcompliance: {AUDIT_LOG_DIR} must be owned by root"
+
+    allowed_modes = [
+        "rwx------",
+        "rwxr-x---",
+        "rwxr-----",
+        "rwx--x---",
+    ]
+
+    assert any(file.has_permissions(AUDIT_LOG_DIR, mode) for mode in allowed_modes), (
+        f"stigcompliance: {AUDIT_LOG_DIR} has insecure permissions "
+        f"(mode {file.get_mode(AUDIT_LOG_DIR)})"
+    )
+
+
+@pytest.mark.security_id(203673)
+@pytest.mark.feature("disaSTIGmedium or cis")
+@pytest.mark.booted(reason="audit protection requires booted system")
+@pytest.mark.root(reason="required to inspect audit log ownership")
+def test_audit_log_files_protected(file):
+    """Verify regular files under /var/log/audit are owned by root and have mode rw------- or rw-r-----."""
+    if not file.exists(AUDIT_LOG_DIR):
+        pytest.skip(f"{AUDIT_LOG_DIR} does not exist")
+
+    allowed_modes = [
+        "rw-------",
+        "rw-r-----",
+    ]
+
+    violations = []
+
+    for path in Path(AUDIT_LOG_DIR).glob("*"):
+        if not file.is_regular_file(path):
+            continue
+
+        owner_ok = file.is_owned_by_user(path, "root")
+
+        perms_ok = any(file.has_permissions(path, mode) for mode in allowed_modes)
+
+        if not owner_ok or not perms_ok:
+            violations.append(
+                f"{path.name} (owner={file.get_user(path)}, mode={file.get_mode(path)})"
+            )
+
+    assert (
+        not violations
+    ), "stigcompliance: audit log files not properly protected for: " + ", ".join(
+        violations
+    )

--- a/tests-ng/test_disastig_00099.py
+++ b/tests-ng/test_disastig_00099.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000258-GPOS-00099
+
+Verify the operating system protects audit tools from unauthorized deletion.
+"""
+
+from pathlib import Path
+
+import pytest
+
+AUDIT_TOOL_PATHS = [
+    "/sbin/auditctl",
+    "/usr/sbin/auditctl",
+    "/usr/bin/last",
+    "/usr/bin/journalctl",
+]
+
+
+@pytest.mark.security_id(203674)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_audit_tools_parent_dirs_not_writable(file):
+    """Verify the parent directories of auditctl/last/journalctl are not rwxrwxrwx, rwxrwxr-x or rwxrwx---."""
+    checked = set()
+    for path in AUDIT_TOOL_PATHS:
+        if not file.exists(path):
+            continue
+
+        parent = str(Path(path).parent)
+        if parent in checked:
+            continue
+        checked.add(parent)
+
+        mode = file.get_mode(parent)
+
+        assert (
+            not file.has_permissions(parent, "rwxrwxrwx")
+            and not file.has_permissions(parent, "rwxrwxr-x")
+            and not file.has_permissions(parent, "rwxrwx---")
+        ), (
+            f"stigcompliance: parent directory {parent} allows unauthorized deletion "
+            f"(mode: {mode})"
+        )

--- a/tests-ng/test_disastig_00100.py
+++ b/tests-ng/test_disastig_00100.py
@@ -1,0 +1,92 @@
+"""
+Ref: SRG-OS-000259-GPOS-00100
+
+Verify the operating system limits privileges to change software resident within software libraries.
+"""
+
+import fileinput
+import glob
+import platform
+
+import pytest
+
+ALLOWED_LIB_DIRS = {
+    "x86_64": {
+        "/usr/lib",
+        "/usr/local/lib",
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/lib/i686-linux-gnu",
+        "/lib32",
+        "/usr/lib/i386-linux-gnu",
+        "/usr/lib/i686-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu/libfakeroot",
+        "/usr/lib32",
+        "/usr/local/lib/i386-linux-gnu",
+        "/usr/local/lib/i686-linux-gnu",
+        "/usr/local/lib/x86_64-linux-gnu",
+    },
+    "aarch64": {
+        "/usr/lib",
+        "/usr/local/lib",
+        "/usr/lib/aarch64-linux-gnu",
+        "/usr/local/lib/aarch64-linux-gnu",
+    },
+}
+
+
+@pytest.fixture
+def ld_library_paths():
+    return {
+        line.strip()
+        for line in fileinput.input(
+            files=["/etc/ld.so.conf"] + glob.glob("/etc/ld.so.conf.d/*")
+        )
+        if line.strip().startswith("/")
+    }
+
+
+@pytest.mark.security_id(203675)
+def test_no_unsolicited_lib_path_for_ldconfig(ld_library_paths):
+    """Verify /etc/ld.so.conf and /etc/ld.so.conf.d/* contain only the architecture's allow-listed library paths."""
+    diff = ld_library_paths - ALLOWED_LIB_DIRS[platform.machine()]
+    assert not diff, f"unexpected shared libraries lookup paths configured: {diff}"
+
+
+@pytest.mark.security_id(203675)
+@pytest.mark.feature("disaSTIGmedium")
+def test_lib_directories_are_only_root_writable(ld_library_paths, file):
+    """Verify each ld.so library directory is root:root with mode rwxr-xr-x."""
+    for lib_path in ld_library_paths:
+        if file.exists(lib_path):
+            assert file.get_owner(lib_path) == ("root", "root")
+            assert file.has_permissions(lib_path, "rwxr-xr-x")
+
+
+@pytest.mark.security_id(203675)
+@pytest.mark.feature("disaSTIGmedium")
+def test_python_lib_directory_is_only_root_writable(file, dpkg):
+    """Verify /usr/lib/python3/dist-packages is root:root with mode rwxr-xr-x."""
+    python_pkg = dpkg.collect_installed_packages().get_package("python3")
+    if python_pkg:
+        dist_packages = "/usr/lib/python3/dist-packages"
+        assert file.get_owner(dist_packages) == ("root", "root")
+        assert file.has_permissions(dist_packages, "rwxr-xr-x")
+
+
+@pytest.mark.security_id(203675)
+def test_python_disallows_installing_packages_with_pip_on_system_level(dpkg, file):
+    """Verify /usr/lib/pythonX.Y/EXTERNALLY-MANAGED exists for the installed python3 version."""
+    python_pkg = dpkg.collect_installed_packages().get_package("python3")
+    if python_pkg:
+        python_major_minor_ver = ".".join(python_pkg["Version"].split(".")[:2])
+        assert file.exists(
+            f"/usr/lib/python{python_major_minor_ver}/EXTERNALLY-MANAGED"
+        )
+
+
+@pytest.mark.security_id(203675)
+def test_only_root_can_install_deb_packages(file):
+    """Verify /var/lib/dpkg is root:root with mode rwxr-xr-x."""
+    assert file.get_owner("/var/lib/dpkg") == ("root", "root")
+    assert file.has_permissions("/var/lib/dpkg", "rwxr-xr-x")

--- a/tests-ng/test_disastig_00103.py
+++ b/tests-ng/test_disastig_00103.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000269-GPOS-00103
+
+Verify, in the event of a system failure, the operating system preserves any information necessary to determine cause of failure and any information necessary to return to operations with least disruption to mission processes.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203677)
+def test_disastig_00103():
+    """Failure-state information preservation is covered by kdump tests."""
+    pytest.skip(
+        reason="covered by core/test_services::test__kdump_kdump_tools_service_enabled, integration/boot/test_initrd::test_kdump_initrd_files"
+    )

--- a/tests-ng/test_disastig_00108.py
+++ b/tests-ng/test_disastig_00108.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000278-GPOS-00108
+
+Verify the operating system uses cryptographic mechanisms to protect the integrity of audit tools.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203682)
+@pytest.mark.booted(reason="Requires working networking")
+def test_auditd_is_not_tampered(dpkg, dpkg_checksums, shell):
+    """Verify /usr/sbin/{auditd,auditctl,augenrules,aureport,ausearch} match the deb package md5sums."""
+    if not dpkg.package_is_installed("auditd"):
+        return
+
+    ideal_checksums = dpkg_checksums.for_package("auditd")
+    for bin in ["auditd", "auditctl", "augenrules", "aureport", "ausearch"]:
+        assert dpkg_checksums.is_matching_with_installed(
+            ideal_checksums, f"/usr/sbin/{bin}"
+        ), f"checksum of /usr/sbin/{bin} does not match the one from the corresponding deb package's md5sums control file"

--- a/tests-ng/test_disastig_00109.py
+++ b/tests-ng/test_disastig_00109.py
@@ -1,0 +1,17 @@
+"""
+Ref: SRG-OS-000279-GPOS-00109
+
+Verify the operating system initiates a session lock after a period of inactivity. Setting TMOUT=900 in a profile.d script ensures interactive shell sessions time out after 15 minutes of inactivity.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-profile-terminal-tmout"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="terminal timeout is configured by disaSTIGmedium"
+)
+@pytest.mark.security_id(203683)
+def test_terminal_tmout_profile_sets_tmout_900(parse_file) -> None:
+    """Verify the profile.d snippet sets TMOUT=900 (15 min)."""
+    assert "TMOUT=900" in parse_file.lines("/etc/profile.d/99-terminal_tmout.sh")

--- a/tests-ng/test_disastig_00110.py
+++ b/tests-ng/test_disastig_00110.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000590-GPOS-00110
+
+Verify the operating system is configured to disable accounts when the accounts are no longer associated to a user.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(263650)
+def test_disastig_00110():
+    """Account expiration enforcement via pam_unix is checked in test_disastig_00170.py."""
+    pytest.skip(reason="covered by test_disastig_00170.py")

--- a/tests-ng/test_disastig_00124.py
+++ b/tests-ng/test_disastig_00124.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000312-GPOS-00124
+
+Verify the operating system allows operating system admins to change security attributes on users, the operating system, or the operating system's components.
+"""
+
+import pytest
+
+
+@pytest.mark.feature("server or disaSTIGmedium")
+def test_sudo_installed(file):
+    """Verify the sudo binary is installed and executable."""
+    assert file.is_executable("/usr/bin/sudo")
+
+
+@pytest.mark.feature(
+    "server and not disaSTIGmedium",
+    reason="disaSTIGmedium intentionally empties the wheel file (SRG-OS-000373-GPOS-00156 takes precedence)",
+)
+def test_sudo_has_wheel_group_enabled(parse_file):
+    """Verify sudoers grants the wheel group access."""
+    lines = parse_file.lines("/etc/sudoers.d/wheel")
+    assert "%wheel" in lines

--- a/tests-ng/test_disastig_00125.py
+++ b/tests-ng/test_disastig_00125.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000324-GPOS-00125
+
+Verify that the operating system prevents non-privileged users from executing privileged functions to include disabling, circumventing, or altering implemented security safeguards/countermeasures.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203695)
+@pytest.mark.feature("disaSTIGhigh")
+def test_ctrl_alt_del_burst_is_disabled(parse_file):
+    """Verify systemd disables the Ctrl-Alt-Del reboot burst action."""
+    config = parse_file.parse("/etc/systemd/system.conf", format="keyval")
+    assert config["CtrlAltDelBurstAction"] == "none"

--- a/tests-ng/test_disastig_00126.py
+++ b/tests-ng/test_disastig_00126.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000326-GPOS-00126
+
+Verify that the operating system prevents all software from executing at higher privilege levels than users executing the software.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203696)
+def test_disastig_00126():
+    """Privilege boundary enforcement is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00067.py")

--- a/tests-ng/test_disastig_00128.py
+++ b/tests-ng/test_disastig_00128.py
@@ -1,0 +1,17 @@
+"""
+Ref: SRG-OS-000329-GPOS-00128
+
+Verify the operating system automatically locks an account until the locked account is released by an administrator when three unsuccessful logon attempts in 15 minutes are made.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203698)
+@pytest.mark.feature("disaSTIGmedium")
+def test_user_locked_after_unsuccessful_logon_attempts(parse_file):
+    """Verify faillock.conf enforces 3 attempts in 900s with admin-only unlock."""
+    config = parse_file.parse("/etc/security/faillock.conf", format="keyval")
+    assert config["deny"] == "3"
+    assert config["fail_interval"] == "900"
+    assert config["unlock_time"] == "0"

--- a/tests-ng/test_disastig_00134.py
+++ b/tests-ng/test_disastig_00134.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000343-GPOS-00134
+
+Verify the operating system takes appropriate action when the audit storage volume is full. Setting disk_full_action=halt in auditd.conf ensures the system halts rather than silently dropping audit records.
+"""
+
+import pytest
+
+AUDITD_CONF = "/etc/audit/auditd.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-audit-auditd-conf"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="auditd disk_full_action is configured by disaSTIGlow"
+)
+@pytest.mark.security_id(203702)
+def test_auditd_conf_disk_full_action_is_halt(parse_file) -> None:
+    """Verify disk_full_action=halt in auditd.conf (SRG-OS-000343-GPOS-00134)."""
+    config = parse_file.parse(AUDITD_CONF, format="keyval")
+    assert config["disk_full_action"] == "halt", (
+        f"stigcompliance: disk_full_action in {AUDITD_CONF} is "
+        f"{config['disk_full_action']!r}, expected 'halt'"
+    )

--- a/tests-ng/test_disastig_00136.py
+++ b/tests-ng/test_disastig_00136.py
@@ -1,0 +1,28 @@
+"""
+Ref: SRG-OS-000348-GPOS-00136
+
+Verify the operating system provides an audit reduction capability that supports on-demand audit review and analysis.
+"""
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203704)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_audit_reduction_capability(shell: ShellRunner):
+    """Verify audit reduction works by piping ausearch into aureport."""
+    output = shell(
+        cmd="ausearch -k ssh_login -ts recent | aureport --summary",
+        capture_output=True,
+    )
+
+    assert (
+        output.returncode == 0
+    ), f"stigcompliance: audit reduction pipeline failed: {output.stderr}"
+
+    assert (
+        "Summary Report" in output.stdout
+    ), "stigcompliance: aureport did not generate summary output"

--- a/tests-ng/test_disastig_00137.py
+++ b/tests-ng/test_disastig_00137.py
@@ -1,0 +1,14 @@
+"""
+Ref: SRG-OS-000351-GPOS-00137
+
+Verify the operating system provides an audit reduction capability that supports after-the-fact investigations of security incidents.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203705)
+@pytest.mark.feature("log")
+def test_disastig_00137():
+    """Audit reduction capability is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests-ng/test_disastig_00138.py
+++ b/tests-ng/test_disastig_00138.py
@@ -1,0 +1,14 @@
+"""
+Ref: SRG-OS-000351-GPOS-00138
+
+Verify the operating system provides a report generation capability that supports on-demand audit review and analysis.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203706)
+@pytest.mark.feature("log")
+def test_disastig_00138():
+    """On-demand audit review report generation is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests-ng/test_disastig_00139.py
+++ b/tests-ng/test_disastig_00139.py
@@ -1,0 +1,14 @@
+"""
+Ref: SRG-OS-000351-GPOS-00139
+
+Verify the operating system provides a report generation capability that supports on-demand reporting requirements.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203707)
+@pytest.mark.feature("log")
+def test_disastig_00139():
+    """On-demand reporting capability is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests-ng/test_disastig_00140.py
+++ b/tests-ng/test_disastig_00140.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000352-GPOS-00140
+
+Verify the operating system provides a report generation capability that supports after-the-fact investigations of security incidents.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203708)
+def test_disastig_00140():
+    """After-the-fact reporting capability is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00063.py")

--- a/tests-ng/test_disastig_00141.py
+++ b/tests-ng/test_disastig_00141.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000353-GPOS-00141
+
+Verify the operating system does not alter original content or time ordering of audit records when it provides an audit reduction capability.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203709)
+def test_disastig_00141():
+    """Audit reduction record-integrity is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00142.py")

--- a/tests-ng/test_disastig_00142.py
+++ b/tests-ng/test_disastig_00142.py
@@ -1,0 +1,23 @@
+import shutil
+from tempfile import TemporaryDirectory
+
+import pytest
+
+"""
+Ref: SRG-OS-000354-GPOS-00142
+
+Verify the operating system does not alter original content or time ordering of
+audit records when it provides a report generation capability.
+"""
+
+
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Needs running auditd")
+@pytest.mark.root(reason="Needs to access root-owned audit.log")
+def test_audit_report_does_not_alter_original_audit_logs(shell, file):
+    with TemporaryDirectory(prefix="pytest-disa-stig-") as tmpd:
+        shutil.copy("/var/log/audit/audit.log", f"{tmpd}/audit.log")
+        before_report_checksum = file.checksum(f"{tmpd}/audit.log")
+        shell(f"aureport -if {tmpd}/audit.log")
+        after_report_checksum = file.checksum(f"{tmpd}/audit.log")
+    assert before_report_checksum == after_report_checksum

--- a/tests-ng/test_disastig_00143.py
+++ b/tests-ng/test_disastig_00143.py
@@ -1,0 +1,43 @@
+"""
+Ref: SRG-OS-000355-GPOS-00143
+
+Verify the operating system, for networked systems, compares internal information system clocks at least every 24 hours with an authoritative time source.
+"""
+
+import pytest
+
+
+@pytest.mark.hypervisor(
+    "gdch or microsoft", reason="Need PTP timesync sources to be reachable"
+)
+@pytest.mark.security_id(203711)
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_sync_ptp_daemon_running(systemd):
+    """Verify chrony is active for PTP-based time sync."""
+    assert systemd.is_active("chrony")
+
+
+@pytest.mark.security_id(203711)
+@pytest.mark.hypervisor("not (azure or gdch)")
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_sync_ntp_daemon_running(systemd):
+    """Verify systemd-timesyncd is active for NTP-based time sync."""
+    assert systemd.is_active("systemd-timesyncd")
+
+
+@pytest.mark.hypervisor(
+    "azure or gdch or google or microsoft",
+    reason="Need NTP/PTP timesync sources to be reachable",
+)
+@pytest.mark.security_id(203711)
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_is_actively_synced(timedatectl, shell):
+    """Verify timedatectl reports NTP as synchronized."""
+    assert timedatectl.get_timesync_status().ntp_synchronized
+
+
+@pytest.mark.security_id(203711)
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_is_synced_at_least_once_a_day(timedatectl):
+    """Verify the max NTP poll interval is below 24 hours."""
+    assert timedatectl.get_timesync_status().poll_interval_max < (24 * 60 * 60)

--- a/tests-ng/test_disastig_00144.py
+++ b/tests-ng/test_disastig_00144.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000356-GPOS-00144
+
+Verify the operating system synchronizes internal information system clocks to the authoritative time source when the time difference is greater than one second.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203712)
+def test_disastig_00144():
+    """Clock synchronization tolerance is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00143.py")

--- a/tests-ng/test_disastig_00145.py
+++ b/tests-ng/test_disastig_00145.py
@@ -1,0 +1,24 @@
+"""
+Ref: SRG-OS-000358-GPOS-00145
+
+Verify the operating system records time stamps for audit records that meet a minimum granularity of one second for a minimum degree of precision.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203713)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_timestamp_granularity(shell):
+    """Verify audit timestamps have at least one-second granularity."""
+    result = shell("ausearch -ts recent", capture_output=True)
+    timestamp_pattern = r"time->\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4}"
+
+    match_found = bool(re.search(timestamp_pattern, result.stdout))
+    assert (
+        match_found
+    ), "stigcompliance: audit records do not contain valid timestamps with second granularity"

--- a/tests-ng/test_disastig_00146.py
+++ b/tests-ng/test_disastig_00146.py
@@ -1,0 +1,29 @@
+"""
+Ref: SRG-OS-000359-GPOS-00146
+
+Verify the operating system records time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).
+"""
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203714)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires system time configuration")
+@pytest.mark.root(reason="required to verify time settings")
+def test_audit_timestamp_utc_mapping(shell: ShellRunner, timedatectl):
+    """Verify timedatectl reports a Timezone containing 'UTC' or 'GMT'."""
+    result = shell(
+        "timedatectl show -p Timezone",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    timezone = result.stdout.strip().split("=")[-1]
+
+    assert timezone, "stigcompliance: timezone not configured"
+
+    assert (
+        "UTC" in timezone or "GMT" in timezone
+    ), f"stigcompliance: timezone not mappable to UTC/GMT: {timezone}"

--- a/tests-ng/test_disastig_00149.py
+++ b/tests-ng/test_disastig_00149.py
@@ -1,0 +1,69 @@
+"""
+Ref: SRG-OS-000362-GPOS-00149
+
+Verify the operating system prohibits user installation of system software without explicit privileged status.
+"""
+
+import pytest
+from plugins.file import File
+
+PKG_BINARIES = [
+    "/usr/bin/apt",
+    "/usr/bin/apt-get",
+    "/usr/bin/dpkg",
+]
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify package manager permissions")
+@pytest.mark.booted(
+    reason="system must be booted to verify package manager permissions"
+)
+@pytest.mark.security_id(203716)
+def test_package_manager_requires_privileged_access(file: File):
+    """Verify /usr/bin/apt, apt-get and dpkg are owned by root with mode rwxr-xr-x or stricter."""
+    for path in PKG_BINARIES:
+        if not file.exists(path):
+            continue
+
+        assert file.is_owned_by_user(
+            path, "root"
+        ), f"stigcompliance: {path} is not owned by root"
+
+        assert (
+            file.has_permissions(path, "rwxr-xr-x")
+            or file.has_permissions(path, "rwxr-x---")
+            or file.has_permissions(path, "rwx------")
+        ), f"stigcompliance: {path} permissions are too permissive"
+
+
+PKG_DB_PATHS = [
+    "/var/lib/dpkg",
+    "/var/lib/dpkg/status",
+]
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify package database protection")
+@pytest.mark.booted(
+    reason="system must be booted to verify package database permissions"
+)
+@pytest.mark.security_id(203716)
+def test_package_database_protected(file: File):
+    """Verify /var/lib/dpkg and /var/lib/dpkg/status are owned by root with non-world-writable modes."""
+    for path in PKG_DB_PATHS:
+        if not file.exists(path):
+            continue
+
+        assert file.is_owned_by_user(
+            path, "root"
+        ), f"stigcompliance: {path} is not owned by root"
+
+        assert (
+            file.has_permissions(path, "rwxr-xr-x")
+            or file.has_permissions(path, "rwxr-x---")
+            or file.has_permissions(path, "rwx------")
+            or file.has_permissions(path, "rw-r--r--")
+            or file.has_permissions(path, "rw-r-----")
+            or file.has_permissions(path, "rw-------")
+        ), f"stigcompliance: {path} permissions are too permissive"

--- a/tests-ng/test_disastig_00152.py
+++ b/tests-ng/test_disastig_00152.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000365-GPOS-00152
+
+Verify the operating system audits the enforcement actions used to restrict access associated with changes to the system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203719)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="audit rules are configured by disaSTIGmedium"
+)
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to query audit logs")
+def test_enforcement_action_audited(audit_rule) -> None:
+    """Verify the operating system audits the enforcement actions used to restrict access associated with changes to the system"""
+    assert audit_rule(
+        fs_watch_path="/etc/shadow", access_types="wa"
+    ), "stigcompliance: no audit rule found watching /etc/shadow for write/append access"

--- a/tests-ng/test_disastig_00153.py
+++ b/tests-ng/test_disastig_00153.py
@@ -1,0 +1,41 @@
+"""
+Ref: SRG-OS-000366-GPOS-00153
+
+Verify the operating system prevents the installation of patches, service packs, device drivers, or operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.
+"""
+
+import re
+
+import pytest
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+
+APT_CONF_DIR = "/etc/apt/apt.conf.d"
+
+
+@pytest.mark.security_id(203720)
+@pytest.mark.feature("not container and not lima and not baremetal")
+@pytest.mark.root(reason="required to verify package signature enforcement")
+def test_package_signature_verification_enabled(parse_file: ParseFile, find: Find):
+    """Verify no file in /etc/apt/apt.conf.d sets AllowUnauthenticated=true or Acquire::AllowInsecureRepositories=true."""
+    find.root_paths = APT_CONF_DIR
+    find.entry_type = "files"
+
+    insecure_pattern_1 = re.compile(r"AllowUnauthenticated\s*=\s*true", re.IGNORECASE)
+    insecure_pattern_2 = re.compile(
+        r"Acquire::AllowInsecureRepositories\s*=\s*true", re.IGNORECASE
+    )
+
+    for path in find:
+        lines = parse_file.lines(path, ignore_missing=True)
+
+        if not lines:
+            continue
+
+        assert (
+            insecure_pattern_1 not in lines
+        ), f"stigcompliance: AllowUnauthenticated enabled in {path}"
+
+        assert (
+            insecure_pattern_2 not in lines
+        ), f"stigcompliance: AllowInsecureRepositories enabled in {path}"

--- a/tests-ng/test_disastig_00154.py
+++ b/tests-ng/test_disastig_00154.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000312-GPOS-00154
+
+As per DISA STIG compliance requirements, the operating system must implement mandatory access controls to restrict the ability of subjects and objects from accessing resources.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203721)
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires booted system to verify LSM enforcement")
+@pytest.mark.root(reason="requires access to system security configuration")
+def test_selinux_is_active_lsm(lsm):
+    """Verify 'selinux' is reported in the active LSM list."""
+    assert (
+        "selinux" in lsm
+    ), "stigcompliance: SELinux is not listed as an active Linux Security Module"

--- a/tests-ng/test_disastig_00155.py
+++ b/tests-ng/test_disastig_00155.py
@@ -1,0 +1,20 @@
+"""
+Ref: SRG-OS-000370-GPOS-00155
+
+Verify the operating system employs a deny-all, permit-by-exception policy to allow the execution of authorized software programs.
+"""
+
+import pytest
+
+
+@pytest.mark.feature(
+    "not container and not gardener and not lima and not capi and not baremetal"
+)
+@pytest.mark.security_id(203722)
+@pytest.mark.booted(reason="requires booted system to verify LSM enforcement")
+@pytest.mark.root(reason="requires access to system security configuration")
+def test_deny_all_execution_mechanism_present(lsm):
+    """Verify 'selinux' appears in the active LSM list."""
+    assert (
+        "selinux" in lsm
+    ), "stigcompliance: no enforcement mechanism (SELinux) present for execution control"

--- a/tests-ng/test_disastig_00156.py
+++ b/tests-ng/test_disastig_00156.py
@@ -1,0 +1,81 @@
+"""
+Ref: SRG-OS-000373-GPOS-00156
+
+Verify the operating system requires users to reauthenticate for privilege escalation. The sudoers wheel file must exist and be empty so that wheel-group membership does not grant passwordless sudo. No sudoers file may grant passwordless privilege escalation via NOPASSWD or bypass authentication via !authenticate.
+"""
+
+import re
+
+import pytest
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+
+SUDOERS_WHEEL = "/etc/sudoers.d/wheel"
+
+
+@pytest.mark.feature(
+    "disaSTIGmedium and not _dev",
+    reason="test runner injects NOPASSWD sudoers in _dev mode for SSH access",
+)
+@pytest.mark.security_id(203723)
+@pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
+def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
+    """Verify no sudoers file enables NOPASSWD."""
+    nopasswd_pattern = re.compile(r"NOPASSWD", re.IGNORECASE)
+
+    find.root_paths = "/etc/sudoers.d"
+    find.entry_type = "files"
+    paths_to_check = ["/etc/sudoers"] + list(find)
+
+    for path in paths_to_check:
+        lines = parse_file.lines(path, ignore_missing=True)
+        if not lines:
+            continue
+        matches = nopasswd_pattern.findall(lines.content)
+        assert not matches, f"stigcompliance: NOPASSWD found in sudoers file {path}"
+
+
+@pytest.mark.feature(
+    "disaSTIGmedium and not _dev",
+    reason="test runner injects NOPASSWD sudoers in _dev mode for SSH access",
+)
+@pytest.mark.security_id(203723)
+@pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
+def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
+    """Verify no sudoers file uses !authenticate to bypass password prompts."""
+    noauthenticate_pattern = re.compile(r"!authenticate", re.IGNORECASE)
+
+    find.root_paths = "/etc/sudoers.d"
+    find.entry_type = "files"
+    paths_to_check = ["/etc/sudoers"] + list(find)
+
+    for path in paths_to_check:
+        lines = parse_file.lines(path, ignore_missing=True)
+        if not lines:
+            continue
+        matches = noauthenticate_pattern.findall(lines.content)
+        assert (
+            not matches
+        ), f"stigcompliance: !authenticate found in sudoers file {path}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-wheel"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="sudoers wheel truncation is applied by disaSTIGmedium"
+)
+@pytest.mark.security_id(203723)
+def test_sudoers_wheel_file_exists(file) -> None:
+    """Verify /etc/sudoers.d/wheel exists (created/truncated by disaSTIGmedium)."""
+    assert file.exists(SUDOERS_WHEEL), f"stigcompliance: {SUDOERS_WHEEL} does not exist"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-wheel"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="sudoers wheel truncation is applied by disaSTIGmedium"
+)
+@pytest.mark.security_id(203723)
+def test_sudoers_wheel_file_is_empty(file) -> None:
+    """Verify /etc/sudoers.d/wheel is empty (disaSTIGmedium truncates it with echo -n)."""
+    assert (
+        file.get_size(SUDOERS_WHEEL) == 0
+    ), f"stigcompliance: {SUDOERS_WHEEL} is not empty (size={file.get_size(SUDOERS_WHEEL)})"

--- a/tests-ng/test_disastig_00170.py
+++ b/tests-ng/test_disastig_00170.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000720-GPOS-00170
+
+Verify the operating system is configured to require immediate selection of a new password upon account recovery for password-based authentication.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-account"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-account"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(263654)
+def test_password_expiration_checking_pam_module_is_in_use(pam_config):
+    """Verify pam_unix.so account entry with success=1 and new_authtok_reqd=done is in /etc/pam.d/common-account."""
+    results = pam_config.find_entries(
+        type_="account",
+        control_contains={"success": "1", "new_authtok_reqd": "done"},
+        module_contains="pam_unix.so",
+    )
+    assert len(results) == 1, "pam_unix module should be used for account checking"

--- a/tests-ng/test_disastig_00172.py
+++ b/tests-ng/test_disastig_00172.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000392-GPOS-00172
+
+Verify the operating system generates audit records for all activities performed during nonlocal maintenance and diagnostic sessions by configuring sudo to log to a dedicated file.
+"""
+
+import pytest
+from plugins.parse_file import ParseFile
+
+SUDO_LOG_CONFIG = "/etc/sudoers.d/disaSTIG-sudo-log"
+
+
+@pytest.mark.security_id(203735)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-sudo-log"])
+@pytest.mark.feature("disaSTIGmedium", reason="sudo log file required by DISA STIG")
+def test_sudo_logfile_configured(parse_file: ParseFile):
+    """Verify sudo is configured to log to /var/log/sudo.log."""
+    lines = parse_file.lines(SUDO_LOG_CONFIG)
+    assert (
+        "Defaults logfile=/var/log/sudo.log" in lines
+    ), "stigcompliance: sudo is not configured to log to /var/log/sudo.log"

--- a/tests-ng/test_disastig_00173.py
+++ b/tests-ng/test_disastig_00173.py
@@ -1,0 +1,64 @@
+"""
+Ref: SRG-OS-000393-GPOS-00173
+
+Verify the operating system implements cryptographic mechanisms to protect the integrity of nonlocal maintenance and diagnostic communications, when used for nonlocal maintenance sessions.
+"""
+
+import pytest
+from plugins.dpkg import Dpkg
+
+
+@pytest.mark.security_id(203736)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_ssh_strong_macs_present(sshd, dpkg: Dpkg):
+    """Verify sshd MACs are limited to strong algorithms (SHA2)."""
+    macs = sshd.get_config_section("macs")
+
+    if isinstance(macs, str):
+        macs = [macs]
+    elif isinstance(macs, set):
+        macs = list(macs)
+
+    mac_list = []
+    for entry in macs:
+        mac_list.extend([m.strip() for m in entry.split(",")])
+
+    strong_macs = {
+        "hmac-sha2-256",
+        "hmac-sha2-512",
+    }
+
+    assert all(
+        mac in strong_macs for mac in mac_list
+    ), "stigcompliance: no strong MAC algorithms configured for SSH integrity protection"
+
+
+@pytest.mark.security_id(203736)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_ssh_weak_macs_not_present(sshd):
+    """Verify sshd does not advertise weak MAC algorithms (hmac-md5)."""
+    macs = sshd.get_config_section("macs")
+
+    if isinstance(macs, str):
+        macs = [macs]
+    elif isinstance(macs, set):
+        macs = list(macs)
+
+    mac_list = []
+    for entry in macs:
+        mac_list.extend([m.strip() for m in entry.split(",")])
+
+    weak_macs = {
+        "hmac-md5",
+        "hmac-md5-96",
+    }
+
+    assert not any(
+        mac in weak_macs for mac in mac_list
+    ), "stigcompliance: weak MAC algorithms present in SSH configuration"

--- a/tests-ng/test_disastig_00175.py
+++ b/tests-ng/test_disastig_00175.py
@@ -1,0 +1,20 @@
+"""
+Ref: SRG-OS-000395-GPOS-00175
+
+Verify the operating system verifies remote disconnection at the termination of nonlocal maintenance and diagnostic sessions, when used for nonlocal maintenance sessions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203738)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_ssh_client_alive_interval_configured(sshd):
+    """Verify sshd ClientAliveInterval is non-zero so timeouts are enforced."""
+    interval = sshd.get_config_section("clientaliveinterval")
+
+    assert (
+        interval != "0"
+    ), "stigcompliance: ClientAliveInterval is disabled (0), session timeout not enforced"

--- a/tests-ng/test_disastig_00176.py
+++ b/tests-ng/test_disastig_00176.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000396-GPOS-00176
+
+Verify the operating system implements NSA-approved cryptography to protect classified information in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203739)
+def test_disastig_00176():
+    """NSA-approved cryptography is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests-ng/test_disastig_00180.py
+++ b/tests-ng/test_disastig_00180.py
@@ -1,0 +1,37 @@
+"""
+Ref: SRG-OS-000725-GPOS-00180
+
+Verify he operating system is configured to allow user selection of long passwords and passphrases, including spaces and all printable characters for password-based authentication.
+"""
+
+import glob
+import re
+from os.path import exists
+
+import pytest
+
+
+@pytest.mark.security_id(263655)
+def test_password_length_is_not_limited_in_pam_configs():
+    """Verify no PAM config caps password length via passwdqc max=."""
+    search_str = r"^\s*password\s+requisite\s+pam_passwdqc.so\s+[^#]*max=\d+"
+    pattern = re.compile(search_str)
+    found = False
+
+    for config in glob.glob("/etc/pam.d/*"):
+        with open(config) as f:
+            for line in f:
+                if pattern.search(line):
+                    found = True
+                    offender = config
+                    break
+    assert not found, f"Password limit is set in {offender}"
+
+
+@pytest.mark.security_id(263655)
+def test_password_length_is_not_limited_in_passwdqc_config(parse_file):
+    """Verify /etc/passwdqc.conf does not cap password length via max=."""
+    config = "/etc/passwdqc.conf"
+    if not exists(config):
+        return
+    assert "max" not in parse_file.parse(config)

--- a/tests-ng/test_disastig_00180.py
+++ b/tests-ng/test_disastig_00180.py
@@ -17,6 +17,7 @@ def test_password_length_is_not_limited_in_pam_configs():
     search_str = r"^\s*password\s+requisite\s+pam_passwdqc.so\s+[^#]*max=\d+"
     pattern = re.compile(search_str)
     found = False
+    offender = ""
 
     for config in glob.glob("/etc/pam.d/*"):
         with open(config) as f:

--- a/tests-ng/test_disastig_00186.py
+++ b/tests-ng/test_disastig_00186.py
@@ -1,0 +1,31 @@
+"""
+Ref: SRG-OS-000420-GPOS-00186
+
+Verify the operating system protects against or limits the effects of Denial of Service (DoS) attacks by ensuring the operating system is implementing rate-limiting measures on impacted network interfaces.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203747)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires running network stack")
+@pytest.mark.root(reason="requires access to sysctl parameters")
+def test_icmp_rate_limiting_enabled(sysctl):
+    """Verify net.ipv4.icmp_ratelimit is set to a positive value."""
+    value = sysctl["net.ipv4.icmp_ratelimit"]
+
+    assert (
+        isinstance(value, int) and value > 0
+    ), f"stigcompliance: ICMP rate limiting not enabled (value={value})"
+
+
+@pytest.mark.security_id(203747)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires network stack")
+@pytest.mark.root(reason="requires access to sysctl parameters")
+def test_tcp_syncookies_enabled(sysctl):
+    """Verify net.ipv4.tcp_syncookies is enabled."""
+    value = sysctl["net.ipv4.tcp_syncookies"]
+
+    assert value == 1, f"stigcompliance: tcp_syncookies not enabled (value={value})"

--- a/tests-ng/test_disastig_00187.py
+++ b/tests-ng/test_disastig_00187.py
@@ -1,0 +1,108 @@
+"""
+Ref: SRG-OS-000423-GPOS-00187
+
+Verify the operating system protects the confidentiality and integrity of transmitted information.
+"""
+
+import pytest
+from plugins.systemd import Systemd
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_telnet_service_disabled(systemd: Systemd):
+    """Verify telnet.service is not enabled."""
+    assert not systemd.is_enabled(
+        "telnet.service"
+    ), "stigcompliance: insecure service telnet.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_telnet_service_active(systemd: Systemd):
+    """Verify telnet.service is not active."""
+    assert not systemd.is_active(
+        "telnet.service"
+    ), "stigcompliance: insecure service telnet.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rsh_service_disabled(systemd: Systemd):
+    """Verify rsh.service is not enabled."""
+    assert not systemd.is_enabled(
+        "rsh.service"
+    ), "stigcompliance: insecure service rsh.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rsh_service_active(systemd: Systemd):
+    """Verify rsh.service is not active."""
+    assert not systemd.is_active(
+        "rsh.service"
+    ), "stigcompliance: insecure service rsh.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rexec_service_disabled(systemd: Systemd):
+    """Verify rexec.service is not enabled."""
+    assert not systemd.is_enabled(
+        "rexec.service"
+    ), "stigcompliance: insecure service rexec.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rexec_service_active(systemd: Systemd):
+    """Verify rexec.service is not active."""
+    assert not systemd.is_active(
+        "rexec.service"
+    ), "stigcompliance: insecure service rexec.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rlogin_service_disabled(systemd: Systemd):
+    """Verify rlogin.service is not enabled."""
+    assert not systemd.is_enabled(
+        "rlogin.service"
+    ), "stigcompliance: insecure service rlogin.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rlogin_service_active(systemd: Systemd):
+    """Verify rlogin.service is not active."""
+    assert not systemd.is_active(
+        "rlogin.service"
+    ), "stigcompliance: insecure service rlogin.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_vsftpd_service_disabled(systemd: Systemd):
+    """Verify vsftpd.service is not enabled."""
+    assert not systemd.is_enabled(
+        "vsftpd.service"
+    ), "stigcompliance: insecure service vsftpd.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_vsftpd_service_active(systemd: Systemd):
+    """Verify vsftpd.service is not active."""
+    assert not systemd.is_active(
+        "vsftpd.service"
+    ), "stigcompliance: insecure service vsftpd.service is active"

--- a/tests-ng/test_disastig_00188.py
+++ b/tests-ng/test_disastig_00188.py
@@ -1,0 +1,52 @@
+"""
+Ref: SRG-OS-000424-GPOS-00188
+
+Verify the operating system implements cryptographic mechanisms to prevent unauthorized disclosure of information and/or detect changes to information during transmission unless otherwise protected by alternative physical safeguards, such as, at a minimum, a Protected Distribution System (PDS).
+"""
+
+import re
+
+import pytest
+from plugins.sshd import Sshd
+
+
+@pytest.mark.security_id(203749)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect ssh cryptographic configuration")
+def test_ssh_ciphers_are_strong(sshd: Sshd):
+    """Verify sshd does not allow weak ciphers (arcfour, 3des, cbc)."""
+    ciphers = sshd.get_config_section("ciphers") or ""
+
+    assert not re.search(
+        r"(arcfour|3des|cbc)", str(ciphers), re.IGNORECASE
+    ), "stigcompliance: weak cipher allowed in SSH configuration"
+
+
+@pytest.mark.security_id(203749)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect ssh cryptographic configuration")
+def test_ssh_macs_are_strong(sshd: Sshd):
+    """Verify sshd does not allow weak MACs (hmac-md5)."""
+    macs = sshd.get_config_section("macs") or ""
+
+    assert not re.search(
+        r"hmac-md5", str(macs), re.IGNORECASE
+    ), "stigcompliance: weak MAC allowed in SSH configuration"
+
+
+@pytest.mark.security_id(203749)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect ssh cryptographic configuration")
+def test_ssh_kex_are_strong(sshd: Sshd):
+    """Verify sshd does not allow weak key exchange (diffie-hellman-group1-sha1)."""
+    kex = sshd.get_config_section("kexalgorithms") or ""
+
+    assert not re.search(
+        r"diffie-hellman-group1-sha1", str(kex), re.IGNORECASE
+    ), "stigcompliance: weak key exchange algorithm allowed in SSH configuration"

--- a/tests-ng/test_disastig_00189.py
+++ b/tests-ng/test_disastig_00189.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000425-GPOS-00189
+
+Verify the operating system maintains the confidentiality and integrity of information during preparation for transmission.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203750)
+def test_disastig_00189():
+    """Confidentiality and integrity for transmission prep is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00187.py")

--- a/tests-ng/test_disastig_00190.py
+++ b/tests-ng/test_disastig_00190.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000426-GPOS-00190
+
+Verify the operating system maintains the confidentiality and integrity of information during reception.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203751)
+def test_disastig_00190():
+    """Confidentiality and integrity during reception is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00187.py")

--- a/tests-ng/test_disastig_00191.py
+++ b/tests-ng/test_disastig_00191.py
@@ -1,0 +1,25 @@
+"""
+Ref: SRG-OS-000432-GPOS-00191
+
+Verify the operating system behaves in a predictable and documented manner that reflects organizational and system objectives when invalid inputs are received.
+"""
+
+import time
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203752)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="useradd and ausearch require root privileges")
+@pytest.mark.modify(reason="creates and removes a temporary user account")
+def test_invalid_input_handling_is_audited(shell: ShellRunner, audit_user):
+    """Verify ausearch -ts recent output contains name="/etc/shadow"."""
+    shell(f"su {audit_user} -c 'echo >> /etc/shadow'", ignore_exit_code=True)
+    time.sleep(1)
+    result = shell(cmd="ausearch -ts recent", capture_output=True)
+    assert (
+        'name="/etc/shadow"' in result.stdout
+    ), "stigcompliance: no failed-syscall audit event found after trying to write to a system file"

--- a/tests-ng/test_disastig_00192.py
+++ b/tests-ng/test_disastig_00192.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000433-GPOS-00192
+
+Verify the operating system implements non-executable data to protect its memory from unauthorized code execution.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203753)
+@pytest.mark.arch("amd64")
+def test_nx_bit_hardware_support():
+    """Verify /proc/cpuinfo advertises the nx CPU flag (amd64)."""
+    with open("/proc/cpuinfo") as cpuinfo:
+        assert (
+            " nx " in cpuinfo.read()
+        ), "Finding: Hardware does not support or report the NX bit."
+
+
+@pytest.mark.security_id(203753)
+@pytest.mark.arch("amd64")
+def test_nx_not_disabled_at_boot(kernel_cmdline):
+    """Verify nx=off is not present in the kernel boot cmdline."""
+    assert (
+        "nx=off" not in kernel_cmdline
+    ), "Finding: The kernel boot parameter 'nx=off' is present, disabling memory protection."

--- a/tests-ng/test_disastig_00193.py
+++ b/tests-ng/test_disastig_00193.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000433-GPOS-00193
+
+Verify the operating system implements address space layout randomization to protect its memory from unauthorized code execution.
+"""
+
+import pytest
+from plugins.sysctl import Sysctl
+
+
+@pytest.mark.feature("disaSTIGmedium and cloud")
+@pytest.mark.booted(reason="requires access to /proc/sys at runtime")
+@pytest.mark.root(reason="requires access to kernel parameters")
+def test_aslr_is_fully_enabled(sysctl: Sysctl):
+    """Verify the operating system implements full address space layout randomization with kernel.randomize_va_space set to 2."""
+    assert (
+        sysctl["kernel.randomize_va_space"] == 2
+    ), "stigcompliance: kernel.randomize_va_space must be 2 (full ASLR)"

--- a/tests-ng/test_disastig_00194.py
+++ b/tests-ng/test_disastig_00194.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000437-GPOS-00194
+
+Verify the operating system removes all software components after updated versions have been installed.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203755)
+def test_no_residual_software_components(shell):
+    """Verify dpkg reports no packages in 'deinstall ok config-files' (rc) state."""
+    package_statuses = shell(
+        "dpkg-query -W -f='${Status} ${Package}\n'", capture_output=True
+    )
+
+    residual_packages = [
+        pkg.split()[-1]
+        for pkg in package_statuses.stdout.splitlines()
+        if "deinstall ok config-files" in pkg
+    ]
+
+    assert not residual_packages, (
+        f"Software components (config files) "
+        f"were not removed after package updates/removal: {residual_packages}"
+    )

--- a/tests-ng/test_disastig_00199.py
+++ b/tests-ng/test_disastig_00199.py
@@ -1,0 +1,103 @@
+"""
+Ref: SRG-OS-000445-GPOS-00199
+
+Verify the operating system verifies correct operation of all security functions.
+"""
+
+import re
+
+import pytest
+
+AIDE_CONF = "/etc/aide/aide.conf.d/31_aide_audit-tools"
+AIDE_TOOLS = [
+    "/sbin/auditctl",
+    "/sbin/auditd",
+    "/sbin/ausearch",
+    "/sbin/aureport",
+    "/sbin/autrace",
+    "/sbin/audispd",
+    "/sbin/augenrules",
+]
+
+
+@pytest.mark.security_id(203756)
+@pytest.mark.feature("log")
+@pytest.mark.booted("Needs working systemd")
+def test_auditd_service_active(systemd):
+    """Verify auditd service is active."""
+    assert systemd.is_active("auditd")
+
+
+@pytest.mark.security_id(203756)
+@pytest.mark.feature("log")
+@pytest.mark.booted("Needs working systemd")
+def test_systemd_configured_to_restart_auditd_service(systemd):
+    """Verify systemd is configured to restart the auditd service on failure."""
+    assert systemd.get_unit_properties("auditd")["Restart"] != "no"
+
+
+@pytest.mark.security_id(203756)
+@pytest.mark.feature("_selinux")
+def test_selinux_enabled(lsm):
+    """Verify SELinux is among the active LSMs."""
+    assert "selinux" in lsm
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-service-aide-init-enable"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="aide-init.service is enabled by disaSTIGmedium"
+)
+@pytest.mark.security_id(203756)
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-enable"])
+@pytest.mark.feature("aide", reason="aide-init.service is enabled by the aide feature")
+@pytest.mark.booted(reason="requires systemd to query unit enable state")
+def test_aide_init_service_is_enabled(systemd) -> None:
+    """Verify aide-init.service is enabled."""
+    assert systemd.is_enabled(
+        "aide-init.service"
+    ), "stigcompliance: aide-init.service is not enabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-service-aide-check-timer-enable"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="aide-check.timer is enabled by disaSTIGmedium"
+)
+@pytest.mark.security_id(203756)
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer-enable"])
+@pytest.mark.feature("aide", reason="aide-check.timer is enabled by the aide feature")
+@pytest.mark.booted(reason="requires systemd to query unit enable state")
+def test_aide_check_timer_is_enabled(systemd) -> None:
+    """Verify aide-check.timer is enabled."""
+    assert systemd.is_enabled(
+        "aide-check.timer"
+    ), "stigcompliance: aide-check.timer is not enabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-aide-audit-tools"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="AIDE monitors audit tools as configured by disaSTIGmedium"
+)
+def test_aide_conf_monitors_audit_tools(parse_file) -> None:
+    """Verify AIDE config monitors the audit tool binaries with sha512."""
+    missing = [
+        tool
+        for tool in AIDE_TOOLS
+        if not re.compile(rf"^{re.escape(tool)}.+sha512", re.MULTILINE)
+        in parse_file.lines(AIDE_CONF)
+    ]
+    assert (
+        not missing
+    ), f"stigcompliance: AIDE does not monitor these tools with sha512 in {AIDE_CONF}: {missing}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-aide-silent-reports"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="AIDE SILENTREPORTS is configured by disaSTIGmedium"
+)
+def test_aide_default_silentreports_is_no(parse_file) -> None:
+    """Verify AIDE SILENTREPORTS in /etc/default/aide is set to 'no'."""
+    config = parse_file.parse("/etc/default/aide", format="keyval")
+    assert config.get("SILENTREPORTS") == "no", (
+        f"stigcompliance: SILENTREPORTS in /etc/default/aide is "
+        f"{config.get('SILENTREPORTS')!r}, expected 'no'"
+    )

--- a/tests-ng/test_disastig_00203.py
+++ b/tests-ng/test_disastig_00203.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000458-GPOS-00203
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to access security objects occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203759)
+def test_disastig_00203():
+    """Audit of security object access is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00089.py")

--- a/tests-ng/test_disastig_00205.py
+++ b/tests-ng/test_disastig_00205.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000461-GPOS-00205
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to access categories of information (e.g., classification levels) occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203760)
+def test_disastig_00205():
+    """Audit of access to information categories is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00210.py")

--- a/tests-ng/test_disastig_00206.py
+++ b/tests-ng/test_disastig_00206.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000462-GPOS-00206
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to modify privileges occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203761)
+def test_disastig_00206():
+    """Audit of privilege modification is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00210.py")

--- a/tests-ng/test_disastig_00207.py
+++ b/tests-ng/test_disastig_00207.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000463-GPOS-00207
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to modify security objects occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203762)
+def test_disastig_00207():
+    """Audit of security object modification is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00211.py")

--- a/tests-ng/test_disastig_00209.py
+++ b/tests-ng/test_disastig_00209.py
@@ -1,0 +1,85 @@
+"""
+Ref: SRG-OS-000465-GPOS-00209
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to modify categories of information (e.g., classification levels) occur.
+"""
+
+import os
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import Parse, ParseFile
+from plugins.shell import ShellRunner
+
+PRIV_ESC_RULE_FILE = "/etc/audit/rules.d/70-privilege-escalation.rules"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to inspect audit config")
+def test_setreuid_rule_file_exists(file: File):
+    """Verify the privilege escalation audit rule file exists."""
+    assert file.exists(
+        PRIV_ESC_RULE_FILE
+    ), f"stigcompliance: {PRIV_ESC_RULE_FILE} does not exist"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to inspect audit config")
+def test_setreuid_rule_contains_syscall(parse_file: ParseFile):
+    """Verify the privilege escalation rule audits the setreuid syscall."""
+    lines = parse_file.lines(PRIV_ESC_RULE_FILE, ignore_missing=True)
+
+    assert (
+        lines is not None and "-S setreuid" in lines
+    ), "stigcompliance: setreuid audit rule not configured"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit rules")
+def test_setreuid_rule_loaded(shell: ShellRunner, parse: type[Parse]):
+    """Verify the setreuid audit rule is loaded into the running kernel."""
+    output = shell(cmd="auditctl -l", capture_output=True)
+
+    assert (
+        output.returncode == 0
+    ), f"stigcompliance: unable to list audit rules: {output.stderr}"
+
+    assert (
+        "setreuid" in output.stdout
+    ), "stigcompliance: setreuid audit rule not loaded in kernel"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to trigger syscall and read audit logs")
+def test_setreuid_event_logged(shell: ShellRunner):
+    """Verify a setreuid call produces a privilege_escalation audit event."""
+    pid = os.fork()
+
+    if pid == 0:
+        try:
+            os.setreuid(123456, 123456)
+        except Exception:
+            pass
+        finally:
+            os._exit(0)
+    else:
+        os.waitpid(pid, 0)
+
+    result = shell(
+        cmd="ausearch -k privilege_escalation -ts recent",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    if result.returncode == 1 or not result.stdout.strip():
+        return
+
+    assert "SYSCALL" in result.stdout, "stigcompliance: no syscall audit event detected"

--- a/tests-ng/test_disastig_00210.py
+++ b/tests-ng/test_disastig_00210.py
@@ -1,0 +1,86 @@
+"""
+Ref: SRG-OS-000466-GPOS-00210
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to delete privileges occur.
+"""
+
+import fileinput
+import os
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def sudoers_edit():
+    for line in fileinput.input("/etc/sudoers", inplace=True, backup=".bak"):
+        if not line.startswith("# Host alias specification"):
+            print(line, end="")
+    yield
+    shutil.copy2("/etc/sudoers.bak", "/etc/sudoers")
+    os.remove("/etc/sudoers.bak")
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit logs")
+def test_audit_rules_for_logging_attempts_to_delete_privileges(audit_rule):
+    """Verify writes/metadata changes to /etc account and sudoers files are audited."""
+    for file in ["passwd", "shadow", "group", "sudoers", "sudoers.d", "pam.d"]:
+        assert audit_rule(
+            fs_watch_path=f"/etc/{file}", access_types="wa"
+        ), f"stigcompliance: writing to or changing metadata of /etc/{file} should be audited"
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.skip("not implemented")
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit logs")
+def test_audit_rules_for_files_capabilities_removal(audit_rule):
+    """Verify the setcap syscall is audited."""
+    assert audit_rule(
+        syscall="setcap"
+    ), "stigcompliance: setcap syscall audit rule is not configured"
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+def test_audit_rules_for_selinux_policies_changes(audit_rule):
+    """Verify writes/metadata changes under /etc/selinux are audited."""
+    assert audit_rule(
+        fs_watch_path="/etc/selinux", access_types="wa"
+    ), "stigcompliance: changes of selinux configuration files should be audited"
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit logs")
+def test_audit_rules_for_logging_attempts_to_modify_apparmor_policies(audit_rule):
+    """Verify writes/metadata changes under /etc/apparmor* are audited."""
+    for file in ["apparmor", "apparmor.d"]:
+        assert audit_rule(
+            fs_watch_path=f"/etc/{file}", access_types="wa"
+        ), f"stigcompliance: writing to or changing metadata of /etc/{file} should be audited"
+
+
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.modify(
+    reason="changing /etc/sudoers file to check if audit works on a running system"
+)
+@pytest.mark.security_id(203764)
+@pytest.mark.root(reason="required to query audit logs")
+def test_attempt_to_delete_privileges_event_logged(audit_rule, shell, sudoers_edit):
+    """Verify modifying /etc/sudoers produces an audit event."""
+    result = shell(
+        cmd="ausearch -f /etc/sudoers --just-one",
+        capture_output=True,
+    )
+
+    assert (
+        "<no matches>" not in result.stdout.strip()
+    ), "stigcompliance: privileges deletion attempt is not detected"

--- a/tests-ng/test_disastig_00211.py
+++ b/tests-ng/test_disastig_00211.py
@@ -1,0 +1,31 @@
+"""
+Ref: SRG-OS-000467-GPOS-00211
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to delete security levels occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203765)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_selinux_runtime_changes_are_audited(audit_rule):
+    """Verify writes/metadata changes to /sys/fs/selinux are audited."""
+    assert audit_rule(fs_watch_path="/sys/fs/selinux", access_types="wa")
+
+
+@pytest.mark.security_id(203765)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_changes_to_extended_file_attributes_are_audited(audit_rule):
+    """Verify the *xattr syscalls are audited."""
+    for sc in [
+        "removexattr",
+        "fremovexattr",
+        "lremovexattr",
+        "setxattr",
+        "lsetxattr",
+        "fsetxattr",
+    ]:
+        assert audit_rule(syscall=sc)

--- a/tests-ng/test_disastig_00212.py
+++ b/tests-ng/test_disastig_00212.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000468-GPOS-00212
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to delete security objects occur.
+"""
+
+import platform
+
+import pytest
+
+
+@pytest.mark.security_id(203766)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_attempts_to_delete_are_audited(audit_rule):
+    """Verify file/dir deletion syscalls are audited for non-system users."""
+    # unlink, rename, rmdir do not exist as separate syscalls on arm64
+    if platform.machine() == "aarch64":
+        syscalls = ["unlinkat", "renameat"]
+    else:
+        syscalls = ["unlink", "unlinkat", "rename", "renameat", "rmdir"]
+    for syscall in syscalls:
+        assert audit_rule(syscall=syscall, rule_fields=["auid>=1000", "auid!=-1"])

--- a/tests-ng/test_disastig_00214.py
+++ b/tests-ng/test_disastig_00214.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000470-GPOS-00214
+
+Verify the operating system generates audit records when successful/unsuccessful logon attempts occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203767)
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Needs running auditd")
+@pytest.mark.root(reason="Needs access to audit logs")
+def test_audit_record_tools_for_logon_attempts_exist(file):
+    """Verify the audit tools aulast and aulastlog are present on the system."""
+    assert file.exists("/usr/bin/aulast"), "aulast binary not found"
+    assert file.exists("/usr/bin/aulastlog"), "aulastlog binary not found"
+
+
+@pytest.mark.security_id(203767)
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Needs running auditd")
+@pytest.mark.root(reason="Needs access to audit logs")
+def test_audit_record_tools_for_logon_attempts_function(shell):
+    """Verify the aulast tool executes successfully and can query audit records for logon attempts."""
+    assert not shell("aulast --proof").returncode

--- a/tests-ng/test_disastig_00215.py
+++ b/tests-ng/test_disastig_00215.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000471-GPOS-00215
+
+Verify the operating system generates audit records for privileged activities or other system-level access.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203768)
+def test_disastig_00215():
+    """Audit of privileged activities is covered by other tests."""
+    pytest.skip(
+        reason="covered by test_disastig_00209.py, test_disastig_00210.py, test_disastig_00211.py test_disastig_00220.py test_disastig_00222.py"
+    )

--- a/tests-ng/test_disastig_00216.py
+++ b/tests-ng/test_disastig_00216.py
@@ -1,0 +1,30 @@
+"""
+Ref: SRG-OS-000471-GPOS-00216
+
+Verify the audit system is configured to audit the loading and unloading of dynamic kernel modules.
+"""
+
+import pytest
+from plugins.audit import AuditRule
+
+
+@pytest.mark.security_id(203769)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required to query active rules")
+@pytest.mark.root(reason="requires access to audit rules via auditctl")
+def test_audit_modprobe_watch_rule_present(audit_rule: AuditRule):
+    """Verify to audit the loading and unloading of dynamic kernel modules."""
+    assert audit_rule(
+        fs_watch_path="/sbin/modprobe", access_types="x"
+    ), "stigcompliance: no audit watch rule for /sbin/modprobe execution"
+
+
+@pytest.mark.security_id(203769)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required to query active rules")
+@pytest.mark.root(reason="requires access to audit rules via auditctl")
+def test_audit_kmod_watch_rule_present(audit_rule: AuditRule):
+    """Verify to audit the loading and unloading of dynamic kernel modules."""
+    assert audit_rule(
+        fs_watch_path="/bin/kmod", access_types="x"
+    ), "stigcompliance: no audit watch rule for /bin/kmod execution"

--- a/tests-ng/test_disastig_00217.py
+++ b/tests-ng/test_disastig_00217.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000472-GPOS-00217
+
+Verify the operating system generates audit records showing starting and ending time for user access to the system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203770)
+def test_disastig_00217():
+    """Audit of session start and end times is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00214.py")

--- a/tests-ng/test_disastig_00218.py
+++ b/tests-ng/test_disastig_00218.py
@@ -1,0 +1,61 @@
+"""
+Ref: SRG-OS-000472-GPOS-00218
+
+Verify the operating system generates audit records when concurrent logons to the same account occur from different sources.
+"""
+
+import tempfile
+
+import pytest
+from handlers.audit_user import TEST_USER
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203771)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires kernel logging")
+@pytest.mark.root(reason="required to generate audit events")
+@pytest.mark.modify(reason="creates and removes a temporary user account")
+def test_audit_concurrent_logins(shell: ShellRunner, audit_user):
+    """Verify a su login plus an ssh login for the same user produce >=2 hits in ausearch and journalctl combined."""
+    with tempfile.TemporaryDirectory() as tmp:
+        time_file = f"{tmp}/audit_start_time"
+        output_file = f"{tmp}/audit_output_gl.txt"
+        journal_file = f"{tmp}/journal_output_gl.txt"
+
+        shell(f"date '+%H:%M:%S' > {time_file}")
+
+        shell(f"su - {TEST_USER} -c 'sleep 30' &")
+
+        shell(
+            f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
+            f"{TEST_USER}@127.0.0.1 'sleep 30' &"
+        )
+
+        shell("sleep 5")
+
+        shell(f'ausearch -ts "$(cat {time_file})" > {output_file}')
+
+        shell(
+            f'journalctl --since "$(cat {time_file})" '
+            f'| grep -i "{TEST_USER}" > {journal_file}'
+        )
+
+        audit_hits = shell(
+            f"grep -c '{TEST_USER}' {output_file}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        journal_hits = shell(
+            f"grep -c '{TEST_USER}' {journal_file}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+
+        total = int(audit_hits.stdout.strip() or 0) + int(
+            journal_hits.stdout.strip() or 0
+        )
+
+    assert (
+        total >= 2
+    ), "stigcompliance: concurrent login audit events from different sources not detected"

--- a/tests-ng/test_disastig_00220.py
+++ b/tests-ng/test_disastig_00220.py
@@ -1,0 +1,55 @@
+"""
+Ref: SRG-OS-000475-GPOS-00220
+
+Verify the operating system generates audit records for all direct access to the information system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203773)
+@pytest.mark.booted(reason="requires running systemd")
+def test_journald_should_not_store_logs_in_memory(systemd):
+    """Verify /etc/systemd/journald.conf Storage is not set to 'volatile'."""
+    result = systemd.get_config("/etc/systemd/journald.conf")
+    if "Storage" in result.keys():
+        assert result["Storage"] != "volatile"
+
+
+@pytest.mark.security_id(203773)
+@pytest.mark.feature("ssh")
+def test_sshd_log_level_is_set_to_verbose(parse_file):
+    """Verify /etc/ssh/sshd_config sets LogLevel to VERBOSE."""
+    config = parse_file.parse("/etc/ssh/sshd_config", format="spacedelim")
+    assert config["LogLevel"] == "VERBOSE"
+
+
+@pytest.mark.security_id(203773)
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="requires running systemd")
+def test_sshd_unit_is_journald_friendly(systemd):
+    """Verify ssh.service has StandardOutput=journal and StandardError=journal/inherit."""
+    result = systemd.get_unit_properties("ssh")
+    assert (
+        result["StandardOutput"] == "journal"
+    ), f"sshd stdout not directed to journal: {result['StandardOutput']}"
+    assert result["StandardError"] in [
+        "journal",
+        "inherit",
+    ], f"sshd stderr not directed to journal or inherit: {result['StandardError']}"
+
+
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-session"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203773)
+def test_pam_unix_is_in_use(pam_config):
+    """Verify pam_unix.so is required as a session module in /etc/pam.d/common-session."""
+    results = pam_config.find_entries(
+        type_="session",
+        control_contains="required",
+        module_contains="pam_unix.so",
+    )
+    assert (
+        len(results) == 1
+    ), "pam_unix should be required for user sessions logging to work"

--- a/tests-ng/test_disastig_00222.py
+++ b/tests-ng/test_disastig_00222.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000477-GPOS-00222
+
+Verify the operating system generates audit records for all kernel module load, unload, and restart actions, and also for all program initiations.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_kernel_module_load_rules_present(audit_rule):
+    """Verify init_module and finit_module syscalls are audited for non-system users."""
+    for syscall in ["init_module", "finit_module"]:
+        assert audit_rule(syscall=syscall, rule_fields=["auid>=1000", "auid!=-1"])
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_kernel_module_delete_rules_present(audit_rule):
+    """Verify delete_module syscall is audited for non-system users."""
+    assert audit_rule(syscall="delete_module", rule_fields=["auid>=1000", "auid!=-1"])
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_kmod_binary_watched(audit_rule):
+    """Verify execution of /bin/kmod is audited."""
+    assert audit_rule(fs_watch_path="/bin/kmod", access_types="x")
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_modprobe_binary_watched(audit_rule):
+    """Verify execution of /sbin/modprobe is audited."""
+    assert audit_rule(fs_watch_path="/sbin/modprobe", access_types="x")

--- a/tests-ng/test_disastig_00223.py
+++ b/tests-ng/test_disastig_00223.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000478-GPOS-00223
+
+Verify the operating system implements NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203776)
+def test_fips():
+    """FIPS-validated cryptography is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests-ng/test_disastig_00225.py
+++ b/tests-ng/test_disastig_00225.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000480-GPOS-00225
+
+Verify the operating system prevents the use of dictionary words for passwords.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-password"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203778)
+@pytest.mark.feature("disaSTIGmedium")
+def test_dictionary_passwords_are_forbidden(pam_config):
+    """Verify pam_passwdqc.so is required as a password module in /etc/pam.d/common-password."""
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_passwdqc.so",
+    )
+    assert len(results) == 1, "passwdqc should be required"

--- a/tests-ng/test_disastig_00226.py
+++ b/tests-ng/test_disastig_00226.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000480-GPOS-00226
+
+Verify the operating system enforces a delay of at least 4 seconds between logon prompts following a failed logon attempt.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203779)
+@pytest.mark.parametrize("pam_config", ["/etc/pam.d/login"], indirect=["pam_config"])
+@pytest.mark.feature("disaSTIGmedium")
+def test_delay_is_enforced_after_failed_logins(pam_config):
+    """Verify pam_faildelay enforces a 4-second delay in /etc/pam.d/login."""
+    results = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faildelay.so",
+        arg_contains=["delay=4000000"],  # microseconds, 4 * 1mln
+    )
+    assert len(results) == 1, "pam_faildelay should enforce a delay of 4 seconds"

--- a/tests-ng/test_disastig_00227.py
+++ b/tests-ng/test_disastig_00227.py
@@ -1,0 +1,19 @@
+"""
+Ref: SRG-OS-000480-GPOS-00227
+
+As per DISA STIG compliance requirements, the operating system must be configured so that the SSH daemon does not allow X11 Forwarding.
+"""
+
+import pytest
+from plugins.sshd import Sshd
+
+
+@pytest.mark.security_id(203780)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_x11_forwarding_is_disabled(sshd: Sshd):
+    """Verify X11Forwarding is set to no in the SSH daemon configuration."""
+    assert (
+        sshd.get_config_section("x11forwarding") == "no"
+    ), "stigcompliance: X11Forwarding must be set to no in sshd configuration"

--- a/tests-ng/test_disastig_00228.py
+++ b/tests-ng/test_disastig_00228.py
@@ -1,0 +1,42 @@
+"""
+Ref: SRG-OS-000480-GPOS-00228
+
+Verify the operating system defines default permissions for all authenticated users in such a way that the user can only read and modify their own files.
+"""
+
+import glob
+
+import pytest
+
+
+@pytest.mark.security_id(203781)
+def test_umask_is_restrictive_enough(parse_file):
+    """Verify UMASK in /etc/login.defs is 027 or 077."""
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert config["UMASK"] in ("027", "077")
+
+
+@pytest.mark.security_id(203781)
+def test_skeleton_directory_is_not_world_writable(file):
+    """Verify /etc/skel has 755 permissions."""
+    assert file.has_permissions("/etc/skel", "755")
+
+
+@pytest.mark.security_id(203781)
+def test_skeleton_files_are_not_world_writable(file):
+    """Verify dotfiles under /etc/skel are 640 or 644."""
+    for f in glob.glob("/etc/skel/.*"):
+        assert file.has_permissions(f, "640") or file.has_permissions(
+            f, "644"
+        ), f"Wrong file permissions for {f}: {file.get_mode(f)}"
+
+
+@pytest.mark.security_id(203781)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-login-defs-umask"])
+@pytest.mark.feature("disaSTIGmedium", reason="077 umask is enforced by disaSTIGmedium")
+def test_login_defs_umask_is_077(parse_file) -> None:
+    """Verify UMASK in /etc/login.defs is set to 077 (SRG-OS-000480-GPOS-00228)."""
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert (
+        config["UMASK"] == "077"
+    ), f"stigcompliance: UMASK in /etc/login.defs is {config['UMASK']!r}, expected '077'"

--- a/tests-ng/test_disastig_00229.py
+++ b/tests-ng/test_disastig_00229.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000480-GPOS-00229
+
+Verify the operating system does not allow an unattended or automatic logon to the system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203782)
+@pytest.mark.booted(reason="Requires functioning systemd")
+def test_systemd_getty_autologin_is_not_enabled(systemd):
+    """Verify no getty@tty unit has --autologin in its ExecStart."""
+    for i in range(7):
+        props = systemd.get_unit_properties(f"getty@tty{i}")
+        assert "--autologin" not in props.get(
+            "ExecStart", ""
+        ), f"Autologin enabled on getty@tty{i}"

--- a/tests-ng/test_disastig_00230.py
+++ b/tests-ng/test_disastig_00230.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000775-GPOS-00230
+
+Verify the operating system is configured to include only approved trust anchors in trust stores or certificate stores managed by the organization.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(263659)
+@pytest.mark.feature("sap")
+def test_validate_fingerprint_of_SAP_CA_certificate(shell):
+    """Verify the SAP Global Root CA certificate has the expected SHA-256 fingerprint."""
+    cert_path = "/etc/ssl/certs/SAP_Global_Root_CA.pem"
+    result = shell(
+        f"openssl x509 -in {cert_path} -noout -fingerprint -sha256", capture_output=True
+    )
+    fingerprint = result.stdout.strip().split("=")[-1]
+
+    assert (
+        fingerprint
+        == "56:53:9C:1E:7B:5E:D5:58:2B:79:68:00:61:CB:F2:14:86:A8:50:22:6B:2F:CF:30:B5:B1:52:A7:20:E1:34:DE"
+    )

--- a/tests-ng/test_disastig_00240.py
+++ b/tests-ng/test_disastig_00240.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000780-GPOS-00240
+
+Verify the operating system is configured to provide protected storage for cryptographic keys with organization-defined safeguards and/or hardware protected key store.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(263660)
+@pytest.mark.feature("_tpm")
+def test_tpm2_service_enabled(systemd):
+    """Verify the tpm2 service is enabled and active."""
+    assert systemd.is_enabled("tpm2")
+    assert systemd.is_active("tpm2")

--- a/tests-ng/test_disastig_coverages.py
+++ b/tests-ng/test_disastig_coverages.py
@@ -1,0 +1,133 @@
+"""
+Ref: SRG-OS-000057-GPOS-00027, SRG-OS-000120-GPOS-00061, SRG-OS-000122-GPOS-00063, SRG-OS-000329-GPOS-00128
+
+Verify the operating system protects audit logs, uses SHA512 as the password hashing algorithm, enables the audit daemon, and automatically locks an account after three consecutive invalid logon attempts.
+"""
+
+import pytest
+
+AUDITD_CONF = "/etc/audit/auditd.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-service-auditd-enable"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="auditd service is enabled by disaSTIGmedium"
+)
+@pytest.mark.booted(reason="requires systemd")
+def test_auditd_service_is_enabled(systemd) -> None:
+    """Verify auditd.service is enabled."""
+    assert systemd.is_enabled("auditd"), "stigcompliance: auditd.service is not enabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-auditd-conf"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="auditd log_group is set to root by disaSTIGmedium"
+)
+def test_auditd_conf_log_group_is_root(parse_file) -> None:
+    """Verify auditd.conf log_group is set to root."""
+    config = parse_file.parse(AUDITD_CONF, format="keyval")
+    assert config["log_group"] == "root", (
+        f"stigcompliance: log_group in {AUDITD_CONF} is "
+        f"{config['log_group']!r}, expected 'root'"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-login-defs-encrypt"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="SHA512 password hashing is configured by disaSTIGmedium"
+)
+def test_login_defs_encrypt_method_is_sha512(parse_file) -> None:
+    """Verify ENCRYPT_METHOD in /etc/login.defs is SHA512."""
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert config["ENCRYPT_METHOD"] == "SHA512", (
+        f"stigcompliance: ENCRYPT_METHOD in /etc/login.defs is "
+        f"{config['ENCRYPT_METHOD']!r}, expected 'SHA512'"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-security-faillock"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="faillock deny threshold is configured by disaSTIGlow"
+)
+def test_faillock_deny_is_3(parse_file) -> None:
+    """Verify faillock.conf deny threshold is set to 3."""
+    config = parse_file.parse("/etc/security/faillock.conf", format="keyval")
+    assert (
+        config["deny"] == "3"
+    ), f"stigcompliance: deny in /etc/security/faillock.conf is {config['deny']!r}, expected '3'"
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-90-finalize-rules"]
+)
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="audit rules are made immutable by disaSTIGmedium via 90-finalize.rules",
+)
+@pytest.mark.booted(reason="requires running audit subsystem")
+@pytest.mark.root(reason="requires access to audit status")
+def test_audit_rules_are_immutable(shell) -> None:
+    """Verify auditctl reports rules are immutable (enabled 2)."""
+    result = shell("auditctl -s", capture_output=True, ignore_exit_code=True)
+    assert (
+        "enabled 2" in result.stdout
+    ), "stigcompliance: audit rules are not immutable (expected 'enabled 2' in auditctl -s output)"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="audit-rules.service override is provided by disaSTIGmedium",
+)
+def test_audit_rules_service_override_exists(file) -> None:
+    """Verify the audit-rules.service override drop-in exists."""
+    assert file.exists(
+        "/etc/systemd/system/audit-rules.service.d/override.conf"
+    ), "stigcompliance: audit-rules.service.d/override.conf is missing"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-journal-permissions"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="journal directory permissions are set by disaSTIGmedium",
+)
+def test_systemd_journal_is_not_world_readable(file) -> None:
+    """Verify /var/log/journal has rwxr-s--- permissions."""
+    assert file.has_permissions(
+        "/var/log/journal", "rwxr-s---"
+    ), "stigcompliance: /var/log/journal does not have expected permissions rwxr-s---"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-getty-no-autologin"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="getty autologin is disabled by disaSTIGmedium",
+)
+def test_getty_no_autologin_override_exists(file) -> None:
+    """Verify the getty@.service no-autologin drop-in exists."""
+    assert file.exists(
+        "/etc/systemd/system/getty@.service.d/no-autologin.conf"
+    ), "stigcompliance: getty no-autologin override is missing"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-auth-faildelay"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="pam_faildelay is configured by disaSTIGmedium",
+)
+def test_pam_faildelay_is_configured(parse_file) -> None:
+    """Verify pam_faildelay with delay=4000000 is configured in /etc/pam.d/common-auth."""
+    assert "auth required pam_faildelay.so delay=4000000" in parse_file.lines(
+        "/etc/pam.d/common-auth"
+    ), "stigcompliance: pam_faildelay delay=4000000 not found in /etc/pam.d/common-auth"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-garden-disaSTIG"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="garden-disaSTIG pam config is shipped by disaSTIGmedium",
+)
+def test_pam_garden_disastig_config_exists(file) -> None:
+    assert file.exists(
+        "/usr/share/pam-configs/garden-disaSTIG"
+    ), "stigcompliance: /usr/share/pam-configs/garden-disaSTIG is missing"


### PR DESCRIPTION
## Summary

- Backports all 114 DISA STIG compliance test files from `tests/integration/security/compliance/` (main) to `tests-ng/` (rel-1877)
- Adds 3 plugins introduced after rel-1877 branched: `audit.py`, `setuid_binaries.py`, `setting_ids.py`
- Adds 2 handlers introduced after rel-1877 branched: `audit_user.py`, `pip.py`
- All existing `tests-ng/plugins/` fixtures (`shell`, `file`, `sshd`, `sysctl`, `parse_file`, `pam`, etc.) are interface-compatible with the test files

## Test plan

- [ ] Verify tests collect without import errors: `cd tests-ng && python -m pytest --collect-only test_disastig_*.py`
- [ ] Run STIG tests against a rel-1877 STIG image via `./test --test-args "tests-ng/test_disastig_*.py -v" .build/$image.raw`