### PR TITLE
Docs: Add readme to _archgrouped feature

### DIFF
--- a/features/_archgrouped/README.md
+++ b/features/_archgrouped/README.md
@@ -1,0 +1,20 @@
+---
+title: "Feature: _archgrouped"
+github_org: gardenlinux
+github_repo: gardenlinux
+github_source_path: features/_archgroped/README.md
+github_target_path: docs/reference/features/_archgrouped.md
+---
+
+## Feature: _archgrouped
+
+### Description
+
+<website-feature>
+Publish this build's architectures as one grouped multi-arch artifact.
+</website-feature>
+
+### Unit testing
+
+This feature does not support unit tests.
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a README to the _archgrouped feature to fix doc's build error.

**Which issue(s) this PR fixes**:
Fixes #-

