### PR TITLE
feat: enable extra fips flavors (azure usi arm64 and gcp fips usi)

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -200,6 +200,16 @@ targets:
       - features:
           - gardener
           - _prod
+          - _usi
+          - _fips
+        arch: arm64
+        build: true
+        test: true
+        test-platform: true
+        publish: true
+      - features:
+          - gardener
+          - _prod
           - _trustedboot
         arch: amd64
         build: true
@@ -387,6 +397,26 @@ targets:
           - gardener
           - _prod
           - _usi
+        arch: arm64
+        build: true
+        test: true
+        test-platform: true
+        publish: true
+      - features:
+          - gardener
+          - _prod
+          - _usi
+          - _fips
+        arch: amd64
+        build: true
+        test: true
+        test-platform: true
+        publish: true
+      - features:
+          - gardener
+          - _prod
+          - _usi
+          - _fips
         arch: arm64
         build: true
         test: true


### PR DESCRIPTION
**What this PR does / why we need it**:
After checking with @tmang0ld @Akendo and @gehoern, these extra flavors should be enabled.