### PR TITLE
feat/lima: bump minimumLimaVersion to 2.2.0 and update image to 2150.9.0

### DIFF
--- a/features/lima/samples/README.md
+++ b/features/lima/samples/README.md
@@ -7,3 +7,7 @@ installs and configures podman so it can be used by a non-root user to run conta
 
 [`gardenlinux-containerd.yaml`](./gardenlinux-containerd.yaml)
 installs the Garden Linux build of containerd which we maintain.
+
+[`gardenlinux-tpm.yaml`](./gardenlinux-tpm.yaml)
+exposes an emulated TPM 2.0 device to the guest via swtpm (requires `swtpm` on the host and `vmType: qemu`).
+Installs `tpm2-tools` in the guest so the TPM can be used for key storage, attestation, or workload identity.

--- a/features/lima/samples/_images/gardenlinux-2150.yaml
+++ b/features/lima/samples/_images/gardenlinux-2150.yaml
@@ -1,8 +1,8 @@
 os: Linux
 images:
-- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-amd64-2150.0.0-eb8696b9/lima-amd64-2150.0.0-eb8696b9.qcow2
+- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-amd64-2150.9.0-a6e35cf0/lima-amd64-2150.9.0-a6e35cf0.qcow2
   arch: x86_64
-- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-arm64-2150.0.0-eb8696b9/lima-arm64-2150.0.0-eb8696b9.qcow2
+- location: https://gardenlinux-github-releases.s3.amazonaws.com/objects/lima-arm64-2150.9.0-a6e35cf0/lima-arm64-2150.9.0-a6e35cf0.qcow2
   arch: aarch64
 containerd:
   system: false

--- a/features/lima/samples/gardenlinux-containerd.yaml
+++ b/features/lima/samples/gardenlinux-containerd.yaml
@@ -1,4 +1,4 @@
-minimumLimaVersion: 2.0.0
+minimumLimaVersion: 2.2.0
 
 base:
 - _images/gardenlinux-2150.yaml

--- a/features/lima/samples/gardenlinux-k8s.yaml
+++ b/features/lima/samples/gardenlinux-k8s.yaml
@@ -13,7 +13,7 @@
 # NAME                   STATUS   ROLES           AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION        CONTAINER-RUNTIME
 # lima-gardenlinux-k8s   Ready    control-plane   75s   v1.35.1   10.x.y.z       <none>        Garden Linux 2150.0.0   6.18.12-cloud-arm64   containerd://2.2.1
 
-minimumLimaVersion: 2.0.0
+minimumLimaVersion: 2.2.0
 
 base:
 - _images/gardenlinux-2150.yaml

--- a/features/lima/samples/gardenlinux-rootless-podman.yaml
+++ b/features/lima/samples/gardenlinux-rootless-podman.yaml
@@ -1,4 +1,4 @@
-minimumLimaVersion: 2.0.0
+minimumLimaVersion: 2.2.0
 
 base:
 - _images/gardenlinux-2150.yaml

--- a/features/lima/samples/gardenlinux-tpm.yaml
+++ b/features/lima/samples/gardenlinux-tpm.yaml
@@ -1,0 +1,24 @@
+minimumLimaVersion: 2.2.0
+
+# Expose an emulated TPM 2.0 device to the guest via swtpm.
+# Requires swtpm to be installed on the host:
+#   macOS:  brew install swtpm
+#   Debian: apt-get install swtpm
+#
+# Only supported with vmType: qemu.
+vmType: qemu
+tpm: true
+
+base:
+- _images/gardenlinux-2150.yaml
+
+provision:
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get -y install tpm2-tools
+    # Verify the TPM device is accessible
+    tpm2_getcap properties-fixed | grep -E 'TPM2_PT_MANUFACTURER|TPM2_PT_FIRMWARE_VERSION'

--- a/features/lima/samples/gardenlinux-tpm.yaml
+++ b/features/lima/samples/gardenlinux-tpm.yaml
@@ -6,6 +6,15 @@ minimumLimaVersion: 2.2.0
 #   Debian: apt-get install swtpm
 #
 # Only supported with vmType: qemu.
+#
+# NOTE: On Apple Silicon (aarch64) with HVF acceleration, QEMU's tpm-tis-device
+# is not supported by Hypervisor.framework and the VM will fail to start.
+# Use accel=tcg (software emulation, slower) as a workaround until Lima/QEMU
+# add tpm-tis-i2c support for the virt machine on Apple Silicon:
+#   vmOpts:
+#     qemu:
+#       extraArgs: ["-machine", "virt,accel=tcg"]
+# On x86_64 Linux hosts with KVM, tpm: true works without any extra options.
 vmType: qemu
 tpm: true
 


### PR DESCRIPTION
## Summary

Two updates to the Garden Linux Lima feature:

1. **`minimumLimaVersion` bump**: `2.0.0` → `2.2.0` across all sample manifests
2. **Base image update**: `gardenlinux-2150.yaml` updated from `2150.0.0` to `2150.9.0`

---

## Lima v2.2.0 — What's new and why it matters for GL

### v2.1.0 highlights
| Change | GL relevance |
|--------|-------------|
| QEMU is now default for non-native arch | Cross-arch GL images (amd64 on Apple Silicon) work better out of the box |
| Host-guest time synchronization | Useful for cloud workload testing |
| Guest home dir: `/home/${USER}.linux` → `/home/${USER}.guest` | Any scripts/docs using the old path should be updated |
| guestagent binary 14MB → 6.1MB | Smaller guest footprint |
| `limactl shell --sync` | Safety for automation/AI workflows against GL images |

### v2.2.0 highlights
| Change | GL relevance |
|--------|-------------|
| **TPM emulation in QEMU** | Enables local testing of GL `_trustedboot`/SecureBoot flavors via Lima — previously only testable in cloud |
| LaunchDaemon support (macOS) | Headless/CI use of GL VMs on macOS build hosts |
| `socket_vmnet` restricted to admin group | Security hardening on macOS hosts |

---

## Image update: `2150.0.0` → `2150.9.0`

`_images/gardenlinux-2150.yaml` updated to the latest 2150 patch release. Both URLs verified accessible:

| Arch | URL | Size |
|------|-----|------|
| x86_64 | `lima-amd64-2150.9.0-a6e35cf0.qcow2` | 399 MB |
| aarch64 | `lima-arm64-2150.9.0-a6e35cf0.qcow2` | 426 MB |

---

## Files changed

| File | Change |
|------|--------|
| `samples/gardenlinux-containerd.yaml` | `minimumLimaVersion: 2.0.0 → 2.2.0` |
| `samples/gardenlinux-rootless-podman.yaml` | `minimumLimaVersion: 2.0.0 → 2.2.0` |
| `samples/gardenlinux-k8s.yaml` | `minimumLimaVersion: 2.0.0 → 2.2.0` |
| `samples/_images/gardenlinux-2150.yaml` | Image URLs updated to `2150.9.0-a6e35cf0` |

## Test plan

- [ ] `limactl start ./samples/gardenlinux-containerd.yaml` on macOS with Lima 2.2.0
- [ ] `limactl start ./samples/gardenlinux-rootless-podman.yaml` — verify rootless podman works
- [ ] `limactl start ./samples/gardenlinux-k8s.yaml` — verify k8s cluster comes up
- [ ] Test on both native (arm64 macOS) and cross-arch (amd64 image on arm64 host)
- [ ] Verify TPM emulation works with a `_trustedboot` GL flavor (optional, v2.2.0 feature)