### PR TITLE
fix/disaSTIG: add gardener exceptions for 8 deviations

### DIFF
--- a/features/disaSTIGlow/exec.config
+++ b/features/disaSTIGlow/exec.config
@@ -9,8 +9,30 @@ sed -i 's/^\(PASS_MIN_DAYS\s*\).*/\11/' /etc/login.defs
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000076-GPOS-00044/
 sed -i 's/^\(PASS_MAX_DAYS\s*\).*/\160/' /etc/login.defs
 
-# Update PAM-settings
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00226/
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000077-GPOS-00045/
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00227/
-DEBIAN_FRONTEND=noninteractive pam-auth-update --remove passwdqc
+# =============================================================================
+# dmesg_restrict (CAT III)
+# =============================================================================
+
+# SRG-OS-000138-GPOS-00069: restrict non-root access to kernel ring buffer.
+# Gardener exception: Cilium and kubelet require non-root dmesg access, so the
+# restrict sysctl is skipped when the gardener feature is active. The gardener
+# feature previously handled this via file.exclude + an explicit =0 override;
+# by making the exception here we remove the need for either of those files.
+if ! grep -q '\bgardener\b' <<< "$GARDENLINUX_FEATURES"; then
+    echo 'kernel.dmesg_restrict = 1' > /etc/sysctl.d/40-restrict-dmesg.conf
+fi
+
+# =============================================================================
+# auditd failure actions (CAT III)
+# =============================================================================
+
+# SRG-OS-000343-GPOS-00134: auditd must take action on disk full/error.
+# STIG requires halt to guarantee no audit events are lost.
+# Gardener exception: halting a Kubernetes node on an audit disk issue causes
+# cascading cluster failures. When gardener is active, degrade to syslog
+# instead so the node remains schedulable and the operator is still alerted.
+if grep -q '\bgardener\b' <<< "$GARDENLINUX_FEATURES"; then
+    sed -i 's/^admin_space_left_action\s*=.*/admin_space_left_action = syslog/' /etc/audit/auditd.conf
+    sed -i 's/^disk_full_action\s*=.*/disk_full_action = syslog/' /etc/audit/auditd.conf
+    sed -i 's/^disk_error_action\s*=.*/disk_error_action = syslog/' /etc/audit/auditd.conf
+fi

--- a/features/disaSTIGmedium/exec.config
+++ b/features/disaSTIGmedium/exec.config
@@ -80,8 +80,13 @@ sed -i 's/^ClientAliveCountMax.*/ClientAliveCountMax 1/' /etc/ssh/sshd_config
 
 # GL-TESTCOV-disaSTIGmedium-config-sudoers-wheel
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000373-GPOS-00156/
-# Truncate rather than delete — ssh/exec.config chmods this file and would fail if absent
-echo -n > /etc/sudoers.d/wheel
+# Truncate rather than delete — ssh/exec.config chmods this file and would fail if absent.
+# Gardener exception: the server feature (included by gardener) sets wheel to
+# NOPASSWD:ALL which is required for Gardener node operations. Skip truncation
+# when gardener is active so that wheel sudo remains functional.
+if ! grep -q '\bgardener\b' <<< "$GARDENLINUX_FEATURES"; then
+    echo -n > /etc/sudoers.d/wheel
+fi
 
 # UMASK: applied in exec.late (base/exec.config resets it to 027 and runs after us)
 
@@ -91,7 +96,12 @@ find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chm
 
 # GL-TESTCOV-disaSTIGmedium-config-root-locked
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000109-GPOS-00056/
-passwd --lock root
+# Gardener exception: Gardener nodes require root access for cloud-provider
+# break-glass recovery (emergency console access). Locking root would make
+# nodes unrecoverable in failure scenarios. Skip when gardener is active.
+if ! grep -q '\bgardener\b' <<< "$GARDENLINUX_FEATURES"; then
+    passwd --lock root
+fi
 
 # GL-TESTCOV-disaSTIGmedium-config-login-defs-encrypt
 # https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000120-GPOS-00061/
@@ -135,3 +145,34 @@ UNIT
 if ! grep -q 'pam_faildelay' /etc/pam.d/common-auth 2>/dev/null; then
     sed -i '1s/^/auth required pam_faildelay.so delay=4000000\n/' /etc/pam.d/common-auth
 fi
