### PR TITLE
fix(gardener): Disable daily apt upgrade/update (Backport for 2150)

### DIFF
--- a/features/gardener/exec.config
+++ b/features/gardener/exec.config
@@ -27,3 +27,9 @@ if [ -e "$gce_network_sysctl_file" ]; then
     sed -i "/^net\.ipv4\.conf\.all\.rp_filter.*/d" "$gce_network_sysctl_file"
     sed -i "/^net\.ipv4\.conf\.default\.rp_filter.*/d" "$gce_network_sysctl_file"
 fi
+
+# disable APT daily update/upgrade timers and services
+systemctl preset apt-daily.timer
+systemctl preset apt-daily-upgrade.timer
+systemctl preset apt-daily.service
+systemctl preset apt-daily-upgrade.service

--- a/features/gardener/file.include/etc/systemd/system-preset/91-disable-apt-daily.preset
+++ b/features/gardener/file.include/etc/systemd/system-preset/91-disable-apt-daily.preset
@@ -1,0 +1,4 @@
+disable apt-daily.timer
+disable apt-daily-upgrade.timer
+disable apt-daily.service
+disable apt-daily-upgrade.service


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport for 2150 from main for: Disable the daily running apt upgrade/update timers and services, since they provide no value with Gardner nodes, which get updated via new images and not upgrading packages.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5267