### PR TITLE
Run the nightly at 05:00

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ concurrency:
   cancel-in-progress: true
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 5 * * *'
       timezone: "Europe/Berlin"
 jobs:
   build:


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of GitHub related "stuff" the nightlies over the last few days failed because the repo wasn't done.
As we can't really move the repo build sooner, we should start the nightly 1h later to ensure that the repo is built by the time it needs to start.