### PR TITLE
Disable the issue creation on nightly failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,36 +128,3 @@ jobs:
       actions: write # TODO: 3215 elevated permissions for included workflow
       id-token: write # TODO: 3215 elevated permissions for included workflow
     secrets: inherit
-  create_issue_on_failure:
-    name: Create issue on failure
-    needs:
-      - build
-      - test
-      - upload_workflow_data
-      - publish_ghcr
-      - publish_s3
-    # TODO: fix this
-    # temporarily disable the issue creating on failure as it doesn't work as expected, it creates an issue on first failure
-    # retries have to be taken into account
-    # if: ${{ always() && failure() }}
-    if: false
-    runs-on: ubuntu-24.04
-    permissions:
-      issues: write
-      actions: read
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install Python dependencies
-        run: pip install requests==2.32.5
-      - name: Create failure issue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python3 hack/create_nightly_issue.py \
-            --repo "${{ github.repository }}" \
-            --run-id "${{ github.run_id }}" \
-            --ref "${{ github.ref }}" \
-            --sha "${{ github.sha }}" \
-            --workflow "${{ github.workflow }}" \
-            --needs '${{ toJson(needs) }}'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -136,7 +136,11 @@ jobs:
       - upload_workflow_data
       - publish_ghcr
       - publish_s3
-    if: ${{ always() && failure() }}
+    # TODO: fix this
+    # temporarily disable the issue creating on failure as it doesn't work as expected, it creates an issue on first failure
+    # retries have to be taken into account
+    # if: ${{ always() && failure() }}
+    if: false
     runs-on: ubuntu-24.04
     permissions:
       issues: write


### PR DESCRIPTION
**What this PR does / why we need it**:
The auto creation of an issue when the nightly fails should be disabled for the time being. It is not working as expected, the issue is created on first failure and most of the time on 2nd/3rd retry the nightly will be green.
This is creating a lot of issues that shouldn't be created.

**Which issue(s) this PR fixes**:
Fixes #
