### PR TITLE
 docs: fix links to new GLRD pages 

### DIFF
--- a/docs/reference/releases/archived-releases.md
+++ b/docs/reference/releases/archived-releases.md
@@ -18,7 +18,7 @@ github_target_path: docs/reference/releases/archived-releases.md
 The table below lists releases that have reached their end of maintenance and are no longer actively supported. If you use one of these versions, migrate to the latest maintained release as soon as possible. For details about the release lifecycle, see [Release Lifecycle](release-lifecycle.md).
 
 :::tip
-All data is sourced from [GLRD](/reference/supporting_tools/glrd)
+All data is sourced from [GLRD](/reference/supporting_tools/glrd/)
 :::
 
 ## Out of maintenance releases

--- a/docs/reference/releases/maintained-releases.md
+++ b/docs/reference/releases/maintained-releases.md
@@ -20,7 +20,7 @@ github_target_path: docs/reference/releases/maintained-releases.md
 The table below provides the current list of actively maintained Garden Linux releases. For details about the release lifecycle phases, see [Release Lifecycle](release-lifecycle.md).
 
 :::tip
-All data is sourced from [GLRD](/reference/supporting_tools/glrd)
+All data is sourced from [GLRD](/reference/supporting_tools/glrd/)
 :::
 
 ## Active releases


### PR DESCRIPTION
**What this PR does / why we need it**:

[docs: fix links to new GLRD pages](https://github.com/gardenlinux/gardenlinux/commit/ed2f458181277720c5cdf0f6e5af4fa085102bed)
