### PR TITLE
Remove fips related flavors from 2150

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -31,24 +31,6 @@ targets:
         publish: true
       - features:
           - gardener
-          - _fips
-          - _prod
-        arch: amd64
-        build: true
-        test: true
-        test-platform: true
-        publish: true
-      - features:
-          - gardener
-          - _prod
-        arch: arm64
-        build: true
-        test: true
-        test-platform: true
-        publish: true
-      - features:
-          - gardener
-          - _fips
           - _prod
         arch: arm64
         build: true


### PR DESCRIPTION
**What this PR does / why we need it**:
It was decided that for 2150 we should not build any fips enabled flavors.

**Which issue(s) this PR fixes**:
Fixes #