+
+# =============================================================================
+# Immutable audit rules (CAT II)
+# =============================================================================
+
+# SRG-OS-000057-GPOS-00027 / V-238298: set audit rules immutable (-e 2) so
+# they cannot be modified without a reboot.
+# Gardener exception: Kubernetes components (kubelet, containerd) need to add
+# audit rules at runtime during node provisioning. Immutable rules would
+# prevent this and break node bootstrap. Remove -e 2 when gardener is active.
+if grep -q '\bgardener\b' <<< "$GARDENLINUX_FEATURES"; then
+    sed -i '/^-e 2/d' /etc/audit/rules.d/90-finalize.rules
+fi
+
+# =============================================================================
+# pwquality.conf (CAT II)
+# =============================================================================
+
+# disaSTIGlow already lays down /etc/security/pwquality.conf with:
+#   lcredit, dcredit, ucredit, ocredit, difok
+# disaSTIGmedium adds: dictcheck, minlen, enforcing, lcredit (duplicate).
+# Rather than shipping a separate file.include that wins by last-write order,
+# append only the settings not already present to avoid duplicate keys.
+# This is a correctness fix independent of gardener.
+for setting in 'dictcheck=1' 'minlen=15' 'enforcing=1'; do
+    key="${setting%%=*}"
+    if ! grep -q "^${key}" /etc/security/pwquality.conf 2>/dev/null; then
+        echo "# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00225/" >> /etc/security/pwquality.conf
+        echo "${setting}" >> /etc/security/pwquality.conf
+    fi
+done

--- a/features/disaSTIGmedium/file.include.markers.yaml
+++ b/features/disaSTIGmedium/file.include.markers.yaml
@@ -22,9 +22,7 @@ markers:
   - "GL-TESTCOV-disaSTIGmedium-config-pam-common-auth"
   "etc/pam.d/common-password":
   - "GL-TESTCOV-disaSTIGmedium-config-pam-common-password"
-  "etc/security/pwquality.conf":
-  - "GL-TESTCOV-disaSTIGmedium-config-security-pwquality"
-  "usr/share/pam-configs/garden-disaSTIG":
+"usr/share/pam-configs/garden-disaSTIG":
   - "GL-TESTCOV-disaSTIGmedium-config-pam-garden-disaSTIG"
   "etc/default/useradd":
   - "GL-TESTCOV-disaSTIGmedium-config-useradd-inactive"

--- a/features/disaSTIGmedium/file.include/etc/security/pwquality.conf
+++ b/features/disaSTIGmedium/file.include/etc/security/pwquality.conf
@@ -1,8 +1,0 @@
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00225/
-dictcheck=1
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000078-GPOS-00046/
-minlen=15
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000480-GPOS-00225/
-enforcing = 1
-# https://stigaview.com/products/srg-gpos/v3r2/SRG-OS-000070-GPOS-00038/
-lcredit=-1


### PR DESCRIPTION
## Summary

This PR adds gardener-conditional guards and bug fixes to `disaSTIGlow/exec.config` and `disaSTIGmedium/exec.config` so that `gardener+disaSTIG` builds are functionally correct without weakening the STIG baseline for other flavors.

All exceptions use `$GARDENLINUX_FEATURES` (available in all `exec.config` scripts since `base/exec.config` exports it from `$BUILDER_FEATURES`) to detect whether `gardener` is in the active feature set.

A follow-up PR will update the corresponding `test_disastig_NNNNN.py` tests to apply `@pytest.mark.feature` conditions for each of these 9 deviations.

---

## Deviations addressed

### 1. dmesg_restrict — `disaSTIGlow/exec.config` (gardener guard)
**STIG**: `kernel.dmesg_restrict=1` (SRG-OS-000138-GPOS-00069)
**Conflict**: Gardener explicitly overrode this to `=0` via `gardener/file.include/etc/sysctl.d/40-allow-nonroot-dmesg.conf` and stripped the STIG file via `gardener/file.exclude`.
**Exception**: Cilium and kubelet require non-root access to the kernel ring buffer. The restrict sysctl is now written conditionally — when `gardener` is active the file is simply not created, removing the need for the gardener-side workaround.

### 2. PAM passwdqc — `disaSTIGlow/exec.config` (bug fix, no guard)
**Conflict**: `disaSTIGlow/exec.config` ran `pam-auth-update --remove passwdqc`, silently undoing the passwdqc configuration installed by `disaSTIGmedium/file.include/etc/pam.d/common-password`. This was a self-contradiction within the disaSTIG features themselves.
**Fix**: The line is removed. No gardener guard needed — it was wrong for all flavors.

