### PR TITLE
fix: decouple test and build container

### DIFF
--- a/test
+++ b/test
@@ -58,7 +58,7 @@ container_mount_opts=(
 )
 
 if [ -z "$container_image" ]; then
-	base_image="$("$dir/build" --print-container-image)"
+	base_image="ghcr.io/gardenlinux/builder:d6d24ba1aec66889a2acab83aedcb00e869abfcd"
 	image_file="$(mktemp)"
 	"$container_engine" build -f Containerfile.chroot --ignorefile tests/.containerignore-chroot-tests --iidfile "$image_file" --build-arg base="$base_image" "$dir/tests"
 	container_image="$(cat "$image_file")"


### PR DESCRIPTION
decouple test and build container to allow builder updates without breaking legacy tests