### 3. Root account lock — `disaSTIGmedium/exec.config` (gardener guard)
**STIG**: Lock root account (SRG-OS-000109-GPOS-00056)
**Exception**: Gardener nodes require root for cloud-provider break-glass recovery via emergency console. Locking root makes nodes unrecoverable in failure scenarios. `passwd --lock root` is skipped when `gardener` is active.

### 4. SSH hardening vs disabled — no change
**Assessment**: No conflict. `disaSTIGmedium` hardens `sshd_config`; gardener disables `ssh.service` via systemd preset. These coexist: the hardened config is harmless dead config while the service is disabled, and provides correct defaults if the operator re-enables ssh for break-glass access.

### 5. Immutable audit rules — `disaSTIGmedium/exec.config` (gardener guard)
**STIG**: Set audit rules immutable with `-e 2` in `90-finalize.rules` (V-238298 / SRG-OS-000057-GPOS-00027)
**Exception**: Kubernetes components (kubelet, containerd) need to add audit rules at runtime during node provisioning. Immutable rules break node bootstrap. The `-e 2` line is removed from `90-finalize.rules` at build time when `gardener` is active.

### 6. auditd halt-on-error — `disaSTIGlow/exec.config` (gardener guard)
**STIG**: `disk_full_action=halt`, `disk_error_action=halt`, `admin_space_left_action=halt` (SRG-OS-000343-GPOS-00134)
**Exception**: Halting on audit disk issues causes cascading Kubernetes cluster failures — a single node going down due to a full audit disk can trigger a cascade. When `gardener` is active, actions are replaced with `syslog` so the node remains schedulable while the operator is still alerted.

### 7. sudoers wheel truncation — `disaSTIGmedium/exec.config` (gardener guard)
**STIG**: Restrict wheel sudo (SRG-OS-000373-GPOS-00156); `disaSTIGmedium` truncates `/etc/sudoers.d/wheel` to empty.
**Exception**: The `server` feature (transitively included by `gardener`) sets wheel to `NOPASSWD:ALL`, which is required for Gardener node operations. Truncation is skipped when `gardener` is active.

### 8. pwquality.conf conflict — `disaSTIGmedium/exec.config` + remove `file.include` (bug fix, no guard)
**Conflict**: Both `disaSTIGlow` and `disaSTIGmedium` shipped separate `pwquality.conf` files with overlapping keys (`lcredit` duplicated). Last-writer-wins made the final config unpredictable depending on feature include order.
**Fix**: `disaSTIGmedium/file.include/etc/security/pwquality.conf` is removed. `disaSTIGmedium/exec.config` now appends only the keys not already present in `disaSTIGlow`'s file (`dictcheck`, `minlen`, `enforcing`), producing a single consistent merged file. No gardener guard needed — correct for all flavors.

### 9. Kernel cmdline — no change
**Assessment**: No conflict. `disaSTIGmedium` appends `audit=1` via `cmdline.d/90-audit.cfg`; gardener adds `security=apparmor`. The `cmdline.d` mechanism is additive; both parameters coexist without conflict.

---

## Files changed

| File | Change |
|------|--------|
| `features/disaSTIGlow/exec.config` | Remove `pam-auth-update --remove passwdqc` (bug fix); add gardener guard for `dmesg_restrict`; add gardener guard for auditd halt actions |
| `features/disaSTIGmedium/exec.config` | Add gardener guard for `passwd --lock root`; add gardener guard for `-e 2` in `90-finalize.rules`; add gardener guard for sudoers wheel truncation; replace file.include-based pwquality with merge logic |
| `features/disaSTIGmedium/file.include/etc/security/pwquality.conf` | Deleted — superseded by merge logic in exec.config |
| `features/disaSTIGmedium/file.include.markers.yaml` | Remove stale entry for deleted pwquality.conf |

## Test plan

- [ ] Build `kvm-disaSTIGmedium-amd64` (non-gardener): verify root is locked, dmesg_restrict=1, wheel empty, `-e 2` present, halt actions present, passwdqc active
- [ ] Build `gcp-gardener-disaSTIGmedium-amd64`: verify root unlocked, dmesg_restrict absent, wheel intact, no `-e 2`, syslog actions, passwdqc active
- [ ] Verify merged `pwquality.conf` contains all 8 expected keys without duplicates in both builds
- [ ] Follow-up: update `test_disastig_NNNNN.py` with `@pytest.mark.feature` gardener conditions for deviations 1, 3, 5, 6, 7