### PR TITLE
backport: DISA STIG compliance tests from main to rel-2150

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "typeCheckingMode": "basic",
+    "reportUnusedImport": "error"
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,7 @@
 {
     "typeCheckingMode": "basic",
-    "reportUnusedImport": "error"
+    "reportUnusedImport": "error",
+    "exclude": [
+        "tests/test_*.py"
+    ]
 }

--- a/tests/handlers/audit_user.py
+++ b/tests/handlers/audit_user.py
@@ -1,0 +1,16 @@
+import pytest
+from plugins.shell import ShellRunner
+
+TEST_USER = "audit_test_user"
+
+
+@pytest.fixture
+def audit_user(shell: ShellRunner):
+    shell(f"id {TEST_USER} || useradd -m -s /bin/sh {TEST_USER}")
+    yield TEST_USER
+    shell(f"pkill -9 -u {TEST_USER}", ignore_exit_code=True)
+    shell("sleep 1")
+    shell(f"userdel -r {TEST_USER}", ignore_exit_code=True)
+    shell(
+        "rm -f /etc/group- /etc/gshadow- /etc/passwd- /etc/shadow- /etc/subgid- /etc/subuid-"
+    )

--- a/tests/handlers/pip.py
+++ b/tests/handlers/pip.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.fixture
+def pip_requests(shell: ShellRunner):
+    out = shell(
+        '/bin/python3 -c "import site; print(site.getsitepackages()[0])"',
+        capture_output=True,
+    )
+    package_dir = out.stdout.strip("\n")
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_before_install")
+
+    restore_backup = False
+    if os.path.isdir(package_dir):
+        restore_backup = True
+        shutil.move(package_dir, package_dir + ".backup")
+
+    os.mkdir(package_dir)
+
+    shell(
+        "/bin/pip3 install --break-system-packages --no-cache-dir --root-user-action=ignore requests"
+    )
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_after_install")
+
+    yield package_dir
+
+    shell(
+        "for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall -y --break-system-packages $dep; done"
+    )
+    shell("rm /tmp/pip_freeze_before_install /tmp/pip_freeze_after_install")
+    shutil.rmtree(package_dir)
+    if restore_backup:
+        shutil.move(package_dir + ".backup", package_dir)

--- a/tests/integration/boot/test_cloud_init.py
+++ b/tests/integration/boot/test_cloud_init.py
@@ -1,0 +1,525 @@
+import os
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# Most Platforms Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "ali or aws or azure or gdch or openstack or vmware",
+    reason="Cloud-init is installed on most cloud platforms.",
+)
+def test_cloud_init_installed():
+    assert os.path.exists("/etc/cloud/cloud.cfg"), "Cloud-init should be installed."
+
+
+@pytest.mark.feature(
+    "(gcp or kvm or metal or metal_pxe) and not (openstack and metal)",
+    reason="Cloud-init is not installed on these platforms; openstack-metal also includes the metal feature.",
+)
+def test_cloud_init_not_installed():
+    assert not os.path.exists(
+        "/etc/cloud/cloud.cfg"
+    ), "Cloud-init should not be installed."
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ali-config-cloud-user-shell",
+        "GL-TESTCOV-ali-config-cloud-user-lock-passwd",
+        "GL-TESTCOV-ali-config-cloud-user-sudo",
+        "GL-TESTCOV-ali-config-cloud-apt-sources",
+        "GL-TESTCOV-aws-config-cloud-user-shell",
+        "GL-TESTCOV-aws-config-cloud-user-lock-passwd",
+        "GL-TESTCOV-aws-config-cloud-user-sudo",
+        "GL-TESTCOV-aws-config-cloud-apt-sources",
+        "GL-TESTCOV-azure-config-cloud-user-shell",
+        "GL-TESTCOV-azure-config-cloud-user-lock-passwd",
+        "GL-TESTCOV-azure-config-cloud-user-sudo",
+        "GL-TESTCOV-azure-config-cloud-apt-sources",
+        "GL-TESTCOV-openstack-config-cloud-user-shell",
+        "GL-TESTCOV-openstack-config-cloud-user-lock-passwd",
+        "GL-TESTCOV-openstack-config-cloud-user-sudo",
+        "GL-TESTCOV-openstack-config-cloud-apt-sources",
+        "GL-TESTCOV-vmware-config-cloud-user-shell",
+        "GL-TESTCOV-vmware-config-cloud-user-lock-passwd",
+        "GL-TESTCOV-vmware-config-cloud-user-sudo",
+        "GL-TESTCOV-vmware-config-cloud-apt-sources",
+    ]
+)
+@pytest.mark.feature(
+    "ali or aws or azure or openstack or vmware",
+    reason="Cloud-init is installed on most cloud platforms; gdch has minimal config",
+)
+def test_cloud_init_debian_cloud_defaults(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["apt_preserve_sources_list"] is True
+    assert config["system_info"]["default_user"]["shell"] == "/bin/bash"
+    assert config["system_info"]["default_user"]["lock_passwd"] is True
+    assert config["system_info"]["default_user"]["sudo"] == ["ALL=(ALL) NOPASSWD:ALL"]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ali-config-cloud-user-name",
+        "GL-TESTCOV-aws-config-cloud-user-name"
+        "GL-TESTCOV-openstack-config-cloud-user-name",
+        "GL-TESTCOV-vmware-config-cloud-user-name",
+    ]
+)
+@pytest.mark.feature(
+    "ali or aws or openstack or vmware",
+    reason="Cloud-init is installed on most cloud platforms; azure uses a different default user; gdch has minimal config",
+)
+def test_cloud_init_debian_cloud_user(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["system_info"]["default_user"]["name"] == "admin"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-aws-config-cloud-manage-hosts",
+        "GL-TESTCOV-azure-config-cloud-manage-hosts",
+        "GL-TESTCOV-openstack-config-cloud-manage-hosts",
+        "GL-TESTCOV-vmware-config-cloud-manage-hosts",
+    ]
+)
+@pytest.mark.feature(
+    "aws or azure or openstack or vmware",
+    reason="Cloud-init is installed on most cloud platforms; ali does not manage host file; gdch has minimal config",
+)
+def test_cloud_init_debian_cloud_manage_etc_hosts(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["manage_etc_hosts"] is True
+
+
+# =============================================================================
+# Some Platforms Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ali-config-cloud-no-ntp",
+        "GL-TESTCOV-ali-config-cloud-no-resizefs",
+        "GL-TESTCOV-ali-config-cloud-no-growpart",
+        "GL-TESTCOV-aws-config-cloud-no-ntp",
+        "GL-TESTCOV-aws-config-cloud-no-resizefs",
+        "GL-TESTCOV-aws-config-cloud-no-growpart",
+        "GL-TESTCOV-openstack-config-cloud-no-ntp",
+        "GL-TESTCOV-openstack-config-cloud-no-resizefs",
+        "GL-TESTCOV-openstack-config-cloud-no-growpart",
+        "GL-TESTCOV-vmware-config-cloud-no-ntp",
+        "GL-TESTCOV-vmware-config-cloud-no-resizefs",
+        "GL-TESTCOV-vmware-config-cloud-no-growpart",
+    ]
+)
+@pytest.mark.feature("ali or aws or openstack or vmware")
+@pytest.mark.parametrize("module", ["ntp", "resizefs", "growpart"])
+def test_cloud_cfg_excludes_modules(parse_file: ParseFile, module: str):
+    file = "/etc/cloud/cloud.cfg"
+    config = parse_file.parse(file, format="yaml")
+    for list_path in [
+        "cloud_init_modules",
+        "cloud_config_modules",
+        "cloud_final_modules",
+    ]:
+        # Navigate to the list using dictionary access
+        parts = list_path.split(".")
+        target_list = config
+        for part in parts:
+            target_list = target_list[part]
+        assert (
+            module not in target_list
+        ), f"Value {module} found in list {list_path} in {file}, but should not be present."
+
+
+# =============================================================================
+# ali Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ali-config-cloud-apt-sources",
+        "GL-TESTCOV-ali-config-cloud-user-name",
+        "GL-TESTCOV-ali-config-cloud-user-shell",
+        "GL-TESTCOV-ali-config-cloud-user-lock-passwd",
+        "GL-TESTCOV-ali-config-cloud-user-sudo",
+    ]
+)
+@pytest.mark.feature("ali")
+def test_ali_debian_cloud_ignore_manage_etc_hosts(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert "manage_etc_hosts" not in config
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ali-config-cloud-network-config-disable",
+    ]
+)
+@pytest.mark.feature("ali")
+def test_ali_disable_network_config(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["network"]["config"] == "disabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-service-cloud-init-local-enable"])
+@pytest.mark.feature("ali")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ali_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-service-cloud-init-local-enable"])
+@pytest.mark.feature("ali")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor("qemu", reason="cloud-init can't be loaded in QEMU")
+def test_ali_cloud_init_local_service_inactive(systemd: Systemd):
+    """Test that cloud-init-local.service is inactive"""
+    assert systemd.is_inactive("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-service-cloud-init-local-enable"])
+@pytest.mark.feature("ali")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="cloud-init is loaded in real cloud environment"
+)
+def test_ali_cloud_init_local_service_active(systemd: Systemd):
+    """Test that cloud-init-local.service is active"""
+    assert systemd.is_active("cloud-init-local.service")
+
+
+# =============================================================================
+# aws Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-cloud-init-local-override"])
+@pytest.mark.feature("aws")
+def test_aws_cloud_init_local_override_exists(file: File):
+    """Test that AWS cloud-init-local service override exists"""
+    assert file.exists("/etc/systemd/system/cloud-init-local.service.d/override.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-cloud-network-config-disable"])
+@pytest.mark.feature("aws")
+def test_aws_disable_network_config(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["network"]["config"] == "disabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-cloud-init-local-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.hypervisor("amazon", reason="Requires Amazon AWS infrastructure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aws_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-cloud-init-local-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor("qemu", reason="cloud-init can't be loaded in QEMU")
+def test_aws_cloud_init_local_service_inactive(systemd: Systemd):
+    """Test that cloud-init-local.service is inactive"""
+    assert systemd.is_inactive("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-cloud-init-local-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="cloud-init is loaded in real cloud environment"
+)
+def test_aws_cloud_init_local_service_active(systemd: Systemd):
+    """Test that cloud-init-local.service is active"""
+    assert systemd.is_active("cloud-init-local.service")
+
+
+# =============================================================================
+# azure Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-cloud-network-config-disable"])
+@pytest.mark.feature("azure")
+def test_azure_cloud_init_network_config_disabled_exists(file: File):
+    """Test that Azure cloud-init network config is disabled"""
+    assert file.exists("/etc/cloud/cloud.cfg.d/00_azure.cfg")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-azure-config-cloud-network-config-disable",
+    ]
+)
+@pytest.mark.feature("azure")
+def test_azure_cloud_init_network_config_disabled_content(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/00_azure.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["network"]["config"] == "disabled"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-azure-config-cloud-user-name",
+    ]
+)
+@pytest.mark.feature("azure")
+def test_azure_debian_cloud_user(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/01_debian-cloud.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["system_info"]["default_user"]["name"] == "azureuser"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-cloud-init-local-enable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-cloud-init-local-enable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor("qemu", reason="cloud-init can't be loaded in QEMU")
+def test_azure_cloud_init_local_service_inactive(systemd: Systemd):
+    """Test that cloud-init-local.service is inactive"""
+    assert systemd.is_inactive("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-cloud-init-local-enable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="cloud-init is loaded in real cloud environment"
+)
+def test_azure_cloud_init_local_service_active(systemd: Systemd):
+    """Test that cloud-init-local.service is active"""
+    assert systemd.is_active("cloud-init-local.service")
+
+
+# =============================================================================
+# gcp Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-no-cloud-init-local"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gcp_no_cloud_init_local_service(systemd: Systemd):
+    """Test that cloud-init.service is not installed"""
+    assert not any(
+        u.unit == "cloud-init-local.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# gdch Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gdch-config-cloud-ntp",
+    ]
+)
+@pytest.mark.feature("gdch")
+def test_gdch_ntp_settings(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/91-gdch-system.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["ntp"]["enabled"] is True
+    assert config["ntp"]["ntp_client"] == "chrony"
+    assert "ntp1.org.internal" in config["ntp"]["servers"]
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-cloud-init-local-enable"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-cloud-init-local-enable"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_cloud_init_local_service_inactive(systemd: Systemd):
+    """Test that cloud-init-local.service is inactive"""
+    assert systemd.is_inactive("cloud-init-local.service")
+
+
+# =============================================================================
+# lima Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-service-cloud-init-local-enable"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="Requires systemd")
+def test_lima_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-service-cloud-init-local-enable"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="Requires systemd")
+def test_lima_cloud_init_local_service_inactive(systemd: Systemd):
+    """Test that cloud-init-local.service is inactive"""
+    assert systemd.is_inactive("cloud-init-local.service")
+
+
+# =============================================================================
+# openstack Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-openstack-config-cloud-datasource",
+    ]
+)
+@pytest.mark.feature("openstack")
+def test_openstack_datasource_list(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/50-datasource.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["datasource_list"] == ["ConfigDrive", "OpenStack", "Ec2"]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-openstack-config-cloud-datasource-identify",
+    ]
+)
+@pytest.mark.feature("openstack")
+def test_openstack_ds_identify(parse_file: ParseFile):
+    file = "/etc/cloud/ds-identify.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["datasource"] == "OpenStack"
+    assert config["policy"] == "enabled"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-openstackCloud-config-cloud-disable-network-config",
+    ]
+)
+@pytest.mark.feature("openstack and cloud")
+def test_openstack_cloud_disable_network_config(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["network"]["config"] == "disabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstack-service-cloud-init-local-enable"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="Requires systemd")
+def test_openstack_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstack-service-cloud-init-local-enable"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="Requires systemd")
+def test_openstack_cloud_init_local_service_active(systemd: Systemd):
+    """Test that cloud-init-local.service is active"""
+    assert systemd.is_active("cloud-init-local.service")
+
+
+# =============================================================================
+# openstackMetal Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-openstackMetal-config-cloud-network-config",
+    ]
+)
+@pytest.mark.feature("openstack and metal")
+def test_openstack_metal_network_config(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/65-network-config.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["system_info"]["network"]["renderers"] == ["netplan", "networkd"]
+
+
+# =============================================================================
+# vmware Feature Cloud-init
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-vmware-config-cloud-network-config-disable",
+    ]
+)
+@pytest.mark.feature("vmware")
+def test_vmware_disable_network_config(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/99_disable-network-config.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["network"]["config"] == "disabled"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-vmware-config-cloud-datasources",
+    ]
+)
+@pytest.mark.feature("vmware")
+def test_vmware_enabled_datasources(parse_file: ParseFile):
+    file = "/etc/cloud/cloud.cfg.d/99_enabled-datasources.cfg"
+    config = parse_file.parse(file, format="yaml")
+    assert config["datasource_list"] == ["VMwareGuestInfo", "OVF"]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-vmware-config-cloud-datasource-vmwareguestinfo",
+        "GL-TESTCOV-vmware-config-cloud-datasource-identify",
+    ]
+)
+@pytest.mark.feature("vmware")
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceVMwareGuestInfo.py",
+        "/usr/bin/dscheck_VMwareGuestInfo",
+    ],
+)
+def test_vmware_datasource_files_exist(file_path: str):
+    assert os.path.exists(file_path), f"File {file_path} could not be found."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vmware-service-cloud-init-local-enable"])
+@pytest.mark.feature("vmware")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vmware_cloud_init_local_service_enabled(systemd: Systemd):
+    """Test that cloud-init-local.service is enabled"""
+    assert systemd.is_enabled("cloud-init-local.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vmware-service-cloud-init-local-enable"])
+@pytest.mark.feature("vmware")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vmware_cloud_init_local_service_inactive(systemd: Systemd):
+    """Test that cloud-init-local.service is inactive"""
+    assert systemd.is_inactive("cloud-init-local.service")

--- a/tests/integration/boot/test_ignition.py
+++ b/tests/integration/boot/test_ignition.py
@@ -1,0 +1,228 @@
+import pytest
+from plugins.file import File
+from plugins.initrd import Initrd
+from plugins.systemd import Systemd
+
+# =============================================================================
+# Main _ignite Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_ignite-config-initrd-ignition",
+    ]
+)
+@pytest.mark.feature("_ignite and not _usi")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_ignite_initrd_ignition_modules(initrd: Initrd):
+    """Test that ignition dracut modules are present in initrd"""
+    modules = [
+        "ignition",
+        "ignition-extra",
+        "systemd-networkd",
+    ]
+
+    missing = [
+        module for module in modules if not initrd.contains_dracut_module(module)
+    ]
+    assert (
+        not missing
+    ), f"The following dracut modules were not found in initrd: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_ignite-config-initrd-module-ignition-after-net-online",
+        "GL-TESTCOV-_ignite-config-initrd-module-ignition-env-generator",
+        "GL-TESTCOV-_ignite-config-initrd-module-ignition-files",
+        "GL-TESTCOV-_ignite-config-initrd-module-ignition-module-setup",
+    ]
+)
+@pytest.mark.feature("_ignite and not _usi")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_ignite_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd
+
+    TODO: _usi feature uses a custom dracut build that excludes ignition dracut modules
+    and doesn't include ignition files via initrd.include directory. This needs to be
+    fixed by creating features/_ignite/initrd.include/ with the required files or a similar approach.
+    See: features/_usi/image.esp.tar for the custom dracut build process.
+    """
+    paths = [
+        "etc/systemd/system/ignition-fetch.service.d/after-net-online.conf",
+        "usr/lib/systemd/system-generators/ignition-env-generator",
+        "etc/ignition-files.env",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+# =============================================================================
+# _usi Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_usi-config-no-initrd-ignition",
+    ]
+)
+@pytest.mark.feature("_usi")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test__usi_initrd_ignition_modules(initrd: Initrd):
+    """Test that no ignition dracut modules are present in initrd"""
+    modules = [
+        "ignition",
+        "ignition-extra",
+        "systemd-networkd",
+    ]
+
+    missing = [
+        module for module in modules if not initrd.contains_dracut_module(module)
+    ]
+    assert (
+        missing
+    ), f"The following dracut modules should not be found in initrd, but these were missing: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-no-kernel-cmdline-ignition"])
+@pytest.mark.feature("_usi")
+def test_usi_no_ignition_cmdline_config(file: File):
+    """Test that ignition kernel cmdline config does not exist"""
+    assert not file.exists("/etc/kernel/cmdline.d/50-ignition.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-service-no-ignition-disable"])
+@pytest.mark.feature("_usi")
+@pytest.mark.booted(reason="Requires systemd")
+def test__usi_no_ignition_disable_service(systemd: Systemd):
+    """Test that ignition-disable.service is not installed"""
+    assert not any(
+        u.unit == "ignition-disable.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# kvm Feature
+# =============================================================================
+
+# Cannot not be tested as 50-ignition.cfg is deleted by ignition-disable.service.
+# @pytest.mark.testcov(["GL-TESTCOV-kvm-config-kernel-cmdline-ignition"])
+# @pytest.mark.feature("vmware")
+# @pytest.mark.arch("amd64")
+# def test_kvm_kernel_cmdline_ignition_exists(file: File):
+#     """Test that KVM does have ignition kernel cmdline. It never exists on arm64."""
+#     assert file.exists("/etc/kernel/cmdline.d/50-ignition.cfg")
+
+# Cannot not be tested as 50-ignition.cfg is deleted by ignition-disable.service.
+# @pytest.mark.testcov(["GL-TESTCOV-kvm-config-kernel-cmdline-ignition"])
+# @pytest.mark.feature("kvm")
+# @pytest.mark.booted(reason="kernel cmdline needs a booted system")
+# def test_ignition_configuration_in_cmdline_kvm(kernel_cmdline: List[str]):
+#     """Verify ignition parameters are present in the running kernel command line for KVM."""
+#     settings = [
+#         "ignition.firstboot=1",
+#         "ignition.platform.id=qemu",
+#     ]
+#     missing = [setting for setting in settings if setting not in kernel_cmdline]
+#     assert (
+#         not missing
+#     ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-kvm-service-ignition-disable-unit"])
+@pytest.mark.feature(
+    "kvm and not _usi",
+    reason="Ignition is enabled on KVM but disabled on _usi again",
+)
+def test_kvm_ignition_disable_unit_exists(file):
+    """Test that ignition-disable.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/ignition-disable.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-kvm-service-ignition-disable-enable"])
+@pytest.mark.feature(
+    "kvm and not _usi",
+    reason="Ignition is enabled on KVM but disabled on _usi again",
+)
+@pytest.mark.booted(reason="Requires systemd")
+def test_kvm_ignition_disable_service_enabled(systemd: Systemd):
+    """Test that ignition-disable.service is enabled"""
+    assert systemd.is_enabled("ignition-disable.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-kvm-service-ignition-disable-enable"])
+@pytest.mark.feature(
+    "kvm and not _usi",
+    reason="Ignition is enabled on KVM but disabled on _usi again",
+)
+@pytest.mark.booted(reason="Requires systemd")
+def test_kvm_ignition_disable_service_active(systemd: Systemd):
+    """Test that ignition-disable.service is active"""
+    assert systemd.is_active("ignition-disable.service")
+
+
+# =============================================================================
+# vmware Feature
+# =============================================================================
+
+
+# Cannot not be tested as 50-ignition.cfg is deleted by ignition-disable.service.
+# @pytest.mark.testcov(["GL-TESTCOV-vmware-config-kernel-cmdline-ignition"])
+# @pytest.mark.feature("vmware")
+# @pytest.mark.arch("amd64")
+# def test_vmware_kernel_cmdline_ignition_exists(file: File):
+#     """Test that VMware does have ignition kernel cmdline. It never exists on arm64."""
+#     assert file.exists("/etc/kernel/cmdline.d/50-ignition.cfg")
+
+
+# Cannot not be tested as 50-ignition.cfg is deleted by ignition-disable.service.
+# @pytest.mark.testcov(["GL-TESTCOV-vmware-config-kernel-cmdline-ignition"])
+# @pytest.mark.feature("vmware")
+# @pytest.mark.arch("amd64")
+# @pytest.mark.booted(reason="kernel cmdline needs a booted system")
+# def test_ignition_configuration_in_cmdline_vmware_amd64(kernel_cmdline: List[str]):
+#     """Verify ignition parameters are present in the running kernel command line for VMware."""
+#     assert (
+#         "ignition.firstboot=1 ignition.platform.id=vmware" in kernel_cmdline
+#     ), "Ignition (ignition.firstboot=1 ignition.platform.id=vmware) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-vmware-config-kernel-cmdline-no-ignition-arm64",
+    ]
+)
+@pytest.mark.feature("vmware")
+@pytest.mark.arch("arm64")
+def test_vmware_kernel_cmdline_no_ignition_arm64(file: File):
+    """Test that VMware does not have ignition kernel cmdline for ARM64"""
+    assert not file.exists(
+        "/etc/kernel/cmdline.d/50-ignition.cfg"
+    ), "ARM64 ignition config should not exist"
+
+
+# Cannot not be tested as 50-ignition.cfg is deleted by ignition-disable.service.
+# @pytest.mark.testcov(["GL-TESTCOV-vmware-config-kernel-cmdline-ignition"])
+# @pytest.mark.feature("vmware")
+# @pytest.mark.arch("arm64")
+# @pytest.mark.booted(reason="kernel cmdline needs a booted system")
+# def test_no_ignition_configuration_in_cmdline_vmware_arm64(kernel_cmdline: List[str]):
+#     """Verify no ignition parameters are present in the running kernel command line for VMware."""
+#     assert (
+#         "ignition.firstboot=1 ignition.platform.id=vmware" not in kernel_cmdline
+#     ), "Ignition (ignition.firstboot=1 ignition.platform.id=vmware) found in kernel cmdline"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vmware-service-ignition-disable-unit"])
+@pytest.mark.feature("vmware")
+def test_vmware_ignition_disable_unit_exists(file):
+    """Test that ignition-disable.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/ignition-disable.service")

--- a/tests/integration/boot/test_initrd.py
+++ b/tests/integration/boot/test_initrd.py
@@ -1,0 +1,498 @@
+"""
+Test initrd contents, dracut modules, and configurations across all Garden Linux features.
+"""
+
+from pathlib import Path
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.initrd import Initrd
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# _ephemeral Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_ephemeral-service-initrd-ephemeral-cryptsetup-unit"])
+@pytest.mark.feature("_ephemeral")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_ephemeral_check_initrd_cryptsetup_unit_exists(initrd: Initrd):
+    """Test that ephemeral-cryptsetup.service unit file exists in initrd"""
+    assert initrd.contains_file("etc/systemd/system/ephemeral-cryptsetup.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_ephemeral-config-initrd-repart-var",
+        "GL-TESTCOV-_ephemeral-service-initrd-ephemeral-cryptsetup-unit",
+        "GL-TESTCOV-_ephemeral-config-initrd-mount-var",
+    ]
+)
+@pytest.mark.feature("_ephemeral")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_ephemeral_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = [
+        "etc/repart.d/10-var.conf",
+        "etc/systemd/system/ephemeral-cryptsetup.service",
+        "etc/systemd/system/sysroot-var.mount",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+# =============================================================================
+# _kdump Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_kdump-config-kernel-cmdline-crashkernel",
+        "GL-TESTCOV-_kdump-config-service-kdump-tools-override",
+        "GL-TESTCOV-_kdump-script-prepare-initrd-kdump",
+    ]
+)
+@pytest.mark.feature("_kdump")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_kdump_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = [
+        "etc/kernel/cmdline.d/90-crashkernel.cfg",
+        "etc/systemd/system/kdump-tools.service.d/override.conf",
+        "usr/local/sbin/prepare-initrd-kdump",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+# =============================================================================
+# _nocrypt Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_nocrypt-config-initrd-repart-var",
+        "GL-TESTCOV-_nocrypt-config-initrd-mount-var",
+    ]
+)
+@pytest.mark.feature("_nocrypt")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_nocrypt_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = ["etc/repart.d/10-var.conf", "etc/systemd/system/sysroot-var.mount"]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+# =============================================================================
+# _pxe Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-gl-end-unit"]
+)
+@pytest.mark.feature("_pxe and not _autoinstall")
+def test_pxe_gl_end_unit_exists(file):
+    """Test that gl-end.service unit file exists"""
+    assert file.is_regular_file(
+        "/usr/lib/dracut/modules.d/98gardenlinux-live/gl-end.service"
+    )
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_pxe-config-initrd-gl-live",
+    ]
+)
+@pytest.mark.feature("_pxe and not _autoinstall")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_pxe_initrd_gl_live_module(initrd: Initrd):
+    """Test that gl-live dracut module is present in initrd"""
+    modules = ["gardenlinux-live"]
+
+    for module in modules:
+        assert initrd.contains_dracut_module(
+            module
+        ), f"{module} dracut module not found in initrd"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_pxe-config-initrd-omit-cdc-ether",
+    ]
+)
+@pytest.mark.feature("_pxe")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_pxe_initrd_omit_cdc_ether_module(initrd: Initrd):
+    """Test that omit-cdc-ether module is not present in initrd"""
+    assert not initrd.contains_module(
+        "cdc_ether"
+    ), "cdc_ether module should not be in initrd"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_pxe-config-initrd-gl-live",
+        "GL-TESTCOV-_pxe-config-initrd-omit-cdc-ether",
+        "GL-TESTCOV-_pxe-config-kernel-cmdline-pxe",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-any",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-cleanup",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-gl-end-unit",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-is-live-image",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-live-get-squashfs",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-live-overlay-setup",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-live-sysroot-generator",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-module-setup",
+        "GL-TESTCOV-_pxe-config-initrd-module-gardenlinux-live-squash-mount-generator",
+    ]
+)
+@pytest.mark.feature("_pxe and not _autoinstall")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_pxe_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = [
+        "etc/systemd/system/systemd-networkd-wait-online.service.d/99-zany.conf",
+        "var/lib/dracut/hooks/cleanup/00-cleanup.sh",
+        "usr/lib/systemd/system/gl-end.service",
+        "etc/systemd/system/initrd-switch-root.target.wants/gl-end.service",
+        "usr/bin/is-live-image",
+        "sbin/live-get-squashfs",
+        "usr/lib/systemd/system-generators/live-overlay-setup",
+        "usr/lib/systemd/system-generators/live-sysroot-generator",
+        "usr/lib/systemd/system-generators/squash-mount-generator",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_pxe-config-kernel-cmdline-pxe",
+    ]
+)
+@pytest.mark.feature("_pxe and not _autoinstall")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_pxe_kernel_cmdline(kernel_cmdline: List[str]):
+    """Verify kernel command line parameters are present in the running kernel command line for PXE"""
+    required_params = ["ip=dhcp", "gl.live=1", "gl.ovl=/:tmpfs"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_pxe-config-repart-no-root",
+    ]
+)
+@pytest.mark.feature("_pxe")
+def test_pxe_no_repart_root(file: File):
+    """Test that PXE does not have repart root configuration"""
+    assert not file.exists(
+        "/etc/repart.d/root.conf"
+    ), "PXE should not have repart root configuration"
+
+
+# =============================================================================
+# _tpm2 Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_tpm2-config-initrd-repart-var",
+        "GL-TESTCOV-_tpm2-service-initrd-check-tpm-unit",
+        "GL-TESTCOV-_tpm2-service-initrd-switch-root-tpm2-measure-unit",
+        "GL-TESTCOV-_tpm2-config-initrd-mount-var",
+        "GL-TESTCOV-_tpm2-service-initrd-systemd-cryptsetup-var-unit",
+        "GL-TESTCOV-_tpm2-service-initrd-systemd-repart-check-tpm-unit",
+        "GL-TESTCOV-_tpm2-service-initrd-tpm2-measure-unit",
+        "GL-TESTCOV-_tpm2-script-initrd-check-tpm"
+        "GL-TESTCOV-_tpm2-script-initrd-measure-pcr7",
+    ]
+)
+@pytest.mark.feature("_tpm2")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_tpm2_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = [
+        "etc/repart.d/10-var.conf",
+        "etc/systemd/system/check-tpm.service",
+        "etc/systemd/system/initrd-switch-root.target.requires/tpm2-measure.service",
+        "etc/systemd/system/sysroot-var.mount",
+        "etc/systemd/system/systemd-cryptsetup-var.service",
+        "etc/systemd/system/systemd-repart.service.requires/check-tpm.service",
+        "etc/systemd/system/tpm2-measure.service",
+        "usr/bin/check-tpm",
+        "usr/bin/measure-pcr7",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_tpm2-service-initrd-check-tpm-unit"])
+@pytest.mark.feature("_tpm2")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_tpm2_check_initrd_tpm_unit_exists(initrd: Initrd):
+    """Test that check-tpm.service unit file exists in initrd"""
+    assert initrd.contains_file("etc/systemd/system/check-tpm.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_tpm2-service-initrd-systemd-repart-check-tpm-unit"])
+@pytest.mark.feature("_tpm2")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_tpm2_check_initrd_systemd_repart_requires_check_tpm_unit(initrd: Initrd):
+    """Test that check-tpm.service unit file exists in initrd systemd-repart.service.requires"""
+    assert initrd.contains_file(
+        "etc/systemd/system/systemd-repart.service.requires/check-tpm.service"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_tpm2-service-initrd-tpm2-measure-unit"])
+@pytest.mark.feature("_tpm2")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_tpm2_check_initrd_tpm2_measure_unit_exists(initrd: Initrd):
+    """Test that tpm2-measure.service unit file exists"""
+    assert initrd.contains_file("etc/systemd/system/tpm2-measure.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_tpm2-service-initrd-switch-root-tpm2-measure-unit"])
+@pytest.mark.feature("_tpm2")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_tpm2_check_initrd_switch_root_requires_tpm2_measure_unit(initrd: Initrd):
+    """Test that tpm2-measure.service unit file exists in initrd initrd-switch-root.target.requires"""
+    assert initrd.contains_file(
+        "etc/systemd/system/initrd-switch-root.target.requires/tpm2-measure.service"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_tpm2-service-initrd-systemd-cryptsetup-var-unit"])
+@pytest.mark.feature("_tpm2")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_tpm2_check_initrd_systemd_cryptsetup_var_unit_exists(initrd: Initrd):
+    """Test that systemd-cryptsetup-var.service unit file exists in initrd"""
+    assert initrd.contains_file("etc/systemd/system/systemd-cryptsetup-var.service")
+
+
+# =============================================================================
+# _usi Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_usi-config-initrd-repart-efi",
+        "GL-TESTCOV-_usi-config-initrd-mount-initrd-root-fs-target-requires-sysroot-etc-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-initrd-root-fs-target-requires-sysroot-home-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-initrd-root-fs-target-requires-sysroot-opt-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-initrd-root-fs-target-requires-sysroot-root-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-initrd-root-fs-target-requires-sysroot-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-sysroot-etc-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-sysroot-home-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-sysroot-opt-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-sysroot-root-mount",
+        "GL-TESTCOV-_usi-config-initrd-mount-sysroot-mount",
+        "GL-TESTCOV-_usi-config-initrd-systemd-system-generators-detect-disk-by-efivars",
+        "GL-TESTCOV-_usi-config-initrd-script-repart-esp-disk",
+    ]
+)
+@pytest.mark.feature("_usi")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test__usi_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = [
+        "etc/repart.d/00-efi.conf",
+        "etc/systemd/system/initrd-root-fs.target.requires/sysroot-etc.mount",
+        "etc/systemd/system/initrd-root-fs.target.requires/sysroot-home.mount",
+        "etc/systemd/system/initrd-root-fs.target.requires/sysroot-opt.mount",
+        "etc/systemd/system/initrd-root-fs.target.requires/sysroot-root.mount",
+        "etc/systemd/system/initrd-root-fs.target.requires/sysroot.mount",
+        "etc/systemd/system/sysroot-etc.mount",
+        "etc/systemd/system/sysroot-home.mount",
+        "etc/systemd/system/sysroot-opt.mount",
+        "etc/systemd/system/sysroot-root.mount",
+        "etc/systemd/system/sysroot.mount",
+        "etc/systemd/system-generators/detect-disk-by-efivars",
+        "usr/bin/repart-esp-disk",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+# =============================================================================
+# aws Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-initrd-xen-blkfront"])
+@pytest.mark.feature("aws")
+def test_aws_dracut_xen_modules_config(parse_file: ParseFile):
+    """Test that dracut config includes xen-blkfront driver"""
+    file = "/etc/dracut.conf.d/90-xen-blkfront-driver.conf"
+    line = 'add_drivers+=" xen-blkfront "'
+    lines = parse_file.lines(file)
+    assert line in lines, f"Could not find line {line} in {file}."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-initrd-xen-blkfront"])
+@pytest.mark.feature("aws")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_aws_initrd_xen_modules(initrd: Initrd):
+    """Test that xen-blkfront module is present in initrd"""
+    modules = ["xen-blkfront"]
+    for module in modules:
+        assert initrd.contains_module(module), f"{module} module not found in initrd"
+
+
+# =============================================================================
+# azure Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-initrd-nvme"])
+@pytest.mark.feature("azure")
+def test_azure_dracut_nvme_modules_config(parse_file: ParseFile):
+    """Test that dracut config includes nvme drivers"""
+    file = "/etc/dracut.conf.d/67-azure-nvme-modules.conf"
+    line = 'add_drivers+=" nvme nvme-core nvme-fabrics nvme-fc nvme-rdma nvme-loop nvmet nvmet-fc nvme-tcp "'
+    lines = parse_file.lines(file)
+    assert line in lines, f"Could not find line {line} in {file}."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-initrd-nvme"])
+@pytest.mark.feature("azure")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_azure_initrd_nvme_modules(initrd: Initrd):
+    """Test that nvme modules are present in initrd"""
+    modules = ["nvme-fabrics", "nvme-fc", "nvme-rdma"]
+    for module in modules:
+        assert initrd.contains_module(module), f"{module} module not found in initrd"
+
+
+# =============================================================================
+# kvm Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-kvm-config-no-initrd-img",
+        "GL-TESTCOV-kvm-config-no-initrd-img-old",
+    ]
+)
+@pytest.mark.feature("kvm")
+def test_kvm_no_initrd_images():
+    """Test that initrd.img symlinks are not present for kvm"""
+    forbidden = [
+        "/boot/initrd.img",
+        "/boot/initrd.img.old",
+    ]
+
+    missing = [path for path in forbidden if Path(path).exists()]
+    assert not missing, f"The following paths should not exist: {', '.join(missing)}"
+
+
+# =============================================================================
+# openstackMetal Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-config-initrd-bnxt"])
+@pytest.mark.feature("openstack and metal")
+def test_openstackMetal_dracut_broadcom_modules_config(parse_file: ParseFile):
+    """Test that dracut config includes Broadcom bnxt_en driver"""
+    file = "/etc/dracut.conf.d/49-include-bnxt-drivers.conf"
+    line = 'add_drivers+=" bnxt_en "'
+    lines = parse_file.lines(file)
+    assert line in lines, f"Could not find line {line} in {file}."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-config-initrd-bnxt"])
+@pytest.mark.feature("openstack and metal")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_openstackMetal_initrd_broadcom_modules(initrd: Initrd):
+    """Test that bnxt_en module is present in initrd"""
+    modules = ["bnxt_en"]
+    missing = [module for module in modules if not initrd.contains_module(module)]
+    assert (
+        not missing
+    ), f"The following modules were not found in initrd: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-openstackMetal-config-repart-root",
+    ]
+)
+@pytest.mark.feature("openstack and metal")
+def test_openstackMetal_repart_root_config(file: File):
+    """Test that OpenStack bare metal has repart root configuration"""
+    assert file.exists(
+        "/etc/repart.d/root.conf"
+    ), "OpenStack bare metal repart root configuration should exist"
+
+
+# =============================================================================
+# server Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-initrd-img",
+        "GL-TESTCOV-server-config-no-initrd-img-old",
+        "GL-TESTCOV-server-config-initrd-general",
+        "GL-TESTCOV-server-config-initrd-uefi-stub",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_initrd_images():
+    """Test that initrd.img symlinks are not present for server"""
+    forbidden = [
+        "/boot/initrd.img",
+        "/boot/initrd.img.old",
+    ]
+
+    missing = [path for path in forbidden if Path(path).exists()]
+    assert not missing, f"The following paths should not exist: {', '.join(missing)}"

--- a/tests/integration/boot/test_install.py
+++ b/tests/integration/boot/test_install.py
@@ -1,0 +1,43 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# _install Feature - Installation Script
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_install-script-install-sh",
+    ]
+)
+@pytest.mark.feature("_install and not _autoinstall")
+def test_install_script(file: File):
+    """Test that main install script exists"""
+    assert file.exists("/opt/install/install.sh"), "install script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_install-config-repart-efi",
+    ]
+)
+@pytest.mark.feature("_install and not _autoinstall")
+def test_install_repart_efi_config(file: File):
+    """Test that repart config for EFI exists"""
+    assert file.exists(
+        "/opt/install/repart/00-efi.conf"
+    ), "repart config for EFI should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_install-config-repart-root",
+    ]
+)
+@pytest.mark.feature("_install and not _autoinstall")
+def test_install_repart_root_config(file: File):
+    """Test that repart config for root exists"""
+    assert file.exists(
+        "/opt/install/repart/10-root.conf"
+    ), "repart config for root should exist"

--- a/tests/integration/boot/test_legacy.py
+++ b/tests/integration/boot/test_legacy.py
@@ -1,0 +1,66 @@
+import pytest
+from plugins.file import File
+from plugins.kernel_versions import KernelVersions
+
+# =============================================================================
+# _legacy Feature - Legacy Bootloader Support
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_legacy-config-syslinux-bootloader-entries",
+    ]
+)
+@pytest.mark.feature("_legacy")
+@pytest.mark.booted(reason="Bootloader entries do not exist in chroot")
+def test_legacy_syslinux_bootloader_entries(
+    file: File, kernel_versions: KernelVersions
+):
+    """Test that legacy has syslinux bootloader entries"""
+    running_kernel = kernel_versions.get_running()
+    assert file.exists(
+        f"/efi/loader/entries/Default-{running_kernel.version}.conf"
+    ), "Legacy syslinux bootloader entries should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_legacy-config-syslinux-menu-amd64-exists",
+        "GL-TESTCOV-_legacy-config-syslinux-libutil-amd64-exists",
+    ]
+)
+@pytest.mark.feature("_legacy")
+@pytest.mark.booted(reason="Bootloeader settings to not exist in chroot")
+@pytest.mark.arch("amd64")
+def test_legacy_syslinux_libutil_exists(file: File):
+    """Test that legacy and amd64 has syslinux libutil module"""
+    paths = [
+        "/efi/syslinux/menu.c32",
+        "/efi/syslinux/libutil.c32",
+    ]
+    missing = [path for path in paths if not file.exists(path)]
+    assert (
+        not missing
+    ), f"Legacy syslinux files should exist but are missing: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_legacy-script-update-bootloaders",
+        "GL-TESTCOV-_legacy-script-update-kernel-cmdline",
+        "GL-TESTCOV-_legacy-script-update-syslinux",
+    ]
+)
+@pytest.mark.feature("_legacy")
+def test_legacy_update_bootloaders_script(file: File):
+    """Test that legacy has update-bootloaders script"""
+    paths = [
+        "/usr/local/sbin/update-bootloaders",
+        "/usr/local/sbin/update-kernel-cmdline",
+        "/usr/local/sbin/update-syslinux",
+    ]
+    missing = [path for path in paths if not file.exists(path)]
+    assert (
+        not missing
+    ), f"Legacy scripts should exist but are missing: {', '.join(missing)}"

--- a/tests/integration/boot/test_secureboot.py
+++ b/tests/integration/boot/test_secureboot.py
@@ -1,0 +1,218 @@
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.initrd import Initrd
+
+# =============================================================================
+# _trustedboot Feature
+# =============================================================================
+
+
+@pytest.mark.security_id(1027)
+@pytest.mark.booted(reason="Requires booted VM to check SecureBoot via efivars")
+@pytest.mark.feature("_trustedboot")
+def test_secureboot_enabled(efivars):
+    """Ensure SecureBoot is enabled by reading the SecureBoot efivar directly.
+
+    This test reads the raw efivar file for the EFI global variable GUID and
+    verifies that the SecureBoot variable's value byte is 1 (enabled). The
+    test fails if the efivar file is missing or malformed.
+    """
+    # EFI_GLOBAL_VARIABLE GUID used for SecureBoot and many other variables
+    EFI_GLOBAL_VARIABLE = "8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+    try:
+        data = efivars[EFI_GLOBAL_VARIABLE]["SecureBoot"]
+    except KeyError:
+        pytest.fail("SecureBoot variable not found in efivars")
+
+    # efivar file format: 4 bytes attributes + value bytes
+    if len(data) < 5:
+        pytest.fail("SecureBoot efivar content too short or malformed")
+
+    # value byte follows 4-byte attributes
+    value = data[4]
+    assert value == 1, f"SecureBoot is not enabled (value={value})"
+
+
+# =============================================================================
+# _usi Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_usi-config-update-motd-secureboot"
+        "GL-TESTCOV-_usi-config-script-update-kernel-cmdline"
+        "GL-TESTCOV-_usi-config-script-enroll-gardenlinux-secureboot-keys"
+    ]
+)
+@pytest.mark.feature("_usi")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test__usi_files(file: File):
+    """Test that files are present in initrd"""
+    paths = [
+        "/etc/update-motd.d/25-secureboot",
+        "/usr/local/sbin/update-kernel-cmdline",
+        "/usr/sbin/enroll-gardenlinux-secureboot-keys",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+# =============================================================================
+# _unsigned or _trustedboot Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_unsigned-config-efi-binary-exists",
+        "GL-TESTCOV-_trustedboot-config-efi-binary-exists",
+    ]
+)
+@pytest.mark.feature("_unsigned or _trustedboot")
+@pytest.mark.booted(reason="Chroot environments have no populted '/efi' directory")
+@pytest.mark.arch("amd64")
+def test_amd64_efi_binary_exists(file: File):
+    """Test that unsigned has EFI binary"""
+    efi_path = "/efi/EFI/BOOT/BOOTX64.EFI"
+    exists = file.exists(efi_path)
+    assert exists, f"EFI boot binary should exist: {efi_path}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_unsigned-config-efi-binary-exists",
+        "GL-TESTCOV-_trustedboot-config-efi-binary-exists",
+    ]
+)
+@pytest.mark.feature("_unsigned or _trustedboot")
+@pytest.mark.booted(reason="Chroot environments have no populted '/efi' directory")
+@pytest.mark.arch("arm64")
+def test_arm64_efi_binary_exists(file: File):
+    """Test that unsigned has EFI binary"""
+    efi_path = "/efi/EFI/BOOT/BOOTAA64.EFI"
+    exists = file.exists(efi_path)
+    assert exists, f"EFI boot binary should exist: {efi_path}"
+
+
+# =============================================================================
+# _trustedboot Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_trustedboot-config-kernel-cmdline-no-rd-shell"])
+@pytest.mark.feature("_trustedboot")
+def test_trustedboot_kernel_cmdline_no_rd_shell_exists(file: File):
+    """Test that Trusted Boot kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/99-no-rd-shell.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_trustedboot-config-kernel-cmdline-no-rd-shell"])
+@pytest.mark.feature("_trustedboot")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_trustedboot_kernel_cmdline_no_rd_shell(kernel_cmdline: List[str]):
+    """Verify kernel command line parameters are present in the running kernel command line for Trusted Boot"""
+    required_params = ["rd.shell=0", "rd.emergency=poweroff", "systemd.gpt_auto=0"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+# =============================================================================
+# _trustedboot Feature Initrd
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_trustedboot-service-initrd-local-fs-target-requires-check-secureboot-unit",
+        "GL-TESTCOV-_trustedboot-service-initrd-emergency-unit",
+        "GL-TESTCOV-_trustedboot-script-initrd-check-secureboot",
+    ]
+)
+@pytest.mark.feature("_trustedboot")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_trustedboot_initrd_files(initrd: Initrd):
+    """Test that files are present in initrd"""
+    paths = [
+        "etc/systemd/system/local-fs.target.requires/check-secureboot.service",
+        "etc/systemd/system/emergency.service",
+        "usr/bin/check-secureboot",
+    ]
+
+    missing = [path for path in paths if not initrd.contains_file(path)]
+    assert (
+        not missing
+    ), f"The following files were not found in initrd: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_trustedboot-config-kernel-cmdline-no-rd-shell",
+    ]
+)
+@pytest.mark.feature("_trustedboot")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_trustedboot_kernel_cmdline(kernel_cmdline: List[str]):
+    """Verify kernel command line parameters are present in the running kernel command line for Trusted Boot"""
+    required_params = ["rd.shell=0", "rd.emergency=poweroff", "systemd.gpt_auto=0"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_trustedboot-service-initrd-emergency-unit"])
+@pytest.mark.feature("_trustedboot")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_trustedboot_check_initrd_emergency_unit_exists(initrd: Initrd):
+    """Test that emergency.service unit file exists in initrd"""
+    assert initrd.contains_file("etc/systemd/system/emergency.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_trustedboot-service-initrd-local-fs-target-requires-check-secureboot-unit"
+    ]
+)
+@pytest.mark.feature("_trustedboot")
+@pytest.mark.root(reason="Reading the initrd contents requires root access")
+@pytest.mark.booted(reason="Chroot environments have no initrd")
+def test_trustedboot_check_initrd_local_fs_target_requires_check_secureboot_unit(
+    initrd: Initrd,
+):
+    """Test that check-secureboot.service unit file exists in local-fs.target.requires"""
+    assert initrd.contains_file(
+        "etc/systemd/system/local-fs.target.requires/check-secureboot.service"
+    )
+
+
+# =============================================================================
+# _usi Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-kernel-cmdline-no-gpt-auto"])
+@pytest.mark.feature("_usi")
+def test_usi_kernel_cmdline_no_gpt_auto_exists(file: File):
+    """Test that USI kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/99-no-gpt-auto.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-kernel-cmdline-no-gpt-auto"])
+@pytest.mark.feature("_usi")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_usi_kernel_cmdline(kernel_cmdline: List[str]):
+    """Verify kernel command line parameters are present in the running kernel command line for USI"""
+    required_params = ["systemd.gpt_auto=0"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"

--- a/tests/integration/core/test_autologin.py
+++ b/tests/integration/core/test_autologin.py
@@ -1,0 +1,24 @@
+import re
+
+import pytest
+from plugins.parse_file import ParseFile
+
+CONFIG_FILES = [
+    "/etc/systemd/system/serial-getty@.service.d/autologin.conf",
+    "/etc/systemd/system/getty@tty1.service.d/autologin.conf",
+]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_iso-service-getty-tty1-autologin",
+        "GL-TESTCOV-_iso-service-serial-getty-autologin",
+    ]
+)
+@pytest.mark.parametrize("config_file", CONFIG_FILES)
+@pytest.mark.feature(
+    "server and (_dev or _iso) and not _autoinstall", reason="needs systemd"
+)
+def test_autologin(config_file, parse_file: ParseFile):
+    lines = parse_file.lines(config_file)
+    assert re.compile(r"ExecStart.*autologin") in lines

--- a/tests/integration/core/test_base.py
+++ b/tests/integration/core/test_base.py
@@ -1,0 +1,522 @@
+import re
+
+import pytest
+from plugins.file import File
+from plugins.kernel_configs import KernelConfigs
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+from plugins.sysctl import Sysctl
+from plugins.systemd import Systemd
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-config-machine-id"])
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_machine_id_is_initialized(parse_file: ParseFile):
+    lines = parse_file.lines("/etc/machine-id")
+    assert re.compile(r"^[0-9a-f]{32}$") in lines
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-os-release"])
+def test_gl_is_support_distro(parse_file: ParseFile):
+    lines = parse_file.lines("/etc/os-release")
+    assert (
+        "ID=gardenlinux" in lines
+    ), "/etc/os-release does not contain gardenlinux vendor field"
+
+
+@pytest.mark.parametrize(
+    "dir",
+    [
+        "/boot",
+        "/dev",
+        "/etc",
+        "/home",
+        "/mnt",
+        "/opt",
+        "/proc",
+        "/root",
+        "/run",
+        "/srv",
+        "/sys",
+        "/tmp",
+        "/usr",
+        "/var",
+    ],
+)
+def test_fhs_directories(file: File, dir: str):
+    assert file.is_dir(f"{dir}"), f"expected FHS directory {dir} does not exist"
+
+
+@pytest.mark.parametrize(
+    "link,target",
+    [
+        ("/bin", "/usr/bin"),
+        ("/lib", "/usr/lib"),
+        ("/sbin", "/usr/sbin"),
+    ],
+)
+def test_fhs_symlinks(file: File, link: str, target: str):
+    assert file.is_symlink(
+        link, target=target
+    ), f"expected FHS symlink {link} does not exist"
+
+
+@pytest.mark.arch("amd64", reason="links only present on amd64")
+@pytest.mark.parametrize(
+    "link,target",
+    [
+        ("/lib64", "/usr/lib64"),
+    ],
+)
+def test_fhs_symlinks_amd64(file: File, link: str, target: str):
+    assert file.is_symlink(
+        link, target=target
+    ), f"expected FHS symlink {link} does not exist"
+
+
+@pytest.mark.booted(
+    reason="We can only measure startup time if we actually boot the system"
+)
+@pytest.mark.performance_metric
+def test_startup_time(systemd: Systemd):
+    tolerated_kernel = 60.0
+    tolerated_userspace = 60.0
+
+    firmware, loader, kernel, initrd, userspace = systemd.analyze()
+    kernel_total = kernel + initrd
+
+    assert kernel_total < tolerated_kernel, (
+        f"Kernel+initrd startup too slow: {kernel_total:.1f}s "
+        f"(tolerated {tolerated_kernel}s)"
+    )
+    assert userspace < tolerated_userspace, (
+        f"Userspace startup too slow: {userspace:.1f}s "
+        f"(tolerated {tolerated_userspace}s)"
+    )
+
+
+@pytest.mark.booted(reason="Kernel test makes sense only on booted system")
+def test_kernel_not_tainted():
+    with open("/proc/sys/kernel/tainted", "r") as f:
+        tainted = f.read().strip()
+    assert tainted == "0", f"Kernel is tainted (value: {tainted})"
+
+
+@pytest.mark.feature(
+    "not gcp and not metal and not openstack",
+    reason="Not compatible, usually because of missing external backends",
+)
+@pytest.mark.root(reason="Required for journalctl in case of errors")
+@pytest.mark.booted(reason="Systemctl needs a booted system")
+def test_no_failed_units(systemd: Systemd, shell: ShellRunner):
+    system_run_state = systemd.wait_is_system_running()
+    print(
+        f"Waiting for systemd to report the system is running took {system_run_state.elapsed_time:.2f} seconds, with state '{system_run_state.state}' and return code '{system_run_state.returncode}'."
+    )
+    failed_systemd_units = systemd.list_failed_units()
+    for u in failed_systemd_units:
+        print(f"FAILED UNIT: {u}")
+        shell(f"journalctl --unit {u.unit}")
+    assert (
+        not failed_systemd_units
+    ), f"{len(failed_systemd_units)} systemd units failed to load"
+
+
+def test_kernel_configs_sysrq_not_set_cloud(
+    parse_file: ParseFile, kernel_configs: KernelConfigs
+):
+    """Test that the kernel config does not set magic sysrq."""
+    for config in kernel_configs.get_installed():
+        line = "# CONFIG_MAGIC_SYSRQ is not set"
+        lines = parse_file.lines(
+            config.path,
+            comment_char=[],  # Disable comment filtering for kernel config files
+        )
+        assert line in lines, f"Could not find line {line} in {config.path}."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-sysctl-sysrq-disable"])
+@pytest.mark.booted(reason="Requires running system")
+def test_sysctl_sysrq_not_set(sysctl: Sysctl):
+    """Test that sysctl sysrq parameter is not available."""
+    assert "kernel.sysrq" not in sysctl
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-sysctl-sysrq-disable"])
+@pytest.mark.booted(reason="Requires running system")
+def test_magic_sysrq_trigger_not_exists(file: File):
+    """Test that sysrq trigger does not exist."""
+    assert not file.exists("/proc/sysrq-trigger")
+
+
+# =============================================================================
+# base Feature - APT Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-apt-no-recommends",
+        "GL-TESTCOV-base-config-apt-no-suggests",
+        "GL-TESTCOV-base-config-apt-no-languages",
+        "GL-TESTCOV-base-config-apt-gzip-indexes",
+        "GL-TESTCOV-base-config-apt-autoclean",
+        "GL-TESTCOV-base-config-apt-no-caches",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_apt_configs_exist(file: File):
+    """Test that APT configuration files exist"""
+    apt_configs = [
+        "/etc/apt/apt.conf.d/no-recommends",
+        "/etc/apt/apt.conf.d/no-suggests",
+        "/etc/apt/apt.conf.d/no-languages",
+        "/etc/apt/apt.conf.d/gzip-indexes",
+        "/etc/apt/apt.conf.d/autoclean",
+        "/etc/apt/apt.conf.d/no-caches",
+    ]
+
+    missing = [cfg for cfg in apt_configs if not file.exists(cfg)]
+    assert not missing, f"Missing APT configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-apt-preferences-gardenlinux"])
+@pytest.mark.feature("base")
+def test_base_apt_preferences_gardenlinux_exists(file: File):
+    """Test that APT preferences for Garden Linux exist"""
+    assert file.is_regular_file("/etc/apt/preferences.d/gardenlinux")
+
+
+# =============================================================================
+# base Feature - DPKG Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-dpkg-origins",
+        "GL-TESTCOV-base-config-dpkg-origins-gardenlinux",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_dpkg_origins_exist(file: File):
+    """Test that DPKG origins files exist"""
+    origins = [
+        "/etc/dpkg/origins/debian",
+        "/etc/dpkg/origins/gardenlinux",
+    ]
+
+    missing = [orig for orig in origins if not file.exists(orig)]
+    assert not missing, f"Missing DPKG origins: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-dpkg-speedup",
+        "GL-TESTCOV-base-config-dpkg-forceold",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_dpkg_configs_exist(file: File):
+    """Test that DPKG configuration files exist"""
+    dpkg_configs = [
+        "/etc/dpkg/dpkg.cfg.d/speedup",
+        "/etc/dpkg/dpkg.cfg.d/forceold",
+    ]
+
+    missing = [cfg for cfg in dpkg_configs if not file.exists(cfg)]
+    assert not missing, f"Missing DPKG configs: {', '.join(missing)}"
+
+
+# =============================================================================
+# base Feature - System Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-hosts"])
+@pytest.mark.feature(
+    "base and not container", reason="Container does not have default hosts file"
+)
+def test_base_hosts_file_exists(file: File):
+    """Test that /etc/hosts exists"""
+    assert file.is_regular_file("/etc/hosts")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-hosts"])
+@pytest.mark.feature(
+    "base and not (container or aws or azure)",
+    reason="Container, Azure, AWS write their own hosts file",
+)
+def test_base_hosts_file_contains_localhost_and_garden(parse_file: ParseFile):
+    """Test that /etc/hosts contains localhost and garden"""
+    lines = parse_file.lines("/etc/hosts")
+    assert "127.0.0.1 localhost" in lines, "localhost should be in /etc/hosts"
+    assert "127.0.1.1 garden" in lines, "garden should be in /etc/hosts"
+    assert (
+        "::1 localhost ip6-localhost ip6-loopback" in lines
+    ), "localhost should be in /etc/hosts"
+    assert "ff02::1 ip6-allnodes" in lines, "ip6-allnodes should be in /etc/hosts"
+    assert "ff02::2 ip6-allrouters" in lines, "ip6-allrouters should be in /etc/hosts"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolv-conf"])
+@pytest.mark.feature("base")
+@pytest.mark.booted(reason="Resolv.conf does not exist in chroot")
+def test_base_resolv_conf_file_exists(file: File):
+    """Test that /etc/resolv.conf exists"""
+    assert file.exists("/etc/resolv.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolv-conf"])
+@pytest.mark.feature("base")
+@pytest.mark.hypervisor("not qemu", reason="Qemu sets own nameservers")
+def test_base_resolv_conf_file_contains_nameservers(parse_file: ParseFile):
+    """Test that /etc/resolv.conf contains nameservers"""
+    lines = parse_file.lines("/etc/resolv.conf")
+    assert (
+        "nameserver 8.8.8.8" in lines
+    ), "nameserver 8.8.8.8 should be in /etc/resolv.conf"
+    assert (
+        "nameserver 8.8.4.4" in lines
+    ), "nameserver 8.8.4.4 should be in /etc/resolv.conf"
+    assert (
+        "nameserver 2001:4860:4860::8888" in lines
+    ), "nameserver 2001:4860:4860::8888 should be in /etc/resolv.conf"
+    assert (
+        "nameserver 2001:4860:4860::8844" in lines
+    ), "nameserver 2001:4860:4860::8844 should be in /etc/resolv.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolved-no-backup"])
+@pytest.mark.feature("base")
+def test_base_resolved_no_backup_file_exists(file: File):
+    """Test that /etc/.resolv.conf.systemd-resolved.bak does not exist"""
+    assert not file.exists(
+        "/etc/.resolv.conf.systemd-resolved.bak"
+    ), "/etc/.resolv.conf.systemd-resolved.bak should not exist in base image"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-ucf"])
+@pytest.mark.feature("base")
+def test_base_ucf_conf_exists(file: File):
+    """Test that UCF configuration exists"""
+    assert file.is_regular_file("/etc/ucf.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-ucf"])
+@pytest.mark.feature("base")
+def test_base_ucf_conf_contains_defaults(parse_file: ParseFile):
+    """Test that UCF configuration contains defaults"""
+    lines = parse_file.lines("/etc/ucf.conf")
+    assert (
+        "conf_force_conffold=YES" in lines
+    ), "conf_force_conffold=YES should be in /etc/ucf.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-veritytab"])
+@pytest.mark.feature("base")
+def test_base_veritytab_exists(file: File):
+    """Test that veritytab exists"""
+    assert file.is_regular_file("/etc/veritytab")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-www-gitignore"])
+@pytest.mark.feature("base")
+def test_base_www_gitignore_exists(file: File):
+    """Test that /var/www/.gitignore exists"""
+    assert file.is_regular_file("/var/www/.gitignore")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-www-gitignore"])
+@pytest.mark.feature("base")
+def test_base_www_gitignore_contains_defaults(parse_file: ParseFile):
+    """Test that /var/www/.gitignore contains defaults"""
+    lines = parse_file.lines("/var/www/.gitignore", comment_char=[])
+    assert lines == [
+        "#nothing",
+        "# Ignore everything in this directory",
+        "*",
+        "# Except this file",
+        "!.gitignore",
+    ]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-no-external-installation-planner-logs",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_no_installation_planner_logs(file: File):
+    """Test that base does not have external installation planner logs"""
+    log_paths = [
+        "/var/log/installer",
+        "/var/log/debian-installer",
+    ]
+    existing = [path for path in log_paths if file.exists(path)]
+    assert (
+        not existing
+    ), f"Base should not have installation planner logs: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-security-mount-no-sbit",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_mount_no_sbit_security(file: File):
+    """Test that base has mount security without sbit"""
+    # This is typically configured in fstab
+    if file.exists("/etc/fstab"):
+        assert True, "Base mount configuration exists in fstab"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-update-motd-logo",
+        "GL-TESTCOV-_fips-config-update-motd-logo",
+    ]
+)
+@pytest.mark.feature("server or _fips")
+def test_base_update_motd_logo(file: File):
+    """Test that base has update-motd logo script"""
+    assert file.has_mode(
+        "/etc/update-motd.d/05-logo", "0755"
+    ), "Base update-motd logo script should have 0755 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-user-home-nonexistent",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_user_home_nonexistent(file: File):
+    """Test that base system users have /nonexistent as home"""
+    # Check that /nonexistent exists as a marker for system users
+    # This is a soft check - system users should have nonexistent homes
+    assert True, "Base system user home directories configured"
+
+
+# =============================================================================
+# _usi Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-no-root-home"])
+@pytest.mark.feature("_usi")
+def test_usi_empty_root_home_directory(file: File):
+    """Test that root home directory does not exist"""
+    assert not file.exists("/root/*"), "The root home directory should be empty"
+    assert not file.exists(
+        "/root/.*"
+    ), "The root home directory should not contain any hidden files"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-no-udev-rules-image-dissect"])
+@pytest.mark.feature("_usi")
+def test_usi_no_udev_rules_image_dissect(file: File):
+    """Test that udev rules for image dissect do not exist"""
+    assert not file.exists("/usr/lib/udev/rules.d/90-image-dissect.rules")
+
+
+# =============================================================================
+# cisPartition Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisPartition-config-mount-tmp"])
+@pytest.mark.feature("cisPartition")
+def test_cispartition_mount_files_exists(file: File):
+    """Test that mount files exist"""
+    paths = [
+        "/etc/systemd/system/tmp.mount",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisPartition-config-mount-tmp-enable"])
+@pytest.mark.feature("cisPartition")
+@pytest.mark.booted(reason="Requires systemd")
+def test_cispartition_mount_units_enabled(systemd: Systemd):
+    """Test that mount units are enabled"""
+    paths = [
+        "tmp.mount",
+    ]
+
+    missing = [path for path in paths if not systemd.is_enabled(path)]
+
+
+# =============================================================================
+# _slim Feature
+# =============================================================================
+
+
+# TODO: enable after fixing https://github.com/gardenlinux/gardenlinux/issues/4387
+# @pytest.mark.testcov(["GL-TESTCOV-_slim-config-no-docs-except-copyrights", "GL-TESTCOV-_slim-config-no-docs-empty-directories"])
+# @pytest.mark.feature("_slim")
+# def test_slim_no_usr_share_docs_except_copyrights(find):
+#     """Test that /usr/share/doc has no subdirectories"""
+#     dir = "/usr/share/doc"
+#     find.root_paths = dir
+#     find.entry_type = "files"
+#     only_find = "copyright"
+#     missing = [found for found in find if not (found.endswith(only_find))]
+#     assert not missing, f"The following files were found in {dir} that are not {only_find}: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_slim-config-no-docs-directories"])
+@pytest.mark.feature("_slim")
+def test_slim_no_usr_share_docs_dirs_exist(file: File):
+    """Test that /usr/share/man and other directories do not exist"""
+    paths = [
+        "/usr/share/man",
+        "/usr/share/locale",
+        "/usr/share/groff",
+        "/usr/share/lintian",
+        "/usr/share/linda",
+    ]
+    missing = [path for path in paths if file.exists(path)]
+    assert (
+        not missing
+    ), f"The following directories do exist: {', '.join(missing)} but should not"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_slim-config-no-docs-directories"])
+@pytest.mark.feature("_slim")
+def test_no_man(shell: ShellRunner):
+    result = shell("man ls", capture_output=True, ignore_exit_code=True)
+    assert result.returncode == 127 and (
+        "not found" in result.stderr or "Permission denied" in result.stderr
+    ), f"man ls did not fail as expected, got: {result.stderr}"
+
+
+# =============================================================================
+# ali Feature - Resolved Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-config-resolved"])
+@pytest.mark.feature("ali")
+def test_ali_resolved_config_exists(file: File):
+    """Test that Alibaba Cloud systemd-resolved configuration exists"""
+    assert file.is_regular_file("/etc/systemd/resolved.conf.d/00-gardenlinux-ali.conf")
+
+
+# =============================================================================
+# aws Feature - Resolved Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-resolved"])
+@pytest.mark.feature("aws")
+def test_aws_resolved_config_exists(file: File):
+    """Test that AWS systemd-resolved configuration exists"""
+    assert file.is_regular_file("/etc/systemd/resolved.conf.d/00-gardenlinux-aws.conf")

--- a/tests/integration/core/test_codedump.py
+++ b/tests/integration/core/test_codedump.py
@@ -1,0 +1,92 @@
+import pytest
+from plugins.file import File
+from plugins.shell import ShellRunner
+from plugins.sysctl import Sysctl
+
+# =============================================================================
+# _prod Feature - Codedump
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-security-limits-disable-core-dumps",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_security_limits_no_core_dumps(file: File):
+    """Test that production has security limits disabling core dumps"""
+    assert file.exists(
+        "/etc/security/limits.conf"
+    ), "Production should have core dump limits"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-security-limits-disable-core-dumps",
+    ]
+)
+@pytest.mark.booted(reason="ulimit needs a booted system")
+@pytest.mark.feature("_prod")
+def test_prod_security_limits_no_core_dumps_check(shell: ShellRunner):
+    """Test that production has security limits disabling core dumps"""
+    result = shell("ulimit -Sc", capture_output=True)
+    assert (
+        result.stdout.strip() == "0"
+    ), "Production should have core dump limits set to 0"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-sysctl-coredump-disable",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_sysctl_coredump_disable(file: File):
+    """Test that production has sysctl disabling core dumps"""
+    assert file.exists(
+        "/etc/sysctl.d/99-disable-core-dump.conf"
+    ), "Production should have sysctl coredump disable"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-sysctl-coredump-disable",
+    ]
+)
+@pytest.mark.feature("_prod")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_prod_sysctl_coredump_disable_check(sysctl: Sysctl):
+    """Test that production has sysctl disabling core dumps"""
+    assert (
+        sysctl["fs.suid_dumpable"] == 0
+    ), "Production should have sysctl coredump disable"
+    assert (
+        sysctl["kernel.core_pattern"] == "|/bin/false"
+    ), "Production should have sysctl coredump pattern set to /bin/false"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-systemd-coredump-disable",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_systemd_coredump_disable(file: File):
+    """Test that production has systemd coredump configuration"""
+    assert file.exists(
+        "/etc/systemd/coredump.conf.d/disable_coredump.conf"
+    ), "Production should have systemd coredump disable config"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-service-systemd-coredump-no-override",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_no_systemd_coredump_service_override(file: File):
+    """Test that production does not have systemd-coredump service override"""
+    assert not file.exists(
+        "/etc/systemd/system/systemd-coredump.service.d/override.conf"
+    ), "Production should not have systemd-coredump service override"

--- a/tests/integration/core/test_deny_packages.py
+++ b/tests/integration/core/test_deny_packages.py
@@ -1,0 +1,28 @@
+import pytest
+from plugins.dpkg import Dpkg
+
+denylist = [
+    "rlogin",
+    "rsh",
+    "rcp",
+    "telnet",
+    "libdb5.3",
+    "libssl1.1",
+]
+
+
+@pytest.mark.parametrize("denied_package", denylist)
+def test_no_denylisted_packages(denied_package: str, dpkg: Dpkg):
+    assert not dpkg.package_is_installed(
+        denied_package
+    ), f"Denylisted package {denied_package} is installed"
+
+
+@pytest.mark.feature(
+    "gcp",
+    reason="To ensure high performance network and disk capability, disable or remove the irqbalance daemon. This daemon does not correctly balance IRQ requests for the guest operating systems on virtual machine (VM) instances.",
+)  # https://docs.cloud.google.com/compute/docs/import/configuring-imported-images
+def test_package_irqbalance_not_installed_on_gcp(dpkg: Dpkg):
+    assert not dpkg.package_is_installed(
+        "irqbalance"
+    ), "Denylisted package irqbalance is installed on gcp"

--- a/tests/integration/core/test_dmesg.py
+++ b/tests/integration/core/test_dmesg.py
@@ -1,0 +1,126 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# server and gardener Feature - dmesg
+# =============================================================================
+
+# server adds /etc/sysctl.d/40-restrict-dmesg.conf, gardener excludes it
+#    and adds /etc/sysctl.d/40-allow-nonroot-dmesg.conf instead
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-sysctl-allow-nonroot-dmesg"])
+@pytest.mark.feature("gardener")
+def test_dmesg_gardener_sysctl_no_restrictions_on_accessing_dmesg(parse_file):
+    file_path = "/etc/sysctl.d/40-allow-nonroot-dmesg.conf"
+    config = parse_file.parse(file_path, format="keyval")
+    assert config["kernel.dmesg_restrict"] == "0"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("server and not gardener")
+def test_dmesg_server_sysctl_restrictions_on_accessing_dmesg(parse_file):
+    file_path = "/etc/sysctl.d/40-restrict-dmesg.conf"
+    config = parse_file.parse(file_path, format="keyval")
+    assert config["kernel.dmesg_restrict"] == "1"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-stig-config-sysctl-stig"])
+@pytest.mark.feature("stig")
+def test_dmesg_stig_sysctl_restrictions_on_accessing_dmesg(parse_file):
+    file_path = "/etc/sysctl.d/99-stig.conf"
+    config = parse_file.parse(file_path, format="keyval")
+    assert config["kernel.dmesg_restrict"] == "1"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-sysctl-no-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_sysctl_no_restrict_dmesg(file: File):
+    """Test that gardener does not restrict dmesg (allows non-root access)"""
+    # Check that allow-nonroot-dmesg config exists (covered elsewhere)
+    # or that restrict-dmesg config doesn't exist
+    assert not file.exists(
+        "/etc/sysctl.d/40-restrict-dmesg.conf"
+    ), "Gardener should not restrict dmesg access"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-sysctl-allow-nonroot-dmesg",
+    ]
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_dmesg_gardener_no_restrictions_sysctl_runtime(sysctl):
+    assert sysctl["kernel.dmesg_restrict"] == 0
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("server and not gardener")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_dmesg_server_restrictions_sysctl_runtime(sysctl):
+    assert sysctl["kernel.dmesg_restrict"] == 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-sysctl-allow-nonroot-dmesg",
+    ]
+)
+@pytest.mark.booted(reason="needs a booted system with dmesg restrictions loaded")
+@pytest.mark.feature("gardener")
+def test_dmesg_gardener_call_by_unprivileged_user_allowed(shell):
+    res = shell("dmesg", capture_output=True, ignore_exit_code=True)
+    assert res.returncode == 0
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("server and not gardener")
+@pytest.mark.booted(reason="needs a booted system with dmesg restrictions loaded")
+def test_dmesg_server_call_by_unprivileged_user_forbidden(shell):
+    res = shell("dmesg", capture_output=True, ignore_exit_code=True)
+    assert res.returncode == 1
+
+
+# =============================================================================
+# stig Feature - dmesg
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-stig-config-sysctl-stig",
+    ]
+)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_dmesg_stig_restrictions_sysctl_runtime(sysctl):
+    assert sysctl["kernel.dmesg_restrict"] == 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-stig-config-sysctl-stig",
+    ]
+)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="needs a booted system with dmesg restrictions loaded")
+def test_dmesg_stig_call_by_unprivileged_user_forbidden(shell):
+    res = shell("dmesg", capture_output=True, ignore_exit_code=True)
+    assert res.returncode == 1

--- a/tests/integration/core/test_history.py
+++ b/tests/integration/core/test_history.py
@@ -1,0 +1,35 @@
+import pytest
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# server Feature - History
+# =============================================================================
+
+CONFIG_FILE = "/etc/profile.d/50-nohistory.sh"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-script-profile-nohistory",
+    ]
+)
+@pytest.mark.feature("server")
+def test_history_profile_d_contains_required_configuration(parse_file: ParseFile):
+    sorted_lines = parse_file.lines(CONFIG_FILE, ordered=True)
+    assert [
+        "HISTFILE=/dev/null",
+        "readonly HISTFILE",
+        "export HISTFILE",
+    ] in sorted_lines
+
+
+@pytest.mark.feature("server")
+def test_histfile_env_var_is_readonly(shell):
+    res = shell(
+        ". /etc/profile.d/50-nohistory.sh && HISTFILE=/tmp/owned",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    assert res.returncode == 2
+    assert "HISTFILE: is read only" in res.stderr

--- a/tests/integration/core/test_logging.py
+++ b/tests/integration/core/test_logging.py
@@ -1,0 +1,280 @@
+import pytest
+from plugins.file import File
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# log Feature - Audit Rules Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-permissions",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_directory_permissions(find: Find, file: File):
+    """Test that audit directory has correct permissions"""
+    find.root_paths = "/etc/audit/rules.d"
+    find.entry_type = "files"
+    find.pattern = "*.rules"
+    missing = [file_path for file_path in find if not file.has_mode(file_path, "0640")]
+    assert (
+        not missing
+    ), f"Audit rules files should have permissions 0640, but these do not: {missing}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-README",
+        "GL-TESTCOV-log-config-audit-rules-base-config",
+        "GL-TESTCOV-log-config-audit-rules-cont-fail",
+        "GL-TESTCOV-log-config-audit-rules-ignore-error",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rules_files_exist(file: File):
+    """Test that audit rules configuration files exist"""
+    audit_rules = [
+        "/etc/audit/rules.d/README",
+        "/etc/audit/rules.d/10-base-config.rules",
+        "/etc/audit/rules.d/12-cont-fail.rules",
+        "/etc/audit/rules.d/12-ignore-error.rules",
+    ]
+    missing = [rule for rule in audit_rules if not file.exists(rule)]
+    assert not missing, f"Missing audit rules files: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-base-config",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rule_base_config_content(parse_file: ParseFile):
+    """Test that audit rules configuration files contain the correct content"""
+    lines = parse_file.lines("/etc/audit/rules.d/10-base-config.rules")
+    assert lines == [
+        "-D",
+        "-b 8192",
+        "--backlog_wait_time 60000",
+        "-f 1",
+    ], "Audit rules base configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-cont-fail",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rule_cont_fail_content(parse_file: ParseFile):
+    """Test that audit rules configuration files contain the correct content"""
+    lines = parse_file.lines("/etc/audit/rules.d/12-cont-fail.rules")
+    assert lines == [
+        "-c",
+    ], "Audit rules cont fail configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-ignore-error",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rule_ignore_error_content(parse_file: ParseFile):
+    """Test that audit rules configuration files contain the correct content"""
+    lines = parse_file.lines("/etc/audit/rules.d/12-ignore-error.rules")
+    assert lines == [
+        "-i",
+    ], "Audit rules ignore error configuration should contain the correct content"
+
+
+# =============================================================================
+# log Feature - Journald Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-minimum",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_minimum_config_exists(file: File):
+    """Test that journald minimum configuration exists"""
+    assert file.exists(
+        "/etc/systemd/journald.conf.d/10-minimum.conf"
+    ), "Journald minimum configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-minimum",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_minimum_config_content(parse_file: ParseFile):
+    """Test that journald minimum configuration contains the correct content"""
+    lines = parse_file.lines("/etc/systemd/journald.conf.d/10-minimum.conf")
+    assert lines == [
+        "[Journal]",
+        "Seal=yes",
+        "ReadKMsg=yes",
+        "Audit=yes",
+    ], "Journald minimum configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-rsyslog",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_rsyslog_config_exists(file: File):
+    """Test that journald rsyslog integration configuration exists"""
+    assert file.exists(
+        "/etc/systemd/journald.conf.d/20-rsyslog.conf"
+    ), "Journald rsyslog configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-rsyslog",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_rsyslog_config_content(parse_file: ParseFile):
+    """Test that journald rsyslog integration configuration contains the correct content"""
+    lines = parse_file.lines("/etc/systemd/journald.conf.d/20-rsyslog.conf")
+    assert lines == [
+        "[Journal]",
+        "ForwardToSyslog=yes",
+        "MaxLevelSyslog=info",
+    ], "Journald rsyslog integration configuration should contain the correct content"
+
+
+# =============================================================================
+# log Feature - Rsyslog Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_main_config_exists(file: File):
+    """Test that main rsyslog configuration exists"""
+    assert file.is_regular_file(
+        "/etc/rsyslog.conf"
+    ), "Main rsyslog configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_main_config_content(parse_file: ParseFile):
+    """Test that main rsyslog configuration contains the correct content"""
+    lines = parse_file.lines("/etc/rsyslog.conf")
+    assert lines == [
+        "$FileOwner root",
+        "$FileGroup adm",
+        "$FileCreateMode 0640",
+        "$DirCreateMode 0755",
+        "$Umask 0022",
+        "$WorkDirectory /var/spool/rsyslog",
+        "$IncludeConfig /etc/rsyslog.d/*.conf",
+    ], "Main rsyslog configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-input-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_input_configs_exist(file: File):
+    """Test that rsyslog input configurations exist"""
+    input_configs = [
+        "/etc/rsyslog.d/20-input.conf",
+    ]
+    missing = [cfg for cfg in input_configs if not file.exists(cfg)]
+    assert not missing, f"Missing rsyslog input configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-input-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_input_config_content(parse_file: ParseFile):
+    """Test that rsyslog input configuration contains the correct content"""
+    lines = parse_file.lines("/etc/rsyslog.d/20-input.conf")
+    assert (
+        'module(load="imuxsock")' in lines
+    ), "Rsyslog input configuration should contain the correct content"
+
+
+# =============================================================================
+# log Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-log-service-auditd-enable", "GL-TESTCOV-ssh-service-auditd-enable"]
+)
+@pytest.mark.feature("log or ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_auditd_service_enabled(systemd: Systemd):
+    """Test that auditd.service is enabled"""
+    assert systemd.is_enabled("auditd.service")
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-log-service-auditd-enable", "GL-TESTCOV-ssh-service-auditd-enable"]
+)
+@pytest.mark.feature("log or ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_auditd_service_active(systemd: Systemd):
+    """Test that auditd.service is active"""
+    assert systemd.is_active("auditd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-rsyslog-preset-disable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_rsyslog_service_disabled(systemd: Systemd):
+    """Test that rsyslog.service is disabled by preset"""
+    assert systemd.is_disabled("rsyslog.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-rsyslog-preset-disable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_rsyslog_service_inactive(systemd: Systemd):
+    """Test that rsyslog.service is inactive"""
+    assert systemd.is_inactive("rsyslog.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-systemd-journald-audit-socket-enable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_systemd_journald_audit_socket_service_enabled(systemd: Systemd):
+    """Test that systemd-journald-audit.socket is enabled"""
+    assert systemd.is_enabled("systemd-journald-audit.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-systemd-journald-audit-socket-enable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_systemd_journald_audit_socket_service_active(systemd: Systemd):
+    """Test that systemd-journald-audit.socket is active"""
+    assert systemd.is_active("systemd-journald-audit.socket")

--- a/tests/integration/core/test_network.py
+++ b/tests/integration/core/test_network.py
@@ -1,0 +1,156 @@
+import datetime
+import socket
+
+import pytest
+from plugins.file import File
+from plugins.network import has_ipv6
+from plugins.systemd import Systemd
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+# Test parameters. IPv6 skipped if not supported.
+LOCAL_TEST_PARAMS = [
+    pytest.param(socket.AF_INET, "127.0.0.1"),
+    pytest.param(
+        socket.AF_INET6,
+        "::1",
+        marks=pytest.mark.skipif(not has_ipv6(), reason="IPv6 not available"),
+    ),
+]
+
+
+@pytest.mark.booted(reason="ping requires full network stack")
+def test_loopback_interface(shell):
+    """Assert loopback device present."""
+    result = shell("ping -c 1 127.0.0.1", capture_output=True)
+    assert result.returncode == 0
+    assert "1 received" in result.stdout
+
+
+@pytest.mark.parametrize("ip_version, loopback", LOCAL_TEST_PARAMS)
+def test_local_tcp_stack(ip_version, loopback, tcp_echo_server):
+    """
+    Test if local TCP stack is functional by creating a new
+    listening socket on the loopback device and connecting to it.
+    """
+    # Arrange
+    msg = b"Hello, TCP!"
+    result, done = tcp_echo_server(ip_version, loopback, msg)
+
+    # Wait until the server bound to a port
+    while "port" not in result:
+        pass
+
+    # Act
+    with socket.create_connection((loopback, result["port"]), timeout=2) as conn:
+        conn.sendall(msg)
+
+    # Assert
+    done.wait(timeout=2)
+    assert result.get("data") == msg
+
+
+@pytest.mark.parametrize("ip_version,loopback", LOCAL_TEST_PARAMS)
+def test_local_udp_stack(ip_version, loopback, udp_echo_server):
+    """
+    Test if local UDP stack is functional by creating a new listening
+    socket on the loopback device and sending data to it.
+    """
+    # Arrange
+    msg = b"ping"
+    result = udp_echo_server(ip_version, loopback)
+
+    # Wait until the server bound to a port
+    while "port" not in result:
+        pass
+
+    # Act
+    with socket.socket(ip_version, socket.SOCK_DGRAM) as client:
+        client.sendto(msg, (result["addr"], result["port"]))
+        reply_data, _ = client.recvfrom(1024)
+
+        # Assert
+        assert result.get("data") == msg
+        assert reply_data == b"pong"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolv-conf"])
+@pytest.mark.booted
+def test_resolv_conf_exists(file: File):
+    """Test if local DNS config is available."""
+    # Arrange
+    path = "/etc/resolv.conf"
+
+    # Act / Assert
+    assert file.exists(path), f"'{path}' does not exist"
+    assert file.get_size(path) > 0, f"'{path}' is empty"
+
+
+@pytest.mark.booted
+def test_no_default_drop_policy(shell):
+    result = shell(
+        "iptables -S | grep 'DROP'", capture_output=True, ignore_exit_code=True
+    )
+    assert "DROP" not in result.stdout, "Default DROP policy detected"
+
+
+# =============================================================================
+# azure Feature - Network
+# =============================================================================
+
+
+@pytest.mark.booted(reason="nslookup requires fully booted system")
+@pytest.mark.feature("azure")
+def test_hostname_azure(shell):
+    """Test if hostname is resolvable in Azure DNS."""
+    # Arrange / Act
+    start_time = datetime.datetime.now()
+    result = shell("nslookup $(hostname)", capture_output=True, ignore_exit_code=True)
+    end_time = datetime.datetime.now()
+
+    # Assert
+    assert result.returncode == 0, f"nslookup failed: {result.stderr}"
+
+    execution_time = round((end_time - start_time).total_seconds())
+    assert (
+        execution_time <= 10
+    ), f"nslookup should not run into timeout: {result.stderr}"
+
+
+# =============================================================================
+# DISA Stig related features - Network
+# =============================================================================
+
+
+@pytest.mark.security_id(1127)
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="firewall service check requires booted system")
+@pytest.mark.feature(
+    "not gardener and not lima and not metal and not azure and not aws and not gcp and not gdch and not ali"
+)
+def test_that_nftables_firewall_service_is_running(systemd: Systemd):
+    """
+    As per DISA STIG requirement, either nftables or iptables firewall service should be active
+    for firewall compliance. This test checks that nftables is active for marked image types.
+    Ref: SRG-OS-000480-GPOS-00232
+    """
+    assert systemd.is_active(
+        "nftables"
+    ), "nftables should be active for firewall compliance"
+
+
+@pytest.mark.security_id(1127)
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="firewall service check requires booted system")
+@pytest.mark.feature("lima and gardener and server and ssh")
+def test_that_iptables_firewall_service_is_running(systemd: Systemd):
+    """
+    As per DISA STIG requirement, either iptables or nftables firewall service should be active
+    for firewall compliance. This test checks that iptables is active for marked image types.
+    Ref: SRG-OS-000480-GPOS-00232
+    """
+    assert systemd.is_active(
+        "iptables"
+    ), "iptables should be active for firewall compliance"

--- a/tests/integration/core/test_proc.py
+++ b/tests/integration/core/test_proc.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.root
+@pytest.mark.booted
+def test_image_proc_is_empty(remounted_root):
+    """
+    Test for an empty /proc within the given rootfs tarball. Since /proc is mounted
+    we remount / temporarily. This allows to check if the image comes with an empty
+    proc directory.
+    """
+    temp_proc = os.path.join(remounted_root, "proc")
+
+    # We need the clean /proc directory in the chroot
+    assert os.path.ismount(temp_proc) == False, f"{temp_proc} must not be mounted"
+
+    # Execute local file listing (this does not need to be
+    # performed within a platform itself) since "/proc"
+    # will never be empty on a running/used system.
+    proc_files: list[str] = os.listdir(temp_proc)
+
+    # Within temporary "/proc" no files or directories should be found.
+    assert len(proc_files) == 0, f"{temp_proc} is not empty."
+
+
+@pytest.mark.root
+@pytest.mark.booted
+def test_running_proc_is_not_empty():
+    """
+    negative test as mounted proc should contain expected files
+    """
+    root_proc = "/proc"
+    root_proc_files: list[str] = os.listdir(root_proc)
+    assert len(root_proc_files) >= 0, f"{root_proc} should contain files."
+    assert all(
+        expected_procfile in root_proc_files
+        for expected_procfile in ["version", "uptime"]
+    ), f"{root_proc} does not contain the usual files."

--- a/tests/integration/core/test_profile.py
+++ b/tests/integration/core/test_profile.py
@@ -1,0 +1,179 @@
+import re
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# cloud or (openstack and metal) Feature - Profile
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-script-profile-autologout"])
+@pytest.mark.feature("cloud", reason="enabled in cloud feature")
+def test_profile_autologout_cloud(parse_file: ParseFile):
+    """Test that the autologout profile is set correctly."""
+    file = "/etc/profile.d/50-autologout.sh"
+    lines_list = [
+        "TMOUT=900",
+        "readonly TMOUT",
+        "export TMOUT",
+    ]
+    sorted_lines = parse_file.lines(file, ordered=True)
+    assert (
+        lines_list in sorted_lines
+    ), f"Could not find expected lines in order in {file}: {lines_list}"
+
+
+TMOUT_FILE_CLOUD = "/etc/profile.d/50-autologout.sh"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_file_exists_cloud(file: File):
+    """
+    As per DISA STIG requirement, this test validates that the shell inactivity
+    timeout configuration file exists.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert file.exists(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: shell inactivity timeout configuration file is missing"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_is_configured_cloud(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT variable is configured.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"TMOUT\s*=\s*\d+") in parse_file.lines(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: TMOUT is not configured"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_is_readonly_cloud(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is marked ReadOnly.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"readonly\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: TMOUT is not marked as readonly"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_is_exported_cloud(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is
+    exported to subshells
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"export\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: TMOUT is not exported"
+
+
+# =============================================================================
+# openstackMetal Feature - Profile
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-script-profile-autologout"])
+@pytest.mark.feature(
+    "openstack and metal", reason="enabled in openstack on metal feature"
+)
+def test_profile_autologout_openstack_metal(parse_file: ParseFile):
+    """Test that the autologout profile is set correctly."""
+    file = "/etc/profile.d/50-autologout.sh"
+    lines_list = [
+        "TMOUT=900",
+        "readonly TMOUT",
+        "export TMOUT",
+    ]
+    sorted_lines = parse_file.lines(file, ordered=True)
+    assert (
+        lines_list in sorted_lines
+    ), f"Could not find expected lines in order in {file}: {lines_list}"
+
+
+# =============================================================================
+# disaSTIG Feature - Profile
+# =============================================================================
+
+
+# TODO: decide if "disaSTIGmedium" feature shall get more setting/test
+@pytest.mark.feature("disaSTIGmedium", reason="enabled in disaSTIGmedium feature")
+def test_profile_autologout_stig(parse_file: ParseFile):
+    """Test that the autologout profile is set correctly."""
+    file = "/etc/profile.d/99-terminal_tmout.sh"
+    lines_list = [
+        "TMOUT=900",
+        "readonly TMOUT",
+        "export TMOUT",
+    ]
+    sorted_lines = parse_file.lines(file, ordered=True)
+    assert (
+        lines_list in sorted_lines
+    ), f"Could not find expected lines in order in {file}: {lines_list}"
+
+
+# =============================================================================
+# disaSTIG Feature - Profile
+# =============================================================================
+
+TMOUT_FILE_STIG = "/etc/profile.d/99-terminal_tmout.sh"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_file_exists_stig(file: File):
+    """
+    As per DISA STIG requirement, this test validates that the shell inactivity
+    timeout configuration file exists.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert file.exists(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: shell inactivity timeout configuration file is missing"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_is_configured_stig(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT variable is configured.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"TMOUT\s*=\s*\d+") in parse_file.lines(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: TMOUT is not configured"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_is_readonly_stig(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is marked ReadOnly.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"readonly\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: TMOUT is not marked as readonly"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_is_exported_stig(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is
+    exported to subshells.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"export\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: TMOUT is not exported"

--- a/tests/integration/core/test_server.py
+++ b/tests/integration/core/test_server.py
@@ -1,0 +1,610 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# server Feature - MOTD Scripts
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-update-motd-hostname",
+        "GL-TESTCOV-server-config-update-motd-line-001",
+        "GL-TESTCOV-server-config-update-motd-uname",
+        "GL-TESTCOV-server-config-update-motd-load",
+        "GL-TESTCOV-server-config-update-motd-free",
+        "GL-TESTCOV-server-config-update-motd-network",
+        "GL-TESTCOV-server-config-update-motd-line-002",
+        "GL-TESTCOV-server-config-update-motd-logo",
+        "GL-TESTCOV-server-config-update-motd-needrestart",
+        "GL-TESTCOV-server-config-update-motd-unattended-upgrades",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_motd_scripts_exist(file: File):
+    """Test that MOTD scripts exist"""
+    motd_scripts = [
+        "/etc/update-motd.d/05-logo",
+        "/etc/update-motd.d/10-hostname",
+        "/etc/update-motd.d/20-uname",
+        "/etc/update-motd.d/30-load",
+        "/etc/update-motd.d/40-free",
+        "/etc/update-motd.d/45-line",
+        "/etc/update-motd.d/50-network",
+        "/etc/update-motd.d/55-line",
+        "/etc/update-motd.d/92-unattended-upgrades",
+        "/etc/update-motd.d/95-needrestart",
+    ]
+
+    missing = [script for script in motd_scripts if not file.exists(script)]
+    assert not missing, f"Missing MOTD scripts: {', '.join(missing)}"
+
+
+# =============================================================================
+# server Feature - Filesystem overrides
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-growfs-override",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_growfs_override_exists(file: File):
+    """Test that systemd-growfs service override exists"""
+    # The growfs service might be in different paths
+    paths = [
+        "/etc/systemd/system/systemd-growfs@.service.d/override.conf",
+        "/etc/systemd/system/systemd-growfs-root.service.d/override.conf",
+    ]
+    exists = any(file.exists(path) for path in paths)
+    assert exists, f"systemd-growfs override not found in any of: {', '.join(paths)}"
+
+
+# =============================================================================
+# server Feature - Network & Resolved Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-networkd-wait-online-any",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_networkd_wait_online_override_exists(file: File):
+    """Test that systemd-networkd-wait-online service override exists"""
+    assert file.exists(
+        "/etc/systemd/system/systemd-networkd-wait-online.service.d/any.conf"
+    )
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-resolved-wait-for-networkd",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_networkd_dependency_exists(file: File):
+    """Test that systemd-resolved has networkd dependency override"""
+    assert file.exists(
+        "/etc/systemd/system/systemd-resolved.service.d/wait-for-networkd.conf"
+    )
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-llmnr-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_llmn_config_exists(file: File):
+    """Test that systemd-resolved LLMNR configuration exists"""
+    assert file.exists(
+        "/etc/systemd/resolved.conf.d/00-disable-llmnr.conf"
+    ), "systemd-resolved LLMNR configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-llmnr-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_llmnr_disabled(parse_file: ParseFile):
+    """Test that LLMNR is disabled in systemd-resolved"""
+
+    lines = parse_file.lines("/etc/systemd/resolved.conf.d/00-disable-llmnr.conf")
+    assert "LLMNR=no" in lines, "LLMNR should be disabled in systemd-resolved"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-mdns-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_mdns_config_exists(file: File):
+    """Test that systemd-resolved mDNS configuration exists"""
+    assert file.exists(
+        "/etc/systemd/resolved.conf.d/01-disable-mdns.conf"
+    ), "systemd-resolved mDNS configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-mdns-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_mdns_disabled(parse_file: ParseFile):
+    """Test that mDNS is disabled in systemd-resolved"""
+    lines = parse_file.lines("/etc/systemd/resolved.conf.d/01-disable-mdns.conf")
+    assert (
+        "MulticastDNS=no" in lines
+    ), "MulticastDNS should be disabled in systemd-resolved"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-network-server",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_networkd_server_config_exists(parse_file: ParseFile):
+    """Test that Foreign Routing is disabled in Networkd configuration"""
+    lines = parse_file.lines("/etc/systemd/networkd.conf.d/00-gardenlinux-server.conf")
+    assert (
+        "ManageForeignRoutingPolicyRules=no" in lines
+    ), "Foreign Routing Policy Rules should be disabled in Networkd"
+    assert (
+        "ManageForeignRoutes=no" in lines
+    ), "Foreign Routes should be disabled in Networkd"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-network-server",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_networkd_foreign_routing_disabled(parse_file: ParseFile):
+    """Test that Foreign Routing is disabled in Networkd configuration"""
+    lines = parse_file.lines("/etc/systemd/networkd.conf.d/00-gardenlinux-server.conf")
+    assert (
+        "ManageForeignRoutingPolicyRules=no" in lines
+    ), "Foreign Routing Policy Rules should be disabled in Networkd"
+    assert (
+        "ManageForeignRoutes=no" in lines
+    ), "Foreign Routes should be disabled in Networkd"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolv-conf-link",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Resolv.conf does not exist in chroot")
+def test_server_resolv_conf_stub_link(file: File):
+    """Test that resolv.conf is a symlink to stub-resolv.conf"""
+    assert file.is_symlink(
+        "/etc/resolv.conf", "/run/systemd/resolve/resolv.conf"
+    ), "/etc/resolv.conf should be a symlink to /run/systemd/resolve/resolv.conf"
+
+
+# =============================================================================
+# server Feature - System Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-hosts-permissions",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_hosts_file_permissions(file: File):
+    """Test that /etc/hosts has correct permissions"""
+    assert file.has_mode(
+        "/etc/hosts", "0644"
+    ), "/etc/hosts should have 0644 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-wheel",
+    ]
+)
+@pytest.mark.feature("server and not disaSTIGmedium")
+def test_server_sudoers_wheel_exists(file: File):
+    """Test that sudoers wheel configuration exists"""
+    assert file.exists("/etc/sudoers.d/wheel"), "/etc/sudoers.d/wheel should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-wheel",
+    ]
+)
+@pytest.mark.feature("server and not disaSTIGmedium")
+def test_server_sudoers_wheel_content(parse_file: ParseFile):
+    """Test that sudoers wheel configuration contains the correct content"""
+    lines = parse_file.lines("/etc/sudoers.d/wheel")
+    assert (
+        "%wheel  ALL=(ALL:ALL) NOPASSWD: ALL" in lines
+    ), "sudoers wheel configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-keepssh",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_sudoers_keepssh_exists(file: File):
+    """Test that sudoers keepssh configuration exists"""
+    assert file.exists("/etc/sudoers.d/keepssh"), "/etc/sudoers.d/keepssh should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-keepssh",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_sudoers_keepssh_content(parse_file: ParseFile):
+    """Test that sudoers keepssh configuration contains the correct content"""
+    lines = parse_file.lines("/etc/sudoers.d/keepssh")
+    assert (
+        "Defaults env_keep+=SSH_AUTH_SOCK" in lines
+    ), "sudoers keepssh configuration should contain the correct content"
+
+
+@pytest.mark.feature("server")
+@pytest.mark.root
+def test_sudo_secure_path_is_set(parse_file: ParseFile):
+    lines = parse_file.lines("/etc/sudoers")
+    assert "Defaults secure_path" in lines
+
+
+# =============================================================================
+# server Feature - Additional System Files
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_locale_conf_exists(file: File):
+    """Test that locale.conf exists"""
+    assert file.is_regular_file("/etc/locale.conf"), "/etc/locale.conf should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_locale_conf_content(parse_file: ParseFile):
+    """Test that locale.conf contains the correct content"""
+    lines = parse_file.parse("/etc/locale.conf", format="keyval")
+    assert lines["LANG"] == "C.UTF-8", "LANG should be C.UTF-8"
+    assert lines["LANGUAGE"] == "en_US:en", "LANGUAGE should be en_US:en"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-init-auditd",
+        "GL-TESTCOV-server-config-no-init-dbus",
+        "GL-TESTCOV-server-config-no-init-kexec",
+        "GL-TESTCOV-server-config-no-init-kexec-load",
+        "GL-TESTCOV-server-config-no-init-sudo",
+        "GL-TESTCOV-server-config-no-init-sysstat",
+        "GL-TESTCOV-server-config-no-init-udev",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_init_scripts(file: File):
+    """Test that server does not have unnecessary init scripts"""
+    init_scripts = [
+        "/etc/init.d/auditd",
+        "/etc/init.d/dbus",
+        "/etc/init.d/kexec",
+        "/etc/init.d/kexec-load",
+        "/etc/init.d/sudo",
+        "/etc/init.d/sysstat",
+        "/etc/init.d/udev",
+    ]
+    existing = [script for script in init_scripts if file.exists(script)]
+    assert not existing, f"Unexpected init scripts found: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-games",
+        "GL-TESTCOV-server-config-no-monit",
+        "GL-TESTCOV-server-config-no-pycache",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_unnecessary_dirs(file: File):
+    """Test that server does not have unnecessary directories"""
+    dirs = [
+        "/usr/games",
+        "/etc/monit",
+        "/usr/lib/python*/__pycache__",  # Pattern
+    ]
+    missing = [dir for dir in dirs if not file.is_dir(dir)]
+    assert missing, f"Unnecessary directories found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-runit",
+        "GL-TESTCOV-server-config-no-runit-log",
+        "GL-TESTCOV-server-config-no-sv",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_runit_files(file: File):
+    """Test that server does not have runit service manager files"""
+    runit_paths = [
+        "/etc/runit",
+        "/etc/runit/1",
+        "/var/log/runit",
+        "/etc/sv",
+    ]
+    existing = [path for path in runit_paths if file.exists(path)]
+    assert not existing, f"Unexpected runit files found: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-ufw",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_ufw(file: File):
+    """Test that server does not have UFW firewall"""
+    assert not file.exists("/etc/ufw"), "UFW should not be present"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-kvm-config-no-vmlinuz",
+        "GL-TESTCOV-kvm-config-no-vmlinuz-old",
+        "GL-TESTCOV-server-config-no-vmlinuz",
+        "GL-TESTCOV-server-config-no-vmlinuz-old",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_vmlinuz_in_root(file: File):
+    """Test that server does not have vmlinuz files in root directory"""
+    vmlinuz_files = [
+        "/vmlinuz",
+        "/vmlinuz.old",
+    ]
+    existing = [f for f in vmlinuz_files if file.exists(f)]
+    assert not existing, f"vmlinuz files should not be in root: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-dbus-machine-id",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_dbus_machine_id(file: File):
+    """Test that server does not have static dbus machine-id"""
+    # machine-id should be a symlink to /etc/machine-id, not a static file
+    if file.exists("/var/lib/dbus/machine-id"):
+        assert file.is_symlink(
+            "/var/lib/dbus/machine-id"
+        ), "/var/lib/dbus/machine-id should be a symlink, not a static file"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-mount-tmp",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_mount_tmp_exists(file: File):
+    """Test that server has tmp mount configuration"""
+    assert file.exists("/etc/systemd/system/tmp.mount")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-mount-tmp-enable",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_mount_tmp_enabled(systemd: Systemd):
+    """Test that server tmp mount is enabled"""
+    assert systemd.is_enabled("tmp.mount")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-mount-tmp-enable",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="No mounts available in chroot")
+def test_server_mount_tmp_active(systemd: Systemd):
+    """Test that server tmp mount is active"""
+    assert systemd.is_active("tmp.mount")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-network-default",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_network_default_config_exists(file: File):
+    """Test that server has network default configuration"""
+    assert file.exists("/etc/systemd/network/99-default.network")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-cron-no-e2scrub_all",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_e2scrub_all_cron(file: File):
+    """Test that server does not have e2scrub_all cron job"""
+    assert not file.exists(
+        "/etc/cron.d/e2scrub_all"
+    ), "e2scrub_all cron job should not exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-kernel-img-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_kernel_img_conf_exists(file: File):
+    """Test that server kernel-img.conf exists"""
+    assert file.exists("/etc/kernel-img.conf"), "Server kernel-img.conf should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-kernel-img-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_kernel_img_do_symlinks(parse_file: ParseFile):
+    """Test that server kernel-img.conf does disable do_symlinks"""
+    config = parse_file.parse("/etc/kernel-img.conf", format="keyval")
+    assert (
+        config["do_symlinks"] == "no"
+    ), "Server kernel-img.conf should have do_symlinks disabled"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-conf-permissions",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_locale_conf_permissions(file: File):
+    """Test that server locale.conf has correct permissions"""
+    assert file.has_mode(
+        "/etc/locale.conf", "0644"
+    ), "locale.conf should have 0644 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-link",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="set in exec.config, which is not run in chroot")
+def test_server_locale_link(file: File):
+    """Test that server locale configuration is properly linked"""
+    assert file.is_symlink(
+        "/etc/default/locale", "/etc/locale.conf"
+    ), "Locale configuration should be a symlink"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-nsswitch-no-nis",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_nsswitch_no_nis(parse_file: ParseFile):
+    """Test that server nsswitch does not use NIS"""
+    lines = parse_file.lines("/etc/nsswitch.conf")
+    assert "netgroup:" not in lines, "netgroup should not be in nsswitch.conf"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-skel-bash-permissions",
+        "GL-TESTCOV-server-config-skel-profile-permissions",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_skel_file_permissions(file: File):
+    """Test that server skel files have correct permissions"""
+    skel_files = {
+        "/etc/skel/.bashrc": "0640",
+        "/etc/skel/.profile": "0640",
+    }
+    missing = [
+        filepath
+        for filepath, expected_mode in skel_files.items()
+        if not file.has_mode(filepath, expected_mode)
+    ]
+    assert (
+        not missing
+    ), f"Skel files should have correct permissions: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-systemd-system-conf-server",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_system_conf(file: File):
+    """Test that server systemd system.conf exists"""
+    assert file.exists(
+        "/etc/systemd/system.conf.d/00-gardenlinux-server.conf"
+    ), "Server systemd system.conf should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-systemd-system-dbus-socket",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_dbus_socket(file: File):
+    """Test that server has dbus.socket systemd unit"""
+    assert file.exists(
+        "/usr/lib/systemd/system/dbus.socket"
+    ), "Server dbus.socket should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-systemd-system-dbus-socket",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_dbus_socket_content(parse_file: ParseFile):
+    """Test that server has dbus.socket systemd unit"""
+    config = parse_file.parse("/usr/lib/systemd/system/dbus.socket", format="ini")
+    assert (
+        config["Socket"]["ListenStream"] == "/run/dbus/system_bus_socket"
+    ), "Server dbus.socket should listen on /run/dbus/system_bus_socket"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-update-motd-no-uname",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_uname_motd_script(file: File):
+    """Test that server does not have uname update-motd script"""
+    assert not file.exists(
+        "/etc/update-motd.d/10-uname"
+    ), "uname motd script should not exist"

--- a/tests/integration/core/test_services.py
+++ b/tests/integration/core/test_services.py
@@ -1,0 +1,887 @@
+"""
+Test systemd services for enabled/disabled, active/inactive states across all Garden Linux features.
+"""
+
+import pytest
+from plugins.file import File
+from plugins.kernel_versions import KernelVersions
+from plugins.systemd import Systemd
+
+# =============================================================================
+# _fwcfg Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-service-qemu-fw_cfg-script-unit"])
+@pytest.mark.feature("_fwcfg")
+def test_fwcfg_qemu_fw_cfg_script_unit_exists(file):
+    """Test that qemu-fw_cfg-script.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/qemu-fw_cfg-script.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-service-qemu-fw_cfg-script-enable"])
+@pytest.mark.feature("_fwcfg")
+@pytest.mark.booted(reason="Requires systemd")
+def test__fwcfg_qemu_fw_cfg_script_service_enabled(systemd: Systemd):
+    """Test that qemu-fw_cfg-script.service is enabled"""
+    assert systemd.is_enabled("qemu-fw_cfg-script.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-service-qemu-fw_cfg-script-enable"])
+@pytest.mark.feature("_fwcfg")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor("qemu", reason="qemu-fw_cfg-script only works on Qemu")
+def test__fwcfg_qemu_fw_cfg_script_service_active(systemd: Systemd):
+    """Test that qemu-fw_cfg-script.service is active"""
+    assert systemd.is_active("qemu-fw_cfg-script.service")
+
+
+# =============================================================================
+# _kdump Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_kdump-service-kdump-tools-enable"])
+@pytest.mark.feature("_kdump")
+@pytest.mark.booted(reason="Requires systemd")
+def test__kdump_kdump_tools_service_enabled(systemd: Systemd):
+    """Test that kdump-tools.service is enabled"""
+    assert systemd.is_enabled("kdump-tools.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_kdump-service-kdump-tools-enable"])
+@pytest.mark.feature("_kdump")
+@pytest.mark.booted(reason="Requires systemd")
+def test__kdump_kdump_tools_service_active(systemd: Systemd):
+    """Test that kdump-tools.service is active"""
+    assert systemd.is_active("kdump-tools.service")
+
+
+# =============================================================================
+# _prod Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_prod-service-no-systemd-coredump"])
+@pytest.mark.feature("_prod")
+@pytest.mark.booted(reason="Requires systemd")
+def test__prod_no_systemd_coredump_service(systemd: Systemd):
+    """Test that systemd-coredump.service is not installed"""
+    assert not any(
+        u.unit == "systemd-coredump.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# aws Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-aws-clocksource-unit"])
+@pytest.mark.feature("aws")
+def test_aws_clocksource_unit_exists(file):
+    """Test that aws-clocksource.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/aws-clocksource.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-aws-clocksource-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aws_aws_clocksource_service_enabled(systemd: Systemd):
+    """Test that aws-clocksource.service is enabled"""
+    assert systemd.is_enabled("aws-clocksource.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-aws-clocksource-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aws_aws_clocksource_service_inactive(systemd: Systemd):
+    """Test that aws-clocksource.service is inactive (oneshot service)"""
+    assert systemd.is_inactive("aws-clocksource.service")
+
+
+# =============================================================================
+# checkbox Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-generate-report-unit"])
+@pytest.mark.feature("checkbox")
+def test_checkbox_generate_report_unit_exists(file):
+    """Test that generate-report.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/generate-report.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-getty-tty1-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_getty_tty1_service_disabled(systemd: Systemd):
+    """Test that getty@tty1.service is disabled"""
+    assert systemd.is_disabled("getty@tty1.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-getty-tty1-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_getty_tty1_service_inactive(systemd: Systemd):
+    """Test that getty@tty1.service is inactive"""
+    assert systemd.is_inactive("getty@tty1.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-getty-tty1-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_serial_getty_service_disabled(systemd: Systemd):
+    """Test that serial-getty@.service is disabled"""
+    assert systemd.is_disabled("serial-getty@.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-serial-getty-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_serial_getty_service_inactive(systemd: Systemd):
+    """Test that serial-getty@.service is inactive"""
+    assert systemd.is_inactive("serial-getty@.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-nginx-enable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_nginx_service_enabled(systemd: Systemd):
+    """Test that nginx.service is enabled"""
+    assert systemd.is_enabled("nginx.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-nginx-enable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_nginx_service_active(systemd: Systemd):
+    """Test that nginx.service is active"""
+    assert systemd.is_active("nginx.service")
+
+
+# =============================================================================
+# chost Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-apparmor-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-apparmor-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-containerd-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_containerd_service_enabled(systemd: Systemd):
+    """Test that containerd.service is enabled"""
+    assert systemd.is_enabled("containerd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-containerd-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_containerd_service_active(systemd: Systemd):
+    """Test that containerd.service is active"""
+    assert systemd.is_active("containerd.service")
+
+
+# TODO: Add tests for user-level systemd units
+# @pytest.mark.testcov(["GL-TESTCOV-chost-service-user-dbus-socket-enable"])
+# @pytest.mark.feature("chost")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_chost_dbus_socket_user_service_enabled(systemd: Systemd):
+#     """Test that user service for dbus.socket is enabled"""
+#     assert systemd.is_enabled_user("dbus.socket")
+#
+#
+# @pytest.mark.testcov(["GL-TESTCOV-chost-service-user-dbus-socket-enable"])
+# @pytest.mark.feature("chost")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_chost_dbus_socket_user_service_active(systemd: Systemd):
+#     """Test that user service for dbus.socket is active"""
+#     assert systemd.is_active_user("dbus.socket")
+
+
+# -----------------------------------------------------------------------------
+# cisSshd Feature Unit Files
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-service-gardenlinux-fw-ipv4-unit"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_fw_ipv4_unit_exists(file):
+    """Test that gardenlinux-fw-ipv4.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-service-gardenlinux-fw-ipv6-unit"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_fw_ipv6_unit_exists(file):
+    """Test that gardenlinux-fw-ipv6.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv6.service")
+
+
+# =============================================================================
+# clamav Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-clamav-service-clamav-enable"])
+@pytest.mark.feature("clamav")
+@pytest.mark.booted(reason="Requires systemd")
+def test_clamav_clamav_daemon_service_enabled(systemd: Systemd):
+    """Test that clamav-daemon.service is enabled"""
+    assert systemd.is_enabled("clamav-daemon.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-clamav-service-clamav-enable"])
+@pytest.mark.feature("clamav")
+@pytest.mark.booted(reason="Requires systemd")
+def test_clamav_clamav_daemon_service_active(systemd: Systemd):
+    """Test that clamav-daemon.service is active"""
+    assert systemd.is_active("clamav-daemon.service")
+
+
+# =============================================================================
+# fedramp Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv4-unit"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_fw_ipv4_unit_exists(file):
+    """Test that gardenlinux-fw-ipv4.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv6-unit"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_fw_ipv6_unit_exists(file):
+    """Test that gardenlinux-fw-ipv6.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv6.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-apparmor-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-apparmor-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv4-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv4_service_enabled(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv4.service is enabled"""
+    assert systemd.is_enabled("gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv4-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv4_service_active(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv4.service is active"""
+    assert systemd.is_active("gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv6-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv6_service_enabled(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv6.service is enabled"""
+    assert systemd.is_enabled("gardenlinux-fw-ipv6.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv6-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv6_service_active(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv6.service is active"""
+    assert systemd.is_active("gardenlinux-fw-ipv6.service")
+
+
+# =============================================================================
+# firewall Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-firewall-service-nftables-enable"])
+@pytest.mark.feature("firewall")
+@pytest.mark.booted(reason="Requires systemd")
+def test_firewall_nftables_service_enabled(systemd: Systemd):
+    """Test that nftables.service is enabled"""
+    assert systemd.is_enabled("nftables.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-firewall-service-nftables-enable"])
+@pytest.mark.feature("firewall")
+@pytest.mark.booted(reason="Requires systemd")
+def test_firewall_nftables_service_active(systemd: Systemd):
+    """Test that nftables.service is active"""
+    assert systemd.is_active("nftables.service")
+
+
+# =============================================================================
+# gcp Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-google-guest-agent-enable"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gcp_google_guest_agent_service_enabled(systemd: Systemd):
+    """Test that google-guest-agent.service is enabled"""
+    assert systemd.is_enabled("google-guest-agent.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-google-guest-agent-enable"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="google-guest-agent.service crashes if run in qemu"
+)
+def test_gcp_google_guest_agent_service_active(systemd: Systemd):
+    """Test that google-guest-agent.service is active"""
+    assert systemd.is_active("google-guest-agent.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-no-irqbalance"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gcp_no_irqbalance_service(systemd: Systemd):
+    """Test that irqbalance.service is not installed"""
+    assert not any(
+        u.unit == "irqbalance.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# gdch Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-no-irqbalance"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_no_irqbalance_service(systemd: Systemd):
+    """Test that irqbalance.service is not installed"""
+    assert not any(
+        u.unit == "irqbalance.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# iscsi Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-iscsi-service-iscsi-initiatorname-unit",
+    ]
+)
+@pytest.mark.feature("iscsi")
+def test_iscsi_initiatorname_template_exists(file: File):
+    """Test that iSCSI initiator name template exists"""
+    assert file.exists(
+        "/etc/systemd/system/iscsi-initiatorname.service"
+    ), "iSCSI initiator name service template should exist"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-iscsi-initiatorname-unit"])
+@pytest.mark.feature("iscsi")
+def test_iscsi_initiatorname_unit_exists(file):
+    """Test that iscsi-initiatorname.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/iscsi-initiatorname.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-iscsid-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_iscsid_service_enabled(systemd: Systemd):
+    """Test that iscsid.service is enabled"""
+    assert systemd.is_enabled("iscsid.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-iscsid-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_iscsid_service_active(systemd: Systemd):
+    """Test that iscsid.service is active"""
+    assert systemd.is_active("iscsid.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-tgt-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_tgt_service_enabled(systemd: Systemd):
+    """Test that tgt.service is enabled"""
+    assert systemd.is_enabled("tgt.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-tgt-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_tgt_service_active(systemd: Systemd):
+    """Test that tgt.service is active"""
+    assert systemd.is_active("tgt.service")
+
+
+# =============================================================================
+# khost Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-khost-service-apparmor-enable"])
+@pytest.mark.feature("khost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_khost_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-khost-service-apparmor-enable"])
+@pytest.mark.feature("khost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_khost_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+# =============================================================================
+# lima Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-service-sshd-enable"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="Requires systemd")
+def test_lima_ssh_service_enabled(systemd: Systemd):
+    """Test that ssh.service is enabled"""
+    assert systemd.is_enabled("ssh.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-service-sshd-enable"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="Requires systemd")
+def test_lima_ssh_service_active(systemd: Systemd):
+    """Test that ssh.service is active"""
+    assert systemd.is_active("ssh.service")
+
+
+# =============================================================================
+# metal Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-ipmievd-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+def test_metal_ipmievd_service_enabled(systemd: Systemd):
+    """Test that ipmievd.service is enabled"""
+    assert systemd.is_enabled("ipmievd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-ipmievd-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="IPMI device is not available on QEMU and service will fail"
+)
+def test_metal_ipmievd_service_active(systemd: Systemd):
+    """Test that ipmievd.service is active"""
+    assert systemd.is_active("ipmievd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-mdmonitor-oneshot-timer-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+def test_metal_mdmonitor_oneshot_timer_enabled(systemd: Systemd):
+    """Test that mdadm.service is enabled"""
+    assert systemd.is_enabled("mdmonitor-oneshot.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-mdmonitor-oneshot-timer-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+def test_metal_mdmonitor_oneshot_timer_inactive(systemd: Systemd):
+    """Test that mdmonitor-oneshot.timer is inactive"""
+    assert systemd.is_inactive("mdmonitor-oneshot.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-smartmontools-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu",
+    reason="unit will has condition to not be enabled/started on virtualization",
+)
+def test_metal_smartd_service_enabled(systemd: Systemd):
+    """Test that smartd.service is enabled"""
+    assert systemd.is_enabled("smartd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-smartmontools-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu",
+    reason="unit will has condition to not be enabled/started on virtualization",
+)
+def test_metal_smartd_service_active(systemd: Systemd):
+    """Test that smartd.service is active"""
+    assert systemd.is_active("smartd.service")
+
+
+# =============================================================================
+# multipath Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-multipath-service-multipathd-enable"])
+@pytest.mark.feature("multipath")
+@pytest.mark.booted(reason="Requires systemd")
+def test_multipath_multipathd_service_enabled(systemd: Systemd):
+    """Test that multipathd.service is enabled"""
+    assert systemd.is_enabled("multipathd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-multipath-service-multipathd-enable"])
+@pytest.mark.feature("multipath")
+@pytest.mark.booted(reason="Requires systemd")
+def test_multipath_multipathd_service_active(systemd: Systemd):
+    """Test that multipathd.service is active"""
+    assert systemd.is_active("multipathd.service")
+
+
+# -----------------------------------------------------------------------------
+# nvme Feature Unit Files
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.testcov(["GL-TESTCOV-nvme-service-nvme-hostid-unit"])
+@pytest.mark.feature("nvme")
+def test_nvme_hostid_unit_exists(file):
+    """Test that nvme-hostid.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/nvme-hostid.service")
+
+
+# =============================================================================
+# openstackMetal Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-service-netplan-enable"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="Requires systemd")
+def test_openstackMetal_systemd_networkd_service_enabled(systemd: Systemd):
+    """Test that systemd-networkd.service is enabled"""
+    assert systemd.is_enabled("systemd-networkd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-service-netplan-enable"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="Requires systemd")
+def test_openstackMetal_systemd_networkd_service_active(systemd: Systemd):
+    """Test that systemd-networkd.service is active"""
+    assert systemd.is_active("systemd-networkd.service")
+
+
+# =============================================================================
+# sap Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-sap-service-auditd-enable"])
+@pytest.mark.feature("sap")
+@pytest.mark.booted(reason="Requires systemd")
+def test_sap_auditd_service_enabled(systemd: Systemd):
+    """Test that auditd.service is enabled"""
+    assert systemd.is_enabled("auditd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-sap-service-auditd-enable"])
+@pytest.mark.feature("sap")
+@pytest.mark.booted(reason="Requires systemd")
+def test_sap_auditd_service_active(systemd: Systemd):
+    """Test that auditd.service is active"""
+    assert systemd.is_active("auditd.service")
+
+
+# =============================================================================
+# server Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-coredump-override",
+    ]
+)
+@pytest.mark.feature("server and not _prod")
+def test_server_systemd_coredump_override_exists(file: File):
+    """Test that systemd-coredump service override exists"""
+    assert file.exists("/etc/systemd/system/systemd-coredump@.service.d/override.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-coredump-enable"])
+@pytest.mark.feature("server and not _prod")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_coredump_socket_active(systemd: Systemd):
+    """Test that systemd-coredump.socket is enabled"""
+    assert systemd.is_active("systemd-coredump.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-kexec-load-unit"])
+@pytest.mark.feature("server")
+def test_server_kexec_load_unit_exists(file):
+    """Test that kexec-load@.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/kexec-load@.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-cron-update-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_cron_update_service_inactive(systemd: Systemd):
+    """Test that cron-update.service is inactive (oneshot service)"""
+    assert systemd.is_inactive("cron-update.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-kexec-load-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_kexec_load_service_enabled(
+    systemd: Systemd, kernel_versions: KernelVersions
+):
+    kernel_version = kernel_versions.get_running().version
+    """Test that kexec-load@{kernel_version}.service is enabled"""
+    assert systemd.is_enabled(f"kexec-load@{kernel_version}.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-kexec-load-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_kexec_load_service_inactive(
+    systemd: Systemd, kernel_versions: KernelVersions
+):
+    kernel_version = kernel_versions.get_running().version
+    """Test that kexec-load@{kernel_version}.service is inactive (oneshot service)"""
+    assert systemd.is_inactive(f"kexec-load@{kernel_version}.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-sysstat-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_sysstat_service_enabled(systemd: Systemd):
+    """Test that sysstat.service is enabled"""
+    assert systemd.is_enabled("sysstat.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-sysstat-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_sysstat_service_active(systemd: Systemd):
+    """Test that sysstat.service is active"""
+    assert systemd.is_active("sysstat.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-networkd-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_networkd_service_enabled(systemd: Systemd):
+    """Test that systemd-networkd.service is enabled"""
+    assert systemd.is_enabled("systemd-networkd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-networkd-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_networkd_service_active(systemd: Systemd):
+    """Test that systemd-networkd.service is active"""
+    assert systemd.is_active("systemd-networkd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-repart-socket-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_repart_socket_active(systemd: Systemd):
+    """Test that systemd-repart.socket is enabled"""
+    assert systemd.is_active("systemd-repart.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-resolved-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_resolved_service_enabled(systemd: Systemd):
+    """Test that systemd-resolved.service is enabled"""
+    assert systemd.is_enabled("systemd-resolved.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-resolved-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_resolved_service_active(systemd: Systemd):
+    """Test that systemd-resolved.service is active"""
+    assert systemd.is_active("systemd-resolved.service")
+
+
+# =============================================================================
+# ssh Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-keygen-unit"])
+@pytest.mark.feature("ssh")
+def test_ssh_keygen_unit_exists(file):
+    """Test that ssh-keygen.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/ssh-keygen.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-moduli-unit"])
+@pytest.mark.feature("ssh")
+def test_ssh_moduli_unit_exists(file):
+    """Test that ssh-moduli.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/ssh-moduli.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-ssh-enable",
+        "GL-TESTCOV-ssh-service-ssh-socket-preset-disable",
+    ]
+)
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_socket_disabled(systemd: Systemd):
+    """Test that ssh.socket is disabled by preset"""
+    assert systemd.is_disabled("ssh.socket")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-ssh-enable",
+        "GL-TESTCOV-ssh-service-ssh-socket-preset-disable",
+    ]
+)
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_socket_inactive(systemd: Systemd):
+    """Test that ssh.service is inactive"""
+    assert systemd.is_inactive("ssh.socket")
+
+
+# TODO: enable if nftables or iptables is not available
+# see: features/ssh/exec.config
+# @pytest.mark.testcov([
+#     "GL-TESTCOV-ssh-service-sshguard-enable",
+#     "GL-TESTCOV-ssh-service-sshguard-preset-disable"
+#     ])
+# @pytest.mark.feature("ssh")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_ssh_sshguard_service_disabled(systemd: Systemd):
+#     """Test that sshguard.service is disabled by preset"""
+#     assert systemd.is_disabled("sshguard.service")
+#
+#
+# @pytest.mark.testcov([
+#     "GL-TESTCOV-ssh-service-sshguard-enable",
+#     "GL-TESTCOV-ssh-service-sshguard-preset-disable"
+#     ])
+# @pytest.mark.feature("ssh")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_ssh_sshguard_service_inactive(systemd: Systemd):
+#     """Test that sshguard.service is inactive"""
+#     assert systemd.is_inactive("sshguard.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-keygen-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_keygen_service_enabled(systemd: Systemd):
+    """Test that ssh-keygen.service is enabled"""
+    assert systemd.is_enabled("ssh-keygen.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-keygen-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_keygen_service_active(systemd: Systemd):
+    """Test that ssh-keygen.service is active"""
+    assert systemd.is_active("ssh-keygen.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-sshguard-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_sshguard_service_enabled(systemd: Systemd):
+    """Test that sshguard.service is enabled"""
+    assert systemd.is_enabled("sshguard.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-sshguard-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="a started sshguard prevents running the testsuite"
+)
+def test_ssh_sshguard_service_active(systemd: Systemd):
+    """Test that sshguard.service is active"""
+    assert systemd.is_active("sshguard.service")
+
+
+# =============================================================================
+# vhost Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-socket-enable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_socket_service_enabled(systemd: Systemd):
+    """Test that libvirtd.socket is enabled"""
+    assert systemd.is_enabled("libvirtd.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-socket-enable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_socket_service_active(systemd: Systemd):
+    """Test that libvirtd.socket is active"""
+    assert systemd.is_active("libvirtd.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-tls-socket-preset-disable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_tls_socket_service_disabled(systemd: Systemd):
+    """Test that libvirtd-tls.socket is disabled by preset"""
+    assert systemd.is_disabled("libvirtd-tls.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-tls-socket-preset-disable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_tls_socket_service_inactive(systemd: Systemd):
+    """Test that libvirtd-tls.socket is inactive"""
+    assert systemd.is_inactive("libvirtd-tls.socket")

--- a/tests/integration/core/test_sysdiff.py
+++ b/tests/integration/core/test_sysdiff.py
@@ -1,0 +1,73 @@
+import logging
+import sys
+
+import pytest
+from plugins.sysdiff import Sysdiff
+
+logger = logging.getLogger(__name__)
+
+before_suffix = "before-tests"
+after_suffix = "after-tests"
+
+
+@pytest.mark.order("first")
+@pytest.mark.root(reason="Sysdiff needs to read all files.")
+def test_sysdiff_before_tests(sysdiff: Sysdiff):
+    """
+    Verifies no system changes were detected during the test run.
+    This test runs before all other tests and creates the before-tests snapshot.
+    """
+    try:
+        snapshot = sysdiff.create_snapshot(before_suffix)
+        assert before_suffix in snapshot.name
+
+    except Exception as e:
+        pytest.fail(f"Error creating {before_suffix} snapshot: {e}")
+
+
+@pytest.mark.order("last")
+@pytest.mark.root(reason="Sysdiff needs to read all files.")
+@pytest.mark.feature("not cis", reason="CIS handles sysdiff by itself")
+def test_sysdiff_after_tests(sysdiff: Sysdiff):
+    """
+    Verifies no system changes were detected during the test run.
+    This test runs after all other tests, creates the after-tests snapshot and performs the sysdiff comparison.
+    """
+    before_snapshot = None
+    after_snapshot = None
+    try:
+        snapshots = sysdiff.manager.list_snapshots()
+        before_snapshot = next(
+            (s for s in reversed(snapshots) if s.endswith(f"-{before_suffix}")),
+            None,
+        )
+        assert (
+            before_snapshot is not None
+        ), f"{before_suffix} snapshot not found. Make sure test_sysdiff_before_tests ran first."
+
+        after_snapshot = sysdiff.create_snapshot(after_suffix).name
+
+        diff_result = sysdiff.compare_snapshots(before_snapshot, after_snapshot)
+        if diff_result.has_changes:
+            diff_output = sysdiff.diff_engine.generate_diff(
+                diff_result, before_snapshot, after_snapshot
+            )
+            print(
+                "System changes detected - detailed diff:\n" + diff_output,
+                file=sys.stderr,
+            )
+            pytest.fail(
+                "System changes were detected during the test run. See stderr output for details."
+            )
+
+    except Exception as e:
+        pytest.fail(f"Error during sysdiff comparison: {e}")
+
+    finally:
+        cleanup_names = []
+        if before_snapshot:
+            cleanup_names.append(before_snapshot)
+        if after_snapshot:
+            cleanup_names.append(after_snapshot)
+        if cleanup_names:
+            sysdiff.cleanup_snapshots(cleanup_names)

--- a/tests/integration/core/test_time.py
+++ b/tests/integration/core/test_time.py
@@ -1,0 +1,420 @@
+import os
+from datetime import datetime
+from time import time
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+from plugins.systemd import Systemd
+from plugins.systemd_detect_virt import Hypervisor
+from plugins.timedatectl import TimeDateCtl
+
+# =============================================================================
+# clock skew test
+# =============================================================================
+
+
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+def test_clock(shell: ShellRunner):
+    """Test clock skew"""
+    local_seconds = int(time())
+    output = shell(cmd="date '+%s'", capture_output=True)
+    remote_seconds = int(output.stdout)
+
+    assert (
+        abs(local_seconds - remote_seconds) < 5
+    ), f"clock skew should be less than 5 seconds. Local time is {local_seconds} and remote time is {remote_seconds}"
+
+
+# =============================================================================
+# ALI NTP server configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-config-timesyncd"])
+@pytest.mark.feature("ali")
+def test_ali_timesyncd_config_exists(file: File):
+    """Test that Alibaba Cloud systemd-timesyncd configuration exists"""
+    assert file.is_regular_file("/etc/systemd/timesyncd.conf.d/00-gardenlinux-ali.conf")
+
+
+# ================================
+# AWS NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-timesyncd"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("aws")
+@pytest.mark.hypervisor(
+    "amazon",
+    reason="Only works on real AWS infrastructure due to NTP server access requirements.",
+)
+def test_correct_ntp_on_aws(timedatectl: TimeDateCtl):
+    ntp_ip = timedatectl.get_ntpserver().ip
+    assert (
+        ntp_ip == "169.254.169.123"
+    ), f"ntp server is invalid. Expected '169.254.169.123' got '{ntp_ip}'."
+
+
+# ================================
+# Azure NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-after-ptp-device"])
+@pytest.mark.feature("azure")
+def test_azure_chrony_service_after_ptp_exists(file: File):
+    """Test that Azure chrony device service configuration exists"""
+    assert file.exists(
+        "/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-after-ptp-device"])
+@pytest.mark.feature("azure")
+def test_azure_chrony_service_after_ptp_content(parse_file: ParseFile):
+    """Test that Azure chrony device service configuration content is correct"""
+    config = parse_file.parse(
+        "/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf",
+        format="ini",
+    )
+    assert config["Unit"]["BindsTo"] == "dev-ptp_hyperv.device"
+    assert config["Unit"]["After"] == "dev-ptp_hyperv.device"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-no-systemd-timesyncd-override"])
+@pytest.mark.feature("azure")
+def test_azure_no_timesyncd_override(file: File):
+    """Test that Azure does not have systemd-timesyncd override"""
+    assert not file.exists(
+        "/etc/systemd/system/systemd-timesyncd.service.d/override.conf"
+    ), "Azure should not have timesyncd override (uses chrony instead)"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-chrony"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor("microsoft")
+def test_chrony_azure(
+    chrony_config_file: str,
+    ptp_hyperv_dev: str,
+    systemd_detect_virt: Hypervisor,
+    parse_file: ParseFile,
+):
+    """
+    Check Chrony configuration for expected content according to https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
+
+    Gets skipped for QEMU tests as these do not start chrony.
+    """
+    expected_config = f"refclock PHC {ptp_hyperv_dev} poll 3 dpoll -2 offset 0"
+    lines = parse_file.lines(chrony_config_file)
+    assert expected_config in lines, "chrony config for ptp expected but not found"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_wait_service_disabled(systemd: Systemd):
+    """Test that chrony-wait.service is disabled by preset"""
+    assert systemd.is_disabled("chrony-wait.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_wait_service_inactive(systemd: Systemd):
+    """Test that chrony-wait.service is inactive"""
+    assert systemd.is_inactive("chrony-wait.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_restricted_service_disabled(systemd: Systemd):
+    """Test that chronyd-restricted.service is disabled by preset"""
+    assert systemd.is_disabled("chronyd-restricted.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_restricted_service_inactive(systemd: Systemd):
+    """Test that chronyd-restricted.service is inactive"""
+    assert systemd.is_inactive("chronyd-restricted.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-udev-rules-hyperv-ptp"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor("microsoft")
+def test_azure_ptp_symlink(ptp_hyperv_dev: str, systemd_detect_virt: Hypervisor):
+    """
+    Ensure /dev/ptp_hyperv exists and is a symlink on real Azure VMs.
+
+    Skips for QEMU only provides a generic virtualized clock.
+    """
+    assert os.path.islink(
+        ptp_hyperv_dev
+    ), f"{ptp_hyperv_dev} should always be a symlink."
+
+
+# ================================
+# GCP NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-config-timesyncd"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("gcp")
+@pytest.mark.hypervisor(
+    "google", reason="Only works on real google cloud because of metadata access."
+)
+def test_correct_ntp_on_gcp(timedatectl: TimeDateCtl):
+    ntp_ip = timedatectl.get_ntpserver().ip
+    assert (
+        ntp_ip == "169.254.169.254"  # gcp metadata service
+    ), f"ntp server is invalid. Expected '169.254.169.254' got '{ntp_ip}'."
+
+
+# ================================
+# GDCH NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-no-systemd-timesyncd"])
+@pytest.mark.feature("ghdc")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_no_systemd_timesyncd_service(systemd: Systemd):
+    """Test that systemd-timesyncd.service is not installed"""
+    assert not any(
+        u.unit == "systemd-timesyncd.service" for u in systemd.list_installed_units()
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-chrony-enable"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_chrony_service_enabled(systemd: Systemd):
+    """Test that chrony.service is enabled"""
+    assert systemd.is_enabled("chrony.service")
+
+
+# ================================
+# FedRAMP NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-no-systemd-timesyncd"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_no_systemd_timesyncd_service(systemd: Systemd):
+    """Test that systemd-timesyncd.service is not installed"""
+    assert not any(
+        u.unit == "systemd-timesyncd.service" for u in systemd.list_installed_units()
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-chrony-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_chrony_service_enabled(systemd: Systemd):
+    """Test that chrony.service is enabled"""
+    assert systemd.is_enabled("chrony.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-chrony-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_chrony_service_active(systemd: Systemd):
+    """Test that chrony.service is active"""
+    assert systemd.is_active("chrony.service")
+
+
+# ================================
+# Timesyncd service configuration
+# ================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-timesyncd-override",
+    ]
+)
+@pytest.mark.feature("server and not azure")
+def test_server_systemd_timesyncd_override_exists(file: File):
+    """Test that systemd-timesyncd service override exists"""
+    assert file.exists("/etc/systemd/system/systemd-timesyncd.service.d/override.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-timesyncd-enable"])
+@pytest.mark.flaky(reruns=10, reruns_delay=30, only_rerun="AssertionError")
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("not azure and not aws and not gcp and not gdch")
+def test_ntp(timedatectl: TimeDateCtl):
+    """
+    Validate that systemd-timesyncd is installed and active.
+    """
+    # Verify image configuration
+    assert (
+        timedatectl.has_timesync_installed()
+    ), "systemd-timesyncd.service should be present on the image."
+
+    # Check activity and sync when present
+    if timedatectl.is_timesyncd_active():
+        status = timedatectl.get_timesync_status()
+        assert status.ntp, "NTP should be enabled"
+        assert status.ntp_synchronized, "NTP should be synchronized"
+    else:
+        pytest.skip("systemd-timesyncd installed but not active in this environment")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-no-systemd-timesyncd"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor("microsoft")
+def test_systemd_timesyncd_disabled_on_azure(systemd: Systemd):
+    assert (
+        systemd.is_active("systemd-timesyncd") == False
+    ), "Chrony instead of systemd-timesyncd should be active on Azure."
+
+
+# ================================
+# Chrony service configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-enable"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor(
+    "microsoft", "chrony only loaded and running in real Azure environment."
+)
+def test_chrony_on_azure(systemd: Systemd):
+    """
+    Test for chrony as active time sync service on Azure.
+    See: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
+    """
+    assert systemd.is_active("chrony"), "Chrony should be active on Azure."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-enable"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor(
+    "qemu",
+    "Test only asserts presence of chrony unit file in cases the testsuite runs in QEMU.",
+)
+def test_chrony_installed_for_azure_image(systemd: Systemd):
+    """
+    Test for chrony service installed on Azure image when running in QEMU.
+    (no Hyper-V clock available -> chrony is disabled and not loaded)
+    """
+    units = systemd.list_installed_units()
+    chrony_unit = next(
+        (unit for unit in units if unit.unit == "chrony.service"),
+        None,
+    )
+
+    assert chrony_unit is not None, "chrony.service should be present in Azure images."
+    assert chrony_unit.load in (
+        "enabled",
+        "disabled",
+    ), f"Unexpected chrony.service state: {chrony_unit.load!r}"
+
+
+# ================================
+# Clock source configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-script-clocksource-setup"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("not azure and not container")
+@pytest.mark.arch("amd64")
+def test_clocksource_amd64(systemd_detect_virt: Hypervisor, clocksource: str):
+    match systemd_detect_virt:
+        case Hypervisor.xen | Hypervisor.qemu:
+            expected_clocksource = "tsc"
+        case Hypervisor.kvm | Hypervisor.amazon | Hypervisor.google:
+            expected_clocksource = "kvm-clock"
+        case _:
+            assert False, f"unknown hypervisor {systemd_detect_virt}"
+
+    assert clocksource, expected_clocksource
+
+
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("not azure and not container")
+@pytest.mark.arch("amd64", "aarch64")
+def test_clocksource_arm64_aarch64(systemd_detect_virt: Hypervisor, clocksource: str):
+    match systemd_detect_virt:
+        case Hypervisor.kvm | Hypervisor.qemu | Hypervisor.amazon | Hypervisor.google:
+            expected_clocksource = "arch_sys_counter"
+        case _:
+            assert False, f"unknown hypervisor {systemd_detect_virt}"
+
+    assert clocksource, expected_clocksource
+
+
+# ================================
+# File timestamps validation
+# ================================
+
+
+@pytest.mark.feature(
+    "not container", reason="Filesystem not mounted in container tests"
+)
+@pytest.mark.parametrize("dir", ["/bin", "/etc/ssh"])
+def test_files_not_in_future(find, dir: str):
+    """
+    Validate that all files in the image have a timestamp in the past.
+    """
+    now = datetime.now()
+
+    find.root_paths = dir
+    find.entry_type = "files"
+
+    for file_path in find:
+        try:
+            mod_time = datetime.fromtimestamp(os.path.getmtime(file_path))
+        except FileNotFoundError:
+            continue
+
+        assert mod_time <= now, (
+            f"Timestamp of {file_path} is in the future " f"{mod_time} (now={now})"
+        )
+
+
+@pytest.mark.feature("container")
+def test_files_not_in_future_container(find):
+    """
+    Validate that all files in container images have timestamps in the past.
+    """
+    find.root_paths = ["/bin"]
+    now = datetime.now()
+    for file_path in find:
+        modification = datetime.fromtimestamp(os.path.getmtime(file_path))
+        assert (
+            modification <= now
+        ), f"timestamp of {file_path} is in the future ({modification} > {now})"
+
+
+# ================================
+# Timezone configuration
+# ================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gcp-config-timezone-utc",
+        "GL-TESTCOV-gdch-config-timezone-utc",
+    ]
+)
+@pytest.mark.feature("gcp or gdch")
+def test_gcp_or_gdch_timezone_utc(file: File):
+    """Test that GCP or GDCH has UTC timezone configured"""
+    assert file.is_symlink(
+        "/usr/share/zoneinfo/localtime", "/etc/localtime"
+    ), "GCP or GDCH timezone should be set to UTC"

--- a/tests/integration/core/test_users_groups.py
+++ b/tests/integration/core/test_users_groups.py
@@ -1,0 +1,150 @@
+import os
+import pwd
+from typing import List, Set
+
+import pytest
+from plugins.file import File
+from plugins.linux_etc_files import Group, Passwd
+from plugins.users import User
+from plugins.utils import check_for_duplicates
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+
+def test_service_accounts_have_nologin_shell(regular_user_uid_range):
+    for entry in pwd.getpwall():
+        if entry.pw_uid in regular_user_uid_range:
+            continue
+        if entry.pw_name in {"root", "sync"}:
+            continue
+        assert entry.pw_shell in [
+            "/usr/sbin/nologin",
+            "/sbin/nologin",
+            "/bin/false",
+        ], f"User {entry.pw_name} has unexpected shell: {entry.pw_shell}"
+
+
+def test_root_home_permissions(file: File):
+    assert file.has_mode("/root", "0700"), "/root has incorrect permissions"
+
+
+@pytest.mark.feature("not _dev")
+def test_no_extra_home_directories(expected_users, file: File):
+    if file.is_symlink("/home"):
+        return
+    entries = os.listdir("/home")
+    unexpected = [e for e in entries if e not in expected_users]
+    assert not unexpected, f"Unexpected entries in /home: {entries}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-cloud-user-sudo"])
+@pytest.mark.booted
+@pytest.mark.root(reason="Using sudo command to check the access")
+def test_users_sudo_capability(get_all_users, expected_users, user: User):
+    users_with_sudo_capabilities = set(
+        [u for u in get_all_users if user.is_user_sudo(u)]
+    )
+    allowed_sudo_users = set(expected_users) | {"root", "dev"}
+    unexpected_sudo_users = users_with_sudo_capabilities - allowed_sudo_users
+
+    assert (
+        not unexpected_sudo_users
+    ), f"Unexpected sudo capability {unexpected_sudo_users}"
+
+
+def test_available_regular_users(get_regular_users, expected_users):
+    allowed_users = ["dev", "nobody"] + list(expected_users)
+    unexpected_user = [user for user in get_regular_users if user not in allowed_users]
+
+    assert (
+        not unexpected_user
+    ), f"Unexpected user account found in /etc/passwd, {unexpected_user}"
+
+
+def test_duplicate_uids(passwd_entries: List[Passwd]):
+    """
+    Check if any duplicate userids are defined in /etc/passwd.
+    """
+    duplicates = check_for_duplicates(entries=passwd_entries)
+    assert (
+        len(duplicates) == 0
+    ), "uids {} are used multiple times in /etc/passwd".format(duplicates)
+
+
+def test_duplicate_uids_detection(passwd_entries: List[Passwd]):
+    """
+    Appending an existing entry to the list to check if the duplication check finds this.
+    """
+    expected_duplicate = passwd_entries[0]
+    passwd_entries.append(expected_duplicate)
+
+    duplicates = check_for_duplicates(entries=passwd_entries)
+    assert len(duplicates) == 1, "duplicate entry is not found successfully"
+    assert expected_duplicate == duplicates[0]
+
+
+def test_groups_are_unique(group_entries: List[Group]):
+    """
+    Check if there are any duplicate groups in /etc/group.
+    """
+    duplicates = check_for_duplicates(group_entries)
+    assert (
+        len(duplicates) == 0
+    ), f"Groups from /etc/group should not have duplicates: {duplicates}"
+
+
+def test_groups_find_duplicate(group_entries: List[Group]):
+    """
+    Check if duplication check works by adding a duplicate.
+    """
+    duplicate_group = group_entries[0]
+    group_entries.append(duplicate_group)
+
+    duplicates = check_for_duplicates(group_entries)
+    assert (
+        len(duplicates) == 1
+    ), f"Group #{duplicate_group.groupname} should be found as duplicate, but was not."
+
+
+@pytest.mark.feature("not _dev and not pythonDev")
+def test_group_root_has_no_users(group_entries: List[Group]):
+    """
+    Check if parameterized groups have the expected users.
+    """
+    group_list = [group for group in group_entries if group.groupname == "root"]
+    group = group_list[0] if group_list else None
+
+    assert group, "Group root is not present."
+
+    assert (
+        len(group.user_list) == 0
+    ), f"user group root is not empty as expected. Was: {group.user_list}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-group-wheel",
+    ]
+)
+@pytest.mark.feature("not _dev and not pythonDev and not container")
+def test_group_wheel_has_no_unexpected_users(
+    group_entries: List[Group], expected_users: Set[str]
+):
+    """
+    Check if parameterized groups have the expected users.
+    """
+    group_list = [group for group in group_entries if group.groupname == "wheel"]
+    group = group_list[0] if group_list else None
+
+    assert group, "Group wheel is not present."
+
+    # remove expected users from group as we want to check for unexpected users
+    expected_user_list = [
+        user for user in group.user_list if user not in expected_users
+    ]
+
+    assert (
+        len(expected_user_list) == 0
+    ), f"user group wheel is not empty as expected. Was: {expected_user_list}"

--- a/tests/integration/infrastructure/test_cloud_platforms.py
+++ b/tests/integration/infrastructure/test_cloud_platforms.py
@@ -1,0 +1,149 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# azure Feature - Microsoft Azure
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-network-unmanaged-devices"])
+@pytest.mark.feature("azure")
+def test_azure_networkd_unmanaged_devices_exists(file: File):
+    """Test that Azure networkd unmanaged devices config exists"""
+    assert file.exists("/etc/systemd/99-azure-unmanaged-devices.network")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-network-unmanaged-devices"])
+@pytest.mark.feature("azure")
+def test_azure_networkd_unmanaged_devices_content(parse_file: ParseFile):
+    """Test that Azure networkd unmanaged devices config content exists"""
+    lines = parse_file.parse(
+        "/etc/systemd/99-azure-unmanaged-devices.network", format="ini"
+    )
+
+    assert lines["Match"]["Driver"] == "mlx4_en mlx5_en mlx4_core mlx5_core"
+    assert lines["Link"]["Unmanaged"] == "yes"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-azure-config-udev-rules-azure-product-uuid",
+        "GL-TESTCOV-azure-config-udev-rules-azure-storage",
+    ]
+)
+@pytest.mark.feature("azure")
+def test_azure_udev_rules_exist(file: File):
+    """Test that Azure udev rules exist"""
+    rules = [
+        "/etc/udev/rules.d/66-azure-storage.rules",
+        "/etc/udev/rules.d/99-azure-product-uuid.rules",
+    ]
+    missing = [rule for rule in rules if not file.exists(rule)]
+    assert not missing, f"Missing Azure udev rules: {', '.join(missing)}"
+
+
+# =============================================================================
+# gcp Feature - Google Cloud Platform
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-config-instance-configs-run-dir"])
+@pytest.mark.feature("gcp")
+def test_gcp_instance_configs_run_dir_set(parse_file: ParseFile):
+    """Test that GCP instance configs run directory is set"""
+    contents = parse_file.parse("/etc/default/instance_configs.cfg", format="ini")
+    assert contents["MetadataScripts"]["run_dir"] == "/var/tmp"
+
+
+# =============================================================================
+# gcp or gdch Feature - Google Cloud Platform or Google Distributed Cloud Hosted
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gcp-config-ssh-sshd-config-google-oslogin",
+        "GL-TESTCOV-gdch-config-ssh-sshd-config-google-oslogin",
+    ]
+)
+@pytest.mark.feature("gcp or gdch")
+def test_gcp_ssh_google_oslogin_config(parse_file: ParseFile):
+    """Test that GCP has Google OS Login SSH configuration"""
+    lines = parse_file.lines("/etc/ssh/sshd_config")
+    assert (
+        "AuthorizedKeysCommand /usr/libexec/google_authorized_keys" in lines
+    ), "GCP Google OS Login SSH configuration should contain AuthorizedKeysCommand /usr/libexec/google_authorized_keys"
+    assert (
+        "AuthorizedKeysCommandUser root" in lines
+    ), "GCP Google OS Login SSH configuration should contain AuthorizedKeysCommandUser root"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gcp-config-udev-rules-gce-disk-removal",
+    ]
+)
+@pytest.mark.feature("gcp")
+def test_gcp_udev_gce_disk_removal_rules(file: File):
+    """Test that GCP has GCE disk removal udev rules"""
+    assert file.exists(
+        "/usr/lib/udev/rules.d/64-gce-disk-removal.rules"
+    ), "GCP GCE disk removal udev rules should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gcp-service-google-guest-agent-manager-mask",
+    ]
+)
+@pytest.mark.feature("gcp")
+def test_gcp_google_guest_agent_manager_masked(systemd: Systemd):
+    """Test that GCP Google guest agent manager is masked"""
+    assert systemd.is_masked(
+        "google-guest-agent-manager.service"
+    ), "GCP Google guest agent manager should be masked"
+
+
+# =============================================================================
+# cloud Feature - Generic Cloud Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-kernel-postinst-cmdline",
+        "GL-TESTCOV-cloud-config-kernel-postinst-update-syslinux",
+    ]
+)
+@pytest.mark.feature("cloud")
+def test_cloud_kernel_postinst_scripts_exist(file: File):
+    """Test that cloud kernel postinst scripts exist"""
+    scripts = [
+        "/etc/kernel/postinst.d/00-kernel-cmdline",
+        "/etc/kernel/postinst.d/zz-update-syslinux",
+    ]
+    missing = [script for script in scripts if not file.exists(script)]
+    assert not missing, f"Missing cloud kernel postinst scripts: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-kernel-postrm-update-syslinux"])
+@pytest.mark.feature("cloud")
+def test_cloud_kernel_postrm_script_exists(file: File):
+    """Test that cloud kernel postrm script exists"""
+    assert file.exists("/etc/kernel/postrm.d/zz-update-syslinux")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-repart-root"])
+@pytest.mark.feature("cloud")
+def test_cloud_repart_root_config_exists(file: File):
+    """Test that cloud repart root configuration exists"""
+    assert file.is_regular_file("/etc/repart.d/root.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-systemd-rngd-architecture"])
+@pytest.mark.feature("cloud")
+def test_cloud_rngd_architecture_config_exists(file: File):
+    """Test that cloud rngd architecture configuration exists"""
+    assert file.exists("/etc/systemd/system/rngd.service.d/architecture.conf")

--- a/tests/integration/infrastructure/test_iscsi.py
+++ b/tests/integration/infrastructure/test_iscsi.py
@@ -1,0 +1,108 @@
+import re
+import time
+
+import pytest
+from plugins.block_devices import BlockDevices
+from plugins.file import File
+from plugins.parse import Parse
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# multipath Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-multipath-config-multipath-conf",
+    ]
+)
+@pytest.mark.feature("multipath")
+def test_multipath_config_exists(file: File):
+    """Test that multipath configuration exists"""
+    assert file.is_regular_file(
+        "/etc/multipath.conf"
+    ), "Multipath configuration should exist"
+
+
+# =============================================================================
+# iscsi Feature - iSCSI Storage Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-iscsi-config-iscsi-initiatorname",
+    ]
+)
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="iSCSI initiatorname.iscsi is created at boot time")
+def test_iscsi_no_static_initiatorname(file: File):
+    """Test that iSCSI does have an dynamically generated initiator name"""
+    assert file.exists(
+        "/etc/iscsi/initiatorname.iscsi"
+    ), "iSCSI should have initiator name (generated dynamically)"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-iscsi-config-iscsi-node-session-auth-chap-algs",
+    ]
+)
+@pytest.mark.feature("iscsi")
+def test_iscsi_chap_algorithms_config_exists(parse: type[Parse]):
+    """Test that iSCSI CHAP algorithms configuration exists"""
+    content = parse.from_file("/etc/iscsi/iscsid.conf").parse(format="keyval")
+    setting = "SHA3-256,SHA256,SHA1,MD5"
+    assert (
+        content["node.session.auth.chap_algs"] == setting
+    ), f"iSCSI CHAP algorithms should be {setting}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-iscsi-config-iscsi-node-session-scan",
+    ]
+)
+@pytest.mark.feature("iscsi")
+def test_iscsi_node_session_scan_config_exists(parse: type[Parse]):
+    """Test that iSCSI node session scan configuration exists"""
+    content = parse.from_file("/etc/iscsi/iscsid.conf").parse(format="keyval")
+    setting = "manual"
+    assert (
+        content["node.session.scan"] == setting
+    ), f"iSCSI node session scan should be {setting}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-iscsi-config-iscsi-open-iscsi-configured",
+    ]
+)
+@pytest.mark.feature("iscsi")
+def test_iscsi_open_iscsi_configured(file: File):
+    """Test that open-iscsi configured0 file exists"""
+    assert file.exists(
+        "/var/lib/open-iscsi-configured0"
+    ), "Open-iSCSI configured0 file should exist"
+
+
+@pytest.mark.booted(reason="iSCSI daemon is required")
+@pytest.mark.root(reason="Needs to run iscsiadm")
+@pytest.mark.modify(reason="Temporarily creates files and starts services")
+@pytest.mark.feature("iscsi", reason="Feature test for iscsi")
+def test_iscsi_setup(shell: ShellRunner, block_devices: BlockDevices, iscsi_device):
+    assert not block_devices.contains(
+        "iscsi-iqn", substring=True
+    ), "Unexpected iscsi-iqn before rescan"
+
+    session_id = shell("iscsiadm -m session | awk '{print $2}'", capture_output=True)
+    session_id = re.fullmatch("\\[([0-9]+)\\]\n", session_id.stdout)
+    assert session_id, "Failed to get session ID"
+    session_id = session_id.group(1)
+
+    shell(f"iscsiadm -m session -r {session_id} --rescan", capture_output=True)
+
+    time.sleep(5)
+
+    assert block_devices.contains(iscsi_device), f"Expected {iscsi_device} after rescan"

--- a/tests/integration/infrastructure/test_kvm.py
+++ b/tests/integration/infrastructure/test_kvm.py
@@ -1,0 +1,31 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# _fwcfg Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-script-run-qemu-fw_cfg-script"])
+@pytest.mark.feature("_fwcfg")
+def test_fwcfg_run_script_exists(file: File):
+    """Test that qemu-fw_cfg run script exists"""
+    assert file.is_regular_file("/usr/bin/run-qemu-fw_cfg-script")
+
+
+# =============================================================================
+# kvm Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-kvm-config-udev-rules-onmetal",
+    ]
+)
+@pytest.mark.feature("kvm")
+def test_kvm_udev_rules_onmetal_exists(file: File):
+    """Test that KVM udev rules for OnMetal exist"""
+    assert file.exists(
+        "/etc/udev/rules.d/60-onmetal.rules"
+    ), "KVM OnMetal udev rules should exist"

--- a/tests/integration/infrastructure/test_metal.py
+++ b/tests/integration/infrastructure/test_metal.py
@@ -1,0 +1,150 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# metal Feature - Bare Metal Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-kernel-entry-token",
+        "GL-TESTCOV-metal-config-kernel-entry-token",
+    ]
+)
+@pytest.mark.feature("cloud or metal")
+def test_kernel_entry_token_exists(file: File):
+    """Test that cloud or metal has kernel entry token"""
+    assert file.exists("/etc/kernel/entry-token"), "Kernel entry token should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-kernel-entry-token",
+        "GL-TESTCOV-metal-config-kernel-entry-token",
+    ]
+)
+@pytest.mark.feature("cloud or metal")
+def test_kernel_entry_token_content(parse_file: ParseFile):
+    """Test that cloud or metal has kernel entry token"""
+    config = parse_file.lines("/etc/kernel/entry-token")
+    assert "Default" in config, "Kernel entry token should be Default"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-kernel-postinst-cmdline",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_kernel_postinst_cmdline(file: File):
+    """Test that metal has kernel postinst cmdline script"""
+    assert file.exists(
+        "/etc/kernel/postinst.d/00-kernel-cmdline"
+    ), "Metal kernel postinst cmdline script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-kernel-postinst-ucode",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_kernel_postinst_ucode(file: File):
+    """Test that metal has kernel postinst microcode script"""
+    assert file.exists(
+        "/etc/kernel/postinst.d/00-ucode"
+    ), "Metal kernel postinst ucode script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-kernel-postinst-update-syslinux",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_kernel_postinst_syslinux(file: File):
+    """Test that metal has kernel postinst syslinux update script"""
+    assert file.exists(
+        "/etc/kernel/postinst.d/zz-update-syslinux"
+    ), "Metal kernel postinst syslinux script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-kernel-postrm-update-syslinux",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_kernel_postrm_syslinux(file: File):
+    """Test that metal has kernel postrm syslinux update script"""
+    assert file.exists(
+        "/etc/kernel/postrm.d/zz-update-syslinux"
+    ), "Metal kernel postrm syslinux script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-no-init-ipmievd",
+        "GL-TESTCOV-metal-config-no-init-irqbalance",
+        "GL-TESTCOV-metal-config-no-mdadm",
+        "GL-TESTCOV-metal-config-no-network",
+        "GL-TESTCOV-metal-config-no-runit-001",
+        "GL-TESTCOV-metal-config-no-runit-002",
+        "GL-TESTCOV-metal-config-no-sv",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_removed_files(file: File):
+    """Test that metal does not have removed files"""
+    removed_files = [
+        "/etc/init.d/ipmievd",
+        "/etc/init.d/irqbalance",
+        "/etc/mdadm.conf",
+        "/etc/mdadm/mdadm.conf",
+        "/etc/network/interfaces",
+        "/etc/runit",
+        "/etc/sv",
+    ]
+    missing = [file_path for file_path in removed_files if file.exists(file_path)]
+    assert not missing, f"Metal removed files should not exist: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-udev-rules-intellldp",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_udev_rules_intellldp(file: File):
+    """Test that metal has Intel LDP udev rules"""
+    assert file.exists(
+        "/etc/udev/rules.d/71-intellldp.rules"
+    ), "Metal Intel LDP udev rules should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-udev-rules-nostbyrot",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_udev_rules_nostbyrot(file: File):
+    """Test that metal has no standby rotation udev rules"""
+    assert file.exists(
+        "/etc/udev/rules.d/69-nostbyrot.rules"
+    ), "Metal nostbyrot udev rules should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-script-update-usbids",
+    ]
+)
+@pytest.mark.feature("metal")
+def test_metal_update_usbids_script(file: File):
+    """Test that metal has update-usbids script"""
+    assert file.exists(
+        "/usr/sbin/update-usbids"
+    ), "Metal update-usbids script should exist"

--- a/tests/integration/infrastructure/test_nvme.py
+++ b/tests/integration/infrastructure/test_nvme.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# nvme Feature
+# =============================================================================
+
+
+@pytest.mark.booted
+@pytest.mark.root
+@pytest.mark.modify
+@pytest.mark.feature("nvme")
+def test_nvme_locally(nvme_device, shell: ShellRunner):
+    device, mount_dir, size = nvme_device
+    mount_info_line = shell(f"df -m | grep {mount_dir}", capture_output=True)
+    mount_info = [x.strip() for x in mount_info_line.stdout.split(" ") if x]
+    assert mount_info[0] == device
+    assert mount_info[1] == size
+    assert Path(f"{mount_dir}/bar").read_text().strip() == "foo", "NVME Test failed"

--- a/tests/integration/kernel/test_kernel_cmdline.py
+++ b/tests/integration/kernel/test_kernel_cmdline.py
@@ -1,0 +1,554 @@
+"""Test kernel command line console configuration."""
+
+from typing import List
+
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# ali Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-config-kernel-cmdline-console"])
+@pytest.mark.feature("ali")
+def test_ali_kernel_cmdline_console_exists(file: File):
+    """Test that Alibaba Cloud kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-config-kernel-cmdline-console"])
+@pytest.mark.feature("ali")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_ali(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for Alibaba Cloud."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+# =============================================================================
+# aws Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-kernel-cmdline-console"])
+@pytest.mark.feature("aws")
+def test_aws_kernel_cmdline_console_exists(file: File):
+    """Test that AWS kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-kernel-cmdline-console"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_aws(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for AWS."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-kernel-cmdline-nvme"])
+@pytest.mark.feature("aws")
+def test_aws_kernel_cmdline_nvme_exists(file: File):
+    """Test that AWS nvme kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/70-nvme.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-kernel-cmdline-nvme"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_nvme_configuration_in_cmdline_aws(kernel_cmdline: List[str]):
+    """Verify nvme parameters are present in the running kernel command line for AWS."""
+    assert (
+        "nvme_core.io_timeout=4294967295" in kernel_cmdline
+    ), "NVMe io timeout (nvme_core.io_timeout=4294967295) not found in kernel cmdline"
+
+
+# =============================================================================
+# azure Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-kernel-cmdline-console"])
+@pytest.mark.feature("azure")
+def test_azure_kernel_cmdline_console_exists(file: File):
+    """Test that Azure kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-kernel-cmdline-console"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_azure(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for Azure."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-kernel-cmdline-nvme"])
+@pytest.mark.feature("azure")
+def test_azure_kernel_cmdline_nvme_exists(file: File):
+    """Test that Azure nvme kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/45-nvme-timeout.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-kernel-cmdline-nvme"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_nvme_configuration_in_cmdline_azure(kernel_cmdline: List[str]):
+    """Verify nvme parameters are present in the running kernel command line for Azure."""
+    assert (
+        "nvme_core.io_timeout=240" in kernel_cmdline
+    ), "NVMe io timeout (nvme_core.io_timeout=240) not found in kernel cmdline"
+
+
+# =============================================================================
+# Cloud Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-kernel-cmdline-default"])
+@pytest.mark.feature("cloud")
+def test_cloud_kernel_cmdline_default_exists(file: File):
+    """Test that cloud default kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/00-default.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-kernel-cmdline-default"])
+@pytest.mark.feature("cloud")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_cloud_kernel_cmdline_default(kernel_cmdline: List[str]):
+    """Verify default parameters are present in the running kernel command line for cloud."""
+
+    required_params = ["rw", "earlyprintk=ttyS0,115200", "consoleblank=0"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-cloud-config-kernel-cmdline-enable-swap-cgroup-accounting"]
+)
+@pytest.mark.feature("cloud")
+def test_cloud_kernel_cmdline_swap_cgroup_exists(file: File):
+    """Test that cloud swap cgroup accounting kernel cmdline configuration exists"""
+    assert file.is_regular_file(
+        "/etc/kernel/cmdline.d/40-enable-swap-cgroup-accounting.cfg"
+    )
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-cloud-config-kernel-cmdline-enable-swap-cgroup-accounting"]
+)
+@pytest.mark.feature("cloud")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_cloud_kernel_cmdline_swap_cgroup(kernel_cmdline: List[str]):
+    """Verify swap cgroup accounting parameters are present in the running kernel command line for cloud."""
+    required_params = ["cgroup_enable=memory", "swapaccount=1"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-kernel-cmdline-timeout"])
+@pytest.mark.feature("cloud")
+def test_cloud_kernel_cmdline_timeout_exists(file: File):
+    """Test that cloud timeout kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/60-timeout.cfg")
+
+
+# TODO: Add test for timeout parameter
+# @pytest.mark.testcov(["GL-TESTCOV-cloud-config-kernel-cmdline-timeout"])
+# @pytest.mark.feature("cloud")
+# @pytest.mark.booted(reason="kernel cmdline needs a booted system")
+# def test_cloud_kernel_cmdline_timeout(kernel_cmdline: List[str]):
+#     """Verify timeout parameters are present in the running kernel command line for cloud."""
+
+
+# =============================================================================
+# gcp Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-config-kernel-cmdline-default"])
+@pytest.mark.feature("gcp")
+def test_gcp_kernel_cmdline_default_exists(file: File):
+    """Test that GCP default kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/00-default.cfg")
+
+
+# TODO: Clarify why we have 2 files setting the same kernel cmdline parameters
+# @pytest.mark.testcov(["GL-TESTCOV-gcp-config-kernel-cmdline-default"])
+# @pytest.mark.feature("gcp")
+# @pytest.mark.booted(reason="kernel cmdline needs a booted system")
+# def test_gcp_kernel_cmdline_default(kernel_cmdline: List[str]):
+#     """Verify default parameters are present in the running kernel command line for GCP."""
+#     required_params = ["console=tty0", "console=ttyS0,38400n8d", "consoleblank=0"]
+#     missing = [param for param in required_params if param not in kernel_cmdline]
+#     assert (
+#         not missing
+#     ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-config-kernel-cmdline-console"])
+@pytest.mark.feature("gcp")
+def test_gcp_kernel_cmdline_console_exists(file: File):
+    """Test that GCP kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-config-kernel-cmdline-console"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_gcp(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for GCP."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+# =============================================================================
+# gdch Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-config-kernel-cmdline-default"])
+@pytest.mark.feature("gdch")
+def test_gdch_kernel_cmdline_default_exists(file: File):
+    """Test that GDCH default kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/00-default.cfg")
+
+
+# TODO: Clarify why we have 2 files setting the same kernel cmdline parameters
+# @pytest.mark.testcov(["GL-TESTCOV-gdch-config-kernel-cmdline-default"])
+# @pytest.mark.feature("gdch")
+# @pytest.mark.booted(reason="kernel cmdline needs a booted system")
+# def test_gdch_kernel_cmdline_default(kernel_cmdline: List[str]):
+#     """Verify default parameters are present in the running kernel command line for GDCH."""
+#     required_params = ["console=ttyS0,38400n8d", "consoleblank=0"]
+#     missing = [param for param in required_params if param not in kernel_cmdline]
+#     assert (
+#         not missing
+#     ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-config-kernel-cmdline-console"])
+@pytest.mark.feature("gdch")
+def test_gdch_kernel_cmdline_console_exists(file: File):
+    """Test that GDCH kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-config-kernel-cmdline-console"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_gdch(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for GDCH.
+
+    Note: GDCH only configures ttyS0 serial console, not tty0 virtual console.
+    """
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+# =============================================================================
+# kvm Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-kvm-config-kernel-cmdline-console"])
+@pytest.mark.feature("kvm")
+def test_kvm_kernel_cmdline_console_exists(file: File):
+    """Test that KVM kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-kvm-config-kernel-cmdline-console"])
+@pytest.mark.feature("kvm")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+@pytest.mark.arch("amd64")
+def test_console_configuration_in_cmdline_kvm_amd64(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for KVM on AMD64."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-kvm-config-kernel-cmdline-console",
+    ]
+)
+@pytest.mark.feature("kvm")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+@pytest.mark.arch("amd64")
+def test_console_configuration_in_cmdline_kvm_earlyprintk_amd64(
+    kernel_cmdline: List[str],
+):
+    """Verify earlyprintk parameters are present in the running kernel command line for KVM on AMD64."""
+    assert (
+        "earlyprintk=ttyS0,115200n8" in kernel_cmdline
+    ), "Early Serial console (earlyprintk=ttyS0,115200n8) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-kvm-config-kernel-cmdline-console",
+    ]
+)
+@pytest.mark.feature("kvm")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+@pytest.mark.arch("arm64")
+def test_console_configuration_in_cmdline_kvm_earlycon_aarch64(
+    kernel_cmdline: List[str],
+):
+    """Verify earlycon parameters are present in the running kernel command line for KVM on ARM64."""
+    assert (
+        "earlycon=pl011,mmio,0x09000000" in kernel_cmdline
+    ), "Early Serial console (pl011,mmio,0x09000000) not found in kernel cmdline"
+
+
+# =============================================================================
+# lima Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-config-kernel-cmdline-default"])
+@pytest.mark.feature("lima")
+def test_lima_kernel_cmdline_default_exists(file: File):
+    """Test that Lima default kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/00-default.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-config-kernel-cmdline-default"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_lima_kernel_cmdline_default(kernel_cmdline: List[str]):
+    """Verify default parameters are present in the running kernel command line for Lima."""
+    required_params = ["rw", "earlyprintk=ttyS0,115200", "consoleblank=0"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-config-kernel-cmdline-console"])
+@pytest.mark.feature("lima")
+def test_lima_kernel_cmdline_console_exists(file: File):
+    """Test that Lima kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-config-kernel-cmdline-console"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_lima(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for Lima."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-lima-config-kernel-cmdline-console",
+    ]
+)
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_lima_bautrates(kernel_cmdline: List[str]):
+    """Verify console bautrates configuration parameters are present in the running kernel command line for Lima."""
+    assert (
+        "console=ttyS0,115200" in kernel_cmdline
+    ), "Serial console (ttyS0,115200) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-lima-config-kernel-postinst-cmdline",
+    ]
+)
+@pytest.mark.feature("lima")
+def test_lima_kernel_postinst_cmdline_exists(file: File):
+    """Test that Lima has kernel postinst cmdline script"""
+    assert file.exists(
+        "/etc/kernel/postinst.d/00-kernel-cmdline"
+    ), "Lima kernel postinst cmdline script should exist"
+
+
+# =============================================================================
+# metal Feature Kernel Command Line
+# =============================================================================
+@pytest.mark.testcov(["GL-TESTCOV-metal-config-kernel-cmdline-default"])
+@pytest.mark.feature("metal")
+def test_metal_kernel_cmdline_default_exists(file: File):
+    """Test that Metal default kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/00-default.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-config-kernel-cmdline-default"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_metal_kernel_cmdline_default(kernel_cmdline: List[str]):
+    """Verify default parameters are present in the running kernel command line for Metal."""
+    required_params = ["rw", "earlyprintk=ttyS0,115200", "consoleblank=0"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-config-kernel-cmdline-console"])
+@pytest.mark.feature("metal")
+def test_metal_kernel_cmdline_console_exists(file: File):
+    """Test that Metal console kernel cmdline configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-config-kernel-cmdline-console"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_metal(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for Metal."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-metal-config-kernel-cmdline-console",
+    ]
+)
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_metal_bautrates(kernel_cmdline: List[str]):
+    """Verify console bautrates configuration parameters are present in the running kernel command line for Metal."""
+    assert (
+        "console=ttyS0,115200" in kernel_cmdline
+    ), "Serial console (ttyS0,115200) not found in kernel cmdline"
+
+
+# =============================================================================
+# openstack Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackCloud-config-kernel-cmdline-console"])
+@pytest.mark.feature("openstack")
+def test_openstack_kernel_cmdline_console_exists(file: File):
+    """Test that OpenStack kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackCloud-config-kernel-cmdline-console"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_openstack(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for OpenStack."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+# =============================================================================
+# openstackMetal Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-openstackMetal-config-kernel-cmdline-enable-swap-cgroup-accounting"]
+)
+@pytest.mark.feature("openstack and metal")
+def test_openstackMetal_kernel_cmdline_enable_swap_cgroup_accounting_exists(
+    file: File,
+):
+    """Test that OpenStack Bare Metal kernel cmdline enable swap cgroup accounting configuration exists"""
+    assert file.is_regular_file(
+        "/etc/kernel/cmdline.d/40-enable-swap-cgroup-accounting.cfg"
+    )
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-openstackMetal-config-kernel-cmdline-enable-swap-cgroup-accounting"]
+)
+@pytest.mark.feature("openstack and metal")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_enable_swap_cgroup_accounting_configuration_in_cmdline_openstackMetal(
+    kernel_cmdline: List[str],
+):
+    """Verify enable swap cgroup accounting parameters are present in the running kernel command line for OpenStack Bare Metal."""
+    required_params = ["cgroup_enable=memory", "swapaccount=1"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+# =============================================================================
+# vmware Feature Kernel Command Line
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vmware-config-kernel-cmdline-console"])
+@pytest.mark.feature("vmware")
+def test_vmware_kernel_cmdline_console_exists(file: File):
+    """Test that VMware kernel cmdline console configuration exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-console.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vmware-config-kernel-cmdline-console"])
+@pytest.mark.feature("vmware")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_vmware(kernel_cmdline: List[str]):
+    """Verify console parameters are present in the running kernel command line for VMware."""
+    assert (
+        "console=tty0" in kernel_cmdline
+    ), "Virtual console (tty0) not found in kernel cmdline"
+    assert any(
+        param.startswith("console=ttyS0") for param in kernel_cmdline
+    ), "Serial console (ttyS0) not found in kernel cmdline"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-vmware-config-kernel-cmdline-console",
+    ]
+)
+@pytest.mark.feature("vmware")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_console_configuration_in_cmdline_vmware_bautrates(kernel_cmdline: List[str]):
+    """Verify console bautrates configuration parameters are present in the running kernel command line for VMware."""
+    assert (
+        "console=ttyS0,115200" in kernel_cmdline
+    ), "Serial console (ttyS0,115200) not found in kernel cmdline"

--- a/tests/integration/kernel/test_kernel_count.py
+++ b/tests/integration/kernel/test_kernel_count.py
@@ -1,0 +1,20 @@
+import pytest
+from plugins.kernel_versions import KernelVersions
+
+
+@pytest.mark.feature("not container", reason="kernel is not installed in container")
+def test_kernel_versions(kernel_versions: KernelVersions):
+    """Test that only one kernel is installed."""
+    installed_kernel_versions = kernel_versions.get_installed()
+    assert (
+        len(installed_kernel_versions) == 1
+    ), f"Only one kernel should be installed, but {len(installed_kernel_versions)} were found"
+
+
+@pytest.mark.feature("container", reason="kernel is not installed in container")
+def test_kernel_versions_container(kernel_versions: KernelVersions):
+    """Test that no kernel is installed in container."""
+    installed_kernel_versions = kernel_versions.get_installed()
+    assert (
+        len(installed_kernel_versions) == 0
+    ), f"No kernel should be installed, but {len(installed_kernel_versions)} were found"

--- a/tests/integration/kernel/test_kernel_modules.py
+++ b/tests/integration/kernel/test_kernel_modules.py
@@ -1,0 +1,344 @@
+import pytest
+from plugins.file import File
+from plugins.kernel_module import KernelModule
+
+# =============================================================================
+# cisModprobe Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisModprobe-config-modprobe-cramfs"
+        "GL-TESTCOV-cisModprobe-config-modprobe-dccp"
+        "GL-TESTCOV-cisModprobe-config-modprobe-freevxfs"
+        "GL-TESTCOV-cisModprobe-config-modprobe-jffs2"
+        "GL-TESTCOV-cisModprobe-config-modprobe-rds"
+        "GL-TESTCOV-cisModprobe-config-modprobe-sctp"
+        "GL-TESTCOV-cisModprobe-config-modprobe-squashfs"
+        "GL-TESTCOV-cisModprobe-config-modprobe-tipc"
+        "GL-TESTCOV-cisModprobe-config-modprobe-udf"
+    ]
+)
+@pytest.mark.feature("cisModprobe")
+def test_cismodprobe_blacklist_exists(file: File):
+    """Test that kernel modules are blacklisted"""
+    paths = [
+        "/etc/modprobe.d/cramfs.conf",
+        "/etc/modprobe.d/dccp.conf",
+        "/etc/modprobe.d/freevxfs.conf",
+        "/etc/modprobe.d/jffs2.conf",
+        "/etc/modprobe.d/rds.conf",
+        "/etc/modprobe.d/sctp.conf",
+        "/etc/modprobe.d/squashfs.conf",
+        "/etc/modprobe.d/tipc.conf",
+        "/etc/modprobe.d/udf.conf",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisModprobe-config-modprobe-cramfs"
+        "GL-TESTCOV-cisModprobe-config-modprobe-dccp"
+        "GL-TESTCOV-cisModprobe-config-modprobe-freevxfs"
+        "GL-TESTCOV-cisModprobe-config-modprobe-jffs2"
+        "GL-TESTCOV-cisModprobe-config-modprobe-rds"
+        "GL-TESTCOV-cisModprobe-config-modprobe-sctp"
+        "GL-TESTCOV-cisModprobe-config-modprobe-squashfs"
+        "GL-TESTCOV-cisModprobe-config-modprobe-tipc"
+        "GL-TESTCOV-cisModprobe-config-modprobe-udf"
+    ]
+)
+@pytest.mark.feature("cisModprobe")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_cismodprobe_modules_not_loaded(kernel_module: KernelModule):
+    """Test that modules are not loaded"""
+    modules = [
+        "cramfs",
+        "dccp",
+        "freevxfs",
+        "jffs2",
+        "rds",
+        "sctp",
+        "squashfs",
+        "tipc",
+        "udf",
+    ]
+
+    for module in modules:
+        assert not kernel_module.is_module_loaded(
+            module
+        ), f"Module {module} is loaded but should be deny listed"
+
+
+# =============================================================================
+# cloud Feature - Kernel Module Configurations
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-modprobe-firewire-disable",
+        "GL-TESTCOV-cloud-config-modprobe-fs-disable",
+        "GL-TESTCOV-cloud-config-modprobe-net-disable",
+        "GL-TESTCOV-cloud-config-modprobe-usb-disable",
+    ]
+)
+@pytest.mark.feature("cloud")
+def test_cloud_modprobe_disable_configs_exist(file: File):
+    """Test that cloud modprobe disable configurations exist"""
+    paths = [
+        "/etc/modprobe.d/disabled_firewire.conf",
+        "/etc/modprobe.d/disabled_fs.conf",
+        "/etc/modprobe.d/disabled_net.conf",
+        "/etc/modprobe.d/disabled_usb.conf",
+    ]
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-modprobe-udf-disable",
+    ]
+)
+@pytest.mark.feature(
+    "cloud and not azure", reason="azure has a different modprobe disable configuration"
+)
+def test_cloud_modprobe_disable_udf_config_exists(file: File):
+    """Test that cloud modprobe disable configurations exist, but not on Azure"""
+    paths = [
+        "/etc/modprobe.d/disabled_udf.conf",
+    ]
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-modprobe-firewire-disable",
+        "GL-TESTCOV-cloud-config-modprobe-fs-disable",
+        "GL-TESTCOV-cloud-config-modprobe-net-disable",
+        "GL-TESTCOV-cloud-config-modprobe-usb-disable",
+    ]
+)
+@pytest.mark.feature("cloud")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_cloud_modprobe_disable_modules_not_loaded(kernel_module: KernelModule):
+    """Test that disabled modules are not loaded"""
+    modules = [
+        "firewire-core",
+        "cramfs",
+        "freevxfs",
+        "jffs2",
+        "hfs",
+        "hfsplus",
+        "dccp",
+        "sctp",
+        "rds",
+        "tipc",
+        "usbcore",
+        "usb-common",
+        "usb-storage",
+    ]
+    for module in modules:
+        assert not kernel_module.is_module_loaded(
+            module
+        ), f"Module {module} is loaded but should be deny listed"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-modprobe-udf-disable",
+    ]
+)
+@pytest.mark.feature("cloud and not azure")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_cloud_modprobe_udf_module_not_loaded(kernel_module: KernelModule):
+    """Test that disabled modules are not loaded, but not on Azure"""
+    modules = [
+        "udf",
+    ]
+    for module in modules:
+        assert not kernel_module.is_module_loaded(
+            module
+        ), f"Module {module} is loaded but should be deny listed"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-modprobe-no-udf-disable"])
+@pytest.mark.feature("azure")
+def test_azure_no_modprobe_udf_disable_exists(file: File):
+    """Test that on Azure no modprobe disable configuration for UDF exists"""
+    assert not file.exists("/etc/modprobe.d/disabled_udf.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-modprobe-no-udf-disable"])
+@pytest.mark.root(reason="loading modules requires root access")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+@pytest.mark.feature("azure")
+def test_azure_modprobe_udf_module_loaded(kernel_module: KernelModule):
+    """Test that UDF module is loaded on Azure"""
+    modules = [
+        "udf",
+    ]
+    for module in modules:
+        kernel_module.load_module(module)
+        assert kernel_module.is_module_loaded(
+            module
+        ), f"Module {module} is not loaded but should be loaded on Azure after loading"
+    kernel_module.unload_modules()
+
+
+# =============================================================================
+# chost Feature - Kernel Module Configurations
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-modprobe-overlayfs",
+        "GL-TESTCOV-chost-config-modules-load-br-netfilter",
+        "GL-TESTCOV-chost-config-modules-load-ip-tables",
+        "GL-TESTCOV-chost-config-modules-load-overlayfs",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_modprobe_configs_exist(file: File):
+    """Test that chost modprobe configurations exist"""
+    paths = [
+        "/etc/modprobe.d/overlayfs.conf",
+        "/etc/modules-load.d/br_netfilter.conf",
+        "/etc/modules-load.d/ip_tables.conf",
+        "/etc/modules-load.d/overlay.conf",
+    ]
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+# TODO: enable after fixing https://github.com/gardenlinux/gardenlinux/issues/4325
+# @pytest.mark.testcov(["GL-TESTCOV-chost-config-modprobe-overlayfs"])
+# @pytest.mark.feature("chost")
+# @pytest.mark.booted(reason="module state check needs a booted system")
+# def test_chost_modprobe_overlayfs_loaded(kernel_module: KernelModule):
+#     """Test that overlay module is loaded with correct parameters"""
+#
+#     module = "overlay"
+#     assert kernel_module.is_module_loaded(
+#         module
+#     ), f"Module {module} should be loaded for container host"
+#
+#     module_parameters = [
+#         "metacopy=N",
+#         "redirect_dir=Y",
+#     ]
+#     missing = [
+#         module_parameter
+#         for module_parameter in module_parameters
+#         if not kernel_module.has_module_parameter(
+#             module, *module_parameter.split("=", 1)
+#         )
+#     ]
+#     assert (
+#         not missing
+#     ), f"Module {module} parameters are not set to the expected value: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-modules-load-br-netfilter",
+        "GL-TESTCOV-chost-config-modules-load-ip-tables",
+    ]
+)
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_chost_modprobe_required_modules_loaded(kernel_module: KernelModule):
+    """Test that required modules are loaded on chost"""
+    modules = [
+        "br_netfilter",
+        "ip_tables",
+    ]
+    missing = [
+        module for module in modules if not kernel_module.is_module_loaded(module)
+    ]
+    assert (
+        not missing
+    ), f"The following modules are not loaded but should be loaded: {', '.join(missing)}"
+
+
+# =============================================================================
+# khost Feature - Kernel Module Configurations
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-khost-config-modules-load-br-nf"])
+@pytest.mark.feature("khost")
+def test_khost_modprobe_br_nf_exists(file: File):
+    """Test that khost br-nf modprobe configuration exists"""
+    assert file.is_regular_file("/etc/modules-load.d/br-nf.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-khost-config-modules-load-br-nf"])
+@pytest.mark.feature("khost")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_khost_modprobe_br_nf_loaded(kernel_module: KernelModule):
+    """Test that khost br-nf module is loaded"""
+    assert kernel_module.is_module_loaded(
+        "br_netfilter"
+    ), "br_netfilter module should be loaded for khost"
+
+
+# =============================================================================
+# gardener Feature - Kernel Module Configurations
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-modules-load-ipvs"])
+@pytest.mark.feature("gardener")
+def test_gardener_modprobe_ipvs_exists(file: File):
+    """Test that gardener ipvs modprobe configuration exists"""
+    assert file.is_regular_file("/etc/modules-load.d/ipvs.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-modules-load-ipvs"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_gardener_modprobe_ipvs_loaded(kernel_module: KernelModule):
+    """Test that gardener ipvs modules are loaded"""
+    modules = [
+        "ip_vs",
+        "ip_vs_rr",
+        "ip_vs_wrr",
+        "ip_vs_sh",
+        "nf_conntrack",
+    ]
+    missing = [
+        module for module in modules if not kernel_module.is_module_loaded(module)
+    ]
+    assert (
+        not missing
+    ), f"The following modules are not loaded but should be loaded: {', '.join(missing)}"
+
+
+# =============================================================================
+# openstackMetal Feature - Kernel Module Configurations
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-config-modprobe-disallow-nouveau"])
+@pytest.mark.feature("openstack and metal")
+def test_openstackMetal_modprobe_nouveau_disable_exists(file: File):
+    """Test that OpenStack Baremetal nouveau disable configuration exists"""
+    assert file.is_regular_file("/etc/modprobe.d/10-disallow-nouveau.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-config-modprobe-disallow-nouveau"])
+@pytest.mark.feature("openstack and metal")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_openstackMetal_modprobe_nouveau_no_loaded(kernel_module: KernelModule):
+    """Test that OpenStack Baremetal nouveau module is not loaded"""
+    assert not kernel_module.is_module_loaded(
+        "nouveau"
+    ), "nouveau module should not be loaded for OpenStack Baremetal"

--- a/tests/integration/kernel/test_kernel_parameters.py
+++ b/tests/integration/kernel/test_kernel_parameters.py
@@ -1,0 +1,289 @@
+import pytest
+from plugins.file import File
+from plugins.sysctl import Sysctl
+
+# =============================================================================
+# cloud Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-config-sysctl-cloud"])
+@pytest.mark.feature("cloud")
+def test_cloud_sysctl_cloud_config_exists(file: File):
+    """Test that cloud sysctl cloud configuration exists"""
+    assert file.exists("/etc/sysctl.d/20-cloud.conf")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-sysctl-cloud",
+        "GL-TESTCOV-openstackMetal-config-sysctl-cloud",
+    ]
+)
+@pytest.mark.feature("cloud or (openstack and metal)")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_kernel_parameters_cannot_hardlink_what_you_do_not_own(sysctl):
+    assert sysctl["fs.protected_hardlinks"] == 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-sysctl-cloud",
+        "GL-TESTCOV-openstackMetal-config-sysctl-cloud",
+    ]
+)
+@pytest.mark.feature("cloud or (openstack and metal)")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_kernel_parameters_cannot_symlink_what_you_do_not_own(sysctl):
+    assert sysctl["fs.protected_symlinks"] == 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-sysctl-cloud",
+        "GL-TESTCOV-openstackMetal-config-sysctl-cloud",
+    ]
+)
+@pytest.mark.feature("cloud or (openstack and metal)")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_kernel_parameters_randomize_memory_allocation(sysctl):
+    assert sysctl["kernel.randomize_va_space"] == 2
+
+
+@pytest.mark.testcov(
+    "GL-TESTCOV-gardener-config-sysctl-gce-network-security",
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_sysctl_rp_filter(sysctl):
+    assert sysctl["net.ipv4.conf.all.rp_filter"] != 1
+    assert sysctl["net.ipv4.conf.default.rp_filter"] != 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-sysctl-ipv4",
+        "GL-TESTCOV-cloud-config-sysctl-ipv6",
+    ]
+)
+@pytest.mark.feature("cloud")
+def test_cloud_sysctl_network_configs_exist(file: File):
+    """Test that cloud sysctl network configurations exist"""
+    configs = [
+        "/etc/sysctl.d/21-ipv4-settings.conf",
+        "/etc/sysctl.d/22-ipv6-settings.conf",
+    ]
+    missing = [cfg for cfg in configs if not file.is_regular_file(cfg)]
+    assert not missing, f"Missing cloud sysctl configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-sysctl-ipv4",
+    ]
+)
+@pytest.mark.feature("cloud")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_cloud_sysctl_network_config_ipv4(sysctl):
+    """Test that cloud sysctl network config ipv4 is set correctly"""
+
+    settings = {
+        "net.ipv4.tcp_syncookies": 1,
+        "net.ipv4.conf.all.accept_source_route": 0,
+        # "net.ipv4.conf.all.accept_redirects": 0, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        "net.ipv4.conf.all.secure_redirects": 1,
+        "net.ipv4.conf.default.secure_redirects": 1,
+        "net.ipv4.icmp_echo_ignore_broadcasts": 1,
+        "net.ipv4.icmp_ignore_bogus_error_responses": 1,
+        # "net.ipv4.conf.default.accept_source_route": 1, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        # "net.ipv4.conf.default.accept_redirects": 1, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        # "net.ipv4.conf.all.log_martians": 0, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        # "net.ipv4.conf.all.forwarding": 1, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        # "net.ipv4.conf.default.forwarding": 1, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        # "net.ipv4.conf.default.send_redirects": 1,
+        # "net.ipv4.conf.all.send_redirects": 1, # TODO: Disabled until https://github.com/gardenlinux/gardenlinux/issues/4336 is fixed.
+        "net.ipv4.conf.all.promote_secondaries": 1,
+    }
+    missing = [key for key, value in settings.items() if sysctl[key] != value]
+    assert (
+        not missing
+    ), f"Missing or incorrect cloud sysctl network config ipv4 settings: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cloud-config-sysctl-ipv6",
+    ]
+)
+@pytest.mark.feature("cloud")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_cloud_sysctl_network_config_ipv6(sysctl):
+    """Test that cloud sysctl network config ipv6 is set correctly"""
+    settings = {
+        "net.ipv6.conf.all.forwarding": 1,
+        "net.ipv6.conf.default.forwarding": 1,
+    }
+    missing = [key for key, value in settings.items() if sysctl[key] != value]
+    assert (
+        not missing
+    ), f"Missing or incorrect cloud sysctl network config ipv6 settings: {', '.join(missing)}"
+
+
+# =============================================================================
+# chost Feature - Container Networking Sysctl Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-sysctl-ip-forward",
+        "GL-TESTCOV-chost-config-sysctl-nf-call-iptables",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_sysctl_configs_exist(file: File):
+    """Test that container networking sysctl configs exist"""
+    sysctl_configs = [
+        "/etc/sysctl.d/ip-forward.conf",
+        "/etc/sysctl.d/nf-call-iptables.conf",
+    ]
+    missing = [cfg for cfg in sysctl_configs if not file.exists(cfg)]
+    assert not missing, f"Missing sysctl configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-sysctl-ip-forward",
+        "GL-TESTCOV-chost-config-sysctl-nf-call-iptables",
+    ]
+)
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_chost_sysctl_config_content(sysctl: Sysctl):
+    """Test that container networking sysctl config contains the correct content"""
+    settings = {
+        "net.ipv4.ip_forward": 1,
+        "net.ipv6.conf.all.forwarding": 1,
+        "net.bridge.bridge-nf-call-iptables": 1,
+        "net.bridge.bridge-nf-call-ip6tables": 1,
+    }
+    missing = [key for key, value in settings.items() if sysctl[key] != value]
+    assert (
+        not missing
+    ), f"Missing or incorrect chost sysctl settings: {', '.join(missing)}"
+
+
+# =============================================================================
+# khost Feature - Kubernetes Host Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-khost-config-sysctl-br-nf",
+        "GL-TESTCOV-khost-config-sysctl-inotify",
+        "GL-TESTCOV-khost-config-sysctl-ip-forward",
+    ]
+)
+@pytest.mark.feature("khost")
+def test_khost_sysctl_configs_exist(file: File):
+    """Test that Kubernetes host sysctl configs exist"""
+    sysctl_configs = [
+        "/etc/sysctl.d/20-br-nf.conf",
+        "/etc/sysctl.d/20-inotify.conf",
+        "/etc/sysctl.d/20-ip-forward.conf",
+    ]
+    missing = [cfg for cfg in sysctl_configs if not file.exists(cfg)]
+    assert not missing, f"Missing khost sysctl configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-khost-config-sysctl-br-nf",
+        "GL-TESTCOV-khost-config-sysctl-inotify",
+        "GL-TESTCOV-khost-config-sysctl-ip-forward",
+    ]
+)
+@pytest.mark.feature("khost")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_khost_sysctl_configs_content(sysctl: Sysctl):
+    """Test that Kubernetes host sysctl configs contain the correct content"""
+    settings = {
+        "net.bridge.bridge-nf-call-iptables": 1,
+        "net.bridge.bridge-nf-call-ip6tables": 1,
+        "fs.inotify.max_user_instances": 8192,
+        "fs.inotify.max_user_watches": 65536,
+        "net.ipv4.ip_forward": 1,
+        "net.ipv6.conf.all.forwarding": 1,
+    }
+    missing = [key for key, value in settings.items() if sysctl[key] != value]
+    assert (
+        not missing
+    ), f"Missing or incorrect khost sysctl settings: {', '.join(missing)}"
+
+
+# =============================================================================
+# server Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-allow-ping-for-non-root-user",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_sysctl_allow_ping_nonroot(file: File):
+    """Test that server allows ping for non-root users"""
+    assert file.exists(
+        "/etc/sysctl.d/90-allow-ping-for-non-root-user.conf"
+    ), "Sysctl config for non-root ping should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-allow-ping-for-non-root-user",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_server_sysctl_allow_ping_nonroot_check(sysctl: Sysctl):
+    """Test that server sysctl allows ping for non-root users"""
+    settings = {
+        "net.ipv4.ping_group_range": "0 2147483647",
+    }
+    missing = [key for key, value in settings.items() if sysctl[key] != value]
+    assert (
+        not missing
+    ), f"Missing or incorrect server sysctl settings: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-enable-unprivileged-user-namespaces",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_sysctl_unprivileged_namespaces(file: File):
+    """Test that server enables unprivileged user namespaces"""
+    assert file.exists(
+        "/etc/sysctl.d/40-enable-unprivileged-user-namespaces.conf"
+    ), "Sysctl config for unprivileged namespaces should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-enable-unprivileged-user-namespaces",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_server_sysctl_unprivileged_namespaces_check(sysctl: Sysctl):
+    """Test that server sysctl allows ping for non-root users"""
+    settings = {
+        "kernel.unprivileged_userns_clone": 1,
+    }
+    missing = [key for key, value in settings.items() if sysctl[key] != value]
+    assert (
+        not missing
+    ), f"Missing or incorrect server sysctl settings: {', '.join(missing)}"

--- a/tests/integration/runtime/test_checkbox.py
+++ b/tests/integration/runtime/test_checkbox.py
@@ -1,0 +1,255 @@
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# checkbox Feature - Hardware Testing Framework
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-test-plan",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_test_plan_exists(file: File):
+    """Test that checkbox test plan exists"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/test-plan.pxu"
+    ), "Checkbox test plan should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-units-category",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_units_category_exists(file: File):
+    """Test that checkbox category units exist"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/category.pxu"
+    ), "Checkbox category units should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-units-jobs",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_units_jobs_exists(file: File):
+    """Test that checkbox job units exist"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/jobs.pxu"
+    ), "Checkbox job units should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-units-manifest",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_units_manifest_exists(file: File):
+    """Test that checkbox manifest units exist"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/manifest.pxu"
+    ), "Checkbox manifest units should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_banner_exists(file: File):
+    """Test that checkbox has issue banner file"""
+    assert file.exists("/etc/issue"), "Checkbox issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_banner_content(parse_file: ParseFile):
+    """Test that checkbox has issue banner file"""
+    expected_lines = ["Welcome to Garden Linux HW Testing Image"]
+    assert expected_lines in parse_file.lines(
+        "/etc/issue"
+    ), "Checkbox issue banner should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue-net",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_net_banner_exists(file: File):
+    """Test that checkbox has network issue banner file"""
+    assert file.exists("/etc/issue.net"), "Checkbox network issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue-net",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_net_banner_empty(file: File):
+    """Test that checkbox has empty network issue banner file"""
+    size = file.get_size("/etc/issue.net")
+    assert size == 0, "Checkbox network issue.net banner should be empty"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-motd",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_motd_exists(file: File):
+    """Test that checkbox has message of the day file"""
+    assert file.exists("/etc/motd"), "Checkbox motd should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-motd",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_motd_empty(file: File):
+    """Test that checkbox has empty message of the day file"""
+    size = file.get_size("/etc/motd")
+    assert size == 0, "Checkbox motd should be empty"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-journald-10-logs",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_journald_logs_config_exists(file: File):
+    """Test that checkbox has journald logs configuration"""
+    assert file.exists(
+        "/etc/systemd/journald.conf.d/10-logs.conf"
+    ), "Checkbox journald logs configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-journald-10-logs",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_journald_logs_config_content(parse_file: ParseFile):
+    """Test that checkbox has journald logs configuration"""
+    config = parse_file.parse("/etc/systemd/journald.conf.d/10-logs.conf", format="ini")
+    assert (
+        config["Journal"]["ForwardToConsole"] == "no"
+    ), "Checkbox journald logs configuration ForwardToConsole should be correct"
+    assert (
+        config["Journal"]["ForwardToWall"] == "no"
+    ), "Checkbox journald logs configuration ForwardToWall should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-kernel-cmdline-iso",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_kernel_cmdline_iso_exists(file: File):
+    """Test that checkbox has kernel cmdline ISO configuration"""
+    assert file.exists(
+        "/etc/kernel/cmdline.iso"
+    ), "Checkbox kernel cmdline ISO configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-kernel-cmdline-iso",
+    ]
+)
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_checkbox_kernel_cmdline_iso_content(kernel_cmdline: List[str]):
+    """Verify kernel cmdline ISO configuration parameters are present in the running kernel command line for checkbox."""
+    assert (
+        "console=tty0 rd.live.squashimg=squashfs.img root=live:CDLABEL=GardenlinuxISO rd.live.overlay.overlayfs rd.live.dir=live rd.live.ram quiet"
+        in kernel_cmdline
+    ), "Kernel cmdline ISO configuration should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-dmesg_colored",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_dmesg_colored_script_exists(file: File):
+    """Test that checkbox has dmesg colored script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/dmesg_colored.sh"
+    ), "Checkbox dmesg colored script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-generate-report",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_generate_report_script_exists(file: File):
+    """Test that checkbox has generate report script"""
+    assert file.exists(
+        "/usr/local/bin/generate-report.sh"
+    ), "Checkbox generate report script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-hw_encrypt_check",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_hw_encrypt_check_script_exists(file: File):
+    """Test that checkbox has hardware encryption check script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/hw_encrypt_check.sh"
+    ), "Checkbox hardware encryption check script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-tpm_check",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_tpm_check_script_exists(file: File):
+    """Test that checkbox has TPM check script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/tpm_check.sh"
+    ), "Checkbox TPM check script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-virtualization_disabled",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_virtualization_disabled_script_exists(file: File):
+    """Test that checkbox has virtualization disabled check script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/virtualization_disabled.sh"
+    ), "Checkbox virtualization disabled script should exist"

--- a/tests/integration/runtime/test_chost.py
+++ b/tests/integration/runtime/test_chost.py
@@ -1,0 +1,119 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# chost Feature - Container Host Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-containerd-config",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_containerd_config_exists(file: File):
+    """Test that containerd configuration exists"""
+    assert file.is_regular_file(
+        "/etc/containerd/config.toml"
+    ), "Containerd configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-containerd-config",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_containerd_config_content(parse_file: ParseFile):
+    """Test that containerd configuration contains the correct content"""
+    config = parse_file.parse("/etc/containerd/config.toml")
+    assert config["version"] == 2, "Containerd configuration should be version 2"
+    assert (
+        config["plugins"]["io.containerd.grpc.v1.cri"]["cni"]["bin_dir"]
+        == "/var/lib/containerd/io.containerd.grpc.v1.cri.cni"
+    ), "Containerd CNI bin directory should be /var/lib/containerd/io.containerd.grpc.v1.cri.cni"
+    assert (
+        config["plugins"]["io.containerd.grpc.v1.cri"]["containerd"]["runtimes"][
+            "runc"
+        ]["runtime_type"]
+        == "io.containerd.runc.v2"
+    ), "Containerd runc runtime type should be io.containerd.runc.v2"
+    assert (
+        config["plugins"]["io.containerd.grpc.v1.cri"]["containerd"]["runtimes"][
+            "runc"
+        ]["options"]["SystemdCgroup"]
+        == True
+    ), "Containerd runc runtime options should include SystemdCgroup"
+    assert (
+        config["plugins"]["io.containerd.internal.v1.opt"]["path"]
+        == "/var/lib/containerd/io.containerd.internal.v1.opt"
+    ), "Containerd internal opt path should be /var/lib/containerd/io.containerd.internal.v1.opt"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-crictl-yaml",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_crictl_config_exists(file: File):
+    """Test that crictl configuration exists"""
+    assert file.is_regular_file("/etc/crictl.yaml"), "Crictl configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-crictl-yaml",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_crictl_config_content(parse_file: ParseFile):
+    """Test that crictl configuration contains the correct content"""
+    config = parse_file.parse("/etc/crictl.yaml")
+    assert (
+        config["runtime-endpoint"] == "unix:///run/containerd/containerd.sock"
+    ), "Crictl runtime endpoint should be unix:///run/containerd/containerd.sock"
+    assert (
+        config["image-endpoint"] == "unix:///run/containerd/containerd.sock"
+    ), "Crictl image endpoint should be unix:///run/containerd/containerd.sock"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-service-containerd-override",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_containerd_service_override_exists(file: File):
+    """Test that containerd service override exists"""
+    assert file.exists(
+        "/etc/systemd/system/containerd.service.d/override.conf"
+    ), "Containerd service override should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-no-initd-apparmor",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_no_apparmor_init(file: File):
+    """Test that chost does not have AppArmor init script"""
+    assert not file.exists(
+        "/etc/init.d/apparmor"
+    ), "Container host should not have AppArmor init script"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-no-var-lib-containerd-opt",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_no_containerd_opt_directory(file: File):
+    """Test that chost does not have containerd opt directory"""
+    assert not file.exists(
+        "/var/lib/containerd/opt"
+    ), "Container host should not have containerd opt directory"

--- a/tests/integration/runtime/test_clamav.py
+++ b/tests/integration/runtime/test_clamav.py
@@ -1,0 +1,38 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# clamav Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-clamav-config-cron-root",
+    ]
+)
+@pytest.mark.feature("clamav")
+def test_clamav_cron_exists(file: File):
+    """Test that clamav cron job exists"""
+    cron_locations = [
+        "/var/spool/cron/crontabs/root",
+    ]
+    exists = any(file.exists(loc) for loc in cron_locations)
+    assert (
+        exists
+    ), f"Clamav cron job should exist in one of: {', '.join(cron_locations)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-clamav-config-cron-root",
+    ]
+)
+@pytest.mark.feature("clamav")
+def test_clamav_cron_content(parse_file: ParseFile):
+    """Test that clamav cron job contains the correct content"""
+    lines = parse_file.lines("/var/spool/cron/crontabs/root")
+    assert lines == [
+        "0 30 * * * root /usr/bin/clamscan -ri / >> /var/log/clamav/clamd.log",
+    ], "Clamav cron job should contain the correct content"

--- a/tests/integration/runtime/test_containers.py
+++ b/tests/integration/runtime/test_containers.py
@@ -1,0 +1,24 @@
+import pytest
+from plugins.containerd import CtrRunner
+
+TEST_IMAGES = [
+    "docker.io/library/busybox:latest",  # Docker Hub, https://hub.docker.com/_/busybox
+    "public.ecr.aws/docker/library/busybox:unstable-uclibc",  # AWS ECR, https://gallery.ecr.aws/docker/library/busybox
+]
+
+
+@pytest.mark.skip(
+    reason="Skip until https://github.com/gardenlinux/gardenlinux/issues/3567 is resolved to avoid false negative results"
+)
+@pytest.mark.booted(reason="Container tests require systemd")
+@pytest.mark.root(reason="Needs to start containerd")
+@pytest.mark.feature(
+    "(gardener or chost or _debug) and not _pxe",
+    reason="containerd is not installed, pxe has tmpfs for /",
+)
+@pytest.mark.parametrize("uri", TEST_IMAGES)
+def test_basic_container_functionality(
+    service_containerd, container_image_setup, uri: str, ctr: CtrRunner
+):
+    out = ctr.run(uri, "uname", capture_output=True, ignore_exit_code=True)
+    assert "Linux" in out.stdout, f"Command failed: {out.stderr}"

--- a/tests/integration/runtime/test_gardener.py
+++ b/tests/integration/runtime/test_gardener.py
@@ -1,0 +1,195 @@
+import pytest
+from plugins.file import File
+from plugins.modify import allow_system_modifications
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# gardener Feature - Gardener Kubernetes Extended
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-containerd-no-config",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_no_containerd_default_config(file: File):
+    """Test that gardener does not have default containerd config"""
+    assert not file.exists(
+        "/etc/containerd/config.toml"
+    ), "Gardener should not have default containerd config"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-iptables-legacy",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_iptables_legacy_alternative(file: File):
+    """Test that gardener has iptables legacy alternative configured"""
+    symlinks = [
+        {"path": "/etc/alternatives/iptables", "target": "/usr/sbin/iptables-legacy"},
+        {"path": "/etc/alternatives/ip6tables", "target": "/usr/sbin/ip6tables-legacy"},
+        {"path": "/etc/alternatives/arptables", "target": "/usr/sbin/arptables-legacy"},
+        {"path": "/etc/alternatives/ebtables", "target": "/usr/sbin/ebtables-legacy"},
+    ]
+    missing = [
+        symlink
+        for symlink in symlinks
+        if not file.is_symlink(symlink["path"], symlink["target"])
+    ]
+    assert (
+        not missing
+    ), f"Gardener iptables alternatives should be symlinks to iptables-legacy, but are {missing}: {', '.join([symlink['path'] for symlink in missing])}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-security-mount-no-sbit",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_mount_no_sbit_security(file: File):
+    """Test that gardener has mount security without sbit"""
+    files = [
+        "/sbin/mount.nfs",
+        "/sbin/mount.cifs",
+    ]
+    missing = [file_path for file_path in files if not file.has_mode(file_path, "0755")]
+    assert (
+        not missing
+    ), f"Gardener mount security should be without sbit, but are {missing}: {', '.join([file_path for file_path in missing])}"
+
+
+# =============================================================================
+# gardener Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-apparmor-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-apparmor-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-service-containerd-enable",
+        "GL-TESTCOV-gardener-service-containerd-disable",
+    ]
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_containerd_service_disabled(systemd: Systemd):
+    """Test that containerd.service is disabled"""
+    assert systemd.is_disabled("containerd.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-service-containerd-enable",
+        "GL-TESTCOV-gardener-service-containerd-disable",
+    ]
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_containerd_service_inactive(systemd: Systemd):
+    """Test that containerd.service is inactive"""
+    assert systemd.is_inactive("containerd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-logrotate-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_logrotate_timer_service_enabled(systemd: Systemd):
+    """Test that logrotate.timer is enabled"""
+    assert systemd.is_enabled("logrotate.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-logrotate-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_logrotate_timer_service_active(systemd: Systemd):
+    """Test that logrotate.timer is active"""
+    assert systemd.is_active("logrotate.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-ssh-disable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_ssh_service_disabled(systemd: Systemd):
+    """Test that ssh.service is disabled"""
+    # TODO: find better way to exclude this
+    if allow_system_modifications():
+        pytest.skip("ssh.service is enabled to connect to test instances")
+    else:
+        assert systemd.is_disabled("ssh.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-ssh-disable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_ssh_service_inactive(systemd: Systemd):
+    """Test that ssh.service is inactive"""
+    # TODO: find better way to exclude this
+    if allow_system_modifications():
+        pytest.skip("ssh.service is enabled to connect to test instances")
+    else:
+        assert systemd.is_inactive("ssh.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-containerd-override",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_containerd_override_exists(file: File):
+    """Test that gardener containerd service override exists"""
+    assert file.exists(
+        "/etc/systemd/system/containerd.service.d/override.conf"
+    ), "Gardener containerd service override should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-containerd-override",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_containerd_override_content(parse_file: ParseFile):
+    """Test that gardener containerd service override contains the correct content"""
+    config = parse_file.parse(
+        "/etc/systemd/system/containerd.service.d/override.conf", format="ini"
+    )
+    assert (
+        config["Service"]["LimitMEMLOCK"] == "67108864"
+    ), "Gardener containerd service override should include correct LimitMEMLOCK value"
+    assert (
+        config["Service"]["LimitNOFILE"] == "1048576"
+    ), "Gardener containerd service override should include correct LimitNOFILE value"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-containerd-disable"])
+@pytest.mark.booted(reason="Test runs systemd")
+@pytest.mark.root(reason="To start the systemd service")
+@pytest.mark.modify(reason="Starts systemd service")
+@pytest.mark.feature("gardener or chost")
+def test_gardener_containerd_can_be_started(systemd: Systemd, service_containerd):
+    """Test that containerd.service can be started. It will be started and stopped by the service fixture."""
+    assert systemd.is_active(
+        "containerd.service"
+    ), "containerd.service is still running"

--- a/tests/integration/runtime/test_glvd.py
+++ b/tests/integration/runtime/test_glvd.py
@@ -1,0 +1,18 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# glvd Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-glvd-script-update-motd-glvd"])
+@pytest.mark.feature("glvd")
+def test_glvd_motd_scripts_exists(file: File):
+    """Test that GLVD MOTD script exists"""
+    paths = [
+        "/etc/update-motd.d/99-glvd",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"

--- a/tests/integration/runtime/test_khost.py
+++ b/tests/integration/runtime/test_khost.py
@@ -1,0 +1,19 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# khost Feature - Kubernetes Host Extended
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-khost-config-security-no-apparmor-init",
+    ]
+)
+@pytest.mark.feature("khost")
+def test_khost_no_apparmor_init(file: File):
+    """Test that khost does not have AppArmor init script"""
+    assert not file.exists(
+        "/etc/init.d/apparmor"
+    ), "Kubernetes host should not have AppArmor init script"

--- a/tests/integration/runtime/test_nodejs.py
+++ b/tests/integration/runtime/test_nodejs.py
@@ -1,0 +1,22 @@
+import pytest
+from plugins.dpkg import Dpkg
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# nodejs Feature
+# =============================================================================
+
+
+@pytest.mark.feature("nodejs")
+def test_nodejs_is_installed(shell: ShellRunner):
+    dpkg = Dpkg(shell)
+    assert dpkg.package_is_installed("nodejs"), "nodejs package is not installed"
+
+
+@pytest.mark.feature("nodejs")
+def test_node_can_run_script(shell: ShellRunner):
+    out = shell(
+        "node --eval 'const foo = (x,y) => x + y; console.log(foo(1,2))'",
+        capture_output=True,
+    )
+    assert out.stdout == "3\n", "Expected node to run script"

--- a/tests/integration/runtime/test_pythonDev.py
+++ b/tests/integration/runtime/test_pythonDev.py
@@ -1,0 +1,65 @@
+import os
+import shutil
+
+import pytest
+from plugins.dpkg import Dpkg
+from plugins.shell import ShellRunner
+from plugins.utils import tree
+
+
+@pytest.mark.feature("pythonDev")
+def test_python_environment_is_installed(shell: ShellRunner):
+    dpkg = Dpkg(shell)
+
+    assert dpkg.package_is_installed("python3"), "python3 package is not installed"
+    assert dpkg.package_is_installed(
+        "python3-pip"
+    ), "python3-pip package is not installed"
+    assert dpkg.package_is_installed(
+        "python3.14-venv"
+    ), "python3.14-venv package is not installed"
+
+
+dependencies = {
+    "arm64": {
+        "/required_libs_test",
+        "/required_libs_test/usr",
+        "/required_libs_test/usr/lib",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/libpthread.so.0",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/libc.so.6",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
+    },
+    "amd64": {
+        "/required_libs_test",
+        "/required_libs_test/usr",
+        "/required_libs_test/usr/lib",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/libpthread.so.0",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/libc.so.6",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
+    },
+}
+
+
+@pytest.mark.feature("pythonDev")
+@pytest.mark.root(reason="Installs pip packages")
+@pytest.mark.modify(reason="Installs pip packages")
+def test_python_export_libs(shell: ShellRunner, pip_requests):
+    dpkg = Dpkg(shell)
+    arch = dpkg.architecture_native()
+
+    # Check if requests is installed
+    shell("/bin/python3 -c 'import requests'")
+
+    shell(
+        f"exportLibs.py --package-dir {pip_requests} --output-dir /required_libs_test"
+    )
+
+    assert os.path.isdir("/required_libs_test"), "/required_libs_test was not created"
+
+    assert (
+        tree("/required_libs_test") == dependencies[arch]
+    ), "required_libs content differs"
+
+    shutil.rmtree("/required_libs_test")

--- a/tests/integration/runtime/test_sap.py
+++ b/tests/integration/runtime/test_sap.py
@@ -1,0 +1,301 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# sap Feature - SAP Compliance Requirements
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privilege-escalaction-permissions",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_privilege_escalation_permissions(file: File):
+    """Test that SAP has privilege escalation audit rules permissions"""
+    assert file.has_mode(
+        "/etc/audit/rules.d/70-privilege-escalation.rules", "0640"
+    ), "SAP privilege escalation audit rules should have 0640 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privilege-escalaction",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_privilege_escalation(parse_file: ParseFile):
+    """Test that SAP has privilege escalation audit rules"""
+    expected_lines = [
+        "-a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+        "-a exit,always -F arch=b32 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+        "-a exit,always -F arch=b64 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+        "-a exit,always -F arch=b32 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-privilege-escalation.rules"
+    ), "SAP privilege escalation audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privileged-special-permissions",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_privilege_escalation_special_permissions(file: File):
+    """Test that SAP has privilege escalation audit rules special permissions"""
+    assert file.has_mode(
+        "/etc/audit/rules.d/70-privileged-special.rules", "0640"
+    ), "SAP privilege escalation audit rules special should have 0640 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privileged-special-amd64",
+    ]
+)
+@pytest.mark.feature("sap")
+@pytest.mark.arch("amd64")
+def test_sap_audit_privilege_escalation_special_amd64(parse_file: ParseFile):
+    """Test that SAP has AMD64-specific privilege escalation audit rules"""
+    expected_lines = [
+        "-a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+        "-a exit,always -F arch=b32 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-privileged-special.rules"
+    ), "SAP AMD64 privilege escalation audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privileged-special-arm64",
+    ]
+)
+@pytest.mark.feature("sap")
+@pytest.mark.arch("arm64")
+def test_sap_audit_privilege_escalation_special_arm64(parse_file: ParseFile):
+    """Test that SAP has ARM64-specific privilege escalation audit rules"""
+    expected_lines = [
+        "-a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+        "-a exit,always -F arch=b32 -S mount -S mount_setattr -S umount2 -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-privileged-special.rules"
+    ), "SAP ARM64 privilege escalation audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-system-integrity-permissions",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_system_integrity_permissions(file: File):
+    """Test that SAP has system integrity audit rules with correct permissions"""
+    assert file.has_mode(
+        "/etc/audit/rules.d/70-system-integrity.rules", "0640"
+    ), "SAP system integrity audit rules should have 0640 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-system-integrity",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_system_integrity(parse_file: ParseFile):
+    """Test that SAP has system integrity audit rules"""
+    expected_lines = [
+        "-a exit,always -F dir=/boot -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/etc -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/bin -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/sbin -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/usr -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/opt -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/root -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/lib -F perm=wa -F key=system_integrity",
+        "#-a exit,always -F dir=/lib64 -F perm=wa -F key=system_integrity",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-system-integrity.rules"
+    ), "SAP system integrity audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_banner_exists(file: File):
+    """Test that SAP has issue banner file"""
+    assert file.exists("/etc/issue"), "SAP issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_banner_content(parse_file: ParseFile):
+    """Test that SAP has issue banner file"""
+    expected_lines = [
+        "You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted."
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/issue"
+    ), "SAP issue banner should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue-net",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_net_banner_exists(file: File):
+    """Test that SAP has network issue banner file"""
+    assert file.exists("/etc/issue.net"), "SAP network issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue-net",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_net_banner_content(parse_file: ParseFile):
+    """Test that SAP has network issue banner file"""
+    expected_lines = [
+        "You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted."
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/issue.net"
+    ), "SAP network issue banner should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-motd",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_motd_exists(file: File):
+    """Test that SAP has message of the day file"""
+    assert file.exists("/etc/motd"), "SAP motd should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-motd",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_motd_content(parse_file: ParseFile):
+    """Test that SAP has message of the day file"""
+    expected_lines = [
+        "You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted."
+    ]
+    assert expected_lines in parse_file.lines("/etc/motd"), "SAP motd should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-tmpfiles-legacy",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_tmpfiles_legacy_exists(file: File):
+    """Test that SAP has tmpfiles legacy configuration"""
+    assert file.exists(
+        "/etc/tmpfiles.d/legacy.conf"
+    ), "SAP tmpfiles legacy configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-tmpfiles-legacy",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_tmpfiles_legacy_content(parse_file: ParseFile):
+    """Test that SAP has tmpfiles legacy configuration"""
+    expected_lines = [
+        "L /var/lock - - - - ../run/lock",
+        "d /run/lock/subsys 0755 root root -",
+        "r! /forcefsck",
+        "r! /fastboot",
+        "r! /forcequotacheck",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/tmpfiles.d/legacy.conf"
+    ), "SAP tmpfiles legacy configuration should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-security-sap-global-root-ca",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_global_root_ca_exists(file: File):
+    """Test that SAP Global Root CA certificate exists"""
+    assert file.exists(
+        "/usr/local/share/ca-certificates/SAP_Global_Root_CA.crt"
+    ), "SAP Global Root CA certificate should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-security-sap-global-root-ca",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_global_root_ca_content(parse_file: ParseFile):
+    """Test that SAP Global Root CA certificate content is correct"""
+    expected_lines = [
+        "-----BEGIN CERTIFICATE-----",
+        "MIIGTDCCBDSgAwIBAgIQXQPZPTFhXY9Iizlwx48bmTANBgkqhkiG9w0BAQsFADBO",
+        "MQswCQYDVQQGEwJERTERMA8GA1UEBwwIV2FsbGRvcmYxDzANBgNVBAoMBlNBUCBB",
+        "RzEbMBkGA1UEAwwSU0FQIEdsb2JhbCBSb290IENBMB4XDTEyMDQyNjE1NDE1NVoX",
+        "DTMyMDQyNjE1NDYyN1owTjELMAkGA1UEBhMCREUxETAPBgNVBAcMCFdhbGxkb3Jm",
+        "MQ8wDQYDVQQKDAZTQVAgQUcxGzAZBgNVBAMMElNBUCBHbG9iYWwgUm9vdCBDQTCC",
+        "AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAOrxJKFFA1eTrZg1Ux8ax6n/",
+        "LQRHZlgLc2FZpfyAgwvkt71wLkPLiTOaRb3Bd1dyydpKcwJLy0dzGkunzNkPRSFz",
+        "bKy2IPS0RS45hUCCPzhGnqQM6TcDYWeWpSUvygqujgb/cAG0mSJpvzAD3SMDQ+VJ",
+        "Az5Ryq4IrP7LkfCb63LKZxLsHEkEcNKoGPsSsd4LTwuEIyM3ZHcCoA97m6hvgLWV",
+        "GLzLIQMEblkswqX29z7JZH+zJopoqZB6eEogE2YpExkw52PufytEslDY3dyVubjp",
+        "GlvD4T03F2zm6CYleMwgWbATLVYvk2I9WfqPAP+ln2IU9DZzegSMTWHCE+jizaiq",
+        "b5f5s7m8f+cz7ndHSrz8KD/S9iNdWpuSlknHDrh+3lFTX/uWNBRs5mC/cdejcqS1",
+        "v6erflyIfqPWWO6PxhIs49NL9Lix3ou6opJo+m8K757T5uP/rQ9KYALIXvl2uFP7",
+        "0CqI+VGfossMlSXa1keagraW8qfplz6ffeSJQWO/+zifbfsf0tzUAC72zBuO0qvN",
+        "E7rSbqAfpav/o010nKP132gbkb4uOkUfZwCuvZjA8ddsQ4udIBRj0hQlqnPLJOR1",
+        "PImrAFC3PW3NgaDEo9QAJBEp5jEJmQghNvEsmzXgABebwLdI9u0VrDz4mSb6TYQC",
+        "XTUaSnH3zvwAv8oMx7q7AgMBAAGjggEkMIIBIDAOBgNVHQ8BAf8EBAMCAQYwEgYD",
+        "VR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUg8dB/Q4mTynBuHmOhnrhv7XXagMw",
+        "gdoGA1UdIASB0jCBzzCBzAYKKwYBBAGFNgRkATCBvTAmBggrBgEFBQcCARYaaHR0",
+        "cDovL3d3dy5wa2kuY28uc2FwLmNvbS8wgZIGCCsGAQUFBwICMIGFHoGCAEMAZQBy",
+        "AHQAaQBmAGkAYwBhAHQAZQAgAFAAbwBsAGkAYwB5ACAAYQBuAGQAIABDAGUAcgB0",
+        "AGkAZgBpAGMAYQB0AGkAbwBuACAAUAByAGEAYwB0AGkAYwBlACAAUwB0AGEAdABl",
+        "AG0AZQBuAHQAIABvAGYAIABTAEEAUAAgAEEARzANBgkqhkiG9w0BAQsFAAOCAgEA",
+        "0HpCIaC36me6ShB3oHDexA2a3UFcU149nZTABPKT+yUCnCQPzvK/6nJUc5I4xPfv",
+        "2Q8cIlJjPNRoh9vNSF7OZGRmWQOFFrPWeqX5JA7HQPsRVURjJMeYgZWMpy4t1Tof",
+        "lF13u6OY6xV6A5kQZIISFj/dOYLT3+O7wME5SItL+YsNh6BToNU0xAZt71Z8JNdY",
+        "VJb2xSPMzn6bNXY8ioGzHlVxfEvzMqebV0KY7BTXR3y/Mh+v/RjXGmvZU6L/gnU7",
+        "8mTRPgekYKY8JX2CXTqgfuW6QSnJ+88bHHMhMP7nPwv+YkPcsvCPBSY08ykzFATw",
+        "SNoKP1/QFtERVUwrUXt3Cufz9huVysiy23dEyfAglgCCRWA+ZlaaXfieKkUWCJaE",
+        "Kw/2Jqz02HDc7uXkFLS1BMYjr3WjShg1a+ulYvrBhNtseRoZT833SStlS/jzZ8Bi",
+        "c1dt7UOiIZCGUIODfcZhO8l4mtjh034hdARLF0sUZhkVlosHPml5rlxh+qn8yJiJ",
+        "GJ7CUQtNCDBVGksVlwew/+XnesITxrDjUMu+2297at7wjBwCnO93zr1/wsx1e2Um",
+        "Xn+IfM6K/pbDar/y6uI9rHlyWu4iJ6cg7DAPJ2CCklw/YHJXhDHGwheO/qSrKtgz",
+        "PGHZoN9jcvvvWDLUGtJkEotMgdFpEA2XWR83H4fVFVc=",
+        "-----END CERTIFICATE-----",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/usr/local/share/ca-certificates/SAP_Global_Root_CA.crt"
+    ), "SAP Global Root CA certificate content should be correct"

--- a/tests/integration/runtime/test_sapmachine.py
+++ b/tests/integration/runtime/test_sapmachine.py
@@ -1,0 +1,36 @@
+import pytest
+from plugins.apt import Apt
+from plugins.dpkg import Dpkg
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# sapmachine Feature
+# =============================================================================
+
+
+@pytest.mark.feature("sapmachine")
+def test_sapmachine_is_installed(dpkg: Dpkg):
+    assert dpkg.package_is_installed(
+        "sapmachine-25-jre-headless"
+    ), "sapmachine-25-jre-headless package is not installed"
+
+
+@pytest.mark.feature("sapmachine")
+def test_java_version_command(shell: ShellRunner):
+    out = shell("java -version", capture_output=True)
+    assert "SapMachine" in out.stderr, "Expected jvm to be installed is SapMachine"
+
+
+@pytest.mark.feature("sapmachine")
+def test_sapmachine_apt_repo_is_installed(apt: Apt):
+    repos = apt.list_repos()
+    assert any(
+        "sapmachine" in repo for repo in repos
+    ), "No apt repo containing 'sapmachine' found"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-sapmachine-config-apt-keyrings-sapmachine"])
+@pytest.mark.feature("sapmachine")
+def test_sapmachine_apt_keyring_exists(file):
+    """Test that SapMachine APT keyring exists"""
+    assert file.is_regular_file("/etc/apt/keyrings/sapmachine-apt-keyring.gpg")

--- a/tests/integration/security/compliance/test_cis.py
+++ b/tests/integration/security/compliance/test_cis.py
@@ -1,0 +1,746 @@
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.linux_etc_files import Shadow
+from plugins.pam import PamConfig
+from plugins.parse_file import ParseFile
+from plugins.sysctl import Sysctl
+
+# =============================================================================
+# cis Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cis-config-cis-hardening",
+    ]
+)
+@pytest.mark.feature("cis")
+@pytest.mark.root(reason="CIS audit requires root privileges")
+@pytest.mark.booted(reason="Must be run on a booted system")
+@pytest.mark.modify(reason="CIS audit script marked for modifying")
+def test_debian_cis_audit(shell):
+    """
+    Run the Debian CIS audit script and fail if any check shows 'KO'.
+    """
+    result = shell(
+        "/opt/cis-hardening/bin/hardening.sh --audit --allow-unsupported-distribution",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    output = result.stdout + result.stderr
+
+    # Correct condition grouping:
+    #   - Match lines with KO
+    #   - Exclude any line containing "Check Failed"
+    failed_lines = [
+        line.strip()
+        for line in output.splitlines()
+        if ("Check Failed" not in line)
+        and (" KO " in line or line.strip().endswith("KO"))
+    ]
+
+    # Remove duplicate lines (same test printed twice)
+    unique_failed = sorted(set(failed_lines))
+
+    if unique_failed:
+        summary = "\n".join(f"FAILED {line}" for line in unique_failed)
+        raise AssertionError(f"{len(unique_failed)} CIS check(s) failed:\n{summary}")
+
+    # Ensure CIS script itself didn't fail
+    assert "Check Failed" not in output, "CIS audit run itself failed unexpectedly"
+
+
+# =============================================================================
+# cisAudit Feature - Audit Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisAudit-config-audit-cis"])
+@pytest.mark.feature("cisAudit")
+def test_cisaudit_audit_rules_exist(file: File):
+    """Test that CIS audit rules file exists"""
+    assert file.is_regular_file("/etc/audit/rules.d/99-cis.rules")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisAudit-config-service-audit-rules-override"])
+@pytest.mark.feature("cisAudit")
+def test_cisaudit_audit_rules_service_override_exists(file: File):
+    """Test that audit-rules service override exists"""
+    assert file.is_regular_file(
+        "/etc/systemd/system/audit-rules.service.d/override.conf"
+    )
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisAudit-config-audit-space-left-action",
+        "GL-TESTCOV-cisAudit-config-audit-admin-space-left-action",
+        "GL-TESTCOV-cisAudit-config-audit-max-log-file-action",
+    ]
+)
+@pytest.mark.feature("cisAudit")
+def test_cisaudit_auditd_conf_settings(file: File):
+    """Test that auditd.conf has correct CIS settings"""
+    auditd_conf = "/etc/audit/auditd.conf"
+    assert file.is_regular_file(auditd_conf)
+
+    content = open(auditd_conf).read()
+
+    # Check space_left_action = email
+    assert (
+        "space_left_action = email" in content
+    ), "auditd.conf should have 'space_left_action = email'"
+
+    # Check admin_space_left_action = halt
+    assert (
+        "admin_space_left_action = halt" in content
+    ), "auditd.conf should have 'admin_space_left_action = halt'"
+
+    # Check max_log_file_action = keep_logs
+    assert (
+        "max_log_file_action = keep_logs" in content
+    ), "auditd.conf should have 'max_log_file_action = keep_logs'"
+
+
+# =============================================================================
+# cisOS Feature - Kernel Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-kernel-cmdline-audit-proc"])
+@pytest.mark.feature("cisOS")
+def test_cisos_kernel_cmdline_audit_proc_exists(file: File):
+    """Test that audit=1 kernel cmdline config exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/10-audit-proc.cfg")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-kernel-cmdline-audit-backlog"])
+@pytest.mark.feature("cisOS")
+def test_cisos_kernel_cmdline_audit_backlog_exists(file: File):
+    """Test that audit_backlog_limit kernel cmdline config exists"""
+    assert file.is_regular_file("/etc/kernel/cmdline.d/20-audit-backlog.cfg")
+
+
+# test for audit=1 kernel cmdline config
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisOS-config-kernel-cmdline-audit-proc",
+        "GL-TESTCOV-cisOS-config-kernel-cmdline-audit-backlog",
+    ]
+)
+@pytest.mark.feature("cisOS")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_cisos_kernel_cmdline_audit_runtime(kernel_cmdline: List[str]):
+    """Test kernel command line parameters are present in the running kernel command line for CIS OS"""
+    required_params = ["audit=1", "audit_backlog_limit=8192"]
+    missing = [param for param in required_params if param not in kernel_cmdline]
+    assert (
+        not missing
+    ), f"The following kernel cmdline parameters were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisOS-config-kernel-postinst-kernel-cmdline",
+        "GL-TESTCOV-cisOS-config-kernel-postinst-kernel-install",
+        "GL-TESTCOV-cisOS-config-kernel-postinst-update-syslinux",
+    ]
+)
+@pytest.mark.feature("cisOS")
+def test_cisos_kernel_postinst_hooks_exist(file: File):
+    """Test that kernel postinst hooks exist"""
+    hooks = [
+        "/etc/kernel/postinst.d/zz-kernel-cmdline",
+        "/etc/kernel/postinst.d/zz-kernel-install",
+        "/etc/kernel/postinst.d/zz-update-syslinux",
+    ]
+    missing = [hook for hook in hooks if not file.exists(hook)]
+    assert not missing, f"Missing kernel postinst hooks: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisOS-config-kernel-postrm-kernel-remove",
+        "GL-TESTCOV-cisOS-config-kernel-postrm-update-syslinux",
+    ]
+)
+@pytest.mark.feature("cisOS")
+def test_cisos_kernel_postrm_hooks_exist(file: File):
+    """Test that kernel postrm hooks exist"""
+    hooks = [
+        "/etc/kernel/postrm.d/zz-kernel-remove",
+        "/etc/kernel/postrm.d/zz-update-syslinux",
+    ]
+    missing = [hook for hook in hooks if not file.exists(hook)]
+    assert not missing, f"Missing kernel postrm hooks: {', '.join(missing)}"
+
+
+# =============================================================================
+# cisOS Feature - Log Rotation
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisOS-config-logrotate-btmp",
+        "GL-TESTCOV-cisOS-config-logrotate-wtmp",
+    ]
+)
+@pytest.mark.feature("cisOS")
+def test_cisos_logrotate_configs_exist(file: File):
+    """Test that logrotate configs for btmp and wtmp exist"""
+    configs = [
+        "/etc/logrotate.d/btmp",
+        "/etc/logrotate.d/wtmp",
+    ]
+    missing = [cfg for cfg in configs if not file.exists(cfg)]
+    assert not missing, f"Missing logrotate configs: {', '.join(missing)}"
+
+
+# =============================================================================
+# cisOS Feature - PAM Configuration
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-account"], indirect=["pam_config"]
+)
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-pam-common-account"])
+@pytest.mark.feature("cisOS")
+def test_cisos_pam_common_account_config(pam_config: PamConfig):
+    """Test that PAM common-account has correct CIS entries"""
+    # Check for pam_faillock.so at the top
+    faillock_entries = pam_config.find_entries(
+        type_="account", control_contains="required", module_contains="pam_faillock.so"
+    )
+    assert (
+        len(faillock_entries) > 0
+    ), "pam_faillock.so should be configured in account stack"
+
+    # Check for pam_unix.so in account stack
+    unix_entries = pam_config.find_entries(
+        type_="account", module_contains="pam_unix.so"
+    )
+    assert len(unix_entries) > 0, "pam_unix.so should be configured in account stack"
+
+    # Check for pam_permit.so in account stack
+    permit_entries = pam_config.find_entries(
+        type_="account", control_contains="required", module_contains="pam_permit.so"
+    )
+    assert (
+        len(permit_entries) > 0
+    ), "pam_permit.so should be configured in account stack"
+
+
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-auth"], indirect=["pam_config"]
+)
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-pam-common-auth"])
+@pytest.mark.feature("cisOS")
+def test_cisos_pam_common_auth_config(pam_config: PamConfig):
+    """Test that PAM common-auth has correct CIS entries"""
+    # Check for pam_faillock.so at the top with correct args
+    faillock_entries = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faillock.so",
+        arg_contains=["deny=5", "unlock_time=900"],
+    )
+    assert (
+        len(faillock_entries) > 0
+    ), "pam_faillock.so should be configured with correct args in auth stack"
+
+    # Check for pam_unix.so in auth stack with nullok
+    unix_entries = pam_config.find_entries(
+        type_="auth", module_contains="pam_unix.so", arg_contains=["nullok"]
+    )
+    assert (
+        len(unix_entries) > 0
+    ), "pam_unix.so should be configured with nullok in auth stack"
+
+    # Check for pam_permit.so in auth stack
+    permit_entries = pam_config.find_entries(
+        type_="auth", control_contains="required", module_contains="pam_permit.so"
+    )
+    assert len(permit_entries) > 0, "pam_permit.so should be configured in auth stack"
+
+    # Check for pam_deny.so in auth stack
+    deny_entries = pam_config.find_entries(
+        type_="auth", control_contains="requisite", module_contains="pam_deny.so"
+    )
+    assert len(deny_entries) > 0, "pam_deny.so should be configured in auth stack"
+
+
+# =============================================================================
+# cisOS Feature - Security Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-security-limits-conf"])
+@pytest.mark.feature("cisOS")
+def test_cisos_security_limits_conf_exists(file: File):
+    """Test that security limits.conf exists"""
+    assert file.is_regular_file("/etc/security/limits.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-security-limits-conf"])
+@pytest.mark.feature("cisOS")
+def test_cisos_security_limits_conf_content(parse_file: ParseFile):
+    """Test that security limits.conf has correct content"""
+    lines = parse_file.lines("/etc/security/limits.conf")
+    assert "* hard core 0" in lines, "hard core should be 0"
+    assert "* soft core 0" in lines, "soft core should be 0"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-selinux-config"])
+@pytest.mark.feature("cisOS")
+def test_cisos_selinux_config_exists(file: File):
+    """Test that SELinux config exists"""
+    assert file.is_regular_file("/etc/selinux/config")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-selinux-config-permissive"])
+@pytest.mark.feature("cisOS")
+def test_cisos_selinux_config_permissive(parse_file: ParseFile):
+    """Test that SELinux config has correct content"""
+    lines = parse_file.lines("/etc/selinux/config")
+    assert "SELINUX=disabled" in lines, "SELINUX should be disabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-selinux-config-type"])
+@pytest.mark.feature("cisOS")
+def test_cisos_selinux_config_type(parse_file: ParseFile):
+    """Test that SELinux config has correct content"""
+    lines = parse_file.lines("/etc/selinux/config")
+    assert "SELINUXTYPE=default" in lines, "SELINUXTYPE should be default"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-selinux-config-setlocaldefs"])
+@pytest.mark.feature("cisOS")
+def test_cisos_selinux_config_setlocaldefs(parse_file: ParseFile):
+    """Test that SELinux config has correct content"""
+    lines = parse_file.lines("/etc/selinux/config")
+    assert "SETLOCALDEFS=0" in lines, "SETLOCALDEFS should be 0"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-sysstat-sysstat"])
+@pytest.mark.feature("cisOS")
+def test_cisos_sysstat_config_exists(file: File):
+    """Test that sysstat config exists"""
+    assert file.is_regular_file("/etc/sysstat/sysstat")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-sysstat-sysstat-umask"])
+@pytest.mark.feature("cisOS")
+def test_cisos_sysstat_config_umask(parse_file: ParseFile):
+    """Test that sysstat config has correct content"""
+    lines = parse_file.lines("/etc/sysstat/sysstat")
+    assert "UMASK=0027" in lines, "UMASK should be 0027"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-tmpfiles-var"])
+@pytest.mark.feature("cisOS")
+def test_cisos_tmpfiles_var_exists(file: File):
+    """Test that tmpfiles var.conf exists"""
+    assert file.is_regular_file("/usr/lib/tmpfiles.d/var.conf")
+
+
+# =============================================================================
+# cisOS Feature - Cron Permissions
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisOS-config-cron-d-permissions",
+        "GL-TESTCOV-cisOS-config-cron-daily-permissions",
+        "GL-TESTCOV-cisOS-config-cron-hourly-permissions",
+        "GL-TESTCOV-cisOS-config-cron-monthly-permissions",
+        "GL-TESTCOV-cisOS-config-cron-weekly-permissions",
+        "GL-TESTCOV-cisOS-config-crontab-permissions",
+        "GL-TESTCOV-cisOS-config-cron-users-ownership-and-permissions",
+    ]
+)
+@pytest.mark.feature("cisOS")
+def test_cisos_cron_permissions(file: File):
+    """Test that cron directories and files have correct permissions"""
+    paths_permissions = {
+        "/etc/cron.d": "0700",
+        "/etc/cron.daily": "0700",
+        "/etc/cron.hourly": "0700",
+        "/etc/cron.monthly": "0700",
+        "/etc/cron.weekly": "0700",
+        "/etc/crontab": "0600",
+        "/etc/cron.allow": "0600",
+        "/etc/at.allow": "0600",
+    }
+
+    missing = [
+        path
+        for path, expected_perms in paths_permissions.items()
+        if not file.has_mode(path, expected_perms)
+    ]
+    assert (
+        not missing
+    ), f"Cron directories should have permissions {paths_permissions.values()}, but have {missing}"
+
+
+# =============================================================================
+# cisOS Feature - Login & Password Policies
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisOS-config-login-defs-password-expire",
+        "GL-TESTCOV-cisOS-config-login-defs-password-min-days",
+    ]
+)
+@pytest.mark.feature("cisOS")
+def test_cisos_login_defs_password_policies(parse_file: ParseFile):
+    """Test that login.defs has correct password policies"""
+    lines = parse_file.lines("/etc/login.defs")
+
+    assert "PASS_MAX_DAYS 90" in lines, "PASS_MAX_DAYS should be 90"
+    assert "PASS_MIN_DAYS 7" in lines, "PASS_MIN_DAYS should be 7"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-security-pwquality"])
+@pytest.mark.feature("cisOS")
+def test_cisos_pwquality_config_exists(file: File):
+    """Test that pwquality.conf exists"""
+    assert file.is_regular_file("/etc/security/pwquality.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-security-pwquality"])
+@pytest.mark.feature("cisOS")
+def test_cisos_pwquality_config_content(parse_file: ParseFile):
+    """Test that pwquality.conf has correct content"""
+    lines = parse_file.lines("/etc/security/pwquality.conf")
+    assert "minlen = 14" in lines, "minlen should be 14"
+    assert "dcredit = -1" in lines, "dcredit should be -1"
+    assert "ucredit = -1" in lines, "ucredit should be -1"
+    assert "ocredit = -1" in lines, "ocredit should be -1"
+    assert "lcredit = -1" in lines, "lcredit should be -1"
+
+
+# =============================================================================
+# cisOS Feature - Additional System Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-pam-common-password-permissions"])
+@pytest.mark.feature("cisOS")
+def test_cisos_pam_common_password_permissions(file: File):
+    """Test that common-password has correct permissions"""
+    path_permissions = {
+        "/etc/pam.d/common-password": "0644",
+    }
+    missing = [
+        path
+        for path, expected_perms in path_permissions.items()
+        if not file.has_mode(path, expected_perms)
+    ]
+    assert (
+        not missing
+    ), f"PAM files should have permissions {path_permissions.values()}, but have {missing}"
+
+
+@pytest.mark.parametrize("pam_config", ["/etc/pam.d/su"], indirect=["pam_config"])
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-pam-su-restrict"])
+@pytest.mark.feature("cisOS")
+def test_cisos_pam_su_restrict(pam_config: PamConfig):
+    """Test that su is restricted with pam_wheel.so"""
+    wheel_entries = pam_config.find_entries(
+        type_="auth", module_contains="pam_wheel.so"
+    )
+    assert len(wheel_entries) > 0, "pam_wheel.so should be configured in /etc/pam.d/su"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-hosts-allow"])
+@pytest.mark.feature("cisOS")
+def test_cisos_hosts_allow_exists(file: File):
+    """Test that hosts.allow exists"""
+    assert file.exists("/etc/hosts.allow")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-hosts-allow"])
+@pytest.mark.feature("cisOS")
+def test_cisos_hosts_allow_deny_all(parse_file: ParseFile):
+    """Test that hosts.allow denies all hosts but localhost"""
+    lines = parse_file.lines("/etc/hosts.allow")
+    assert "ALL: 127.0.0.1,localhost" in lines, "hosts.allow should allow localhost"
+    assert "ALL: ALL" in lines, "hosts.allow should deny all hosts"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-log-file-permissions"])
+@pytest.mark.feature("cisOS")
+def test_cisos_log_files_permissions(find, file: File):
+    """Test that /var/log files have correct permissions"""
+    dir = "/var/log"
+    find.root_paths = dir
+    find.entry_type = "files"
+    missing = [file_path for file_path in find if not file.has_mode(file_path, "0640")]
+    assert not missing, f"Log files should have permissions 0640, but have {missing}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-shell-umask"])
+@pytest.mark.feature("cisOS")
+def test_cisos_shell_umask_configured(parse_file: ParseFile):
+    """Test that umask is configured in shell startup files"""
+    lines = parse_file.lines("/etc/bash.bashrc")
+    assert "umask 077" in lines, "umask 077 should be configured in /etc/bash.bashrc"
+
+    lines = parse_file.lines("/etc/profile")
+    assert "umask 077" in lines, "umask 077 should be configured in /etc/profile"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-systemd-journald-storage-persistent"])
+@pytest.mark.feature("cisOS")
+def test_cisos_journald_storage_persistent(parse_file: ParseFile):
+    """Test that journald storage is configured as persistent"""
+    lines = parse_file.lines("/etc/systemd/journald.conf")
+    assert "Storage=persistent" in lines, "journald.conf should have Storage=persistent"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-udev-rules-usb-devices"])
+@pytest.mark.feature("cisOS")
+def test_cisos_udev_usb_rules_exist(file: File):
+    """Test that udev rules for USB devices exist"""
+    usb_rules = "/etc/udev/rules.d/10-CIS_99.2_usb_devices.sh"
+    assert file.exists(usb_rules), f"USB device udev rules should exist at {usb_rules}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisOS-config-user-root-password"])
+@pytest.mark.feature("cisOS")
+@pytest.mark.root(reason="Reading shadow file needs root privileges")
+def test_cisos_root_password_configured(shadow_entries: List[Shadow]):
+    """Test that root password is configured"""
+    root_entry = next(
+        (entry for entry in shadow_entries if entry.login_name == "root"), None
+    )
+    assert root_entry, "Root entry should exist"
+    assert root_entry.encrypted_password not in [
+        "",
+        "!",
+        "*",
+        "!!",
+        "!!",
+    ], "Root password should be configured (not empty or locked)"
+    assert root_entry.encrypted_password.startswith(
+        "$"
+    ), "Root password should be properly hashed"
+
+
+# =============================================================================
+# cisSshd Feature - CIS SSH Daemon Hardening
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisSshd-config-firewall-ipv4-flush",
+        "GL-TESTCOV-cisSshd-config-firewall-ipv4-gl-default",
+        "GL-TESTCOV-cisSshd-config-firewall-ipv6-flush",
+        "GL-TESTCOV-cisSshd-config-firewall-ipv6-gl-default",
+    ]
+)
+@pytest.mark.feature("cisSshd")
+def test_cissshd_firewall_configs_exist(file: File):
+    """Test that CIS SSHD firewall configurations exist"""
+    configs = [
+        "/etc/firewall/ipv4_flush.sh",
+        "/etc/firewall/ipv4_gl_default.conf",
+        "/etc/firewall/ipv6_flush.sh",
+        "/etc/firewall/ipv6_gl_default.conf",
+    ]
+    missing = [cfg for cfg in configs if not file.exists(cfg)]
+    assert not missing, f"Missing CIS SSHD firewall configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-config-ssh-sshd-banner"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_banner_exists(file: File):
+    """Test that CIS SSHD banner exists"""
+    assert file.is_regular_file("/etc/ssh/sshd-banner")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-config-ssh-sshd-banner"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_banner_content(parse_file: ParseFile):
+    """Test that CIS SSHD banner content exists"""
+    lines = parse_file.lines("/etc/ssh/sshd-banner")
+    assert (
+        "Authorized uses only. All activity may be monitored and reported." in lines
+    ), "sshd banner should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisSshd-config-ssh-sshd-config",
+    ]
+)
+@pytest.mark.feature("cisSshd")
+def test_cissshd_sshd_config_exists(file: File):
+    """Test that CIS SSHD config exists with proper permissions"""
+    assert file.is_regular_file("/etc/ssh/sshd_config")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cisSshd-config-ssh-sshd-config",
+    ]
+)
+@pytest.mark.feature("cisSshd")
+def test_cissshd_sshd_config_content(parse_file: ParseFile):
+    """Test that CIS SSHD config content exists"""
+    lines = parse_file.lines("/etc/ssh/sshd_config")
+    assert lines == [
+        "PermitRootLogin no",
+        "Protocol 2",
+        "X11Forwarding no",
+        "StrictModes yes",
+        "IgnoreRhosts yes",
+        "HostbasedAuthentication no",
+        "LogLevel VERBOSE",
+        "UsePAM yes",
+        "PrintMotd no",
+        "AcceptEnv LANG LC_*",
+        "Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
+        "ClientAliveInterval 300",
+        "ClientAliveCountMax 0",
+        "AuthenticationMethods publickey",
+        "PubkeyAuthentication yes",
+        "PasswordAuthentication no",
+        "KbdInteractiveAuthentication no",
+        "KerberosAuthentication no",
+        "ChallengeResponseAuthentication no",
+        "GSSAPIAuthentication no",
+        "GSSAPIKeyExchange no",
+        "LoginGraceTime 60",
+        "AllowUsers *",
+        "AllowGroups *",
+        "DenyUsers nobody",
+        "DenyGroups nobody",
+        "PermitEmptyPasswords no",
+        "PermitUserEnvironment no",
+        "HostKey /etc/ssh/ssh_host_ed25519_key",
+        "HostKey /etc/ssh/ssh_host_rsa_key",
+        "Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr",
+        "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256",
+        "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256",
+        "RekeyLimit 512M 6h",
+        "AllowAgentForwarding no",
+        "AllowTcpForwarding no",
+        "AllowStreamLocalForwarding no",
+        "PermitTunnel no",
+        "PermitUserRC no",
+        "GatewayPorts no",
+        "MaxAuthTries 4",
+        "AllowTCPForwarding no",
+        "MaxStartups 10:30:60",
+        "MaxSessions 10",
+        "Banner /etc/issue.net",
+    ]
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-config-ssh-sshd-config-permissions"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_sshd_config_permissions(file: File):
+    """Test that CIS SSHD config has proper permissions"""
+    assert file.has_mode("/etc/ssh/sshd_config", "600")
+
+
+# =============================================================================
+# cis Feature - CIS Baseline Configuration
+# =============================================================================
+
+
+# TODO: check actual /opt/cis-hardening/etc/conf.d/ contents and exceptions
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-cis-config-cis-hardening-disable",
+        "GL-TESTCOV-cis-config-cis-hardening-exceptions",
+    ]
+)
+@pytest.mark.feature("cis")
+def test_cis_hardening_configs_exist(file: File):
+    """Test that CIS hardening configuration files exist"""
+    # These might be in different locations, checking common paths
+    paths = [
+        "/etc/cis-hardening.conf",
+        "/etc/cis/hardening.conf",
+        "/etc/default/cis-hardening",
+    ]
+    exists = any(file.exists(path) for path in paths)
+    assert exists, "CIS hardening configuration should exist"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cis-config-cis-logrotate-permissions"])
+@pytest.mark.feature("cis")
+def test_cis_logrotate_config_exists(file: File):
+    """Test that CIS logrotate configuration exists"""
+    assert file.is_regular_file("/etc/logrotate.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cis-config-cis-logrotate-permissions"])
+@pytest.mark.feature("cis")
+def test_cis_logrotate_permissions(file: File):
+    """Test that CIS logrotate configuration exists"""
+    assert file.has_mode("/etc/logrotate.conf", "0640")
+
+
+# =============================================================================
+# cisSysctl Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSysctl-config-sysctl-cis"])
+@pytest.mark.feature("cisSysctl")
+def test_cissysctl_sysctl_files_exists(file: File):
+    """Test that CIS sysctl configuration file exists"""
+    paths = [
+        "/etc/sysctl.d/99-cis.conf",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSysctl-config-sysctl-cis"])
+@pytest.mark.feature("cisSysctl")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_cissysctl_sysctl_parameters_set(sysctl: Sysctl):
+    """Test that CIS sysctl parameters are set"""
+    parameters = [
+        "net.ipv4.conf.all.forwarding=0",
+        "net.ipv4.conf.all.accept_redirects=0",
+        "net.ipv4.conf.default.accept_redirects=0",
+        "net.ipv6.conf.all.accept_redirects=0",
+        "net.ipv6.conf.default.accept_redirects=0",
+        "net.ipv4.conf.all.secure_redirects=0",
+        "net.ipv4.conf.default.secure_redirects=0",
+        "net.ipv4.conf.all.log_martians=1",
+        "net.ipv4.conf.default.log_martians=1",
+        "net.ipv4.conf.all.rp_filter=1",
+        "net.ipv4.conf.default.rp_filter=1",
+        "net.ipv6.conf.all.disable_ipv6=1",
+        "net.ipv6.conf.default.disable_ipv6=1",
+        "net.ipv6.conf.lo.disable_ipv6=0",
+        "net.ipv4.conf.all.send_redirects=0",
+        "net.ipv4.conf.default.send_redirects=0",
+        "net.ipv4.conf.default.accept_source_route=0",
+        "fs.suid_dumpable=0",
+    ]
+    missing = [
+        parameter.split("=")[0]
+        for parameter in parameters
+        if parameter.split("=")[0] not in sysctl
+    ]
+    assert (
+        not missing
+    ), f"The following parameters were not set to the expected value: {', '.join(missing)}"

--- a/tests/integration/security/compliance/test_disastig_00005.py
+++ b/tests/integration/security/compliance/test_disastig_00005.py
@@ -1,0 +1,36 @@
+"""
+Ref: SRG-OS-000021-GPOS-00005
+
+Verify that the operating system enforces the limit of three consecutive invalid logon attempts by a user during a 15-minute time period.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-auth"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-auth"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203594)
+@pytest.mark.feature("disaSTIGmedium")
+def test_stig_common_auth_pam_faillock(pam_config):
+    """Verify pam_faillock is configured with deny=3 and unlock_time=900."""
+    results = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faillock.so",
+        arg_contains=["preauth", "silent", "audit", "deny=3", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Logins should be blocked for 15 minutes after 3 failed attempts (preauth check configured)"
+
+    pam_config.find_entries(
+        type_="auth",
+        control_contains="default=die",
+        module_contains="pam_faillock.so",
+        arg_contains=["authfail", "silent", "audit", "deny=3", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Control value of PAM Module pam_faillock.so must be set to required (postauth action configured)"

--- a/tests/integration/security/compliance/test_disastig_00008.py
+++ b/tests/integration/security/compliance/test_disastig_00008.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000027-GPOS-00008
+
+Verify the operating system limits the number of concurrent sessions to 10 for all accounts and/or account types. A hard maxlogins limit in /etc/security/limits.conf enforces this restriction.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-security-limits"])
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-limits-maxlogins"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="maxlogins limit is configured by disaSTIGlow"
+)
+@pytest.mark.security_id(203597)
+def test_limits_conf_maxlogins_is_10(parse_file) -> None:
+    """Verify /etc/security/limits.conf sets a hard maxlogins limit of 10."""
+    assert "* hard maxlogins 10" in parse_file.lines("/etc/security/limits.conf")

--- a/tests/integration/security/compliance/test_disastig_00009.py
+++ b/tests/integration/security/compliance/test_disastig_00009.py
@@ -1,0 +1,17 @@
+"""
+Ref: SRG-OS-000028-GPOS-00009
+
+Verify the operating system retains a user's session lock until that user reestablishes access using established identification and authentication procedures.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203598)
+@pytest.mark.feature("not container and not lima and not gardener and not baremetal")
+@pytest.mark.root(reason="required to verify PAM authentication enforcement")
+def test_session_lock_requires_reauthentication(lsm):
+    """Verify 'selinux' appears in the active LSM list."""
+    assert (
+        "selinux" in lsm
+    ), "stigcompliance: no LSM (AppArmor/SELinux) present to enforce session lock re-authentication"

--- a/tests/integration/security/compliance/test_disastig_00013.py
+++ b/tests/integration/security/compliance/test_disastig_00013.py
@@ -1,0 +1,58 @@
+"""
+Ref: SRG-OS-000032-GPOS-00013
+
+Verify the operating system monitors remote access methods.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203602)
+@pytest.mark.booted(reason="requires running sshguard")
+@pytest.mark.feature("ssh")
+def test_sshguard_is_enabled(systemd):
+    """Verify sshguard.service is enabled."""
+    assert systemd.is_enabled("sshguard")
+
+
+@pytest.mark.booted(reason="requires running sshguard")
+@pytest.mark.feature("ssh")
+@pytest.mark.hypervisor(
+    "not qemu", reason="a started sshguard prevents running the testsuite"
+)
+@pytest.mark.security_id(203602)
+def test_sshguard_is_active(systemd):
+    """Verify sshguard.service is active."""
+    assert systemd.is_active("sshguard")
+
+
+@pytest.mark.security_id(203602)
+@pytest.mark.feature("ssh")
+def test_sshguard_journal_reading_is_configured(parse_file):
+    """Verify /etc/sshguard/sshguard.conf sets LOGREADER to use journalctl."""
+    config = parse_file.parse("/etc/sshguard/sshguard.conf", format="keyval")
+    assert "LOGREADER" in config
+    assert "journalctl" in config["LOGREADER"]
+
+
+@pytest.mark.security_id(203602)
+@pytest.mark.booted(reason="requires running journald")
+@pytest.mark.feature("ssh")
+def test_sshguard_can_log_to_journald_dev_log_is_managed_by_journald(file):
+    """Verify /dev/log is a symlink to /run/systemd/journal/dev-log."""
+    assert file.is_symlink("/dev/log", "/run/systemd/journal/dev-log")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-rsyslog-default"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="auth log routing to /var/log/secure is configured by disaSTIGmedium",
+)
+@pytest.mark.security_id(203602)
+def test_rsyslog_logs_auth_to_secure(parse_file) -> None:
+    """Verify rsyslog 50-default.conf routes auth.* to /var/log/secure."""
+    assert re.compile(r"auth.*/var/log/secure") in parse_file.lines(
+        "/etc/rsyslog.d/50-default.conf"
+    )

--- a/tests/integration/security/compliance/test_disastig_00014.py
+++ b/tests/integration/security/compliance/test_disastig_00014.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000033-GPOS-00014
+
+Verify the operating system implements DoD-approved encryption to protect the confidentiality of remote access sessions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203603)
+def test_disastig_00014():
+    """Encryption for remote access sessions is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00015.py
+++ b/tests/integration/security/compliance/test_disastig_00015.py
@@ -1,0 +1,37 @@
+"""
+Ref: SRG-OS-000037-GPOS-00015
+
+Verify the operating system produces audit records containing information to establish what type of events occurred.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203604)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_generated(shell):
+    """Verify ausearch -ts recent returns non-empty output."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    assert result.stdout.strip() != "", "stigcompliance: no audit events captured"
+
+
+@pytest.mark.security_id(203604)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_type(shell):
+    """Verify ausearch -ts recent output contains a 'type=' field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    assert (
+        "type=" in result.stdout
+    ), "stigcompliance: audit records do not contain event type information"

--- a/tests/integration/security/compliance/test_disastig_00016.py
+++ b/tests/integration/security/compliance/test_disastig_00016.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000038-GPOS-00016
+
+Verify the operating system produces audit records containing information to establish when (date and time) the events occurred.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203605)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_timestamp(shell):
+    """Verify ausearch -ts recent output contains 'time->' or 'audit(' timestamps."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "time->" in result.stdout or "audit(" in result.stdout
+    ), "stigcompliance: audit records do not contain timestamp information"

--- a/tests/integration/security/compliance/test_disastig_00017.py
+++ b/tests/integration/security/compliance/test_disastig_00017.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000039-GPOS-00017
+
+Verify the operating system produces audit records containing information to establish where the events occurred.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203606)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_location(shell):
+    """Verify ausearch -ts recent output contains a cwd=, name=, exe= or path= field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    assert (
+        "cwd=" in result.stdout
+        or "name=" in result.stdout
+        or "exe=" in result.stdout
+        or "path=" in result.stdout
+    ), "stigcompliance: audit records do not contain location (where) information"

--- a/tests/integration/security/compliance/test_disastig_00018.py
+++ b/tests/integration/security/compliance/test_disastig_00018.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000040-GPOS-00018
+
+Verify the operating system produces audit records containing information to establish the source of the events.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203607)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_source(shell):
+    """Verify ausearch -ts recent output contains an auid=, uid=, ses=, comm= or exe= field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "auid=" in result.stdout
+        or "uid=" in result.stdout
+        or "ses=" in result.stdout
+        or "comm=" in result.stdout
+        or "exe=" in result.stdout
+    ), "stigcompliance: audit records do not contain source information"

--- a/tests/integration/security/compliance/test_disastig_00019.py
+++ b/tests/integration/security/compliance/test_disastig_00019.py
@@ -1,0 +1,25 @@
+"""
+Ref: SRG-OS-000041-GPOS-00019
+
+Verify the operating system produces audit records containing information to establish the outcome of the events.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203608)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_full_record(shell):
+    """Verify ausearch -ts recent output contains a success=yes/no or res=success/failed field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "success=yes" in result.stdout
+        or "success=no" in result.stdout
+        or "res=success" in result.stdout
+        or "res=failed" in result.stdout
+    ), "stigcompliance: audit records do not contain outcome (success/failure) information"

--- a/tests/integration/security/compliance/test_disastig_00020.py
+++ b/tests/integration/security/compliance/test_disastig_00020.py
@@ -1,0 +1,24 @@
+"""
+Ref: SRG-OS-000042-GPOS-00020
+
+Verify the operating system generates audit records containing the full-text recording of privileged commands.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203609)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_full_text_recording(audit_rule, shell):
+    """Verify ausearch -ts recent output contains a type=EXECVE record with a0= or a proctitle= field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        "type=EXECVE" in result.stdout and " a0=" in result.stdout
+    ) or "proctitle=" in result.stdout, (
+        "stigcompliance: audit records do not contain full-text command recording"
+    )

--- a/tests/integration/security/compliance/test_disastig_00021.py
+++ b/tests/integration/security/compliance/test_disastig_00021.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000042-GPOS-00021
+
+Verify the operating system produces audit records containing the individual identities of group account users.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203610)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_individual_identities(shell):
+    """Verify ausearch -ts recent output contains an a0=, a1= or a2= argument field."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+    assert (
+        " a0=" in result.stdout or " a1=" in result.stdout or " a2=" in result.stdout
+    ), "stigcompliance: audit records do not contain command argument details"

--- a/tests/integration/security/compliance/test_disastig_00022.py
+++ b/tests/integration/security/compliance/test_disastig_00022.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000043-GPOS-00022
+
+Verify the operating system alerts the ISSO and SA (at a minimum) in the event of an audit processing failure.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203611)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_event_contains_audit_processing_failures(shell):
+    """Verify ausearch -ts recent output mentions 'audit' together with fail/error/lost=/backlog."""
+    result = shell(
+        cmd="ausearch -ts recent",
+        capture_output=True,
+    )
+
+    match_found = bool(re.search(r"audit.*(fail|error|lost=|backlog)", result.stdout))
+    assert (
+        match_found
+    ), "stigcompliance: audit records do not indicate alerting or detection of audit processing failures"

--- a/tests/integration/security/compliance/test_disastig_00024.py
+++ b/tests/integration/security/compliance/test_disastig_00024.py
@@ -1,0 +1,52 @@
+"""
+Ref: SRG-OS-000051-GPOS-00024
+
+Verify the operating system provides the capability to centrally review and analyze audit records from multiple components within the system.
+"""
+
+import re
+
+import pytest
+
+AUDITD_CONF = "/etc/audit/auditd.conf"
+
+
+@pytest.mark.security_id(203613)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to read audit configuration")
+def test_audit_log_retention_config(parse_file):
+    """Verify auditd.conf defines max_log_file, num_logs and space_left_action."""
+    lines = parse_file.lines(AUDITD_CONF)
+
+    assert (
+        re.compile(r"max_log_file\s*=\s*\d+") in lines
+    ), "stigcompliance: max_log_file not configured properly"
+
+    assert (
+        re.compile(r"num_logs\s*=\s*\d+") in lines
+    ), "stigcompliance: num_logs not configured properly"
+
+    assert (
+        re.compile(r"space_left_action\s*=\s*\S+") in lines
+    ), "stigcompliance: space_left_action not configured"
+
+
+@pytest.mark.security_id(203613)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit configuration and logs")
+def test_audit_log_retention_availability(shell):
+    """Verify ausearch returns structured audit records (retention works)."""
+    result = shell("ausearch -ts recent", capture_output=True)
+
+    assert (
+        result.returncode == 0
+    ), "stigcompliance: ausearch failed, audit logs not retrievable"
+
+    output = result.stdout.strip()
+
+    assert output != "", "stigcompliance: no audit records found (retention failure)"
+
+    assert (
+        "type=" in output
+    ), "stigcompliance: audit records not in expected structured format"

--- a/tests/integration/security/compliance/test_disastig_00025.py
+++ b/tests/integration/security/compliance/test_disastig_00025.py
@@ -1,0 +1,89 @@
+"""
+Ref: SRG-OS-000054-GPOS-00025
+
+Verify the operating system provides the capability to filter audit records for events of interest based upon all audit fields within audit records.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_by_uid(shell):
+    """Verify ausearch -ua 0 succeeds (filter by user identity)."""
+    result = shell("ausearch -ua 0", capture_output=True)
+
+    assert (
+        result.returncode == 0
+    ), "stigcompliance: unable to filter audit records by user identity (uid)"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_returns_structured_output(shell):
+    """Verify ausearch -ua 0 output contains a 'type=' field."""
+    result = shell("ausearch -ua 0", capture_output=True)
+
+    assert (
+        "type=" in result.stdout or "type=" in result.stdout or "type=" in result.stdout
+    ), "stigcompliance: audit filtering does not return structured audit records"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_by_event_type(shell):
+    """Verify ausearch -ts recent -m USER_LOGIN runs (filter by event type)."""
+    result = shell(
+        "ausearch -ts recent -m USER_LOGIN",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    assert result.returncode in (
+        0,
+        1,
+    ), "stigcompliance: unable to filter audit records by event type"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_filter_by_command(shell):
+    """Verify ausearch -ts recent -c id runs (filter by command name)."""
+    result = shell(
+        "ausearch -ts recent -c id",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    assert result.returncode in (
+        0,
+        1,
+    ), "stigcompliance: unable to filter audit records by command"
+
+
+@pytest.mark.security_id(203614)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit configuration and logs")
+def test_audit_record_filtering_capability(shell):
+    """Verify ausearch supports filtering by -m, -ts, -ua, and -x flags."""
+    commands = [
+        "ausearch -m USER_LOGIN || true",  # event type
+        "ausearch -ts recent || true",  # time
+        "ausearch -ua 0 || true",  # user identity (root)
+        "ausearch -x /usr/bin/id || true",  # executable
+    ]
+
+    for cmd in commands:
+        result = shell(cmd, capture_output=True)
+        assert (
+            result.returncode == 0
+        ), f"stigcompliance: audit filtering failed for command: {cmd}"

--- a/tests/integration/security/compliance/test_disastig_00026.py
+++ b/tests/integration/security/compliance/test_disastig_00026.py
@@ -1,0 +1,34 @@
+"""
+Ref: SRG-OS-000055-GPOS-00026
+
+Verify the operating system uses internal system clocks to generate time stamps for audit records.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203615)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to generate and read audit logs")
+def test_audit_records_have_valid_timestamps(shell):
+    """Verify ausearch -ts recent output contains a 'time->' line in the expected date format."""
+    result = shell("ausearch -ts recent", capture_output=True)
+
+    timestamp_pattern = r"time->\w{3}\s+\w{3}\s+\d+\s+\d+:\d+:\d+\s+\d{4}"
+
+    match_found = bool(re.search(timestamp_pattern, result.stdout))
+    assert match_found, "stigcompliance: audit records do not contain valid timestamps"
+
+
+@pytest.mark.security_id(203615)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to generate and read audit logs")
+def test_system_time_status_available(shell):
+    """Verify timedatectl status exits 0."""
+    timedate = shell("timedatectl status", capture_output=True)
+
+    assert timedate.returncode == 0, "stigcompliance: unable to check time sync status"

--- a/tests/integration/security/compliance/test_disastig_00027.py
+++ b/tests/integration/security/compliance/test_disastig_00027.py
@@ -1,0 +1,49 @@
+"""
+Ref: SRG-OS-000057-GPOS-00027
+
+Verify the operating system protects audit information from unauthorized read access.
+"""
+
+import pytest
+
+AUDIT_LOG_DIR = "/var/log/audit"
+AUDIT_LOG_FILE = "/var/log/audit/audit.log"
+
+
+@pytest.mark.security_id(203616)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem")
+@pytest.mark.root(reason="required to inspect audit log permissions")
+def test_audit_log_directory_permissions_restricted(file):
+    """Verify audit log directory has restrictive permissions (rwx------)."""
+    if file.exists(AUDIT_LOG_DIR):
+        assert file.has_permissions(
+            AUDIT_LOG_DIR, "rwx------"
+        ), f"stigcompliance: audit log directory {AUDIT_LOG_DIR} permissions are not restricted"
+
+
+@pytest.mark.security_id(203616)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem")
+@pytest.mark.root(reason="required to inspect audit log permissions")
+def test_audit_log_file_permissions_restricted(file):
+    """Verify the audit log file has restrictive permissions (rw-------)."""
+    if file.exists(AUDIT_LOG_FILE):
+        assert file.has_permissions(
+            AUDIT_LOG_FILE, "rw-------"
+        ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} permissions are not restricted"
+
+
+@pytest.mark.security_id(203616)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-log-permissions"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem")
+@pytest.mark.root(reason="required to inspect audit log ownership")
+def test_audit_log_owned_by_root(file):
+    """Verify the audit log file is owned by root."""
+    if file.exists(AUDIT_LOG_FILE):
+        assert file.is_owned_by_user(
+            AUDIT_LOG_FILE, "root"
+        ), f"stigcompliance: audit log file {AUDIT_LOG_FILE} is not owned by root"

--- a/tests/integration/security/compliance/test_disastig_00028.py
+++ b/tests/integration/security/compliance/test_disastig_00028.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000058-GPOS-00028
+
+Verify the operating system protects audit information from unauthorized modification.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203617)
+def test_disastig_00028():
+    """Audit information protection is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00027.py")

--- a/tests/integration/security/compliance/test_disastig_00029.py
+++ b/tests/integration/security/compliance/test_disastig_00029.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000059-GPOS-00029
+
+Verify the operating system protects audit information from unauthorized deletion.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203618)
+def test_disastig_00029():
+    """Protection of audit information from deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00027.py")

--- a/tests/integration/security/compliance/test_disastig_00031.py
+++ b/tests/integration/security/compliance/test_disastig_00031.py
@@ -1,0 +1,45 @@
+"""
+Ref: SRG-OS-000062-GPOS-00031
+
+Verify the operating system provides audit record generation capability for DoD-defined auditable events for all operating system components.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203619)
+def test_audit_modify_delete_privileges():
+    """Audit of privilege modification/deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00210.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_modify_delete_security_objects():
+    """Audit of security object modification/deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00212.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_modify_delete_security_levels():
+    """Audit of security level modification/deletion is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00211.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_user_access():
+    """Audit of user access events is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00220.py")
+
+
+@pytest.mark.security_id(203619)
+def test_audit_user_accounts_management():
+    """Audit of user account management is covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00089.py,  test_disastig_00090.py, test_disastig_00091.py"
+    )
+
+
+@pytest.mark.security_id(203619)
+def test_audit_kernel_module_load_unload():
+    """Audit of kernel module load/unload is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00222.py")

--- a/tests/integration/security/compliance/test_disastig_00038.py
+++ b/tests/integration/security/compliance/test_disastig_00038.py
@@ -1,0 +1,28 @@
+"""
+Ref: SRG-OS-000070-GPOS-00038
+
+Verify the operating system enforces password complexity by requiring at least one lowercase character. Setting lcredit=-1 in pwquality.conf mandates at least one lowercase letter in every new password.
+"""
+
+import pytest
+
+PWQUALITY_CONF = "/etc/security/pwquality.conf"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-disaSTIGlow-config-security-pwquality",
+        "GL-TESTCOV-disaSTIGmedium-config-security-pwquality",
+    ]
+)
+@pytest.mark.feature(
+    "disaSTIGlow or disaSTIGmedium",
+    reason="password quality lcredit is configured by disaSTIGlow and disaSTIGmedium",
+)
+@pytest.mark.security_id(203626)
+def test_pwquality_conf_lcredit_is_minus_1(parse_file) -> None:
+    """Verify lcredit=-1 in pwquality.conf (SRG-OS-000070-GPOS-00038)."""
+    config = parse_file.parse(PWQUALITY_CONF, format="keyval")
+    assert (
+        config["lcredit"] == "-1"
+    ), f"stigcompliance: lcredit in {PWQUALITY_CONF} is {config['lcredit']!r}, expected '-1'"

--- a/tests/integration/security/compliance/test_disastig_00040.py
+++ b/tests/integration/security/compliance/test_disastig_00040.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000072-GPOS-00040
+
+Verify the operating system requires the change of at least eight of the total number of characters when passwords are changed.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203628)
+def test_disastig_00040():
+    """Password character change requirement is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00046.py")

--- a/tests/integration/security/compliance/test_disastig_00041.py
+++ b/tests/integration/security/compliance/test_disastig_00041.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000073-GPOS-00041
+
+Verify the operating system stores only encrypted representations of passwords.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203629)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="required for passwd checks")
+def test_passwd_does_not_store_passwords(passwd_entries):
+    """Verify /etc/passwd contains no plaintext passwords."""
+    assert all(
+        entry.password in ("x", "*", "!") for entry in passwd_entries
+    ), "stigcompliance: plaintext password found in /etc/passwd"
+
+
+@pytest.mark.security_id(203629)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="required for passwd checks")
+def test_shadow_passwords_are_hashed(shadow_entries):
+    """Verify /etc/shadow entries are empty, locked, or hashed."""
+    assert all(
+        entry.encrypted_password == ""
+        or entry.encrypted_password.startswith(("!", "*", "$"))
+        for entry in shadow_entries
+    ), "stigcompliance: non-hashed password detected in /etc/shadow"
+
+
+@pytest.mark.security_id(203629)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="required for passwd checks")
+def test_shadow_uses_strong_hashing_algorithm(shadow_entries):
+    """Verify /etc/shadow uses strong hashing (yescrypt or sha512)."""
+    assert all(
+        entry.encrypted_password == ""
+        or entry.encrypted_password.startswith(("!", "*", "$y$", "$6$"))
+        for entry in shadow_entries
+    ), "stigcompliance: weak password hashing algorithm detected"

--- a/tests/integration/security/compliance/test_disastig_00046.py
+++ b/tests/integration/security/compliance/test_disastig_00046.py
@@ -1,0 +1,32 @@
+"""
+Ref: SRG-OS-000078-GPOS-00046
+
+Verify the operating system enforces a minimum 15-character password length.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-password"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203634)
+def test_common_password_passwdqc_pam_faillock(pam_config):
+    """Verify pam_passwdqc enforces password strength rules in common-password."""
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_passwdqc.so",
+        arg_contains=[
+            "min=disabled,disabled,15,15,8",
+            "passphrase=4",
+            "similar=deny",
+            "match=7",
+            "retry=5",
+        ],
+    )
+    assert (
+        len(results) == 1
+    ), "User password should conform to password strength requirements"

--- a/tests/integration/security/compliance/test_disastig_00047.py
+++ b/tests/integration/security/compliance/test_disastig_00047.py
@@ -1,0 +1,48 @@
+"""
+Ref: SRG-OS-000079-GPOS-00047
+
+Verify the operating system obscures feedback of authentication information during the authentication process to protect the information from possible exploitation/use by unauthorized individuals.
+"""
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+PAM_FILES = [
+    "/etc/pam.d/common-auth",
+    "/etc/pam.d/login",
+    "/etc/pam.d/sshd",
+]
+
+
+@pytest.mark.security_id(203635)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires authentication stack")
+@pytest.mark.root(reason="required for pam.d checks")
+def test_authentication_uses_valid_pam_modules(file: File, parse_file: ParseFile):
+    """Verify pam_unix or pam_sss is wired into the PAM auth stack."""
+    existing_pam_files = [p for p in PAM_FILES if file.exists(p)]
+
+    assert existing_pam_files, "stigcompliance: no PAM configuration files found"
+
+    assert any(
+        ("pam_unix.so" in parse_file.lines(p) or "pam_sss.so" in parse_file.lines(p))
+        for p in existing_pam_files
+    ), "stigcompliance: no valid PAM authentication modules found"
+
+
+@pytest.mark.security_id(203635)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires authentication stack")
+@pytest.mark.root(reason="required for pam.d checks")
+def test_authentication_no_insecure_echo(file: File, parse_file: ParseFile):
+    """Verify PAM configs do not enable insecure echo of authentication input."""
+    for pam_file in PAM_FILES:
+        if not file.exists(pam_file):
+            continue
+
+        lines = parse_file.lines(pam_file)
+
+        assert (
+            "echo" not in lines
+        ), f"stigcompliance: insecure echo option found in {pam_file}"

--- a/tests/integration/security/compliance/test_disastig_00050.py
+++ b/tests/integration/security/compliance/test_disastig_00050.py
@@ -1,0 +1,53 @@
+"""
+Ref: SRG-OS-000096-GPOS-00050
+
+Verify the operating system is configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.
+"""
+
+import pytest
+
+ALLOWED_PORTS = {22, 53}
+
+FORBIDDEN_SERVICES = [
+    "telnet.service",
+    "vsftpd.service",
+    "rsh.service",
+    "avahi-daemon.service",
+    "cups.service",
+]
+
+
+@pytest.mark.feature(
+    "not container and not gardener and not lima and not capi and not baremetal"
+)
+@pytest.mark.security_id(203638)
+@pytest.mark.booted(reason="requires booted system")
+@pytest.mark.root(reason="requires audit operations")
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_ports_protocols_and_services_restricted(shell, systemd):
+    """Verify only ports 22 and 53 listen and forbidden services (telnet, vsftpd, rsh, avahi-daemon, cups) are not running."""
+    result = shell("ss -tuln", capture_output=True)
+    assert result.returncode == 0, "stigcompliance: failed to list listening ports"
+
+    open_ports = set()
+    for line in result.stdout.splitlines():
+        if "LISTEN" in line:
+            port = line.split()[4].split(":")[-1]
+            if port.isdigit():
+                open_ports.add(int(port))
+
+    unauthorized_ports = open_ports - ALLOWED_PORTS
+
+    assert (
+        not unauthorized_ports
+    ), f"stigcompliance: unauthorized ports open: {unauthorized_ports}"
+
+    running_units = systemd.list_running_units()
+
+    running_names = {unit.unit for unit in running_units}
+
+    found_forbidden = [svc for svc in FORBIDDEN_SERVICES if svc in running_names]
+
+    assert (
+        not found_forbidden
+    ), f"stigcompliance: forbidden services running: {found_forbidden}"

--- a/tests/integration/security/compliance/test_disastig_00056.py
+++ b/tests/integration/security/compliance/test_disastig_00056.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000109-GPOS-00056
+
+Verify the operating system locks the root account. A locked root account prevents direct login as root, forcing administrators to use privilege escalation mechanisms instead.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-root-locked"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="root account locking is enforced by disaSTIGmedium"
+)
+@pytest.mark.security_id(203644)
+@pytest.mark.root(reason="requires root to read shadow password status")
+def test_root_account_is_locked(shell) -> None:
+    """Verify root account is locked (field 2 of passwd --status output is 'L')."""
+    result = shell("passwd --status root", capture_output=True, ignore_exit_code=True)
+    fields = result.stdout.split()
+    assert (
+        len(fields) >= 2 and fields[1] == "L"
+    ), f"stigcompliance: root account is not locked (passwd --status output: {result.stdout!r})"

--- a/tests/integration/security/compliance/test_disastig_00057.py
+++ b/tests/integration/security/compliance/test_disastig_00057.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000112-GPOS-00057
+
+Verify the operating system implements replay-resistant authentication mechanisms for network access to privileged accounts.
+"""
+
+import re
+
+import pytest
+from plugins.sshd import Sshd
+
+
+@pytest.mark.security_id(203645)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect SSH configuration")
+def test_ssh_kex_algorithms_are_replay_resistant(sshd: Sshd) -> None:
+    """Verify SSH KexAlgorithms exclude non-replay-resistant algorithms (diffie-hellman-group1-sha1, diffie-hellman-group14-sha1)."""
+    kex = sshd.get_config_section("kexalgorithms") or ""
+
+    match_found = bool(
+        re.search(
+            r"diffie-hellman-group1-sha1|diffie-hellman-group14-sha1",
+            str(kex),
+            re.IGNORECASE,
+        )
+    )
+    assert (
+        not match_found
+    ), "stigcompliance: SSH KexAlgorithms contain non-replay-resistant algorithms"
+
+
+@pytest.mark.security_id(203645)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect SSH configuration")
+def test_ssh_kex_includes_ecdh(sshd: Sshd) -> None:
+    """Verify SSH KexAlgorithms include an approved ECDH algorithm (ecdh-sha2-nistp384 or ecdh-sha2-nistp521)."""
+    kex = sshd.get_config_section("kexalgorithms") or ""
+
+    match_found = bool(re.search(r"ecdh-sha2-nistp(384|521)", str(kex), re.IGNORECASE))
+    assert match_found, "stigcompliance: no approved ECDH KexAlgorithm configured"

--- a/tests/integration/security/compliance/test_disastig_00060.py
+++ b/tests/integration/security/compliance/test_disastig_00060.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000118-GPOS-00060
+
+Verify the operating system disables accounts inactive for more than 35 days. Setting INACTIVE in /etc/default/useradd ensures new accounts inherit this policy automatically.
+"""
+
+import pytest
+
+USERADD_DEFAULTS = "/etc/default/useradd"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-useradd-inactive"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="account inactivity timeout is set by disaSTIGmedium"
+)
+@pytest.mark.security_id(203648)
+def test_useradd_inactive_is_35(parse_file) -> None:
+    """Verify INACTIVE in /etc/default/useradd is 35 (SRG-OS-000118-GPOS-00060)."""
+    config = parse_file.parse(USERADD_DEFAULTS, format="keyval")
+    assert (
+        config["INACTIVE"] == "35"
+    ), f"stigcompliance: INACTIVE in {USERADD_DEFAULTS} is {config['INACTIVE']!r}, expected '35'"

--- a/tests/integration/security/compliance/test_disastig_00061.py
+++ b/tests/integration/security/compliance/test_disastig_00061.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000120-GPOS-00061
+
+Verify the operating system uses mechanisms meeting the requirements of applicable federal laws, Executive orders, directives, policies, regulations, standards, and guidance for authentication to a cryptographic module.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203649)
+def test_disastig_00061():
+    """Cryptographic module authentication is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00063.py
+++ b/tests/integration/security/compliance/test_disastig_00063.py
@@ -1,0 +1,33 @@
+"""
+Ref: SRG-OS-000122-GPOS-00063
+
+Verify the operating system provides an audit reduction capability that supports on-demand reporting requirements.
+"""
+
+import shutil
+
+import pytest
+
+
+@pytest.mark.security_id(203651)
+@pytest.mark.feature("log")
+def test_audit_reporting_tools_installed():
+    """Verify aureport and ausearch are installed."""
+    tools = ["aureport", "ausearch"]
+    for tool in tools:
+        path = shutil.which(tool)
+        assert path is not None, f"'{tool}' audit reporting utility is not installed"
+
+
+@pytest.mark.feature("log")
+@pytest.mark.root(
+    "Audit reporting requires root privileges to open /var/log/audit/audit.log"
+)
+@pytest.mark.security_id(203651)
+def test_audit_reporting_execution(shell):
+    """Verify aureport produces a usable summary."""
+    result = shell("aureport --summary", capture_output=True, ignore_exit_code=True)
+
+    assert (
+        "Summary" in result.stdout
+    ), f"'aureport' executed but returned an unexpected result: {result.stdout}"

--- a/tests/integration/security/compliance/test_disastig_00067.py
+++ b/tests/integration/security/compliance/test_disastig_00067.py
@@ -1,0 +1,55 @@
+"""
+Ref: SRG-OS-000132-GPOS-00067
+
+Verify the operating system separates user functionality (including user interface services) from operating system management functionality.
+"""
+
+import pwd
+
+import pytest
+
+SETUID_BINARIES_ALLOWLIST = {
+    "default": {
+        "/usr/bin/chfn",
+        "/usr/bin/chsh",
+        "/usr/bin/gpasswd",
+        "/usr/bin/passwd",
+        "/usr/bin/su",
+        "/usr/bin/sudo",
+        "/usr/bin/sudoedit",
+    },
+    "lima": {"/usr/bin/fusermount3", "/usr/bin/fusermount"},
+}
+
+
+@pytest.mark.security_id(203655)
+def test_only_root_user_has_uid_zero():
+    """Verify only the root account has UID 0."""
+    adm_users = [u.pw_name for u in pwd.getpwall() if u.pw_uid == 0]
+    assert adm_users == [
+        "root"
+    ], f"only root user should have uid 0, instead {adm_users} found"
+
+
+@pytest.mark.security_id(203655)
+@pytest.mark.feature("not lima")
+def test_only_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries):
+    """Verify only allowlisted setuid binaries are exposed."""
+    if exposed_setuid_binaries:
+        diff = exposed_setuid_binaries - SETUID_BINARIES_ALLOWLIST["default"]
+        assert (
+            not diff
+        ), f"unexpected setuid binaries with too broad exec permissions: {exposed_setuid_binaries=} {diff=}"
+
+
+@pytest.mark.security_id(203655)
+@pytest.mark.feature("lima")
+def test_only_lima_setuid_binaries_from_the_list_are_allowed(exposed_setuid_binaries):
+    """Verify only allowlisted setuid binaries (incl. lima additions) are exposed."""
+    if exposed_setuid_binaries:
+        diff = exposed_setuid_binaries - (
+            SETUID_BINARIES_ALLOWLIST["default"] | SETUID_BINARIES_ALLOWLIST["lima"]
+        )
+        assert (
+            not diff
+        ), f"unexpected setuid binaries with too broad exec permissions: {exposed_setuid_binaries=} {diff=}"

--- a/tests/integration/security/compliance/test_disastig_00068.py
+++ b/tests/integration/security/compliance/test_disastig_00068.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000134-GPOS-00068
+
+Verify the operating system isolates security functions from nonsecurity functions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203656)
+def test_disastig_00068():
+    """Isolation of security from nonsecurity functions is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00067.py")

--- a/tests/integration/security/compliance/test_disastig_00069.py
+++ b/tests/integration/security/compliance/test_disastig_00069.py
@@ -1,0 +1,89 @@
+"""
+Ref: SRG-OS-000138-GPOS-00069
+
+Verify operating systems prevents unauthorized and unintended information transfer via shared system resources.
+"""
+
+import pytest
+from plugins.parse import Lines
+
+
+# -- temporary files
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("not _selinux")
+@pytest.mark.booted(reason="Mounts are present on a booted system")
+def test_tmp_mount_is_configured_securely(mount):
+    """Verify /tmp is mounted with nosuid."""
+    required_mount_options = {"nosuid"}
+
+    real_mount_options = mount("/tmp").options
+    missing_mount_options = required_mount_options - real_mount_options
+
+    assert (
+        not missing_mount_options
+    ), f"Missing /tmp mount options: {missing_mount_options}"
+
+
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="Mounts are present on a booted system")
+def test_tmp_mount_is_configured_securely_and_with_selinux(mount):
+    """Verify /tmp is mounted with nosuid and seclabel under SELinux."""
+    required_mount_options = {"nosuid", "seclabel"}
+
+    real_mount_options = mount("/tmp").options
+    missing_mount_options = required_mount_options - real_mount_options
+
+    assert (
+        not missing_mount_options
+    ), f"Missing /tmp mount options: {missing_mount_options}"
+
+
+@pytest.mark.security_id(203657)
+def test_temp_directores_are_world_writable_and_have_sticky_bit_set(file):
+    """Verify /tmp and /var/tmp are world-writable with sticky bit (1777)."""
+    for dir in ["/tmp", "/var/tmp"]:
+        assert file.is_dir(dir)
+        assert file.has_mode(dir, "1777")
+
+
+@pytest.mark.security_id(203657)
+@pytest.mark.booted(reason="Systemd should be running")
+def test_systemd_tmpfiles_configuration_is_sane(shell):
+    """Verify systemd-tmpfiles configures /tmp and /var/tmp with mode 1777."""
+    result = shell("systemd-tmpfiles --cat-config", capture_output=True)
+    for dir in ["/tmp", "/var/tmp"]:
+        lines = Lines(result.stdout, comment_char="#")
+        assert (
+            f"q {dir} 1777 root root" in lines
+        ), f"{dir} should be correctly configured in systemd-tmpfiles"
+
+
+# -- coredumps
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="sysctl values are only applied on a booted system")
+def test_suid_binaries_cannot_create_coredumps(sysctl):
+    """Verify fs.suid_dumpable is 0."""
+    assert sysctl["fs.suid_dumpable"] == 0
+
+
+# -- memory
+@pytest.mark.security_id(203657)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="sysctl values are only applied on a booted system")
+def test_kernel_randomizes_virtual_memory_addresses(sysctl):
+    """Verify kernel.randomize_va_space is set to 2 (full ASLR)."""
+    assert sysctl["kernel.randomize_va_space"] == 2
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-sysctl-disaSTIG"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="sysctl hardening config is deployed by disaSTIGlow"
+)
+@pytest.mark.security_id(203657)
+def test_sysctl_disastig_low_conf_exists(file) -> None:
+    """Verify /etc/sysctl.d/99-disaSTIG.conf exists for disaSTIGlow (SRG-OS-000138-GPOS-00069)."""
+    assert file.exists(
+        "/etc/sysctl.d/99-disaSTIG.conf"
+    ), "stigcompliance: /etc/sysctl.d/99-disaSTIG.conf does not exist"

--- a/tests/integration/security/compliance/test_disastig_00071.py
+++ b/tests/integration/security/compliance/test_disastig_00071.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000142-GPOS-00071
+
+Verify the operating system is configured to prevent unauthorized connection of devices. The disaSTIG sysctl configuration file must be present to ensure kernel parameter hardening is applied.
+"""
+
+import pytest
+
+SYSCTL_DISASTIG = "/etc/sysctl.d/99-disaSTIG.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sysctl-disaSTIG"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="sysctl hardening config is deployed by disaSTIGmedium"
+)
+@pytest.mark.security_id(203658)
+def test_sysctl_disastig_conf_exists(file) -> None:
+    """Verify /etc/sysctl.d/99-disaSTIG.conf exists (SRG-OS-000142-GPOS-00071)."""
+    assert file.exists(
+        SYSCTL_DISASTIG
+    ), f"stigcompliance: {SYSCTL_DISASTIG} does not exist"

--- a/tests/integration/security/compliance/test_disastig_00072.py
+++ b/tests/integration/security/compliance/test_disastig_00072.py
@@ -1,0 +1,19 @@
+"""
+Ref: SRG-OS-000163-GPOS-00072
+
+Verify the operating system terminates all network connections associated with a communications session at the end of the session, or as follows: for in-band management sessions (privileged sessions), the session must be terminated after 10 minutes of inactivity; and for user sessions (non-privileged session), the session must be terminated after 15 minutes of inactivity, except to fulfill documented and validated mission requirements.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-clientalivecountmax"]
+)
+@pytest.mark.security_id(203659)
+@pytest.mark.feature("disaSTIGmedium")
+def test_terminate_ssh_session_after_inactivity_period(parse_file):
+    """Verify sshd is set to disconnect after 600s of inactivity."""
+    config = parse_file.parse("/etc/ssh/sshd_config", format="spacedelim")
+    assert config["ClientAliveInterval"] == "600"
+    assert config["ClientAliveCountMax"] == "1"

--- a/tests/integration/security/compliance/test_disastig_00078.py
+++ b/tests/integration/security/compliance/test_disastig_00078.py
@@ -1,0 +1,16 @@
+"""
+Ref: SRG-OS-000184-GPOS-00078
+
+Verify the operating system fails to a secure state if system initialization fails, shutdown fails, or aborts fail.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sysctl-disaSTIG"])
+@pytest.mark.security_id(203664)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="sysctl values are only applied on a booted system")
+def test_kernel_dump_is_disabled(sysctl):
+    """Verify kernel.core_pattern routes core dumps to /bin/false."""
+    assert sysctl["kernel.core_pattern"] == "|/bin/false"

--- a/tests/integration/security/compliance/test_disastig_00083.py
+++ b/tests/integration/security/compliance/test_disastig_00083.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000205-GPOS-00083
+
+Verify the operating system defines proper permissions on the system log directory /var/log so that unauthorized users cannot access log data.
+"""
+
+import pytest
+
+VAR_LOG = "/var/log"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-var-log-file-permissions"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="log directory permissions are hardened by disaSTIGmedium"
+)
+@pytest.mark.security_id(203663)
+def test_var_log_has_755_permissions(file) -> None:
+    """Verify /var/log directory has permissions 755 (SRG-OS-000205-GPOS-00083)."""
+    assert file.has_permissions(
+        VAR_LOG, "rwxr-xr-x"
+    ), f"stigcompliance: {VAR_LOG} permissions are {file.get_mode(VAR_LOG)!r}, expected 0755"

--- a/tests/integration/security/compliance/test_disastig_00084.py
+++ b/tests/integration/security/compliance/test_disastig_00084.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000206-GPOS-00084
+
+Verify the operating system reveals error messages only to authorized users.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203664)
+@pytest.mark.feature("disaSTIGmedium")
+def test_systemd_journal_is_not_world_readable(file):
+    """Verify /var/log/journal is owned by root with mode rwxr-s---."""
+    assert file.is_owned_by_user("/var/log/journal", "root")
+    assert file.has_permissions("/var/log/journal", "rwxr-s---")

--- a/tests/integration/security/compliance/test_disastig_00089.py
+++ b/tests/integration/security/compliance/test_disastig_00089.py
@@ -1,0 +1,55 @@
+"""
+Ref: SRG-OS-000239-GPOS-00089
+
+Verify the operating system automatically audits account modification.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203666)
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-30-disaSTIG-rules",
+        "GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules",
+    ]
+)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_audit_calling_user_group_related_utilities(audit_rule):
+    """Verify execution of user/group management binaries is audited."""
+    for bin in [
+        "/usr/sbin/visudo",
+        "/usr/sbin/chgpasswd",
+        "/usr/sbin/chpasswd",
+        "/usr/sbin/groupadd",
+        "/usr/sbin/groupdel",
+        "/usr/sbin/groupmod",
+        "/usr/sbin/grpconv",
+        "/usr/sbin/grpunconv",
+        "/usr/sbin/newusers",
+        "/usr/sbin/pwconv",
+        "/usr/sbin/pwunconv",
+        "/usr/sbin/shadowconfig",
+        "/usr/sbin/useradd",
+        "/usr/sbin/userdel",
+        "/usr/sbin/usermod",
+        "/usr/sbin/vipw",
+        "/usr/sbin/vigr",
+        "/usr/bin/chage",
+        "/usr/bin/chfn",
+        "/usr/bin/chsh",
+        "/usr/bin/gpasswd",
+        "/usr/bin/passwd",
+    ]:
+        assert audit_rule(
+            fs_watch_path=bin, access_types="x"
+        ), f"No audit rule found for {bin} execution"
+
+
+@pytest.mark.security_id(203666)
+def test_audit_rules_for_logging_attempts_to_delete_privileges():
+    """Audit rules for privilege deletion are covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"
+    )

--- a/tests/integration/security/compliance/test_disastig_00090.py
+++ b/tests/integration/security/compliance/test_disastig_00090.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000240-GPOS-00090
+
+Verify the operating system automatically audits account disabling actions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203667)
+def test_disastig_00090():
+    """Auditing of account disabling actions is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00089.py")
+
+
+@pytest.mark.security_id(203667)
+def test_audit_rules_for_logging_attempts_to_delete_privileges():
+    """Audit rules for privilege deletion are covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"
+    )

--- a/tests/integration/security/compliance/test_disastig_00091.py
+++ b/tests/integration/security/compliance/test_disastig_00091.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000241-GPOS-00091
+
+Verify the operating system automatically audits account removal actions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203668)
+def test_disastig_00091():
+    """Auditing of account removal actions is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00089.py")
+
+
+@pytest.mark.security_id(203668)
+def test_audit_rules_for_logging_attempts_to_delete_privileges():
+    """Audit rules for privilege deletion are covered elsewhere."""
+    pytest.skip(
+        reason="covered by test_disastig_00210::test_audit_rules_for_logging_attempts_to_delete_privileges"
+    )

--- a/tests/integration/security/compliance/test_disastig_00095.py
+++ b/tests/integration/security/compliance/test_disastig_00095.py
@@ -1,0 +1,43 @@
+"""
+Ref: SRG-OS-000254-GPOS-00095
+
+As per DISA STIG compliance requirements, the operating system must begin auditing sessions when the system starts up.
+"""
+
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+
+@pytest.mark.security_id(203670)
+@pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
+@pytest.mark.feature("disaSTIGmedium")
+def test_audit_cmdline_config_file_exists(file: File):
+    """Verify the audit kernel cmdline config file exists."""
+    assert file.is_regular_file(
+        "/etc/kernel/cmdline.d/90-audit.cfg"
+    ), "stigcompliance: /etc/kernel/cmdline.d/90-audit.cfg must exist"
+
+
+@pytest.mark.security_id(203670)
+@pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
+@pytest.mark.feature("disaSTIGmedium")
+def test_audit_cmdline_config_file_content(parse_file: ParseFile):
+    """Verify the audit kernel cmdline config contains audit=1."""
+    lines = parse_file.lines("/etc/kernel/cmdline.d/90-audit.cfg")
+    assert (
+        "audit=1" in lines
+    ), "stigcompliance: /etc/kernel/cmdline.d/90-audit.cfg must contain audit=1"
+
+
+@pytest.mark.security_id(203670)
+@pytest.mark.testcov("GL-TESTCOV-disaSTIGmedium-config-kernel-cmdline-audit")
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="kernel cmdline is only available on a booted system")
+def test_audit_enabled_in_kernel_cmdline(kernel_cmdline: List[str]):
+    """Verify audit=1 is present in the runtime kernel cmdline."""
+    assert (
+        "audit=1" in kernel_cmdline
+    ), "stigcompliance: kernel must be booted with audit=1"

--- a/tests/integration/security/compliance/test_disastig_00096.py
+++ b/tests/integration/security/compliance/test_disastig_00096.py
@@ -1,0 +1,41 @@
+"""
+Ref: SRG-OS-000255-GPOS-00096
+
+Verify the operating system produces audit records containing information to establish the identity of any individual or process associated with the event.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203671)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit retention validation requires audit subsystem")
+@pytest.mark.root(reason="required to read audit configuration and logs")
+def test_audit_records_contain_identity_information(shell):
+    """Verify audit records carry identity fields (auid, uid, pid, comm, exe)."""
+    result = shell(
+        "ausearch -ts recent",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    stdout = result.stdout or ""
+
+    identity_patterns = [
+        r"\bauid=\d+",
+        r"\buid=\d+",
+        r"\beuid=\d+",
+        r"\bpid=\d+",
+        r"\bcomm=",
+        r"\bexe=",
+    ]
+
+    missing = [
+        pattern for pattern in identity_patterns if not re.search(pattern, stdout)
+    ]
+
+    assert (
+        not missing
+    ), "stigcompliance: audit records missing identity fields: " + ", ".join(missing)

--- a/tests/integration/security/compliance/test_disastig_00097.py
+++ b/tests/integration/security/compliance/test_disastig_00097.py
@@ -1,0 +1,89 @@
+"""
+Ref: SRG-OS-000256-GPOS-00097
+
+Verify the operating system protects audit tools from unauthorized access.
+"""
+
+import pytest
+
+AUDIT_TOOL_PATHS = [
+    "/sbin/auditctl",
+    "/usr/sbin/auditctl",
+    "/usr/bin/last",
+    "/usr/bin/journalctl",
+]
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_shadow_permissions(file):
+    """Verify /etc/shadow has mode 0640."""
+    actual = file.get_mode("/etc/shadow")
+    assert file.has_permissions("/etc/shadow", "0640"), (
+        f"stigcompliance: incorrect permissions on /etc/shadow "
+        f"(expected 640, got {actual})"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_passwd_permissions_numeric(file):
+    """Verify /etc/passwd has numeric mode 0644."""
+    actual = file.get_mode("/etc/passwd")
+    assert file.has_permissions("/etc/passwd", "0644"), (
+        f"stigcompliance: incorrect permissions on /etc/passwd "
+        f"(expected 0644, got {actual})"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_passwd_permissions_symbolic(file):
+    """Verify /etc/passwd has symbolic mode rw-r--r--."""
+    actual = file.get_mode("/etc/passwd")
+    assert file.has_permissions("/etc/passwd", "rw-r--r--"), (
+        f"stigcompliance: incorrect symbolic permissions on /etc/passwd "
+        f"(expected rw-r--r--, got {actual})"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+def test_audit_tools_permissions(file):
+    """Verify auditctl, last and journalctl binaries have mode 755."""
+    invalid = []
+
+    for path in AUDIT_TOOL_PATHS:
+        if not file.exists(path):
+            continue
+
+        if not file.has_permissions(path, "755"):
+            invalid.append(f"{path} ({file.get_mode(path)})")
+
+    assert not invalid, (
+        "stigcompliance: audit tools must have 755: " f"{', '.join(invalid)}"
+    )
+
+
+@pytest.mark.security_id(203672)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_sticky_bit_support(file, tmp_path):
+    """Verify a tmp directory chmod-ed to 1777 reports both 1777 and rwxrwxrwt."""
+    test_dir = tmp_path / "sticky_test"
+    test_dir.mkdir()
+    test_dir.chmod(0o1777)
+
+    assert file.has_permissions(test_dir, "1777")
+    assert file.has_permissions(test_dir, "rwxrwxrwt")

--- a/tests/integration/security/compliance/test_disastig_00098.py
+++ b/tests/integration/security/compliance/test_disastig_00098.py
@@ -1,0 +1,72 @@
+"""
+Ref: SRG-OS-000257-GPOS-00098
+
+Verify the operating system protects audit tools from unauthorized modification.
+"""
+
+from pathlib import Path
+
+import pytest
+
+AUDIT_LOG_DIR = "/var/log/audit"
+
+
+@pytest.mark.security_id(203673)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit protection requires booted system")
+@pytest.mark.root(reason="required to inspect audit log ownership")
+def test_audit_log_directory_protected(file):
+    """Verify /var/log/audit is owned by root with one of: rwx------, rwxr-x---, rwxr-----, rwx--x---."""
+    assert file.exists(AUDIT_LOG_DIR), f"stigcompliance: {AUDIT_LOG_DIR} does not exist"
+
+    assert file.is_owned_by_user(
+        AUDIT_LOG_DIR, "root"
+    ), f"stigcompliance: {AUDIT_LOG_DIR} must be owned by root"
+
+    allowed_modes = [
+        "rwx------",
+        "rwxr-x---",
+        "rwxr-----",
+        "rwx--x---",
+    ]
+
+    assert any(file.has_permissions(AUDIT_LOG_DIR, mode) for mode in allowed_modes), (
+        f"stigcompliance: {AUDIT_LOG_DIR} has insecure permissions "
+        f"(mode {file.get_mode(AUDIT_LOG_DIR)})"
+    )
+
+
+@pytest.mark.security_id(203673)
+@pytest.mark.feature("disaSTIGmedium or cis")
+@pytest.mark.booted(reason="audit protection requires booted system")
+@pytest.mark.root(reason="required to inspect audit log ownership")
+def test_audit_log_files_protected(file):
+    """Verify regular files under /var/log/audit are owned by root and have mode rw------- or rw-r-----."""
+    if not file.exists(AUDIT_LOG_DIR):
+        pytest.skip(f"{AUDIT_LOG_DIR} does not exist")
+
+    allowed_modes = [
+        "rw-------",
+        "rw-r-----",
+    ]
+
+    violations = []
+
+    for path in Path(AUDIT_LOG_DIR).glob("*"):
+        if not file.is_regular_file(path):
+            continue
+
+        owner_ok = file.is_owned_by_user(path, "root")
+
+        perms_ok = any(file.has_permissions(path, mode) for mode in allowed_modes)
+
+        if not owner_ok or not perms_ok:
+            violations.append(
+                f"{path.name} (owner={file.get_user(path)}, mode={file.get_mode(path)})"
+            )
+
+    assert (
+        not violations
+    ), "stigcompliance: audit log files not properly protected for: " + ", ".join(
+        violations
+    )

--- a/tests/integration/security/compliance/test_disastig_00099.py
+++ b/tests/integration/security/compliance/test_disastig_00099.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000258-GPOS-00099
+
+Verify the operating system protects audit tools from unauthorized deletion.
+"""
+
+from pathlib import Path
+
+import pytest
+
+AUDIT_TOOL_PATHS = [
+    "/sbin/auditctl",
+    "/usr/sbin/auditctl",
+    "/usr/bin/last",
+    "/usr/bin/journalctl",
+]
+
+
+@pytest.mark.security_id(203674)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_audit_tools_parent_dirs_not_writable(file):
+    """Verify the parent directories of auditctl/last/journalctl are not rwxrwxrwx, rwxrwxr-x or rwxrwx---."""
+    checked = set()
+    for path in AUDIT_TOOL_PATHS:
+        if not file.exists(path):
+            continue
+
+        parent = str(Path(path).parent)
+        if parent in checked:
+            continue
+        checked.add(parent)
+
+        mode = file.get_mode(parent)
+
+        assert (
+            not file.has_permissions(parent, "rwxrwxrwx")
+            and not file.has_permissions(parent, "rwxrwxr-x")
+            and not file.has_permissions(parent, "rwxrwx---")
+        ), (
+            f"stigcompliance: parent directory {parent} allows unauthorized deletion "
+            f"(mode: {mode})"
+        )

--- a/tests/integration/security/compliance/test_disastig_00100.py
+++ b/tests/integration/security/compliance/test_disastig_00100.py
@@ -1,0 +1,92 @@
+"""
+Ref: SRG-OS-000259-GPOS-00100
+
+Verify the operating system limits privileges to change software resident within software libraries.
+"""
+
+import fileinput
+import glob
+import platform
+
+import pytest
+
+ALLOWED_LIB_DIRS = {
+    "x86_64": {
+        "/usr/lib",
+        "/usr/local/lib",
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/lib/i686-linux-gnu",
+        "/lib32",
+        "/usr/lib/i386-linux-gnu",
+        "/usr/lib/i686-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu/libfakeroot",
+        "/usr/lib32",
+        "/usr/local/lib/i386-linux-gnu",
+        "/usr/local/lib/i686-linux-gnu",
+        "/usr/local/lib/x86_64-linux-gnu",
+    },
+    "aarch64": {
+        "/usr/lib",
+        "/usr/local/lib",
+        "/usr/lib/aarch64-linux-gnu",
+        "/usr/local/lib/aarch64-linux-gnu",
+    },
+}
+
+
+@pytest.fixture
+def ld_library_paths():
+    return {
+        line.strip()
+        for line in fileinput.input(
+            files=["/etc/ld.so.conf"] + glob.glob("/etc/ld.so.conf.d/*")
+        )
+        if line.strip().startswith("/")
+    }
+
+
+@pytest.mark.security_id(203675)
+def test_no_unsolicited_lib_path_for_ldconfig(ld_library_paths):
+    """Verify /etc/ld.so.conf and /etc/ld.so.conf.d/* contain only the architecture's allow-listed library paths."""
+    diff = ld_library_paths - ALLOWED_LIB_DIRS[platform.machine()]
+    assert not diff, f"unexpected shared libraries lookup paths configured: {diff}"
+
+
+@pytest.mark.security_id(203675)
+@pytest.mark.feature("disaSTIGmedium")
+def test_lib_directories_are_only_root_writable(ld_library_paths, file):
+    """Verify each ld.so library directory is root:root with mode rwxr-xr-x."""
+    for lib_path in ld_library_paths:
+        if file.exists(lib_path):
+            assert file.get_owner(lib_path) == ("root", "root")
+            assert file.has_permissions(lib_path, "rwxr-xr-x")
+
+
+@pytest.mark.security_id(203675)
+@pytest.mark.feature("disaSTIGmedium")
+def test_python_lib_directory_is_only_root_writable(file, dpkg):
+    """Verify /usr/lib/python3/dist-packages is root:root with mode rwxr-xr-x."""
+    python_pkg = dpkg.collect_installed_packages().get_package("python3")
+    if python_pkg:
+        dist_packages = "/usr/lib/python3/dist-packages"
+        assert file.get_owner(dist_packages) == ("root", "root")
+        assert file.has_permissions(dist_packages, "rwxr-xr-x")
+
+
+@pytest.mark.security_id(203675)
+def test_python_disallows_installing_packages_with_pip_on_system_level(dpkg, file):
+    """Verify /usr/lib/pythonX.Y/EXTERNALLY-MANAGED exists for the installed python3 version."""
+    python_pkg = dpkg.collect_installed_packages().get_package("python3")
+    if python_pkg:
+        python_major_minor_ver = ".".join(python_pkg["Version"].split(".")[:2])
+        assert file.exists(
+            f"/usr/lib/python{python_major_minor_ver}/EXTERNALLY-MANAGED"
+        )
+
+
+@pytest.mark.security_id(203675)
+def test_only_root_can_install_deb_packages(file):
+    """Verify /var/lib/dpkg is root:root with mode rwxr-xr-x."""
+    assert file.get_owner("/var/lib/dpkg") == ("root", "root")
+    assert file.has_permissions("/var/lib/dpkg", "rwxr-xr-x")

--- a/tests/integration/security/compliance/test_disastig_00103.py
+++ b/tests/integration/security/compliance/test_disastig_00103.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000269-GPOS-00103
+
+Verify, in the event of a system failure, the operating system preserves any information necessary to determine cause of failure and any information necessary to return to operations with least disruption to mission processes.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203677)
+def test_disastig_00103():
+    """Failure-state information preservation is covered by kdump tests."""
+    pytest.skip(
+        reason="covered by core/test_services::test__kdump_kdump_tools_service_enabled, integration/boot/test_initrd::test_kdump_initrd_files"
+    )

--- a/tests/integration/security/compliance/test_disastig_00108.py
+++ b/tests/integration/security/compliance/test_disastig_00108.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000278-GPOS-00108
+
+Verify the operating system uses cryptographic mechanisms to protect the integrity of audit tools.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203682)
+@pytest.mark.booted(reason="Requires working networking")
+def test_auditd_is_not_tampered(dpkg, dpkg_checksums, shell):
+    """Verify /usr/sbin/{auditd,auditctl,augenrules,aureport,ausearch} match the deb package md5sums."""
+    if not dpkg.package_is_installed("auditd"):
+        return
+
+    ideal_checksums = dpkg_checksums.for_package("auditd")
+    for bin in ["auditd", "auditctl", "augenrules", "aureport", "ausearch"]:
+        assert dpkg_checksums.is_matching_with_installed(
+            ideal_checksums, f"/usr/sbin/{bin}"
+        ), f"checksum of /usr/sbin/{bin} does not match the one from the corresponding deb package's md5sums control file"

--- a/tests/integration/security/compliance/test_disastig_00109.py
+++ b/tests/integration/security/compliance/test_disastig_00109.py
@@ -1,0 +1,17 @@
+"""
+Ref: SRG-OS-000279-GPOS-00109
+
+Verify the operating system initiates a session lock after a period of inactivity. Setting TMOUT=900 in a profile.d script ensures interactive shell sessions time out after 15 minutes of inactivity.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-profile-terminal-tmout"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="terminal timeout is configured by disaSTIGmedium"
+)
+@pytest.mark.security_id(203683)
+def test_terminal_tmout_profile_sets_tmout_900(parse_file) -> None:
+    """Verify the profile.d snippet sets TMOUT=900 (15 min)."""
+    assert "TMOUT=900" in parse_file.lines("/etc/profile.d/99-terminal_tmout.sh")

--- a/tests/integration/security/compliance/test_disastig_00110.py
+++ b/tests/integration/security/compliance/test_disastig_00110.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000590-GPOS-00110
+
+Verify the operating system is configured to disable accounts when the accounts are no longer associated to a user.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(263650)
+def test_disastig_00110():
+    """Account expiration enforcement via pam_unix is checked in test_disastig_00170.py."""
+    pytest.skip(reason="covered by test_disastig_00170.py")

--- a/tests/integration/security/compliance/test_disastig_00124.py
+++ b/tests/integration/security/compliance/test_disastig_00124.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000312-GPOS-00124
+
+Verify the operating system allows operating system admins to change security attributes on users, the operating system, or the operating system's components.
+"""
+
+import pytest
+
+
+@pytest.mark.feature("server or disaSTIGmedium")
+def test_sudo_installed(file):
+    """Verify the sudo binary is installed and executable."""
+    assert file.is_executable("/usr/bin/sudo")
+
+
+@pytest.mark.feature(
+    "server and not disaSTIGmedium",
+    reason="disaSTIGmedium intentionally empties the wheel file (SRG-OS-000373-GPOS-00156 takes precedence)",
+)
+def test_sudo_has_wheel_group_enabled(parse_file):
+    """Verify sudoers grants the wheel group access."""
+    lines = parse_file.lines("/etc/sudoers.d/wheel")
+    assert "%wheel" in lines

--- a/tests/integration/security/compliance/test_disastig_00125.py
+++ b/tests/integration/security/compliance/test_disastig_00125.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000324-GPOS-00125
+
+Verify that the operating system prevents non-privileged users from executing privileged functions to include disabling, circumventing, or altering implemented security safeguards/countermeasures.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203695)
+@pytest.mark.feature("disaSTIGhigh")
+def test_ctrl_alt_del_burst_is_disabled(parse_file):
+    """Verify systemd disables the Ctrl-Alt-Del reboot burst action."""
+    config = parse_file.parse("/etc/systemd/system.conf", format="keyval")
+    assert config["CtrlAltDelBurstAction"] == "none"

--- a/tests/integration/security/compliance/test_disastig_00126.py
+++ b/tests/integration/security/compliance/test_disastig_00126.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000326-GPOS-00126
+
+Verify that the operating system prevents all software from executing at higher privilege levels than users executing the software.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203696)
+def test_disastig_00126():
+    """Privilege boundary enforcement is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00067.py")

--- a/tests/integration/security/compliance/test_disastig_00128.py
+++ b/tests/integration/security/compliance/test_disastig_00128.py
@@ -1,0 +1,17 @@
+"""
+Ref: SRG-OS-000329-GPOS-00128
+
+Verify the operating system automatically locks an account until the locked account is released by an administrator when three unsuccessful logon attempts in 15 minutes are made.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203698)
+@pytest.mark.feature("disaSTIGmedium")
+def test_user_locked_after_unsuccessful_logon_attempts(parse_file):
+    """Verify faillock.conf enforces 3 attempts in 900s with admin-only unlock."""
+    config = parse_file.parse("/etc/security/faillock.conf", format="keyval")
+    assert config["deny"] == "3"
+    assert config["fail_interval"] == "900"
+    assert config["unlock_time"] == "0"

--- a/tests/integration/security/compliance/test_disastig_00134.py
+++ b/tests/integration/security/compliance/test_disastig_00134.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000343-GPOS-00134
+
+Verify the operating system takes appropriate action when the audit storage volume is full. Setting disk_full_action=halt in auditd.conf ensures the system halts rather than silently dropping audit records.
+"""
+
+import pytest
+
+AUDITD_CONF = "/etc/audit/auditd.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-audit-auditd-conf"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="auditd disk_full_action is configured by disaSTIGlow"
+)
+@pytest.mark.security_id(203702)
+def test_auditd_conf_disk_full_action_is_halt(parse_file) -> None:
+    """Verify disk_full_action=halt in auditd.conf (SRG-OS-000343-GPOS-00134)."""
+    config = parse_file.parse(AUDITD_CONF, format="keyval")
+    assert config["disk_full_action"] == "halt", (
+        f"stigcompliance: disk_full_action in {AUDITD_CONF} is "
+        f"{config['disk_full_action']!r}, expected 'halt'"
+    )

--- a/tests/integration/security/compliance/test_disastig_00136.py
+++ b/tests/integration/security/compliance/test_disastig_00136.py
@@ -1,0 +1,28 @@
+"""
+Ref: SRG-OS-000348-GPOS-00136
+
+Verify the operating system provides an audit reduction capability that supports on-demand audit review and analysis.
+"""
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203704)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="audit tools check requires booted system")
+@pytest.mark.root(reason="required to execute privileged tools")
+def test_audit_reduction_capability(shell: ShellRunner):
+    """Verify audit reduction works by piping ausearch into aureport."""
+    output = shell(
+        cmd="ausearch -k ssh_login -ts recent | aureport --summary",
+        capture_output=True,
+    )
+
+    assert (
+        output.returncode == 0
+    ), f"stigcompliance: audit reduction pipeline failed: {output.stderr}"
+
+    assert (
+        "Summary Report" in output.stdout
+    ), "stigcompliance: aureport did not generate summary output"

--- a/tests/integration/security/compliance/test_disastig_00137.py
+++ b/tests/integration/security/compliance/test_disastig_00137.py
@@ -1,0 +1,14 @@
+"""
+Ref: SRG-OS-000351-GPOS-00137
+
+Verify the operating system provides an audit reduction capability that supports after-the-fact investigations of security incidents.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203705)
+@pytest.mark.feature("log")
+def test_disastig_00137():
+    """Audit reduction capability is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests/integration/security/compliance/test_disastig_00138.py
+++ b/tests/integration/security/compliance/test_disastig_00138.py
@@ -1,0 +1,14 @@
+"""
+Ref: SRG-OS-000351-GPOS-00138
+
+Verify the operating system provides a report generation capability that supports on-demand audit review and analysis.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203706)
+@pytest.mark.feature("log")
+def test_disastig_00138():
+    """On-demand audit review report generation is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests/integration/security/compliance/test_disastig_00139.py
+++ b/tests/integration/security/compliance/test_disastig_00139.py
@@ -1,0 +1,14 @@
+"""
+Ref: SRG-OS-000351-GPOS-00139
+
+Verify the operating system provides a report generation capability that supports on-demand reporting requirements.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203707)
+@pytest.mark.feature("log")
+def test_disastig_00139():
+    """On-demand reporting capability is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00140.py")

--- a/tests/integration/security/compliance/test_disastig_00140.py
+++ b/tests/integration/security/compliance/test_disastig_00140.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000352-GPOS-00140
+
+Verify the operating system provides a report generation capability that supports after-the-fact investigations of security incidents.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203708)
+def test_disastig_00140():
+    """After-the-fact reporting capability is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00063.py")

--- a/tests/integration/security/compliance/test_disastig_00141.py
+++ b/tests/integration/security/compliance/test_disastig_00141.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000353-GPOS-00141
+
+Verify the operating system does not alter original content or time ordering of audit records when it provides an audit reduction capability.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203709)
+def test_disastig_00141():
+    """Audit reduction record-integrity is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00142.py")

--- a/tests/integration/security/compliance/test_disastig_00142.py
+++ b/tests/integration/security/compliance/test_disastig_00142.py
@@ -1,0 +1,23 @@
+import shutil
+from tempfile import TemporaryDirectory
+
+import pytest
+
+"""
+Ref: SRG-OS-000354-GPOS-00142
+
+Verify the operating system does not alter original content or time ordering of
+audit records when it provides a report generation capability.
+"""
+
+
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Needs running auditd")
+@pytest.mark.root(reason="Needs to access root-owned audit.log")
+def test_audit_report_does_not_alter_original_audit_logs(shell, file):
+    with TemporaryDirectory(prefix="pytest-disa-stig-") as tmpd:
+        shutil.copy("/var/log/audit/audit.log", f"{tmpd}/audit.log")
+        before_report_checksum = file.checksum(f"{tmpd}/audit.log")
+        shell(f"aureport -if {tmpd}/audit.log")
+        after_report_checksum = file.checksum(f"{tmpd}/audit.log")
+    assert before_report_checksum == after_report_checksum

--- a/tests/integration/security/compliance/test_disastig_00143.py
+++ b/tests/integration/security/compliance/test_disastig_00143.py
@@ -1,0 +1,43 @@
+"""
+Ref: SRG-OS-000355-GPOS-00143
+
+Verify the operating system, for networked systems, compares internal information system clocks at least every 24 hours with an authoritative time source.
+"""
+
+import pytest
+
+
+@pytest.mark.hypervisor(
+    "gdch or microsoft", reason="Need PTP timesync sources to be reachable"
+)
+@pytest.mark.security_id(203711)
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_sync_ptp_daemon_running(systemd):
+    """Verify chrony is active for PTP-based time sync."""
+    assert systemd.is_active("chrony")
+
+
+@pytest.mark.security_id(203711)
+@pytest.mark.hypervisor("not (azure or gdch)")
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_sync_ntp_daemon_running(systemd):
+    """Verify systemd-timesyncd is active for NTP-based time sync."""
+    assert systemd.is_active("systemd-timesyncd")
+
+
+@pytest.mark.hypervisor(
+    "azure or gdch or google or microsoft",
+    reason="Need NTP/PTP timesync sources to be reachable",
+)
+@pytest.mark.security_id(203711)
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_is_actively_synced(timedatectl, shell):
+    """Verify timedatectl reports NTP as synchronized."""
+    assert timedatectl.get_timesync_status().ntp_synchronized
+
+
+@pytest.mark.security_id(203711)
+@pytest.mark.booted(reason="requires running systemd")
+def test_time_is_synced_at_least_once_a_day(timedatectl):
+    """Verify the max NTP poll interval is below 24 hours."""
+    assert timedatectl.get_timesync_status().poll_interval_max < (24 * 60 * 60)

--- a/tests/integration/security/compliance/test_disastig_00144.py
+++ b/tests/integration/security/compliance/test_disastig_00144.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000356-GPOS-00144
+
+Verify the operating system synchronizes internal information system clocks to the authoritative time source when the time difference is greater than one second.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203712)
+def test_disastig_00144():
+    """Clock synchronization tolerance is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00143.py")

--- a/tests/integration/security/compliance/test_disastig_00145.py
+++ b/tests/integration/security/compliance/test_disastig_00145.py
@@ -1,0 +1,24 @@
+"""
+Ref: SRG-OS-000358-GPOS-00145
+
+Verify the operating system records time stamps for audit records that meet a minimum granularity of one second for a minimum degree of precision.
+"""
+
+import re
+
+import pytest
+
+
+@pytest.mark.security_id(203713)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to read audit logs")
+def test_audit_timestamp_granularity(shell):
+    """Verify audit timestamps have at least one-second granularity."""
+    result = shell("ausearch -ts recent", capture_output=True)
+    timestamp_pattern = r"time->\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4}"
+
+    match_found = bool(re.search(timestamp_pattern, result.stdout))
+    assert (
+        match_found
+    ), "stigcompliance: audit records do not contain valid timestamps with second granularity"

--- a/tests/integration/security/compliance/test_disastig_00146.py
+++ b/tests/integration/security/compliance/test_disastig_00146.py
@@ -1,0 +1,29 @@
+"""
+Ref: SRG-OS-000359-GPOS-00146
+
+Verify the operating system records time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).
+"""
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203714)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="requires system time configuration")
+@pytest.mark.root(reason="required to verify time settings")
+def test_audit_timestamp_utc_mapping(shell: ShellRunner, timedatectl):
+    """Verify timedatectl reports a Timezone containing 'UTC' or 'GMT'."""
+    result = shell(
+        "timedatectl show -p Timezone",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    timezone = result.stdout.strip().split("=")[-1]
+
+    assert timezone, "stigcompliance: timezone not configured"
+
+    assert (
+        "UTC" in timezone or "GMT" in timezone
+    ), f"stigcompliance: timezone not mappable to UTC/GMT: {timezone}"

--- a/tests/integration/security/compliance/test_disastig_00149.py
+++ b/tests/integration/security/compliance/test_disastig_00149.py
@@ -1,0 +1,69 @@
+"""
+Ref: SRG-OS-000362-GPOS-00149
+
+Verify the operating system prohibits user installation of system software without explicit privileged status.
+"""
+
+import pytest
+from plugins.file import File
+
+PKG_BINARIES = [
+    "/usr/bin/apt",
+    "/usr/bin/apt-get",
+    "/usr/bin/dpkg",
+]
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify package manager permissions")
+@pytest.mark.booted(
+    reason="system must be booted to verify package manager permissions"
+)
+@pytest.mark.security_id(203716)
+def test_package_manager_requires_privileged_access(file: File):
+    """Verify /usr/bin/apt, apt-get and dpkg are owned by root with mode rwxr-xr-x or stricter."""
+    for path in PKG_BINARIES:
+        if not file.exists(path):
+            continue
+
+        assert file.is_owned_by_user(
+            path, "root"
+        ), f"stigcompliance: {path} is not owned by root"
+
+        assert (
+            file.has_permissions(path, "rwxr-xr-x")
+            or file.has_permissions(path, "rwxr-x---")
+            or file.has_permissions(path, "rwx------")
+        ), f"stigcompliance: {path} permissions are too permissive"
+
+
+PKG_DB_PATHS = [
+    "/var/lib/dpkg",
+    "/var/lib/dpkg/status",
+]
+
+
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.root(reason="required to verify package database protection")
+@pytest.mark.booted(
+    reason="system must be booted to verify package database permissions"
+)
+@pytest.mark.security_id(203716)
+def test_package_database_protected(file: File):
+    """Verify /var/lib/dpkg and /var/lib/dpkg/status are owned by root with non-world-writable modes."""
+    for path in PKG_DB_PATHS:
+        if not file.exists(path):
+            continue
+
+        assert file.is_owned_by_user(
+            path, "root"
+        ), f"stigcompliance: {path} is not owned by root"
+
+        assert (
+            file.has_permissions(path, "rwxr-xr-x")
+            or file.has_permissions(path, "rwxr-x---")
+            or file.has_permissions(path, "rwx------")
+            or file.has_permissions(path, "rw-r--r--")
+            or file.has_permissions(path, "rw-r-----")
+            or file.has_permissions(path, "rw-------")
+        ), f"stigcompliance: {path} permissions are too permissive"

--- a/tests/integration/security/compliance/test_disastig_00152.py
+++ b/tests/integration/security/compliance/test_disastig_00152.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000365-GPOS-00152
+
+Verify the operating system audits the enforcement actions used to restrict access associated with changes to the system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203719)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-disaSTIG-rules"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="audit rules are configured by disaSTIGmedium"
+)
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="required to query audit logs")
+def test_enforcement_action_audited(audit_rule) -> None:
+    """Verify the operating system audits the enforcement actions used to restrict access associated with changes to the system"""
+    assert audit_rule(
+        fs_watch_path="/etc/shadow", access_types="wa"
+    ), "stigcompliance: no audit rule found watching /etc/shadow for write/append access"

--- a/tests/integration/security/compliance/test_disastig_00153.py
+++ b/tests/integration/security/compliance/test_disastig_00153.py
@@ -1,0 +1,41 @@
+"""
+Ref: SRG-OS-000366-GPOS-00153
+
+Verify the operating system prevents the installation of patches, service packs, device drivers, or operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.
+"""
+
+import re
+
+import pytest
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+
+APT_CONF_DIR = "/etc/apt/apt.conf.d"
+
+
+@pytest.mark.security_id(203720)
+@pytest.mark.feature("not container and not lima and not baremetal")
+@pytest.mark.root(reason="required to verify package signature enforcement")
+def test_package_signature_verification_enabled(parse_file: ParseFile, find: Find):
+    """Verify no file in /etc/apt/apt.conf.d sets AllowUnauthenticated=true or Acquire::AllowInsecureRepositories=true."""
+    find.root_paths = APT_CONF_DIR
+    find.entry_type = "files"
+
+    insecure_pattern_1 = re.compile(r"AllowUnauthenticated\s*=\s*true", re.IGNORECASE)
+    insecure_pattern_2 = re.compile(
+        r"Acquire::AllowInsecureRepositories\s*=\s*true", re.IGNORECASE
+    )
+
+    for path in find:
+        lines = parse_file.lines(path, ignore_missing=True)
+
+        if not lines:
+            continue
+
+        assert (
+            insecure_pattern_1 not in lines
+        ), f"stigcompliance: AllowUnauthenticated enabled in {path}"
+
+        assert (
+            insecure_pattern_2 not in lines
+        ), f"stigcompliance: AllowInsecureRepositories enabled in {path}"

--- a/tests/integration/security/compliance/test_disastig_00154.py
+++ b/tests/integration/security/compliance/test_disastig_00154.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000312-GPOS-00154
+
+As per DISA STIG compliance requirements, the operating system must implement mandatory access controls to restrict the ability of subjects and objects from accessing resources.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203721)
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires booted system to verify LSM enforcement")
+@pytest.mark.root(reason="requires access to system security configuration")
+def test_selinux_is_active_lsm(lsm):
+    """Verify 'selinux' is reported in the active LSM list."""
+    assert (
+        "selinux" in lsm
+    ), "stigcompliance: SELinux is not listed as an active Linux Security Module"

--- a/tests/integration/security/compliance/test_disastig_00155.py
+++ b/tests/integration/security/compliance/test_disastig_00155.py
@@ -1,0 +1,20 @@
+"""
+Ref: SRG-OS-000370-GPOS-00155
+
+Verify the operating system employs a deny-all, permit-by-exception policy to allow the execution of authorized software programs.
+"""
+
+import pytest
+
+
+@pytest.mark.feature(
+    "not container and not gardener and not lima and not capi and not baremetal"
+)
+@pytest.mark.security_id(203722)
+@pytest.mark.booted(reason="requires booted system to verify LSM enforcement")
+@pytest.mark.root(reason="requires access to system security configuration")
+def test_deny_all_execution_mechanism_present(lsm):
+    """Verify 'selinux' appears in the active LSM list."""
+    assert (
+        "selinux" in lsm
+    ), "stigcompliance: no enforcement mechanism (SELinux) present for execution control"

--- a/tests/integration/security/compliance/test_disastig_00156.py
+++ b/tests/integration/security/compliance/test_disastig_00156.py
@@ -1,0 +1,81 @@
+"""
+Ref: SRG-OS-000373-GPOS-00156
+
+Verify the operating system requires users to reauthenticate for privilege escalation. The sudoers wheel file must exist and be empty so that wheel-group membership does not grant passwordless sudo. No sudoers file may grant passwordless privilege escalation via NOPASSWD or bypass authentication via !authenticate.
+"""
+
+import re
+
+import pytest
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+
+SUDOERS_WHEEL = "/etc/sudoers.d/wheel"
+
+
+@pytest.mark.feature(
+    "disaSTIGmedium and not _dev",
+    reason="test runner injects NOPASSWD sudoers in _dev mode for SSH access",
+)
+@pytest.mark.security_id(203723)
+@pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
+def test_sudoers_no_nopasswd(find: Find, parse_file: ParseFile):
+    """Verify no sudoers file enables NOPASSWD."""
+    nopasswd_pattern = re.compile(r"NOPASSWD", re.IGNORECASE)
+
+    find.root_paths = "/etc/sudoers.d"
+    find.entry_type = "files"
+    paths_to_check = ["/etc/sudoers"] + list(find)
+
+    for path in paths_to_check:
+        lines = parse_file.lines(path, ignore_missing=True)
+        if not lines:
+            continue
+        matches = nopasswd_pattern.findall(lines.content)
+        assert not matches, f"stigcompliance: NOPASSWD found in sudoers file {path}"
+
+
+@pytest.mark.feature(
+    "disaSTIGmedium and not _dev",
+    reason="test runner injects NOPASSWD sudoers in _dev mode for SSH access",
+)
+@pytest.mark.security_id(203723)
+@pytest.mark.root(reason="requires access to /etc/sudoers and /etc/sudoers.d")
+def test_sudoers_no_authenticate_bypass(find: Find, parse_file: ParseFile):
+    """Verify no sudoers file uses !authenticate to bypass password prompts."""
+    noauthenticate_pattern = re.compile(r"!authenticate", re.IGNORECASE)
+
+    find.root_paths = "/etc/sudoers.d"
+    find.entry_type = "files"
+    paths_to_check = ["/etc/sudoers"] + list(find)
+
+    for path in paths_to_check:
+        lines = parse_file.lines(path, ignore_missing=True)
+        if not lines:
+            continue
+        matches = noauthenticate_pattern.findall(lines.content)
+        assert (
+            not matches
+        ), f"stigcompliance: !authenticate found in sudoers file {path}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-wheel"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="sudoers wheel truncation is applied by disaSTIGmedium"
+)
+@pytest.mark.security_id(203723)
+def test_sudoers_wheel_file_exists(file) -> None:
+    """Verify /etc/sudoers.d/wheel exists (created/truncated by disaSTIGmedium)."""
+    assert file.exists(SUDOERS_WHEEL), f"stigcompliance: {SUDOERS_WHEEL} does not exist"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-wheel"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="sudoers wheel truncation is applied by disaSTIGmedium"
+)
+@pytest.mark.security_id(203723)
+def test_sudoers_wheel_file_is_empty(file) -> None:
+    """Verify /etc/sudoers.d/wheel is empty (disaSTIGmedium truncates it with echo -n)."""
+    assert (
+        file.get_size(SUDOERS_WHEEL) == 0
+    ), f"stigcompliance: {SUDOERS_WHEEL} is not empty (size={file.get_size(SUDOERS_WHEEL)})"

--- a/tests/integration/security/compliance/test_disastig_00170.py
+++ b/tests/integration/security/compliance/test_disastig_00170.py
@@ -1,0 +1,22 @@
+"""
+Ref: SRG-OS-000720-GPOS-00170
+
+Verify the operating system is configured to require immediate selection of a new password upon account recovery for password-based authentication.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-account"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-account"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(263654)
+def test_password_expiration_checking_pam_module_is_in_use(pam_config):
+    """Verify pam_unix.so account entry with success=1 and new_authtok_reqd=done is in /etc/pam.d/common-account."""
+    results = pam_config.find_entries(
+        type_="account",
+        control_contains={"success": "1", "new_authtok_reqd": "done"},
+        module_contains="pam_unix.so",
+    )
+    assert len(results) == 1, "pam_unix module should be used for account checking"

--- a/tests/integration/security/compliance/test_disastig_00172.py
+++ b/tests/integration/security/compliance/test_disastig_00172.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000392-GPOS-00172
+
+Verify the operating system generates audit records for all activities performed during nonlocal maintenance and diagnostic sessions by configuring sudo to log to a dedicated file.
+"""
+
+import pytest
+from plugins.parse_file import ParseFile
+
+SUDO_LOG_CONFIG = "/etc/sudoers.d/disaSTIG-sudo-log"
+
+
+@pytest.mark.security_id(203735)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-sudoers-sudo-log"])
+@pytest.mark.feature("disaSTIGmedium", reason="sudo log file required by DISA STIG")
+def test_sudo_logfile_configured(parse_file: ParseFile):
+    """Verify sudo is configured to log to /var/log/sudo.log."""
+    lines = parse_file.lines(SUDO_LOG_CONFIG)
+    assert (
+        "Defaults logfile=/var/log/sudo.log" in lines
+    ), "stigcompliance: sudo is not configured to log to /var/log/sudo.log"

--- a/tests/integration/security/compliance/test_disastig_00173.py
+++ b/tests/integration/security/compliance/test_disastig_00173.py
@@ -1,0 +1,64 @@
+"""
+Ref: SRG-OS-000393-GPOS-00173
+
+Verify the operating system implements cryptographic mechanisms to protect the integrity of nonlocal maintenance and diagnostic communications, when used for nonlocal maintenance sessions.
+"""
+
+import pytest
+from plugins.dpkg import Dpkg
+
+
+@pytest.mark.security_id(203736)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_ssh_strong_macs_present(sshd, dpkg: Dpkg):
+    """Verify sshd MACs are limited to strong algorithms (SHA2)."""
+    macs = sshd.get_config_section("macs")
+
+    if isinstance(macs, str):
+        macs = [macs]
+    elif isinstance(macs, set):
+        macs = list(macs)
+
+    mac_list = []
+    for entry in macs:
+        mac_list.extend([m.strip() for m in entry.split(",")])
+
+    strong_macs = {
+        "hmac-sha2-256",
+        "hmac-sha2-512",
+    }
+
+    assert all(
+        mac in strong_macs for mac in mac_list
+    ), "stigcompliance: no strong MAC algorithms configured for SSH integrity protection"
+
+
+@pytest.mark.security_id(203736)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_ssh_weak_macs_not_present(sshd):
+    """Verify sshd does not advertise weak MAC algorithms (hmac-md5)."""
+    macs = sshd.get_config_section("macs")
+
+    if isinstance(macs, str):
+        macs = [macs]
+    elif isinstance(macs, set):
+        macs = list(macs)
+
+    mac_list = []
+    for entry in macs:
+        mac_list.extend([m.strip() for m in entry.split(",")])
+
+    weak_macs = {
+        "hmac-md5",
+        "hmac-md5-96",
+    }
+
+    assert not any(
+        mac in weak_macs for mac in mac_list
+    ), "stigcompliance: weak MAC algorithms present in SSH configuration"

--- a/tests/integration/security/compliance/test_disastig_00175.py
+++ b/tests/integration/security/compliance/test_disastig_00175.py
@@ -1,0 +1,20 @@
+"""
+Ref: SRG-OS-000395-GPOS-00175
+
+Verify the operating system verifies remote disconnection at the termination of nonlocal maintenance and diagnostic sessions, when used for nonlocal maintenance sessions.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203738)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_ssh_client_alive_interval_configured(sshd):
+    """Verify sshd ClientAliveInterval is non-zero so timeouts are enforced."""
+    interval = sshd.get_config_section("clientaliveinterval")
+
+    assert (
+        interval != "0"
+    ), "stigcompliance: ClientAliveInterval is disabled (0), session timeout not enforced"

--- a/tests/integration/security/compliance/test_disastig_00176.py
+++ b/tests/integration/security/compliance/test_disastig_00176.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000396-GPOS-00176
+
+Verify the operating system implements NSA-approved cryptography to protect classified information in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203739)
+def test_disastig_00176():
+    """NSA-approved cryptography is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00180.py
+++ b/tests/integration/security/compliance/test_disastig_00180.py
@@ -1,0 +1,37 @@
+"""
+Ref: SRG-OS-000725-GPOS-00180
+
+Verify he operating system is configured to allow user selection of long passwords and passphrases, including spaces and all printable characters for password-based authentication.
+"""
+
+import glob
+import re
+from os.path import exists
+
+import pytest
+
+
+@pytest.mark.security_id(263655)
+def test_password_length_is_not_limited_in_pam_configs():
+    """Verify no PAM config caps password length via passwdqc max=."""
+    search_str = r"^\s*password\s+requisite\s+pam_passwdqc.so\s+[^#]*max=\d+"
+    pattern = re.compile(search_str)
+    found = False
+
+    for config in glob.glob("/etc/pam.d/*"):
+        with open(config) as f:
+            for line in f:
+                if pattern.search(line):
+                    found = True
+                    offender = config
+                    break
+    assert not found, f"Password limit is set in {offender}"
+
+
+@pytest.mark.security_id(263655)
+def test_password_length_is_not_limited_in_passwdqc_config(parse_file):
+    """Verify /etc/passwdqc.conf does not cap password length via max=."""
+    config = "/etc/passwdqc.conf"
+    if not exists(config):
+        return
+    assert "max" not in parse_file.parse(config)

--- a/tests/integration/security/compliance/test_disastig_00180.py
+++ b/tests/integration/security/compliance/test_disastig_00180.py
@@ -17,6 +17,7 @@ def test_password_length_is_not_limited_in_pam_configs():
     search_str = r"^\s*password\s+requisite\s+pam_passwdqc.so\s+[^#]*max=\d+"
     pattern = re.compile(search_str)
     found = False
+    offender = ""
 
     for config in glob.glob("/etc/pam.d/*"):
         with open(config) as f:

--- a/tests/integration/security/compliance/test_disastig_00186.py
+++ b/tests/integration/security/compliance/test_disastig_00186.py
@@ -1,0 +1,31 @@
+"""
+Ref: SRG-OS-000420-GPOS-00186
+
+Verify the operating system protects against or limits the effects of Denial of Service (DoS) attacks by ensuring the operating system is implementing rate-limiting measures on impacted network interfaces.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203747)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires running network stack")
+@pytest.mark.root(reason="requires access to sysctl parameters")
+def test_icmp_rate_limiting_enabled(sysctl):
+    """Verify net.ipv4.icmp_ratelimit is set to a positive value."""
+    value = sysctl["net.ipv4.icmp_ratelimit"]
+
+    assert (
+        isinstance(value, int) and value > 0
+    ), f"stigcompliance: ICMP rate limiting not enabled (value={value})"
+
+
+@pytest.mark.security_id(203747)
+@pytest.mark.feature("not container")
+@pytest.mark.booted(reason="requires network stack")
+@pytest.mark.root(reason="requires access to sysctl parameters")
+def test_tcp_syncookies_enabled(sysctl):
+    """Verify net.ipv4.tcp_syncookies is enabled."""
+    value = sysctl["net.ipv4.tcp_syncookies"]
+
+    assert value == 1, f"stigcompliance: tcp_syncookies not enabled (value={value})"

--- a/tests/integration/security/compliance/test_disastig_00187.py
+++ b/tests/integration/security/compliance/test_disastig_00187.py
@@ -1,0 +1,108 @@
+"""
+Ref: SRG-OS-000423-GPOS-00187
+
+Verify the operating system protects the confidentiality and integrity of transmitted information.
+"""
+
+import pytest
+from plugins.systemd import Systemd
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_telnet_service_disabled(systemd: Systemd):
+    """Verify telnet.service is not enabled."""
+    assert not systemd.is_enabled(
+        "telnet.service"
+    ), "stigcompliance: insecure service telnet.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_telnet_service_active(systemd: Systemd):
+    """Verify telnet.service is not active."""
+    assert not systemd.is_active(
+        "telnet.service"
+    ), "stigcompliance: insecure service telnet.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rsh_service_disabled(systemd: Systemd):
+    """Verify rsh.service is not enabled."""
+    assert not systemd.is_enabled(
+        "rsh.service"
+    ), "stigcompliance: insecure service rsh.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rsh_service_active(systemd: Systemd):
+    """Verify rsh.service is not active."""
+    assert not systemd.is_active(
+        "rsh.service"
+    ), "stigcompliance: insecure service rsh.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rexec_service_disabled(systemd: Systemd):
+    """Verify rexec.service is not enabled."""
+    assert not systemd.is_enabled(
+        "rexec.service"
+    ), "stigcompliance: insecure service rexec.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rexec_service_active(systemd: Systemd):
+    """Verify rexec.service is not active."""
+    assert not systemd.is_active(
+        "rexec.service"
+    ), "stigcompliance: insecure service rexec.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rlogin_service_disabled(systemd: Systemd):
+    """Verify rlogin.service is not enabled."""
+    assert not systemd.is_enabled(
+        "rlogin.service"
+    ), "stigcompliance: insecure service rlogin.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_rlogin_service_active(systemd: Systemd):
+    """Verify rlogin.service is not active."""
+    assert not systemd.is_active(
+        "rlogin.service"
+    ), "stigcompliance: insecure service rlogin.service is active"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_vsftpd_service_disabled(systemd: Systemd):
+    """Verify vsftpd.service is not enabled."""
+    assert not systemd.is_enabled(
+        "vsftpd.service"
+    ), "stigcompliance: insecure service vsftpd.service is enabled"
+
+
+@pytest.mark.security_id(203748)
+@pytest.mark.booted(reason="requires booted system to verify services")
+@pytest.mark.root(reason="required to inspect system services")
+def test_vsftpd_service_active(systemd: Systemd):
+    """Verify vsftpd.service is not active."""
+    assert not systemd.is_active(
+        "vsftpd.service"
+    ), "stigcompliance: insecure service vsftpd.service is active"

--- a/tests/integration/security/compliance/test_disastig_00188.py
+++ b/tests/integration/security/compliance/test_disastig_00188.py
@@ -1,0 +1,52 @@
+"""
+Ref: SRG-OS-000424-GPOS-00188
+
+Verify the operating system implements cryptographic mechanisms to prevent unauthorized disclosure of information and/or detect changes to information during transmission unless otherwise protected by alternative physical safeguards, such as, at a minimum, a Protected Distribution System (PDS).
+"""
+
+import re
+
+import pytest
+from plugins.sshd import Sshd
+
+
+@pytest.mark.security_id(203749)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect ssh cryptographic configuration")
+def test_ssh_ciphers_are_strong(sshd: Sshd):
+    """Verify sshd does not allow weak ciphers (arcfour, 3des, cbc)."""
+    ciphers = sshd.get_config_section("ciphers") or ""
+
+    assert not re.search(
+        r"(arcfour|3des|cbc)", str(ciphers), re.IGNORECASE
+    ), "stigcompliance: weak cipher allowed in SSH configuration"
+
+
+@pytest.mark.security_id(203749)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect ssh cryptographic configuration")
+def test_ssh_macs_are_strong(sshd: Sshd):
+    """Verify sshd does not allow weak MACs (hmac-md5)."""
+    macs = sshd.get_config_section("macs") or ""
+
+    assert not re.search(
+        r"hmac-md5", str(macs), re.IGNORECASE
+    ), "stigcompliance: weak MAC allowed in SSH configuration"
+
+
+@pytest.mark.security_id(203749)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-ssh-sshd-config-d-disaSTIG"])
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires sshd effective configuration")
+@pytest.mark.root(reason="required to inspect ssh cryptographic configuration")
+def test_ssh_kex_are_strong(sshd: Sshd):
+    """Verify sshd does not allow weak key exchange (diffie-hellman-group1-sha1)."""
+    kex = sshd.get_config_section("kexalgorithms") or ""
+
+    assert not re.search(
+        r"diffie-hellman-group1-sha1", str(kex), re.IGNORECASE
+    ), "stigcompliance: weak key exchange algorithm allowed in SSH configuration"

--- a/tests/integration/security/compliance/test_disastig_00189.py
+++ b/tests/integration/security/compliance/test_disastig_00189.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000425-GPOS-00189
+
+Verify the operating system maintains the confidentiality and integrity of information during preparation for transmission.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203750)
+def test_disastig_00189():
+    """Confidentiality and integrity for transmission prep is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00187.py")

--- a/tests/integration/security/compliance/test_disastig_00190.py
+++ b/tests/integration/security/compliance/test_disastig_00190.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000426-GPOS-00190
+
+Verify the operating system maintains the confidentiality and integrity of information during reception.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203751)
+def test_disastig_00190():
+    """Confidentiality and integrity during reception is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00187.py")

--- a/tests/integration/security/compliance/test_disastig_00191.py
+++ b/tests/integration/security/compliance/test_disastig_00191.py
@@ -1,0 +1,25 @@
+"""
+Ref: SRG-OS-000432-GPOS-00191
+
+Verify the operating system behaves in a predictable and documented manner that reflects organizational and system objectives when invalid inputs are received.
+"""
+
+import time
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203752)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires audit subsystem running")
+@pytest.mark.root(reason="useradd and ausearch require root privileges")
+@pytest.mark.modify(reason="creates and removes a temporary user account")
+def test_invalid_input_handling_is_audited(shell: ShellRunner, audit_user):
+    """Verify ausearch -ts recent output contains name="/etc/shadow"."""
+    shell(f"su {audit_user} -c 'echo >> /etc/shadow'", ignore_exit_code=True)
+    time.sleep(1)
+    result = shell(cmd="ausearch -ts recent", capture_output=True)
+    assert (
+        'name="/etc/shadow"' in result.stdout
+    ), "stigcompliance: no failed-syscall audit event found after trying to write to a system file"

--- a/tests/integration/security/compliance/test_disastig_00192.py
+++ b/tests/integration/security/compliance/test_disastig_00192.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000433-GPOS-00192
+
+Verify the operating system implements non-executable data to protect its memory from unauthorized code execution.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203753)
+@pytest.mark.arch("amd64")
+def test_nx_bit_hardware_support():
+    """Verify /proc/cpuinfo advertises the nx CPU flag (amd64)."""
+    with open("/proc/cpuinfo") as cpuinfo:
+        assert (
+            " nx " in cpuinfo.read()
+        ), "Finding: Hardware does not support or report the NX bit."
+
+
+@pytest.mark.security_id(203753)
+@pytest.mark.arch("amd64")
+def test_nx_not_disabled_at_boot(kernel_cmdline):
+    """Verify nx=off is not present in the kernel boot cmdline."""
+    assert (
+        "nx=off" not in kernel_cmdline
+    ), "Finding: The kernel boot parameter 'nx=off' is present, disabling memory protection."

--- a/tests/integration/security/compliance/test_disastig_00193.py
+++ b/tests/integration/security/compliance/test_disastig_00193.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000433-GPOS-00193
+
+Verify the operating system implements address space layout randomization to protect its memory from unauthorized code execution.
+"""
+
+import pytest
+from plugins.sysctl import Sysctl
+
+
+@pytest.mark.feature("disaSTIGmedium and cloud")
+@pytest.mark.booted(reason="requires access to /proc/sys at runtime")
+@pytest.mark.root(reason="requires access to kernel parameters")
+def test_aslr_is_fully_enabled(sysctl: Sysctl):
+    """Verify the operating system implements full address space layout randomization with kernel.randomize_va_space set to 2."""
+    assert (
+        sysctl["kernel.randomize_va_space"] == 2
+    ), "stigcompliance: kernel.randomize_va_space must be 2 (full ASLR)"

--- a/tests/integration/security/compliance/test_disastig_00194.py
+++ b/tests/integration/security/compliance/test_disastig_00194.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000437-GPOS-00194
+
+Verify the operating system removes all software components after updated versions have been installed.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203755)
+def test_no_residual_software_components(shell):
+    """Verify dpkg reports no packages in 'deinstall ok config-files' (rc) state."""
+    package_statuses = shell(
+        "dpkg-query -W -f='${Status} ${Package}\n'", capture_output=True
+    )
+
+    residual_packages = [
+        pkg.split()[-1]
+        for pkg in package_statuses.stdout.splitlines()
+        if "deinstall ok config-files" in pkg
+    ]
+
+    assert not residual_packages, (
+        f"Software components (config files) "
+        f"were not removed after package updates/removal: {residual_packages}"
+    )

--- a/tests/integration/security/compliance/test_disastig_00199.py
+++ b/tests/integration/security/compliance/test_disastig_00199.py
@@ -1,0 +1,103 @@
+"""
+Ref: SRG-OS-000445-GPOS-00199
+
+Verify the operating system verifies correct operation of all security functions.
+"""
+
+import re
+
+import pytest
+
+AIDE_CONF = "/etc/aide/aide.conf.d/31_aide_audit-tools"
+AIDE_TOOLS = [
+    "/sbin/auditctl",
+    "/sbin/auditd",
+    "/sbin/ausearch",
+    "/sbin/aureport",
+    "/sbin/autrace",
+    "/sbin/audispd",
+    "/sbin/augenrules",
+]
+
+
+@pytest.mark.security_id(203756)
+@pytest.mark.feature("log")
+@pytest.mark.booted("Needs working systemd")
+def test_auditd_service_active(systemd):
+    """Verify auditd service is active."""
+    assert systemd.is_active("auditd")
+
+
+@pytest.mark.security_id(203756)
+@pytest.mark.feature("log")
+@pytest.mark.booted("Needs working systemd")
+def test_systemd_configured_to_restart_auditd_service(systemd):
+    """Verify systemd is configured to restart the auditd service on failure."""
+    assert systemd.get_unit_properties("auditd")["Restart"] != "no"
+
+
+@pytest.mark.security_id(203756)
+@pytest.mark.feature("_selinux")
+def test_selinux_enabled(lsm):
+    """Verify SELinux is among the active LSMs."""
+    assert "selinux" in lsm
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-service-aide-init-enable"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="aide-init.service is enabled by disaSTIGmedium"
+)
+@pytest.mark.security_id(203756)
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-enable"])
+@pytest.mark.feature("aide", reason="aide-init.service is enabled by the aide feature")
+@pytest.mark.booted(reason="requires systemd to query unit enable state")
+def test_aide_init_service_is_enabled(systemd) -> None:
+    """Verify aide-init.service is enabled."""
+    assert systemd.is_enabled(
+        "aide-init.service"
+    ), "stigcompliance: aide-init.service is not enabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-service-aide-check-timer-enable"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="aide-check.timer is enabled by disaSTIGmedium"
+)
+@pytest.mark.security_id(203756)
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer-enable"])
+@pytest.mark.feature("aide", reason="aide-check.timer is enabled by the aide feature")
+@pytest.mark.booted(reason="requires systemd to query unit enable state")
+def test_aide_check_timer_is_enabled(systemd) -> None:
+    """Verify aide-check.timer is enabled."""
+    assert systemd.is_enabled(
+        "aide-check.timer"
+    ), "stigcompliance: aide-check.timer is not enabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-aide-audit-tools"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="AIDE monitors audit tools as configured by disaSTIGmedium"
+)
+def test_aide_conf_monitors_audit_tools(parse_file) -> None:
+    """Verify AIDE config monitors the audit tool binaries with sha512."""
+    missing = [
+        tool
+        for tool in AIDE_TOOLS
+        if not re.compile(rf"^{re.escape(tool)}.+sha512", re.MULTILINE)
+        in parse_file.lines(AIDE_CONF)
+    ]
+    assert (
+        not missing
+    ), f"stigcompliance: AIDE does not monitor these tools with sha512 in {AIDE_CONF}: {missing}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-aide-silent-reports"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="AIDE SILENTREPORTS is configured by disaSTIGmedium"
+)
+def test_aide_default_silentreports_is_no(parse_file) -> None:
+    """Verify AIDE SILENTREPORTS in /etc/default/aide is set to 'no'."""
+    config = parse_file.parse("/etc/default/aide", format="keyval")
+    assert config.get("SILENTREPORTS") == "no", (
+        f"stigcompliance: SILENTREPORTS in /etc/default/aide is "
+        f"{config.get('SILENTREPORTS')!r}, expected 'no'"
+    )

--- a/tests/integration/security/compliance/test_disastig_00203.py
+++ b/tests/integration/security/compliance/test_disastig_00203.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000458-GPOS-00203
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to access security objects occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203759)
+def test_disastig_00203():
+    """Audit of security object access is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00089.py")

--- a/tests/integration/security/compliance/test_disastig_00205.py
+++ b/tests/integration/security/compliance/test_disastig_00205.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000461-GPOS-00205
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to access categories of information (e.g., classification levels) occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203760)
+def test_disastig_00205():
+    """Audit of access to information categories is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00210.py")

--- a/tests/integration/security/compliance/test_disastig_00206.py
+++ b/tests/integration/security/compliance/test_disastig_00206.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000462-GPOS-00206
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to modify privileges occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203761)
+def test_disastig_00206():
+    """Audit of privilege modification is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00210.py")

--- a/tests/integration/security/compliance/test_disastig_00207.py
+++ b/tests/integration/security/compliance/test_disastig_00207.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000463-GPOS-00207
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to modify security objects occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203762)
+def test_disastig_00207():
+    """Audit of security object modification is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00211.py")

--- a/tests/integration/security/compliance/test_disastig_00209.py
+++ b/tests/integration/security/compliance/test_disastig_00209.py
@@ -1,0 +1,85 @@
+"""
+Ref: SRG-OS-000465-GPOS-00209
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to modify categories of information (e.g., classification levels) occur.
+"""
+
+import os
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import Parse, ParseFile
+from plugins.shell import ShellRunner
+
+PRIV_ESC_RULE_FILE = "/etc/audit/rules.d/70-privilege-escalation.rules"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to inspect audit config")
+def test_setreuid_rule_file_exists(file: File):
+    """Verify the privilege escalation audit rule file exists."""
+    assert file.exists(
+        PRIV_ESC_RULE_FILE
+    ), f"stigcompliance: {PRIV_ESC_RULE_FILE} does not exist"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to inspect audit config")
+def test_setreuid_rule_contains_syscall(parse_file: ParseFile):
+    """Verify the privilege escalation rule audits the setreuid syscall."""
+    lines = parse_file.lines(PRIV_ESC_RULE_FILE, ignore_missing=True)
+
+    assert (
+        lines is not None and "-S setreuid" in lines
+    ), "stigcompliance: setreuid audit rule not configured"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit rules")
+def test_setreuid_rule_loaded(shell: ShellRunner, parse: type[Parse]):
+    """Verify the setreuid audit rule is loaded into the running kernel."""
+    output = shell(cmd="auditctl -l", capture_output=True)
+
+    assert (
+        output.returncode == 0
+    ), f"stigcompliance: unable to list audit rules: {output.stderr}"
+
+    assert (
+        "setreuid" in output.stdout
+    ), "stigcompliance: setreuid audit rule not loaded in kernel"
+
+
+@pytest.mark.security_id(203763)
+@pytest.mark.feature("not container and not lima")
+@pytest.mark.booted(reason="audit event validation requires audit subsystem")
+@pytest.mark.root(reason="required to trigger syscall and read audit logs")
+def test_setreuid_event_logged(shell: ShellRunner):
+    """Verify a setreuid call produces a privilege_escalation audit event."""
+    pid = os.fork()
+
+    if pid == 0:
+        try:
+            os.setreuid(123456, 123456)
+        except Exception:
+            pass
+        finally:
+            os._exit(0)
+    else:
+        os.waitpid(pid, 0)
+
+    result = shell(
+        cmd="ausearch -k privilege_escalation -ts recent",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    if result.returncode == 1 or not result.stdout.strip():
+        return
+
+    assert "SYSCALL" in result.stdout, "stigcompliance: no syscall audit event detected"

--- a/tests/integration/security/compliance/test_disastig_00210.py
+++ b/tests/integration/security/compliance/test_disastig_00210.py
@@ -1,0 +1,86 @@
+"""
+Ref: SRG-OS-000466-GPOS-00210
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to delete privileges occur.
+"""
+
+import fileinput
+import os
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def sudoers_edit():
+    for line in fileinput.input("/etc/sudoers", inplace=True, backup=".bak"):
+        if not line.startswith("# Host alias specification"):
+            print(line, end="")
+    yield
+    shutil.copy2("/etc/sudoers.bak", "/etc/sudoers")
+    os.remove("/etc/sudoers.bak")
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit logs")
+def test_audit_rules_for_logging_attempts_to_delete_privileges(audit_rule):
+    """Verify writes/metadata changes to /etc account and sudoers files are audited."""
+    for file in ["passwd", "shadow", "group", "sudoers", "sudoers.d", "pam.d"]:
+        assert audit_rule(
+            fs_watch_path=f"/etc/{file}", access_types="wa"
+        ), f"stigcompliance: writing to or changing metadata of /etc/{file} should be audited"
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.skip("not implemented")
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit logs")
+def test_audit_rules_for_files_capabilities_removal(audit_rule):
+    """Verify the setcap syscall is audited."""
+    assert audit_rule(
+        syscall="setcap"
+    ), "stigcompliance: setcap syscall audit rule is not configured"
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+def test_audit_rules_for_selinux_policies_changes(audit_rule):
+    """Verify writes/metadata changes under /etc/selinux are audited."""
+    assert audit_rule(
+        fs_watch_path="/etc/selinux", access_types="wa"
+    ), "stigcompliance: changes of selinux configuration files should be audited"
+
+
+@pytest.mark.security_id(203764)
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.root(reason="required to query audit logs")
+def test_audit_rules_for_logging_attempts_to_modify_apparmor_policies(audit_rule):
+    """Verify writes/metadata changes under /etc/apparmor* are audited."""
+    for file in ["apparmor", "apparmor.d"]:
+        assert audit_rule(
+            fs_watch_path=f"/etc/{file}", access_types="wa"
+        ), f"stigcompliance: writing to or changing metadata of /etc/{file} should be audited"
+
+
+@pytest.mark.feature("not lima")
+@pytest.mark.booted(reason="audit rule validation requires running audit subsystem")
+@pytest.mark.modify(
+    reason="changing /etc/sudoers file to check if audit works on a running system"
+)
+@pytest.mark.security_id(203764)
+@pytest.mark.root(reason="required to query audit logs")
+def test_attempt_to_delete_privileges_event_logged(audit_rule, shell, sudoers_edit):
+    """Verify modifying /etc/sudoers produces an audit event."""
+    result = shell(
+        cmd="ausearch -f /etc/sudoers --just-one",
+        capture_output=True,
+    )
+
+    assert (
+        "<no matches>" not in result.stdout.strip()
+    ), "stigcompliance: privileges deletion attempt is not detected"

--- a/tests/integration/security/compliance/test_disastig_00211.py
+++ b/tests/integration/security/compliance/test_disastig_00211.py
@@ -1,0 +1,31 @@
+"""
+Ref: SRG-OS-000467-GPOS-00211
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to delete security levels occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203765)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_selinux_runtime_changes_are_audited(audit_rule):
+    """Verify writes/metadata changes to /sys/fs/selinux are audited."""
+    assert audit_rule(fs_watch_path="/sys/fs/selinux", access_types="wa")
+
+
+@pytest.mark.security_id(203765)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_changes_to_extended_file_attributes_are_audited(audit_rule):
+    """Verify the *xattr syscalls are audited."""
+    for sc in [
+        "removexattr",
+        "fremovexattr",
+        "lremovexattr",
+        "setxattr",
+        "lsetxattr",
+        "fsetxattr",
+    ]:
+        assert audit_rule(syscall=sc)

--- a/tests/integration/security/compliance/test_disastig_00212.py
+++ b/tests/integration/security/compliance/test_disastig_00212.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000468-GPOS-00212
+
+Verify the operating system generates audit records when successful/unsuccessful attempts to delete security objects occur.
+"""
+
+import platform
+
+import pytest
+
+
+@pytest.mark.security_id(203766)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="auditctl requires a live kernel audit subsystem")
+def test_attempts_to_delete_are_audited(audit_rule):
+    """Verify file/dir deletion syscalls are audited for non-system users."""
+    # unlink, rename, rmdir do not exist as separate syscalls on arm64
+    if platform.machine() == "aarch64":
+        syscalls = ["unlinkat", "renameat"]
+    else:
+        syscalls = ["unlink", "unlinkat", "rename", "renameat", "rmdir"]
+    for syscall in syscalls:
+        assert audit_rule(syscall=syscall, rule_fields=["auid>=1000", "auid!=-1"])

--- a/tests/integration/security/compliance/test_disastig_00214.py
+++ b/tests/integration/security/compliance/test_disastig_00214.py
@@ -1,0 +1,26 @@
+"""
+Ref: SRG-OS-000470-GPOS-00214
+
+Verify the operating system generates audit records when successful/unsuccessful logon attempts occur.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203767)
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Needs running auditd")
+@pytest.mark.root(reason="Needs access to audit logs")
+def test_audit_record_tools_for_logon_attempts_exist(file):
+    """Verify the audit tools aulast and aulastlog are present on the system."""
+    assert file.exists("/usr/bin/aulast"), "aulast binary not found"
+    assert file.exists("/usr/bin/aulastlog"), "aulastlog binary not found"
+
+
+@pytest.mark.security_id(203767)
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Needs running auditd")
+@pytest.mark.root(reason="Needs access to audit logs")
+def test_audit_record_tools_for_logon_attempts_function(shell):
+    """Verify the aulast tool executes successfully and can query audit records for logon attempts."""
+    assert not shell("aulast --proof").returncode

--- a/tests/integration/security/compliance/test_disastig_00215.py
+++ b/tests/integration/security/compliance/test_disastig_00215.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000471-GPOS-00215
+
+Verify the operating system generates audit records for privileged activities or other system-level access.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203768)
+def test_disastig_00215():
+    """Audit of privileged activities is covered by other tests."""
+    pytest.skip(
+        reason="covered by test_disastig_00209.py, test_disastig_00210.py, test_disastig_00211.py test_disastig_00220.py test_disastig_00222.py"
+    )

--- a/tests/integration/security/compliance/test_disastig_00216.py
+++ b/tests/integration/security/compliance/test_disastig_00216.py
@@ -1,0 +1,30 @@
+"""
+Ref: SRG-OS-000471-GPOS-00216
+
+Verify the audit system is configured to audit the loading and unloading of dynamic kernel modules.
+"""
+
+import pytest
+from plugins.audit import AuditRule
+
+
+@pytest.mark.security_id(203769)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required to query active rules")
+@pytest.mark.root(reason="requires access to audit rules via auditctl")
+def test_audit_modprobe_watch_rule_present(audit_rule: AuditRule):
+    """Verify to audit the loading and unloading of dynamic kernel modules."""
+    assert audit_rule(
+        fs_watch_path="/sbin/modprobe", access_types="x"
+    ), "stigcompliance: no audit watch rule for /sbin/modprobe execution"
+
+
+@pytest.mark.security_id(203769)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required to query active rules")
+@pytest.mark.root(reason="requires access to audit rules via auditctl")
+def test_audit_kmod_watch_rule_present(audit_rule: AuditRule):
+    """Verify to audit the loading and unloading of dynamic kernel modules."""
+    assert audit_rule(
+        fs_watch_path="/bin/kmod", access_types="x"
+    ), "stigcompliance: no audit watch rule for /bin/kmod execution"

--- a/tests/integration/security/compliance/test_disastig_00217.py
+++ b/tests/integration/security/compliance/test_disastig_00217.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000472-GPOS-00217
+
+Verify the operating system generates audit records showing starting and ending time for user access to the system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203770)
+def test_disastig_00217():
+    """Audit of session start and end times is covered elsewhere."""
+    pytest.skip(reason="covered by test_disastig_00214.py")

--- a/tests/integration/security/compliance/test_disastig_00218.py
+++ b/tests/integration/security/compliance/test_disastig_00218.py
@@ -1,0 +1,61 @@
+"""
+Ref: SRG-OS-000472-GPOS-00218
+
+Verify the operating system generates audit records when concurrent logons to the same account occur from different sources.
+"""
+
+import tempfile
+
+import pytest
+from handlers.audit_user import TEST_USER
+from plugins.shell import ShellRunner
+
+
+@pytest.mark.security_id(203771)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires kernel logging")
+@pytest.mark.root(reason="required to generate audit events")
+@pytest.mark.modify(reason="creates and removes a temporary user account")
+def test_audit_concurrent_logins(shell: ShellRunner, audit_user):
+    """Verify a su login plus an ssh login for the same user produce >=2 hits in ausearch and journalctl combined."""
+    with tempfile.TemporaryDirectory() as tmp:
+        time_file = f"{tmp}/audit_start_time"
+        output_file = f"{tmp}/audit_output_gl.txt"
+        journal_file = f"{tmp}/journal_output_gl.txt"
+
+        shell(f"date '+%H:%M:%S' > {time_file}")
+
+        shell(f"su - {TEST_USER} -c 'sleep 30' &")
+
+        shell(
+            f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
+            f"{TEST_USER}@127.0.0.1 'sleep 30' &"
+        )
+
+        shell("sleep 5")
+
+        shell(f'ausearch -ts "$(cat {time_file})" > {output_file}')
+
+        shell(
+            f'journalctl --since "$(cat {time_file})" '
+            f'| grep -i "{TEST_USER}" > {journal_file}'
+        )
+
+        audit_hits = shell(
+            f"grep -c '{TEST_USER}' {output_file}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        journal_hits = shell(
+            f"grep -c '{TEST_USER}' {journal_file}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+
+        total = int(audit_hits.stdout.strip() or 0) + int(
+            journal_hits.stdout.strip() or 0
+        )
+
+    assert (
+        total >= 2
+    ), "stigcompliance: concurrent login audit events from different sources not detected"

--- a/tests/integration/security/compliance/test_disastig_00220.py
+++ b/tests/integration/security/compliance/test_disastig_00220.py
@@ -1,0 +1,55 @@
+"""
+Ref: SRG-OS-000475-GPOS-00220
+
+Verify the operating system generates audit records for all direct access to the information system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203773)
+@pytest.mark.booted(reason="requires running systemd")
+def test_journald_should_not_store_logs_in_memory(systemd):
+    """Verify /etc/systemd/journald.conf Storage is not set to 'volatile'."""
+    result = systemd.get_config("/etc/systemd/journald.conf")
+    if "Storage" in result.keys():
+        assert result["Storage"] != "volatile"
+
+
+@pytest.mark.security_id(203773)
+@pytest.mark.feature("ssh")
+def test_sshd_log_level_is_set_to_verbose(parse_file):
+    """Verify /etc/ssh/sshd_config sets LogLevel to VERBOSE."""
+    config = parse_file.parse("/etc/ssh/sshd_config", format="spacedelim")
+    assert config["LogLevel"] == "VERBOSE"
+
+
+@pytest.mark.security_id(203773)
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="requires running systemd")
+def test_sshd_unit_is_journald_friendly(systemd):
+    """Verify ssh.service has StandardOutput=journal and StandardError=journal/inherit."""
+    result = systemd.get_unit_properties("ssh")
+    assert (
+        result["StandardOutput"] == "journal"
+    ), f"sshd stdout not directed to journal: {result['StandardOutput']}"
+    assert result["StandardError"] in [
+        "journal",
+        "inherit",
+    ], f"sshd stderr not directed to journal or inherit: {result['StandardError']}"
+
+
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-session"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203773)
+def test_pam_unix_is_in_use(pam_config):
+    """Verify pam_unix.so is required as a session module in /etc/pam.d/common-session."""
+    results = pam_config.find_entries(
+        type_="session",
+        control_contains="required",
+        module_contains="pam_unix.so",
+    )
+    assert (
+        len(results) == 1
+    ), "pam_unix should be required for user sessions logging to work"

--- a/tests/integration/security/compliance/test_disastig_00222.py
+++ b/tests/integration/security/compliance/test_disastig_00222.py
@@ -1,0 +1,44 @@
+"""
+Ref: SRG-OS-000477-GPOS-00222
+
+Verify the operating system generates audit records for all kernel module load, unload, and restart actions, and also for all program initiations.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_kernel_module_load_rules_present(audit_rule):
+    """Verify init_module and finit_module syscalls are audited for non-system users."""
+    for syscall in ["init_module", "finit_module"]:
+        assert audit_rule(syscall=syscall, rule_fields=["auid>=1000", "auid!=-1"])
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_kernel_module_delete_rules_present(audit_rule):
+    """Verify delete_module syscall is audited for non-system users."""
+    assert audit_rule(syscall="delete_module", rule_fields=["auid>=1000", "auid!=-1"])
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_kmod_binary_watched(audit_rule):
+    """Verify execution of /bin/kmod is audited."""
+    assert audit_rule(fs_watch_path="/bin/kmod", access_types="x")
+
+
+@pytest.mark.security_id(203775)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="audit subsystem required")
+@pytest.mark.root(reason="requires access to audit rules")
+def test_audit_modprobe_binary_watched(audit_rule):
+    """Verify execution of /sbin/modprobe is audited."""
+    assert audit_rule(fs_watch_path="/sbin/modprobe", access_types="x")

--- a/tests/integration/security/compliance/test_disastig_00223.py
+++ b/tests/integration/security/compliance/test_disastig_00223.py
@@ -1,0 +1,13 @@
+"""
+Ref: SRG-OS-000478-GPOS-00223
+
+Verify the operating system implements NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203776)
+def test_fips():
+    """FIPS-validated cryptography is covered elsewhere."""
+    pytest.skip(reason="covered by test_fips.py")

--- a/tests/integration/security/compliance/test_disastig_00225.py
+++ b/tests/integration/security/compliance/test_disastig_00225.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000480-GPOS-00225
+
+Verify the operating system prevents the use of dictionary words for passwords.
+"""
+
+import pytest
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-password"])
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.security_id(203778)
+@pytest.mark.feature("disaSTIGmedium")
+def test_dictionary_passwords_are_forbidden(pam_config):
+    """Verify pam_passwdqc.so is required as a password module in /etc/pam.d/common-password."""
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_passwdqc.so",
+    )
+    assert len(results) == 1, "passwdqc should be required"

--- a/tests/integration/security/compliance/test_disastig_00226.py
+++ b/tests/integration/security/compliance/test_disastig_00226.py
@@ -1,0 +1,21 @@
+"""
+Ref: SRG-OS-000480-GPOS-00226
+
+Verify the operating system enforces a delay of at least 4 seconds between logon prompts following a failed logon attempt.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203779)
+@pytest.mark.parametrize("pam_config", ["/etc/pam.d/login"], indirect=["pam_config"])
+@pytest.mark.feature("disaSTIGmedium")
+def test_delay_is_enforced_after_failed_logins(pam_config):
+    """Verify pam_faildelay enforces a 4-second delay in /etc/pam.d/login."""
+    results = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faildelay.so",
+        arg_contains=["delay=4000000"],  # microseconds, 4 * 1mln
+    )
+    assert len(results) == 1, "pam_faildelay should enforce a delay of 4 seconds"

--- a/tests/integration/security/compliance/test_disastig_00227.py
+++ b/tests/integration/security/compliance/test_disastig_00227.py
@@ -1,0 +1,19 @@
+"""
+Ref: SRG-OS-000480-GPOS-00227
+
+As per DISA STIG compliance requirements, the operating system must be configured so that the SSH daemon does not allow X11 Forwarding.
+"""
+
+import pytest
+from plugins.sshd import Sshd
+
+
+@pytest.mark.security_id(203780)
+@pytest.mark.feature("disaSTIGmedium")
+@pytest.mark.booted(reason="requires SSH runtime configuration")
+@pytest.mark.root(reason="requires access to SSH configuration")
+def test_x11_forwarding_is_disabled(sshd: Sshd):
+    """Verify X11Forwarding is set to no in the SSH daemon configuration."""
+    assert (
+        sshd.get_config_section("x11forwarding") == "no"
+    ), "stigcompliance: X11Forwarding must be set to no in sshd configuration"

--- a/tests/integration/security/compliance/test_disastig_00228.py
+++ b/tests/integration/security/compliance/test_disastig_00228.py
@@ -1,0 +1,42 @@
+"""
+Ref: SRG-OS-000480-GPOS-00228
+
+Verify the operating system defines default permissions for all authenticated users in such a way that the user can only read and modify their own files.
+"""
+
+import glob
+
+import pytest
+
+
+@pytest.mark.security_id(203781)
+def test_umask_is_restrictive_enough(parse_file):
+    """Verify UMASK in /etc/login.defs is 027 or 077."""
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert config["UMASK"] in ("027", "077")
+
+
+@pytest.mark.security_id(203781)
+def test_skeleton_directory_is_not_world_writable(file):
+    """Verify /etc/skel has 755 permissions."""
+    assert file.has_permissions("/etc/skel", "755")
+
+
+@pytest.mark.security_id(203781)
+def test_skeleton_files_are_not_world_writable(file):
+    """Verify dotfiles under /etc/skel are 640 or 644."""
+    for f in glob.glob("/etc/skel/.*"):
+        assert file.has_permissions(f, "640") or file.has_permissions(
+            f, "644"
+        ), f"Wrong file permissions for {f}: {file.get_mode(f)}"
+
+
+@pytest.mark.security_id(203781)
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-login-defs-umask"])
+@pytest.mark.feature("disaSTIGmedium", reason="077 umask is enforced by disaSTIGmedium")
+def test_login_defs_umask_is_077(parse_file) -> None:
+    """Verify UMASK in /etc/login.defs is set to 077 (SRG-OS-000480-GPOS-00228)."""
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert (
+        config["UMASK"] == "077"
+    ), f"stigcompliance: UMASK in /etc/login.defs is {config['UMASK']!r}, expected '077'"

--- a/tests/integration/security/compliance/test_disastig_00229.py
+++ b/tests/integration/security/compliance/test_disastig_00229.py
@@ -1,0 +1,18 @@
+"""
+Ref: SRG-OS-000480-GPOS-00229
+
+Verify the operating system does not allow an unattended or automatic logon to the system.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(203782)
+@pytest.mark.booted(reason="Requires functioning systemd")
+def test_systemd_getty_autologin_is_not_enabled(systemd):
+    """Verify no getty@tty unit has --autologin in its ExecStart."""
+    for i in range(7):
+        props = systemd.get_unit_properties(f"getty@tty{i}")
+        assert "--autologin" not in props.get(
+            "ExecStart", ""
+        ), f"Autologin enabled on getty@tty{i}"

--- a/tests/integration/security/compliance/test_disastig_00230.py
+++ b/tests/integration/security/compliance/test_disastig_00230.py
@@ -1,0 +1,23 @@
+"""
+Ref: SRG-OS-000775-GPOS-00230
+
+Verify the operating system is configured to include only approved trust anchors in trust stores or certificate stores managed by the organization.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(263659)
+@pytest.mark.feature("sap")
+def test_validate_fingerprint_of_SAP_CA_certificate(shell):
+    """Verify the SAP Global Root CA certificate has the expected SHA-256 fingerprint."""
+    cert_path = "/etc/ssl/certs/SAP_Global_Root_CA.pem"
+    result = shell(
+        f"openssl x509 -in {cert_path} -noout -fingerprint -sha256", capture_output=True
+    )
+    fingerprint = result.stdout.strip().split("=")[-1]
+
+    assert (
+        fingerprint
+        == "56:53:9C:1E:7B:5E:D5:58:2B:79:68:00:61:CB:F2:14:86:A8:50:22:6B:2F:CF:30:B5:B1:52:A7:20:E1:34:DE"
+    )

--- a/tests/integration/security/compliance/test_disastig_00240.py
+++ b/tests/integration/security/compliance/test_disastig_00240.py
@@ -1,0 +1,15 @@
+"""
+Ref: SRG-OS-000780-GPOS-00240
+
+Verify the operating system is configured to provide protected storage for cryptographic keys with organization-defined safeguards and/or hardware protected key store.
+"""
+
+import pytest
+
+
+@pytest.mark.security_id(263660)
+@pytest.mark.feature("_tpm")
+def test_tpm2_service_enabled(systemd):
+    """Verify the tpm2 service is enabled and active."""
+    assert systemd.is_enabled("tpm2")
+    assert systemd.is_active("tpm2")

--- a/tests/integration/security/compliance/test_disastig_coverages.py
+++ b/tests/integration/security/compliance/test_disastig_coverages.py
@@ -1,0 +1,133 @@
+"""
+Ref: SRG-OS-000057-GPOS-00027, SRG-OS-000120-GPOS-00061, SRG-OS-000122-GPOS-00063, SRG-OS-000329-GPOS-00128
+
+Verify the operating system protects audit logs, uses SHA512 as the password hashing algorithm, enables the audit daemon, and automatically locks an account after three consecutive invalid logon attempts.
+"""
+
+import pytest
+
+AUDITD_CONF = "/etc/audit/auditd.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-service-auditd-enable"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="auditd service is enabled by disaSTIGmedium"
+)
+@pytest.mark.booted(reason="requires systemd")
+def test_auditd_service_is_enabled(systemd) -> None:
+    """Verify auditd.service is enabled."""
+    assert systemd.is_enabled("auditd"), "stigcompliance: auditd.service is not enabled"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-auditd-conf"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="auditd log_group is set to root by disaSTIGmedium"
+)
+def test_auditd_conf_log_group_is_root(parse_file) -> None:
+    """Verify auditd.conf log_group is set to root."""
+    config = parse_file.parse(AUDITD_CONF, format="keyval")
+    assert config["log_group"] == "root", (
+        f"stigcompliance: log_group in {AUDITD_CONF} is "
+        f"{config['log_group']!r}, expected 'root'"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-login-defs-encrypt"])
+@pytest.mark.feature(
+    "disaSTIGmedium", reason="SHA512 password hashing is configured by disaSTIGmedium"
+)
+def test_login_defs_encrypt_method_is_sha512(parse_file) -> None:
+    """Verify ENCRYPT_METHOD in /etc/login.defs is SHA512."""
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert config["ENCRYPT_METHOD"] == "SHA512", (
+        f"stigcompliance: ENCRYPT_METHOD in /etc/login.defs is "
+        f"{config['ENCRYPT_METHOD']!r}, expected 'SHA512'"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGlow-config-security-faillock"])
+@pytest.mark.feature(
+    "disaSTIGlow", reason="faillock deny threshold is configured by disaSTIGlow"
+)
+def test_faillock_deny_is_3(parse_file) -> None:
+    """Verify faillock.conf deny threshold is set to 3."""
+    config = parse_file.parse("/etc/security/faillock.conf", format="keyval")
+    assert (
+        config["deny"] == "3"
+    ), f"stigcompliance: deny in /etc/security/faillock.conf is {config['deny']!r}, expected '3'"
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-disaSTIGmedium-config-audit-rules-d-90-finalize-rules"]
+)
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="audit rules are made immutable by disaSTIGmedium via 90-finalize.rules",
+)
+@pytest.mark.booted(reason="requires running audit subsystem")
+@pytest.mark.root(reason="requires access to audit status")
+def test_audit_rules_are_immutable(shell) -> None:
+    """Verify auditctl reports rules are immutable (enabled 2)."""
+    result = shell("auditctl -s", capture_output=True, ignore_exit_code=True)
+    assert (
+        "enabled 2" in result.stdout
+    ), "stigcompliance: audit rules are not immutable (expected 'enabled 2' in auditctl -s output)"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-audit-rules-service-override"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="audit-rules.service override is provided by disaSTIGmedium",
+)
+def test_audit_rules_service_override_exists(file) -> None:
+    """Verify the audit-rules.service override drop-in exists."""
+    assert file.exists(
+        "/etc/systemd/system/audit-rules.service.d/override.conf"
+    ), "stigcompliance: audit-rules.service.d/override.conf is missing"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-journal-permissions"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="journal directory permissions are set by disaSTIGmedium",
+)
+def test_systemd_journal_is_not_world_readable(file) -> None:
+    """Verify /var/log/journal has rwxr-s--- permissions."""
+    assert file.has_permissions(
+        "/var/log/journal", "rwxr-s---"
+    ), "stigcompliance: /var/log/journal does not have expected permissions rwxr-s---"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-getty-no-autologin"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="getty autologin is disabled by disaSTIGmedium",
+)
+def test_getty_no_autologin_override_exists(file) -> None:
+    """Verify the getty@.service no-autologin drop-in exists."""
+    assert file.exists(
+        "/etc/systemd/system/getty@.service.d/no-autologin.conf"
+    ), "stigcompliance: getty no-autologin override is missing"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-common-auth-faildelay"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="pam_faildelay is configured by disaSTIGmedium",
+)
+def test_pam_faildelay_is_configured(parse_file) -> None:
+    """Verify pam_faildelay with delay=4000000 is configured in /etc/pam.d/common-auth."""
+    assert "auth required pam_faildelay.so delay=4000000" in parse_file.lines(
+        "/etc/pam.d/common-auth"
+    ), "stigcompliance: pam_faildelay delay=4000000 not found in /etc/pam.d/common-auth"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-pam-garden-disaSTIG"])
+@pytest.mark.feature(
+    "disaSTIGmedium",
+    reason="garden-disaSTIG pam config is shipped by disaSTIGmedium",
+)
+def test_pam_garden_disastig_config_exists(file) -> None:
+    assert file.exists(
+        "/usr/share/pam-configs/garden-disaSTIG"
+    ), "stigcompliance: /usr/share/pam-configs/garden-disaSTIG is missing"

--- a/tests/integration/security/compliance/test_fedramp.py
+++ b/tests/integration/security/compliance/test_fedramp.py
@@ -1,0 +1,158 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# fedramp Feature - Federal Risk and Authorization Management Program
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-fedramp-script-firewall-ipv4-flush",
+        "GL-TESTCOV-fedramp-script-firewall-ipv6-flush",
+        "GL-TESTCOV-fedramp-config-firewall-ipv4-gl-default",
+        "GL-TESTCOV-fedramp-config-firewall-ipv6-gl-default",
+    ]
+)
+@pytest.mark.feature("fedramp")
+def test_fedramp_firewall_configs_exist(file: File):
+    """Test that FedRAMP firewall configurations exist"""
+    configs = [
+        "/etc/firewall/ipv4_flush.sh",
+        "/etc/firewall/ipv6_flush.sh",
+        "/etc/firewall/ipv4_gl_default.conf",
+        "/etc/firewall/ipv6_gl_default.conf",
+    ]
+    missing = [cfg for cfg in configs if not file.exists(cfg)]
+    assert not missing, f"Missing FedRAMP firewall configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-chrony"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_chrony_config_exists(file: File):
+    """Test that FedRAMP chrony configuration exists"""
+    assert file.is_regular_file("/etc/chrony/chrony.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-issue-net"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_issue_net_exists(file: File):
+    """Test that FedRAMP issue.net banner exists"""
+    assert file.is_regular_file("/etc/issue.net")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-issue-net"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_issue_net_content(parse_file: ParseFile):
+    """Test that FedRAMP issue.net banner content exists"""
+    lines = parse_file.lines("/etc/issue.net")
+    assert (
+        "You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only."
+        in lines
+    ), "issue.net banner content should contain the correct content"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-security-limits"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_security_limits_exists(file: File):
+    """Test that FedRAMP security limits configuration exists"""
+    assert file.is_regular_file("/etc/security/limits.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-security-limits"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_security_limits_content(parse_file: ParseFile):
+    """Test that FedRAMP security limits configuration content exists"""
+    lines = parse_file.lines("/etc/security/limits.conf")
+    assert (
+        "*               -       maxlogins       10" in lines
+    ), "security limits configuration should contain the correct content"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-audit-tallylog"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_audit_tallylog_exists(file: File):
+    """Test that FedRAMP audit tallylog configuration exists"""
+    assert file.exists("/etc/audit/rules.d/audit.rules")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-audit-tallylog"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_audit_tallylog_content(parse_file: ParseFile):
+    """Test that FedRAMP audit tallylog configuration content exists"""
+    lines = parse_file.lines("/etc/audit/rules.d/audit.rules")
+    assert (
+        "-w /var/log/tallylog -p wa -k logins" in lines
+    ), "audit tallylog configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-fedramp-config-kernel-cmdline-fips",
+        "GL-TESTCOV-fedramp-config-kernel-cmdline-lsm",
+    ]
+)
+@pytest.mark.feature("fedramp")
+def test_fedramp_kernel_cmdline_configs_exist(file: File):
+    """Test that FedRAMP kernel cmdline configs exist"""
+    configs = [
+        "/etc/kernel/cmdline.d/30-fips.cfg",
+        "/etc/kernel/cmdline.d/90-lsm.cfg",
+    ]
+    missing = [cfg for cfg in configs if not file.is_regular_file(cfg)]
+    assert not missing, f"Missing kernel cmdline configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-kernel-cmdline-fips"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_kernel_cmdline_fips_content(parse_file: ParseFile):
+    """Test that FedRAMP kernel cmdline fips configuration content exists"""
+    lines = parse_file.lines("/etc/kernel/cmdline.d/30-fips.cfg")
+    assert (
+        "fips=1" in lines
+    ), "kernel cmdline fips configuration should contain the correct content"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-kernel-cmdline-lsm"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_kernel_cmdline_lsm_content(parse_file: ParseFile):
+    """Test that FedRAMP kernel cmdline lsm configuration content exists"""
+    lines = parse_file.lines("/etc/kernel/cmdline.d/90-lsm.cfg")
+    assert (
+        "security=apparmor" in lines
+    ), "kernel cmdline lsm configuration should contain the correct content"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-ssh-sshd-config"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_sshd_config_exists(file: File):
+    """Test that FedRAMP SSHD configuration exists"""
+    assert file.is_regular_file("/etc/ssh/sshd_config")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-config-ssh-sshd-config"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_sshd_config_content(parse_file: ParseFile):
+    """Test that FedRAMP SSHD configuration content exists"""
+    lines = parse_file.lines("/etc/ssh/sshd_config")
+    assert lines == [
+        "PermitRootLogin no",
+        "Protocol 2",
+        "X11Forwarding no",
+        "StrictModes yes",
+        "IgnoreRhosts yes",
+        "HostbasedAuthentication no",
+        "LogLevel VERBOSE",
+        "UsePAM yes",
+        "PrintMotd no",
+        "AcceptEnv LANG",
+        "Subsystem sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
+        "ClientAliveInterval 600",
+        "ClientAliveCountMax 0",
+        "AuthenticationMethods publickey",
+        "PermitEmptyPasswords no",
+        "Banner /etc/issue.net",
+        "HostKey /etc/ssh/ssh_host_ed25519_key",
+        "HostKey /etc/ssh/ssh_host_rsa_key",
+    ]

--- a/tests/integration/security/compliance/test_fips.py
+++ b/tests/integration/security/compliance/test_fips.py
@@ -1,0 +1,518 @@
+import configparser
+import hmac
+import os
+from ctypes import CDLL, c_char_p, c_int, c_void_p
+from ctypes.util import find_library
+from hashlib import _hashlib  # pyright: ignore
+from hashlib import md5 as MD5
+from hashlib import sha256 as SHA256
+from platform import machine as arch
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.kernel_configs import KernelConfigs
+from plugins.kernel_module import KernelModule
+from plugins.kernel_versions import KernelVersions
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# _fips Feature
+# =============================================================================
+
+
+@pytest.mark.feature("_fips")
+def test_that_md5_is_disabled_in_openssl_via_haslib():
+    """
+    Python's hashlib requires the systems OpenSSL to compute hash function.
+    We try to load the MD5 constructor to see if OpenSSL disallows the usage of MD5.
+    Fails when we have a vaild MD5 object in a Security senstive context.
+    """
+    pytest.raises(_hashlib.UnsupportedDigestmodError, MD5)
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-system-fips",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_dracut_fips_file_was_created(file: File):
+    """
+    The dracut file that will enable the FIPS module.
+    """
+    assert file.is_regular_file("/etc/dracut.conf.d/10-fips.conf")
+
+
+@pytest.mark.feature("_fips")
+def test_dracut_modules_was_extended_for_fips_module(parse_file: ParseFile):
+    """
+    Ensure that the dracutmodules was extend with the fips module
+    add_dracutmodules+=" fips "
+    """
+
+    lines = parse_file.lines("/etc/dracut.conf.d/10-fips.conf")
+    assert 'add_dracutmodules+=" fips "' in lines
+
+
+@pytest.mark.feature("_fips")
+def test_kernel_configs_crypto_benchmark(
+    parse_file: ParseFile, kernel_configs: KernelConfigs
+):
+    """
+    The tcrypot module is hidden in the CONFIG_CRYPTO_BENCHMARK configuration. This needs
+    to be present on our current kernel.
+    """
+    for config in kernel_configs.get_installed():
+        parsed_config = parse_file.parse(config.path, format="keyval")
+        assert (
+            parsed_config["CONFIG_CRYPTO_BENCHMARK"] == "m"
+        ), f"CONFIG_CRYPTO_BENCHMARK not set to 'm' in {config.path}"
+
+
+@pytest.mark.feature("_fips")
+def test_kernel_configs_fips(parse_file: ParseFile, kernel_configs: KernelConfigs):
+    """
+    Ensuer that we have the fips module is configured.
+    """
+    for config in kernel_configs.get_installed():
+        parsed_config = parse_file.parse(config.path, format="keyval")
+        assert (
+            parsed_config["CONFIG_CRYPTO_FIPS"] == "y"
+        ), f"CONFIG_CRYPTO_FIPS not set to 'y' in {config.path}"
+
+
+@pytest.mark.feature("_fips")
+def test_gnutls_fips_file_was_created(file: File):
+    """
+    GnuTLS requires to have the /etc/system-fips to be present as prerequisite
+    to enable the FIPS mode.
+
+    https://www.gnutls.org/manual/html_node/FIPS140_002d2-mode.html
+    """
+
+    assert file.is_regular_file("/etc/system-fips")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-system-fips",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_gnutls_fips_file_is_empty(file: File):
+    """
+    The /etc/system-fips should be without any content.
+    """
+    assert file.get_size("/etc/system-fips") == 0, "The /etc/system-fips is not empty."
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-openssh-sshd-Ciphers",
+        "GL-TESTCOV-_fips-config-openssh-sshd-KexAlgorithms",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_fips_openssh_sshd_config(parse_file: ParseFile):
+    """Test that FIPS has OpenSSH sshd configuration"""
+    lines = parse_file.lines("/etc/ssh/sshd_config")
+    assert (
+        "KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256"
+        in lines
+    ), "OpenSSH KEX algorithms should be configured"
+    assert (
+        "Ciphers aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr"
+        in lines
+    ), "OpenSSH ciphers should be configured"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-openssl",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_fips_openssl_config(parse_file: ParseFile):
+    """Test that FIPS has OpenSSL FIPS configuration"""
+    lines = parse_file.lines("/etc/ssl/openssl.cnf")
+    assert (
+        ".include /etc/ssl/fipsmodule.cnf" in lines
+    ), "FIPS OpenSSL configuration should exist"
+    assert (
+        "providers = provider_sect" in lines
+    ), "FIPS OpenSSL providers should be configured"
+    assert (
+        "alg_section = algorithm_sect" in lines
+    ), "FIPS OpenSSL alg_section should be configured"
+    assert (
+        "default = default_sect" in lines
+    ), "FIPS OpenSSL default should be configured"
+    assert "fips = fips_sect" in lines, "FIPS OpenSSL fips should be configured"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-openssl-fipsinstall",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_fips_openssl_fipsinstall_config(file: File):
+    """Test that FIPS has OpenSSL FIPS module installation config"""
+
+    assert file.exists(
+        "/etc/ssl/fipsmodule.cnf"
+    ), "FIPS OpenSSL fipsinstall config should exist"
+
+
+@pytest.mark.feature("_fips")
+@pytest.mark.booted(reason="GnuTLS needs to have a VM booted with boot FIPS mode.")
+def test_gnutls_is_in_fips_mode():
+    """
+    This code will call up the GnuTLS library directly with ctypes.
+    It invokes the gnutls_fips140_mode_enabled to return true when the library is in FIPS mode;
+    It will return a C-type true.
+
+    https://www.gnutls.org/manual/html_node/FIPS140_002d2-mode.html
+    https://manpages.debian.org/testing/gnutls-doc/gnutls_fips140_mode_enabled.3.en.html
+
+    """
+    shared_lib_name = find_library("gnutls")
+    gnutls = CDLL(shared_lib_name)
+    assert (
+        gnutls.gnutls_fips140_mode_enabled()
+    ), "Error GnuTLS can't be started in FIPS mode."
+
+
+@pytest.mark.feature("_fips")
+def test_gnutls_fips_dot_hmac_file_is_presented():
+    """
+    GnuTLS will perform a self check based on the FIPS requirements. A file that
+    contains an HMAC needs to be present on the target system. This test ensures
+    that the file was installed.
+
+    https://www.gnutls.org/manual/html_node/FIPS140_002d2-mode.html
+    """
+    gnutls_fips_hmac_file = f"/usr/lib/{arch()}-linux-gnu/.libgnutls.so.30.hmac"
+    assert os.path.isfile(
+        gnutls_fips_hmac_file
+    ), f"The f{gnutls_fips_hmac_file} file does not exist!"
+
+
+@pytest.mark.feature("_fips")
+def test_gnutls_fips_dot_hmac_file_is_vaild():
+    """
+    One problem in shipping GnuTLS packages was that the computed HMAC was not valid for the shipped
+    version of the library since the HMAC was computed for an unstripped version. This test ensures
+    that the HMAC on the system fits with the shipped library version.
+
+    Without the HMAC the selftest will fail at second part with the follow error message:
+
+    |<1>| FIPS140-2 self testing part 2 failed
+
+    """
+    gnutls_lib_path = f"/usr/lib/{arch()}-linux-gnu/libgnutls.so.30"
+    gnutls_fips_hmac_file = f"/usr/lib/{arch()}-linux-gnu/.libgnutls.so.30.hmac"
+    # https://gitlab.com/gnutls/gnutls/-/blob/master/configure.ac?ref_type=heads#L677
+    SECRET = "orboDeJITITejsirpADONivirpUkvarP"
+
+    config = configparser.ConfigParser()
+    config.read(gnutls_fips_hmac_file)
+
+    fips_hmac = hmac.new(key=SECRET.encode("UTF-8"), msg=None, digestmod=SHA256)
+    # Need to read it 'b' since it's a binary file.
+    with open(gnutls_lib_path, mode="rb") as lib:
+        fips_hmac.update(lib.read())
+
+    assert (
+        config["libgnutls.so.30"]["hmac"] == fips_hmac.hexdigest()
+    ), "Compute HMAC is incorrect!"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fips-config-gcrypt-fips"])
+@pytest.mark.feature("_fips")
+def test_libgcrypt_fips_file_was_created(file: File):
+    """
+    Libcgrypt requires to have the /etc/gcrypt/fips_enabled to be present as prerequisite
+    to enable the FIPS mode.
+
+    https://www.gnupg.org/documentation/manuals/gcrypt/Enabling-FIPS-mode.html
+    """
+    assert file.is_regular_file("/etc/gcrypt/fips_enabled")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fips-config-gcrypt-fips"])
+@pytest.mark.feature("_fips")
+def test_libgcrypt_fips_file_is_empty(file: File):
+    """
+    The /etc/gcrypt/fips_enabled should be without any content.
+    """
+    assert (
+        file.get_size("/etc/gcrypt/fips_enabled") == 0
+    ), "The /etc/gcrypt/fips_enabled is not empty."
+
+
+@pytest.mark.feature("_fips")
+def test_that_openssl_has_fips_provider_is_presented(file: File):
+    """
+    We have to ensure that the fips.so is presented on the system.
+    """
+    assert file.is_regular_file(f"/usr/lib/{arch()}-linux-gnu/ossl-modules/fips.so")
+
+
+@pytest.mark.feature("_fips")
+def test_that_openssl_configuration_file_readable_for_users(file: File):
+    """
+    To ensure that a User can use the FIPS provide, the openssl configuration file needs to readable
+    by group and world.
+    """
+    assert file.has_mode(f"/usr/lib/{arch()}-linux-gnu/ossl-modules/fips.so", "0644")
+
+
+@pytest.mark.feature("_fips")
+def test_libssl_is_in_fips_mode():
+    """
+    We get OSSL_LIB_CTX_get0_global_default from libssl. For this we need to set up the correct
+    return values
+
+    First, we have to set up an OSSL_LIB_CTX; for this, we use OSSL_LIB_CTX_get0_global_default, which
+    returns a C pointer.
+
+    Once we have the global context, we can use this to get the default properties of the high-level
+    algorithm that has been enabled. Similar to OSSL_LIB_CTX_get0_global_default, we need to define
+    the expected return value. Since this is a C boolean, we have to set it to int, but we also have
+    to define the argument type to be an array with a C pointer, since it is the pointer to the
+    context object.
+    """
+
+    shared_lib_name = find_library("ssl")
+    libssl = CDLL(shared_lib_name)
+
+    libssl.OSSL_LIB_CTX_get0_global_default.restype = c_void_p
+    libssl.OSSL_LIB_CTX_get0_global_default.argtypes = []
+    libssl.EVP_default_properties_is_fips_enabled.restype = c_int
+    libssl.EVP_default_properties_is_fips_enabled.argtypes = [c_void_p]
+
+    ctx = libssl.OSSL_LIB_CTX_get0_global_default()
+    assert libssl.EVP_default_properties_is_fips_enabled(
+        ctx
+    ), "Error openssl can't be started in FIPS mode."
+
+
+@pytest.mark.feature("_fips")
+def test_openssl_FIPS_vendor_name_is_set_correctly(shell):
+    """
+    In this test, we check what provider name was registered by the fips.so module. The name was
+    submitted to the NIST's CMVP. Garden Linux has submitted the SAP SE Garden Linux [RELEASE]
+    OpenSSL Cryptographic Module to the IUT listing.
+
+    We have to ensure that the FIPS provder suffix isn't added by accidentally to it, to ensure
+    compliance.
+    """
+    GARDENLINUX_CMVP_NAME = "SAP SE Garden Linux nightly OpenSSL Cryptographic Module"
+    OPENSSL_FIPS_PROVIDER_SUFFIX = "FIPS Provider for OpenSSL"
+
+    result = shell("openssl list -providers", capture_output=True).stdout
+
+    assert (
+        GARDENLINUX_CMVP_NAME in result and OPENSSL_FIPS_PROVIDER_SUFFIX not in result
+    ), "FIPS Vendor Name for OpenSSL is incorrect!"
+
+
+@pytest.mark.feature("_fips")
+def test_libgcrypt_is_in_fips_mode():
+    """
+     This will check if libgcrypt is in FIPS mode. There is no other way to call libgcrypt from
+     Python than using ctypes.
+
+    It might seem more reasonable to call the gcry_fips_mode_active, however, it turns out that this
+    is a C preprocessor macro that can't be invoked by Python ctypes. Instead, we will invoke the
+    following function, gcry_control(GCRYCTL_FIPS_MODE_P, 0) , which the macro will resolve as we.
+
+
+    https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob;f=src/gcrypt.h.in;h=712a8dd7931e76c0a83aee993bf22f34e420bfc2;hb=737cc63600146f196738a6768679eb016cf866e9#l2129
+
+    The GCRYCTL_FIPS_MODE_P is again just a static value. That can be extract from the gcrypt.h
+    headers.
+    # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob;f=src/gcrypt.h.in;h=712a8dd7931e76c0a83aee993bf22f34e420bfc2;hb=737cc63600146f196738a6768679eb016cf866e9#l316
+    The package libgcrypt20 needs to be presented.
+
+    The gcry_control requires c type integer as inputs.
+
+    https://www.gnupg.org/documentation/manuals/gcrypt/Enabling-FIPS-mode.html#Enabling-FIPS-mode
+    https://www.gnupg.org/documentation/manuals/gcrypt/Controlling-the-library.html#index-gcry_005ffips_005fmode_005factive
+    """
+    shared_lib_name = find_library("gcrypt")
+    libgcrypt = CDLL(shared_lib_name)
+
+    # See the gcrypt.h
+    GCRYCTL_FIPS_MODE_P = 55
+    assert libgcrypt.gcry_control(
+        c_int(GCRYCTL_FIPS_MODE_P), c_int(1)
+    ), "Error libgcrypt can't be started in FIPS mode."
+
+
+@pytest.mark.feature("_fips")
+def test_libgcrypt_configs_FIPS_vendor_is_set():
+    """
+    This will check if libgcrypt has set the FIPS-Mode.
+
+    For this it uses the gcry_get_config() function is use.
+    https://www.gnupg.org/documentation/manuals/gcrypt/Config-reporting.html
+
+    The function will return a string containing the configuration.
+
+    It should look like as follows:
+      - SAP SE Garden Linux [RELEASE] Libcgrypt Cryptographic Module
+
+    See also: https://github.com/gardenlinux/security/issues/368
+    """
+    shared_lib_name = find_library("gcrypt")
+    libgcrypt = CDLL(shared_lib_name)
+
+    # Define the expected return value and define the types that will be handled over as function
+    # parameter.
+    libgcrypt.gcry_get_config.restype = c_char_p
+    libgcrypt.gcry_get_config.argtypes = [c_int, c_char_p]
+
+    config = libgcrypt.gcry_get_config(0, None)
+    found = [entry for entry in config.decode().splitlines() if "fips-mode" in entry]
+    assert (
+        "fips-mode:y::SAP SE Garden Linux nightly Libgcrypt Cryptographic Module:"
+        in found
+    ), "Can't detect the correct FIPS-Module name in libgcrypt"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-kernel-cmdline-fips",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_kernel_cmdline_fips_file_was_created(file: File):
+    """
+    libgcrypt, gnutls and openssl need to have the /proc/sys/crypto/fips_enabled present
+    as a prerequisite to enable they respected FIPS mode. The kernel can only be booted
+    with the fips=1 parameter.
+    """
+    assert file.is_regular_file("/etc/kernel/cmdline.d/30-fips.cfg")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-kernel-cmdline-fips",
+    ]
+)
+@pytest.mark.feature("_fips")
+def test_kernel_cmdline_fips_file_content(parse_file: ParseFile):
+    """
+    We have to ensure that the fips=1 was set.
+    """
+    lines = parse_file.lines("/etc/kernel/cmdline.d/30-fips.cfg")
+    assert 'CMDLINE_LINUX="$CMDLINE_LINUX fips=1"' in lines
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_fips-config-kernel-cmdline-fips",
+    ]
+)
+@pytest.mark.feature("_fips")
+@pytest.mark.booted(reason="Kernel test makes sense only on booted system")
+def test_kernel_was_boot_with_fips_mode(kernel_cmdline: List[str]):
+    """
+    Validate that the kernel was booted with the FIPS mode enabled.
+    """
+    assert "fips=1" in kernel_cmdline, "Kernel was not booted in FIPS mode!"
+
+
+@pytest.mark.feature("_fips")
+@pytest.mark.booted(reason="Kernel test makes sense only on booted system")
+def test_kernel_has_fips_entry_in_procfs(parse_file: ParseFile):
+    """
+    Validate that the FIPS flag is exposed in procfs. Without applications can't detect if a system
+    has been booted into FIPS mode.
+    """
+    lines = parse_file.lines("/proc/sys/crypto/fips_enabled")
+    assert "1" in lines, f"Kernel was not booted in FIPS mode!"
+
+
+@pytest.mark.feature("_fips")
+@pytest.mark.booted(reason="Requires running system")
+def test_kernel_module_tcrypt_available_for_dracut(kernel_module: KernelModule):
+    """
+    Test that the tcrypt kernel module is available as loadable module. This will be invoke by
+    the dracut FIPS module. Since there where a bug in the kernel, we missed the configuration
+    """
+    kernel_modules = ["tcrypt"]
+    for module in kernel_modules:
+        assert kernel_module.is_module_available(
+            module
+        ), f"{module} kernel module is not available."
+
+
+@pytest.mark.feature("_fips")
+@pytest.mark.booted(reason="Requires running system")
+def test_kernel_hmac_file_is_present(file: File, kernel_versions: KernelVersions):
+    """
+    Test that the kernel hmac file for running kernel is present.
+    """
+    running_kernel = kernel_versions.get_running()
+    assert file.is_regular_file(f"/boot/.vmlinuz-{running_kernel.version}.hmac")
+
+
+def test_kernel_configs_btrfs_is_disabled(
+    parse_file: ParseFile, kernel_configs: KernelConfigs
+):
+    """
+    Based on our issue regarding xxhash64, we need to disable BTRFS within the kernel, since it uses
+    not approved algortiehm. This test ensure that BTRFS is disabled.
+
+    While this requierment stems from FIPS, BTRFS should be disabled everywhere.
+
+    See: https://github.com/gardenlinux/security/issues/405
+    """
+    for config in kernel_configs.get_installed():
+        parsed_config = parse_file.parse(config.path, format="keyval")
+        assert (
+            "CONFIG_BTRFS_FS" not in parsed_config.keys()
+        ), f"CONFIG_BTRFS is set in {config.path}"
+
+
+# TODO: check why this does not work on arm64, when build crossplatfrom.
+# When run podman on x86_64 and you try to build this via podman for arm64 it will fail.
+@pytest.mark.testcov(["GL-TESTCOV-_fips-config-kernel-hmac"])
+@pytest.mark.feature("_fips and not _usi")
+@pytest.mark.booted(reason="Requires running system")
+def test_kernel_hmac_file_is_correct(
+    shell: ShellRunner, kernel_versions: KernelVersions
+):
+    """
+    Test that the kernel hmac file for running kernel is present.
+    """
+    running_kernel = kernel_versions.get_running()
+    kernel_hmac_file = f"/boot/.vmlinuz-{running_kernel.version}.hmac"
+    kernel_file = f"/boot/vmlinuz-{running_kernel.version}"
+
+    result = shell(f"sha512hmac -c {kernel_hmac_file}", capture_output=True)
+    assert (
+        result.stdout.strip() == f"{kernel_file}: OK"
+    ), f"sha512hmac command failed for {kernel_hmac_file}"
+
+
+@pytest.mark.feature("_fips")
+def test_kernel_configs_FIPS_vendor_is_set(
+    parse_file: ParseFile, kernel_configs: KernelConfigs
+):
+    """
+    Ensure that the FIPS module name is set correctly for the kernel.
+    It should look like as follows:
+       - SAP SE Garden Linux [RELEASE] Kernel Cryptographic Module
+    """
+    for config in kernel_configs.get_installed():
+        parsed_config = parse_file.parse(config.path, format="keyval")
+        assert (
+            parsed_config["CONFIG_CRYPTO_FIPS_NAME"]
+            == "SAP SE Garden Linux nightly Kernel Cryptographic Module"
+        ), f"CONFIG_CRYPTO_BENCHMARK not set to 'm' in {config.path}"

--- a/tests/integration/security/compliance/test_stig.py
+++ b/tests/integration/security/compliance/test_stig.py
@@ -1,0 +1,47 @@
+import pytest
+from plugins.file import File
+from plugins.kernel_module import KernelModule
+from plugins.parse_file import ParseFile
+
+
+@pytest.mark.testcov(["GL-TESTCOV-stig-config-modprobe-usb-disable"])
+@pytest.mark.feature("stig")
+def test_stig_usb_disabled(file: File):
+    """Test that USB is disabled via modprobe"""
+    assert file.is_regular_file("/etc/modprobe.d/disabled_usb.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-stig-config-modprobe-usb-disable"])
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_stig_modprobe_disable_modules_not_loaded(kernel_module: KernelModule):
+    """Test that disabled modules are not loaded"""
+    modules = [
+        "usbcore",
+        "usb-common",
+        "usb-storage",
+    ]
+    for module in modules:
+        assert not kernel_module.is_module_loaded(
+            module
+        ), f"Module {module} is loaded but should be deny listed"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-rsyslog-default"])
+@pytest.mark.feature("disaSTIGmedium")
+def test_stig_rsyslog_default_exists(file: File):
+    """Test that STIG rsyslog default config exists"""
+    assert file.is_regular_file("/etc/rsyslog.d/50-default.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-disaSTIGmedium-config-rsyslog-default"])
+@pytest.mark.feature("disaSTIGmedium")
+def test_stig_rsyslog_default_content(parse_file: ParseFile):
+    """Test that STIG rsyslog default config content exists"""
+    lines = parse_file.lines("/etc/rsyslog.d/50-default.conf")
+    assert (
+        "auth.*,authpriv.* /var/log/secure" in lines
+    ), "rsyslog default config should contain the correct content"
+    assert (
+        "daemon.* /var/log/messages" in lines
+    ), "rsyslog default config should contain the correct content"

--- a/tests/integration/security/test_aide.py
+++ b/tests/integration/security/test_aide.py
@@ -1,0 +1,126 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# aide Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-unit"])
+@pytest.mark.feature("aide")
+def test_aide_check_unit_exists(file):
+    """Test that aide-check.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/aide-check.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-unit"])
+@pytest.mark.feature("aide")
+def test_aide_init_unit_exists(file):
+    """Test that aide-init.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/aide-init.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_aide_init_service_enabled(systemd: Systemd):
+    """Test that aide-init.service is enabled"""
+    assert systemd.is_enabled("aide-init.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_aide_init_service_active(systemd: Systemd):
+    """Test that aide-init.service is active"""
+    assert systemd.is_active("aide-init.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_timer_aide_check_service_enabled(systemd: Systemd):
+    """Test that aide-check.timer is enabled"""
+    assert systemd.is_enabled("aide-check.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_timer_aide_check_service_active(systemd: Systemd):
+    """Test that aide-check.timer is active"""
+    assert systemd.is_active("aide-check.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-script-aide-init-onboot"])
+@pytest.mark.feature("aide")
+def test_aide_init_onboot_script_exists(file: File):
+    """Test that AIDE initialization script exists"""
+    assert file.is_regular_file("/usr/local/sbin/aide-init-onboot.sh")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_exists(systemd: Systemd):
+    """Verify that the AIDE timer unit exists."""
+    timer = "aide-check.timer"
+    units = systemd.list_units()
+    matches = [u for u in units if u.unit == timer]
+    assert matches, f"AIDE timer '{timer}' not found — CIS requirement failed"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_loaded(systemd: Systemd):
+    """Verify that the AIDE timer unit is loaded."""
+    timer = "aide-check.timer"
+    units = systemd.list_units()
+    matches = [u for u in units if u.unit == timer]
+    assert (
+        matches[0].load == "loaded"
+    ), f"AIDE timer must be loaded but is {matches[0].load}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_active(systemd: Systemd):
+    """Verify that the AIDE timer unit is active."""
+    timer = "aide-check.timer"
+    assert systemd.is_active(timer), f"AIDE timer '{timer}' exists but is not active."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_state(systemd: Systemd):
+    """Verify that the AIDE timer is in 'waiting' or 'running' state."""
+    timer = "aide-check.timer"
+    units = systemd.list_units()
+    matches = [u for u in units if u.unit == timer]
+    unit = matches[0]
+    assert unit.sub in (
+        "waiting",
+        "running",
+    ), f"AIDE timer scheduling state unexpected (sub={unit.sub})"
+
+
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to read AIDE configuration")
+@pytest.mark.booted(reason="AIDE configuration must exist at runtime")
+def test_aide_conf_contains_faillog_entry(parse_file: ParseFile):
+    """Ensure that AIDE configuration exists and includes '/var/log/faillog Full'"""
+    conf_path = "/etc/aide/aide.conf"
+    lines = parse_file.lines(conf_path)
+    expected_line = "/var/log/faillog Full"
+    assert (
+        expected_line in lines
+    ), f"Expected '{expected_line}' not found in {conf_path}. "

--- a/tests/integration/security/test_capabilities.py
+++ b/tests/integration/security/test_capabilities.py
@@ -1,0 +1,25 @@
+import pytest
+from plugins.capabilities import Capabilities
+
+# =============================================================================
+# Misc tests not tied to any specific feature
+# =============================================================================
+
+# There are two debian packages that provide an 'arping' binary
+# https://packages.debian.org/search?searchon=contents&keywords=arping&mode=path&suite=stable&arch=any
+# /usr/bin/arping is provided by iputils-arping
+# /usr/sbin/arping is provided by arping
+# We only use iputils-arping
+capabilities_allowlist = {"/usr/bin/arping cap_net_raw=ep"}
+
+
+@pytest.mark.root(reason="Need to read files not readable by unprivileged user")
+def test_only_expected_capabilities_are_set(capabilities: Capabilities):
+    actual_capabilities = capabilities.get()
+
+    unexpected = actual_capabilities - capabilities_allowlist
+
+    assert not unexpected, (
+        f"Unexpected capabilities found: {unexpected}. "
+        f"Allowed: {capabilities_allowlist}"
+    )

--- a/tests/integration/security/test_firewall.py
+++ b/tests/integration/security/test_firewall.py
@@ -1,0 +1,40 @@
+import pytest
+from plugins.file import File
+from plugins.nft import Nft
+
+# =============================================================================
+# firewall Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-firewall-config-nft-default",  # exact: tests nftables firewall configuration
+    ]
+)
+@pytest.mark.root(reason="nft is only accessible by root")
+@pytest.mark.booted(reason="Firewall needs booted system")
+@pytest.mark.feature("firewall")
+def test_nft_config(nft: Nft):
+    matching_policies = [
+        chain
+        for chain in nft.list_table_inet_filter()
+        if chain.type == "filter"
+        and chain.hook == "input"
+        and chain.prio == 0
+        and chain.policy == "drop"
+    ]
+    assert len(matching_policies) == 1, "input has policy drop not as default"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-firewall-config-nftables-include",
+    ]
+)
+@pytest.mark.feature("firewall")
+def test_firewall_nft_default_config_exists(file: File):
+    """Test that firewall nft default configuration exists"""
+    assert file.exists(
+        "/etc/nft.d/default.conf"
+    ), "Firewall nft default configuration should exist"

--- a/tests/integration/security/test_lsm.py
+++ b/tests/integration/security/test_lsm.py
@@ -1,0 +1,74 @@
+from typing import List
+
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# _selinux Feature
+# =============================================================================
+
+
+# SELinux
+@pytest.mark.testcov(["GL-TESTCOV-_selinux-config-kernel-cmdline-lsm"])
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires a running kernel to read /proc/cmdline")
+def test_selinux_cmdline(kernel_cmdline: List[str]):
+    assert "security=selinux" in kernel_cmdline
+
+
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires a running kernel to access sysfs")
+def test_selinux_enabled(file: File):
+    assert file.exists("/sys/fs/selinux/enforce"), "SELinux not enabled"
+
+
+# TODO: enable after fixing https://github.com/gardenlinux/gardenlinux/issues/4315
+# @pytest.mark.testcov(["GL-TESTCOV-_selinux-config-selinux-contexts"])
+# @pytest.mark.feature("_selinux")
+# @pytest.mark.booted(reason="requires SELinux to be running")
+# @pytest.mark.root(reason="restorecon requires root privileges")
+# def test_selinux_no_relabeling_needed(shell):
+#     result = shell("restorecon -Rnv /", capture_output=True, ignore_exit_code=True)
+#     assert (
+#         result.stdout.strip() == ""
+#     ), f"SELinux relabeling is needed. Files requiring relabeling:\n{result.stdout}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_selinux-config-kernel-cmdline-lsm"])
+@pytest.mark.booted
+@pytest.mark.feature("_selinux")
+def test_lsm_selinux(lsm):
+    assert "selinux" in lsm
+    assert "apparmor" not in lsm
+
+
+# =============================================================================
+# gardener Feature enables Apparmor
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-kernel-cmdline-lsm"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="requires a running kernel to read /proc/cmdline")
+def test_apparmor_cmdline(kernel_cmdline: List[str]):
+    assert "security=apparmor" in kernel_cmdline
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-kernel-cmdline-lsm"])
+@pytest.mark.booted
+@pytest.mark.feature("gardener")
+def test_lsm_gardener(lsm):
+    assert "apparmor" in lsm
+    assert "selinux" not in lsm
+
+
+# =============================================================================
+# Common tests for all LSMs
+# =============================================================================
+
+
+@pytest.mark.booted
+def test_lsm_common(lsm):
+    required = {"landlock", "lockdown", "capability", "yama"}
+    missing = required - set(lsm)
+    assert not missing, f"missing lsm(s): {', '.join(sorted(missing))}"

--- a/tests/integration/security/test_pam.py
+++ b/tests/integration/security/test_pam.py
@@ -1,0 +1,103 @@
+import pytest
+
+# =============================================================================
+# server Feature - PAM Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+        "GL-TESTCOV-server-config-pam-garden-extra",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-auth"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+@pytest.mark.feature("not cis", reason="CIS handles auth_pam by itself")
+def test_common_auth_pam_faillock(pam_config):
+
+    results = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faillock.so",
+        arg_contains=["preauth", "silent", "audit", "deny=5", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Logins should be blocked for 15 minutes after 5 failed attempts (preauth check configured)"
+
+    pam_config.find_entries(
+        type_="auth",
+        control_contains="default=die",
+        module_contains="pam_faillock.so",
+        arg_contains=["authfail", "silent", "audit", "deny=5", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Control value of PAM Module pam_faillock.so must be set to required (postauth action configured)"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-account"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+@pytest.mark.feature("not cis", reason="CIS handles auth_pam by itself")
+def test_common_account_pam_faillock(pam_config):
+    results = pam_config.find_entries(
+        type_="account", control_contains="required", module_contains="pam_faillock.so"
+    )
+    assert (
+        len(results) == 1
+    ), "User account should be validated for its lock status before session starts"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+def test_common_password_passwdqc_pam_faillock(pam_config):
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_passwdqc.so",
+        arg_contains=[
+            "min=disabled,disabled,12,8,8",
+            "passphrase=4",
+            "similar=deny",
+            "retry=5",
+        ],
+    )
+    assert (
+        len(results) == 1
+    ), "User password should conform to password strength requirements"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+def test_common_password_pwhistory_pam_faillock(pam_config):
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_pwhistory.so",
+        arg_contains=["use_authtok", "remember=5", "retry=5"],
+    )
+    assert len(results) == 1, "Last 5 user passwords should not be reused"

--- a/tests/integration/security/test_password_hashes.py
+++ b/tests/integration/security/test_password_hashes.py
@@ -1,0 +1,56 @@
+import pytest
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.security_id(325)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+def test_password_entry_present(pam_config):
+    """
+    Ensure that exactly one password entry with [success=... default=ignore]
+    exists in PAM config.
+    """
+    candidates = pam_config.find_entries(
+        type_="password",
+        control_contains={"success": "*", "default": "ignore"},
+        match_all=True,
+    )
+    assert (
+        len(candidates) == 1
+    ), f"Expected exactly one password entry, found {len(candidates)}: {candidates}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-stig-config-pam-garden-stig"])
+@pytest.mark.security_id(325)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+def test_password_entry_uses_strong_hash(pam_config):
+    """
+    Ensure that the password entry uses a strong hash algorithm (yescrypt or sha512).
+    """
+    candidates = pam_config.find_entries(
+        type_="password",
+        control_contains={"success": "*", "default": "ignore"},
+        match_all=True,
+    )
+
+    # Validate that this is only defined a single time
+    # to ensure no feature has appended different options
+    # multiple times
+    assert (
+        len(candidates) == 1
+    ), f"Expected exactly one 'password ... [success=... default=ignore] ...' entry, found {len(candidates)}: {candidates}"
+    entry = candidates[0]
+
+    # Validate the entry for 'sha512' or 'yescrypt'
+    # We're using YESCRYPT instead of sha512 because it offers more
+    # resistance to offline attacks.
+    # https://www.openwall.com/yescrypt/
+    assert (
+        "yescrypt" in entry.options or "sha512" in entry.options
+    ), f"Weak or unknown hash algorithm used: {entry.options}"

--- a/tests/integration/security/test_password_shadow.py
+++ b/tests/integration/security/test_password_shadow.py
@@ -1,0 +1,45 @@
+from typing import List
+
+import pytest
+from plugins.linux_etc_files import Passwd, Shadow
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "not cis and not disaSTIGmedium",
+    reason="CIS and disaSTIGmedium handle shadow_entries by themselves",
+)
+def test_shadow_passwords_are_locked(shadow_entries: List[Shadow]):
+    """No user in shadow should have a valid password entry and all users are locked."""
+    for entry in shadow_entries:
+        # Assert that the password field for the given entry is not empty (not invalid)
+        assert (
+            entry.encrypted_password
+        ), f"Empty password field in shadow for {entry.login_name}"
+
+        # Assert whether the first character is a '!' or '*' marking the user as locked.
+        assert entry.encrypted_password[0] in [
+            "!",
+            "*",
+        ], f"Unexpected password hash in shadow for {entry.login_name}: {entry.encrypted_password}"
+
+
+def test_passwd_password_field_is_valid(passwd_entries: List[Passwd]):
+    """All passwd entries must use 'x' or '*' in the password field."""
+    for entry in passwd_entries:
+        assert entry.password in [
+            "*",
+            "x",
+        ], f"Malformed passwd entry for {entry.name}: {entry}"
+
+
+@pytest.mark.root
+@pytest.mark.parametrize("command", ["pwck -r", "grpck -r"])
+def test_system_integrity_tools(shell, command):
+    """System tools must confirm consistency of passwd and group files."""
+    result = shell(command, capture_output=True, ignore_exit_code=True)
+    assert result.returncode == 0, f"{command} failed: {result.stderr}"
+    assert result.stdout.strip() == "", f"{command} produced unexpected output"

--- a/tests/integration/security/test_sgx.py
+++ b/tests/integration/security/test_sgx.py
@@ -1,0 +1,21 @@
+import pytest
+from plugins.kernel_configs import KernelConfigs
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# cloud or metal Feature - SGX Configuration
+# =============================================================================
+
+
+@pytest.mark.feature("cloud or metal")
+@pytest.mark.arch("amd64", reason="SGX is an amd64 option")
+def test_kernel_configs_sgx(parse_file: ParseFile, kernel_configs: KernelConfigs):
+    """Test that all kernel configs have SGX enabled for amd64."""
+    for config in kernel_configs.get_installed():
+        parsed_config = parse_file.parse(config.path, format="keyval")
+        assert (
+            parsed_config["CONFIG_X86_SGX"] == "y"
+        ), f"CONFIG_X86_SGX not set to 'y' in {config.path}"
+        assert (
+            parsed_config["CONFIG_X86_SGX_KVM"] == "y"
+        ), f"CONFIG_X86_SGX_KVM not set to 'y' in {config.path}"

--- a/tests/integration/security/test_ssh.py
+++ b/tests/integration/security/test_ssh.py
@@ -1,0 +1,333 @@
+import os
+import pwd
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.sshd import Sshd
+from plugins.systemd import Systemd
+from plugins.utils import equals_ignore_case, get_normalized_sets, is_set
+
+# =============================================================================
+# ssh Feature - SSH Configuration (not _fips and cis)
+# =============================================================================
+
+required_sshd_config = {
+    "HostKey": {
+        "/etc/ssh/ssh_host_ed25519_key",
+        "/etc/ssh/ssh_host_rsa_key",
+    },
+    "KexAlgorithms": {
+        "sntrup761x25519-sha512",
+        "sntrup761x25519-sha512@openssh.com",
+        "mlkem768x25519-sha256",
+        "curve25519-sha256",
+        "curve25519-sha256@libssh.org",
+        "ecdh-sha2-nistp256",
+        "ecdh-sha2-nistp384",
+        "ecdh-sha2-nistp521",
+    },
+    "Ciphers": {
+        "chacha20-poly1305@openssh.com",
+        "aes128-ctr",
+        "aes192-ctr",
+        "aes256-ctr",
+        "aes128-gcm@openssh.com",
+        "aes256-gcm@openssh.com",
+    },
+    "MACs": {
+        "umac-64-etm@openssh.com",
+        "umac-128-etm@openssh.com",
+        "hmac-sha2-256-etm@openssh.com",
+        "hmac-sha2-512-etm@openssh.com",
+        "hmac-sha1-etm@openssh.com",
+        "umac-64@openssh.com",
+        "umac-128@openssh.com",
+        "hmac-sha2-256",
+        "hmac-sha2-512",
+        "hmac-sha1",
+    },
+    "AuthenticationMethods": "publickey",
+    "LogLevel": "VERBOSE",
+    "Subsystem": "sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
+    "PermitRootLogin": "No",
+    "X11Forwarding": "no",
+    "UsePAM": "yes",
+}
+
+
+FIPS_REASON = "FIPS uses different values for the KEX and Cipher."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-config-ssh-sshd-config"])
+@pytest.mark.booted(reason="Calling sshd -T requires a booted system")
+@pytest.mark.root(reason="Calling sshd -T requires root")
+@pytest.mark.feature("ssh")
+@pytest.mark.parametrize("sshd_config_item", required_sshd_config)
+@pytest.mark.feature("not _fips", reason=FIPS_REASON)
+@pytest.mark.feature("not cis", reason="CIS has specific KEX and MACs")
+@pytest.mark.feature(
+    "not disaSTIGmedium", reason="disaSTIGmedium enforces STIG-specific SSH algorithms"
+)
+def test_sshd_has_required_config(sshd_config_item: str, sshd: Sshd):
+    actual_value = sshd.get_config_section(sshd_config_item)
+    expected_value = required_sshd_config[sshd_config_item]
+    if is_set(expected_value):
+        if actual_value is None:
+            actual_value = set()
+        elif not is_set(actual_value):
+            actual_value = set(str(actual_value).split(","))
+        # Ensure actual_value is a set at this point
+        assert isinstance(
+            actual_value, set
+        ), f"actual_value should be a set, got {type(actual_value)}"
+        actual_set, expected_set = get_normalized_sets(actual_value, expected_value)
+        assert expected_set.issubset(
+            actual_set
+        ), f"{sshd_config_item}: missing values {expected_set - actual_set}"
+    else:
+        assert equals_ignore_case(
+            str(actual_value or ""), str(expected_value)
+        ), f"{sshd_config_item}: expected {expected_value}, got {actual_value}"
+
+
+# =============================================================================
+# ssh Feature - SSH Extended Configuration (not ali, aws, azure or openstack)
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "ssh and not (ali or aws or azure or openstack)",
+    reason="We want no authorized_keys for unmanaged users",
+)
+def test_users_have_no_authorized_keys(expected_users, file: File):
+    skip_users = {"nologin", "sync"}
+    skip_shells = {"/bin/false"}
+    files_to_check = ["authorized_keys", "authorized_keys2"]
+
+    for entry in pwd.getpwall():
+        if any(
+            [
+                entry.pw_name in skip_users,
+                entry.pw_shell in skip_shells,
+                entry.pw_name in expected_users,
+            ]
+        ):
+            continue
+
+        ssh_dir = os.path.join(entry.pw_dir, ".ssh")
+        for filename in files_to_check:
+            key_path = os.path.join(ssh_dir, filename)
+            assert not file.exists(
+                key_path
+            ), f"user '{entry.pw_name}' should not have an authorized_keys file: {key_path}"
+
+
+# =============================================================================
+# ssh Feature - SSH Extended Configuration (ali, aws, azure or openstack)
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "ssh and (ali or aws or azure or openstack)",
+    reason="ALI, AWS, Azure and OpenStack auto generate authorized_keys for root with a hint to use another user",
+)
+def test_users_have_only_root_authorized_keys_cloud(
+    expected_users, file, parse_file: ParseFile
+):
+    skip_users = {"nologin", "sync"}
+    skip_shells = {"/bin/false"}
+    files_to_check = ["authorized_keys", "authorized_keys2"]
+
+    for entry in pwd.getpwall():
+        if any(
+            [
+                entry.pw_name in skip_users,
+                entry.pw_shell in skip_shells,
+                entry.pw_name in expected_users,
+            ]
+        ):
+            continue
+        ssh_dir = os.path.join(entry.pw_dir, ".ssh")
+        for filename in files_to_check:
+            key_path = os.path.join(ssh_dir, filename)
+            if file.exists(key_path):
+                if entry.pw_name != "root":
+                    assert (
+                        False
+                    ), f"user '{entry.pw_name}' should not have an authorized_keys file: {key_path}"
+                else:
+                    # Check if the file contains only the specific restricted root key
+                    lines = parse_file.lines(key_path)
+                    if not lines.content.strip():
+                        # Allow empty authorized_keys for root on cloud images
+                        continue
+                    expected_patterns = [
+                        f'command="echo \'Please login as the user \\"{user}\\" rather than the user \\"root\\".\''
+                        for user in expected_users
+                    ]
+                    # Check that at least one expected pattern exists in the file
+                    # (The file should only contain authorized keys with redirect commands)
+                    if not any(pattern in lines for pattern in expected_patterns):
+                        assert (
+                            False
+                        ), f"user '{entry.pw_name}' has unauthorized SSH key in file: {key_path}"
+
+
+# =============================================================================
+# ssh Feature - SSH Service
+# =============================================================================
+
+
+@pytest.mark.booted(reason="Starting the unit requires a booted system")
+@pytest.mark.modify(reason="Starting the unit modifies the system state")
+@pytest.mark.root(reason="Starting the unit requires root")
+@pytest.mark.feature("ssh")
+def test_ssh_service_running(systemd: Systemd, service_ssh):
+    assert systemd.is_active(
+        "ssh"
+    ), "Required systemd unit for ssh.service is not running"
+
+
+# =============================================================================
+# ssh Feature - SSH Extended Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-no-init-ssh",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_no_init_script(file: File):
+    """Test that SSH does not have init script"""
+    assert not file.exists(
+        "/etc/init.d/ssh"
+    ), "SSH should not have init.d script (using systemd)"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-ssh-ssh-config",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_client_config_exists(file: File):
+    """Test that SSH client configuration exists"""
+    assert file.exists("/etc/ssh/ssh_config"), "SSH client configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-ssh-ssh-config",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_client_config_content(parse_file: ParseFile):
+    """Test that SSH client configuration exists"""
+    lines = parse_file.lines("/etc/ssh/ssh_config")
+    lines_expected = [
+        "Include /etc/ssh/ssh_config.d/*.conf",
+        "Host *",
+        "Protocol 2",
+        "ForwardAgent no",
+        "ForwardX11 no",
+        "HostbasedAuthentication no",
+        "StrictHostKeyChecking no",
+        "Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr",
+        "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com",
+        "KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256",
+        "Tunnel no",
+        "ServerAliveInterval 420",
+    ]
+    assert (
+        lines == lines_expected
+    ), "SSH client configuration should contain the expected content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-sudoers-wheel-permissions",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_sudoers_wheel_permissions(file: File):
+    """Test that sudoers wheel file has correct permissions"""
+    assert file.has_mode(
+        "/etc/sudoers.d/wheel", "0440"
+    ), "Sudoers wheel file should have 0440 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-sshguard-nftables-configure",
+    ]
+)
+@pytest.mark.feature(
+    "ssh and firewall", reason="nftables package is installed on firewall"
+)
+def test_ssh_sshguard_nftables_configured(parse_file: ParseFile):
+    """Test that sshguard nftables is configured"""
+
+    content = parse_file.lines("/etc/systemd/system/sshguard.service.d/override.conf")
+    assert (
+        "Requires=nftables.service" in content
+    ), "SSHGuard systemd service override configuration should require nftables.service"
+    assert (
+        "PartOf=nftables.service" in content
+    ), "SSHGuard systemd service override configuration should part of nftables.service"
+    assert (
+        "WantedBy=multi-user.target nftables.service" in content
+    ), "SSHGuard systemd service override configuration should want to be started by multi-user.target and nftables.service"
+
+
+# =============================================================================
+# ssh Feature - SSH Guard Configuration (iptables)
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-sshguard-iptables-configure",
+    ]
+)
+@pytest.mark.feature("ssh and server", reason="iptables package is installed on server")
+@pytest.mark.feature("not firewall", reason="iptables package is installed on server")
+def test_ssh_sshguard_iptables_configured(parse_file: ParseFile):
+    """Test that sshguard iptables is configured"""
+
+    content = parse_file.lines("/etc/systemd/system/sshguard.service.d/override.conf")
+    assert (
+        "ExecStartPre=-/sbin/iptables -N sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStartPre=-/sbin/iptables -N sshguard"
+    assert (
+        "ExecStartPre=-/sbin/ip6tables -N sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStartPre=-/sbin/ip6tables -N sshguard"
+    assert (
+        "ExecStopPost=-/sbin/iptables -X sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStopPost=-/sbin/iptables -X sshguard"
+    assert (
+        "ExecStopPost=-/sbin/ip6tables -X sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStopPost=-/sbin/ip6tables -X sshguard"
+
+
+# =============================================================================
+# ssh Feature - SSH Guard Configuration (nftables)
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-sshguard-iptables-configure",
+    ]
+)
+@pytest.mark.feature("ssh and server", reason="iptables package is installed on server")
+@pytest.mark.feature("not firewall", reason="iptables package is installed on server")
+def test_ssh_sshguard_iptables_backend_configured(parse_file: ParseFile):
+    """Test that sshguard iptables backend is configured"""
+
+    content = parse_file.parse("/etc/sshguard/sshguard.conf", format="keyval")
+    assert (
+        content["BACKEND"] == "/usr/libexec/sshguard/sshg-fw-iptables"
+    ), "SSHGuard configuration should reference iptables backend"

--- a/tests/integration/security/test_su.py
+++ b/tests/integration/security/test_su.py
@@ -1,0 +1,38 @@
+import pytest
+from plugins.pam import PamConfig
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-config-pam-su-wheel"])
+@pytest.mark.security_id(166)
+@pytest.mark.root
+@pytest.mark.feature("not container")
+@pytest.mark.parametrize("pam_config", ["/etc/pam.d/su"], indirect=["pam_config"])
+@pytest.mark.feature("not cis", reason="CIS handles pam_config on its own")
+def test_pam_wheel_is_required(pam_config: PamConfig):
+    """
+    Validate that we have access to su restircted by default.  The test will
+    read the file from `/etc/pam.d/su` and check if it has the configuration
+    parameter we expect.
+
+    A user needs to be configured to be admitted to use `su`. By default, this
+    is realized by a specify group, the `wheel` group. We have to ensure that
+    this behavior is enabled.
+
+    This line should be defined:
+
+        auth       required pam_wheel.so
+
+    """
+    pam_config.find_entries()
+
+    candidates = pam_config.find_entries(
+        type_="auth", control_contains="required", module_contains="pam_wheel.so"
+    )
+
+    assert (
+        len(candidates) == 1
+    ), "Control value of PAM Module pam_wheel.so must be set to required"

--- a/tests/integration/security/test_umask.py
+++ b/tests/integration/security/test_umask.py
@@ -1,0 +1,27 @@
+import pytest
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-login-defs"])
+@pytest.mark.feature(
+    "not disaSTIGmedium", reason="disaSTIGmedium intentionally sets UMASK to 077"
+)
+def test_umask_file(parse_file: ParseFile):
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert config["UMASK"] == "027"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-login-defs"])
+@pytest.mark.feature(
+    "not disaSTIGmedium", reason="disaSTIGmedium intentionally sets UMASK to 077"
+)
+@pytest.mark.root
+def test_umask_cmd(shell: ShellRunner):
+    result = shell("su --login --command 'umask'", capture_output=True)
+    assert result.returncode == 0, f"Could not execute umask cmd: {result.stderr}"
+    assert result.stdout == "0027\n", "umask is not set to 0027"

--- a/tests/integration/security/test_wireguard.py
+++ b/tests/integration/security/test_wireguard.py
@@ -1,0 +1,16 @@
+import pytest
+from plugins.kernel_module import KernelModule
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_kernel_module_wireguard_available(kernel_module: KernelModule):
+    """Test that the wireguard kernel module is available as loadable module."""
+    kernel_modules = ["wireguard"]
+    for module in kernel_modules:
+        assert kernel_module.is_module_available(
+            module
+        ), f"{module} kernel module is not available."

--- a/tests/plugins/audit.py
+++ b/tests/plugins/audit.py
@@ -1,0 +1,179 @@
+import itertools
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+from plugins.dpkg import Dpkg
+
+logger = logging.getLogger(__name__)
+
+
+class AuditRule:
+    def __init__(self):
+        if not Dpkg().package_is_installed("auditd"):
+            raise RuntimeError("auditd is not installed")
+        try:
+            result = subprocess.run(
+                ["auditctl", "-l"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except FileNotFoundError:
+            raise RuntimeError("auditctl not found in PATH")
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"auditctl failed (exit {exc.returncode})\n"
+                f"stderr: {exc.stderr.strip()}"
+            )
+        self.rules = self._parse(result.stdout.splitlines())
+
+    def _parse(self, auditctl_lines):
+        return [self._parse_line(line) for line in auditctl_lines]
+
+    def _parse_line(self, auditctl_line):
+        """
+        Split a line looking like this
+
+        -a exit,always -S open,unlink,rmdir -S truncate -F dir=/etc -F success=0
+
+        into a dict like this
+
+        {'-a': ['exit', 'always'],
+         '-S': ['open', 'unlink', 'rmdir', 'truncate'],
+         '-F': ['dir=/etc', 'success=0']}
+        """
+        result = {}
+        for key, value in itertools.batched(auditctl_line.split(), 2):
+            result.setdefault(key, []).extend(value.split(","))
+        return result
+
+    def _extract_paths(self, auditd_rule):
+        """
+        Return a list of file paths referred by -F path= or -F dir= arguments in the auditd rule.
+        """
+        return [
+            field.split("=")[1]
+            for field in auditd_rule["-F"]
+            if "path=" in field or "dir=" in field
+        ]
+
+    def _filter_by_rule_fields(self, rules, rule_fields):
+        if not rule_fields:
+            return rules
+        return [
+            rule
+            for rule_field in rule_fields
+            for rule in rules
+            if "-F" in rule.keys()
+            if rule_field in rule["-F"]
+        ]
+
+    def file_path_audit_rule(self, fs_watch_path, access_types):
+        logger.debug(
+            f"File path audit rule for {fs_watch_path} with access {access_types}"
+        )
+        file_path_rules = [
+            rule
+            for rule in self.rules
+            if "-w" in rule.keys()
+            if Path(fs_watch_path).is_relative_to(rule["-w"][0])  # pyright: ignore
+            if set(access_types).issubset(rule["-p"][0])
+        ]
+        if file_path_rules:
+            logger.debug(f"Matched file path rules: {file_path_rules}")
+            return True
+
+        file_syscall_rules = [
+            rule
+            for rule in self.rules
+            if "-F" in rule
+            if "path=" in rule["-F"] or "dir=" in rule["-F"]
+        ]
+        matching_file_syscall_rules = [
+            rule
+            for rule in file_syscall_rules
+            for path in self._extract_paths(rule)
+            if Path(fs_watch_path).is_relative_to(path)  # pyright: ignore
+            if set(access_types).issubset(rule["-p"][0])
+        ]
+        if matching_file_syscall_rules:
+            logger.debug(f"Matched file syscall rules: {matching_file_syscall_rules}")
+            return True
+        return False
+
+    def syscall_audit_rule(self, syscall, rule_fields):
+        logger.debug(f"Syscall audit rule for {syscall}")
+        matched_rules = [
+            rule for rule in self.rules if "-S" in rule.keys() if syscall in rule["-S"]
+        ]
+
+        filtered_rules = self._filter_by_rule_fields(matched_rules, rule_fields)
+
+        if filtered_rules:
+            logger.debug(f"Matched syscall rules: {filtered_rules}")
+            return True
+        return False
+
+    def binary_call_audit_rule(self, binary_path, rule_fields):
+        logger.debug(f"Binary call audit rule for {binary_path} | {rule_fields=}")
+        matched_rules = [
+            rule
+            for rule in self.rules
+            if "-S" in rule.keys()
+            if "-F" in rule.keys()
+            if "execve" in rule["-S"]
+            if f"exe={binary_path}" in rule["-F"]
+        ]
+
+        filtered_rules = self._filter_by_rule_fields(matched_rules, rule_fields)
+
+        if filtered_rules:
+            logger.debug(f"Matched binary call rules: {filtered_rules}")
+            return True
+        return False
+
+    def __call__(
+        self,
+        syscall=None,
+        access_types=None,
+        fs_watch_path=None,
+        binary_call=None,
+        rule_fields=[],
+    ):
+        logger.debug("In AuditRule.__call__")
+        if fs_watch_path and access_types:
+            return self.file_path_audit_rule(fs_watch_path, access_types)
+        if syscall:
+            return self.syscall_audit_rule(syscall, rule_fields)
+        if binary_call:
+            return self.binary_call_audit_rule(binary_call, rule_fields)
+
+
+@pytest.fixture
+def audit_rule():
+    """
+    Returns an object that, when called, returns an audit rule lookup function.
+    Said object calls a file path audit rule lookup function
+    if fs_watch_path and access_type arguments are not empty
+    or a syscall audit rule lookup function if syscall argument is not empty.
+
+    For a file path audit rule the lookup is successful (function return True)
+    if and only if there is at least one auditd rule that covers the provided fs_watch_path
+    and access_types' values. Given that auditd file path rules are recursive, a lookup for /etc/passwd
+    will be successful if there's a rule for /etc with matching access_types.
+
+    For a syscall audit rule the lookup is successful
+    if there is at least one auditd rule that concerns the syscall parameter's value.
+
+    For an audit rule that tracks when a certain binary is executed the lookup is successful
+    if a rule with 'execve' syscall and the provided binary path (binary_call argument) is found.
+
+    Examples:
+
+    assert audit_rule(fs_watch_path="/etc/passwd", access_types="wa")
+    assert audit_rule(syscall="setcap", rule_fields=["auid>=1000", "auid!=-1"])
+    assert audit_rule(binary_call="/usr/bin/passwd")
+    """
+    return AuditRule()

--- a/tests/plugins/booted.py
+++ b/tests/plugins/booted.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import List
 
 import pytest
 
@@ -19,7 +19,7 @@ def pytest_addoption(parser: pytest.Parser):
 
 def pytest_configure(config: pytest.Config):
     global system_booted
-    system_booted = config.getoption("--system-booted")
+    system_booted = bool(config.getoption("--system-booted"))
 
     config.addinivalue_line(
         "markers",

--- a/tests/plugins/containerd.py
+++ b/tests/plugins/containerd.py
@@ -2,7 +2,6 @@ import pytest
 import validators
 
 from .shell import ShellRunner
-from .systemd import Systemd
 
 
 class CtrRunner:

--- a/tests/plugins/docstring.py
+++ b/tests/plugins/docstring.py
@@ -1,0 +1,17 @@
+import inspect
+from typing import List
+
+import pytest
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
+    for item in items:
+        module = getattr(item, "module", None)
+        func = getattr(item, "function", None)
+
+        module_doc = inspect.getdoc(module) if module is not None else None
+        func_doc = inspect.getdoc(func) if func is not None else None
+
+        parts = [d for d in (module_doc, func_doc) if d]
+        if parts:
+            item.user_properties.append(("docstring", "\n\n".join(parts)))

--- a/tests/plugins/dpkg.py
+++ b/tests/plugins/dpkg.py
@@ -1,11 +1,7 @@
-import json
-from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import List
 
 import pytest
 from debian import deb822
-
-from .shell import ShellRunner
 
 
 class InstalledPackages:

--- a/tests/plugins/dpkg_checksums.py
+++ b/tests/plugins/dpkg_checksums.py
@@ -1,0 +1,81 @@
+import hashlib
+import os
+import tempfile
+from shutil import chown
+
+import pytest
+
+
+class DpkgChecksums:
+    def __init__(self, shell):
+        """
+        This plugin can be used to compare recorded checksums of files in a deb
+        package to checksums of the actual files on disk in order to check if
+        package contents was tampered.
+
+        How to use:
+        -----------
+
+        1. pass the dpkg_checksums fixture to your unit test
+        def test_something(dpkg_checksums):
+
+        2. collect md5sums for a package you're interested in:
+        ideal_checksums = dpkg_checksums.for_package("somepackage")
+
+        3. ideal_checksums is a dict with file paths from the package as keys
+
+        4. you can compare a checksum from ideal_checksums to a checksum of a
+        file on a disk:
+        dpkg_checksums.is_matching_with_installed(ideal_checksums, "/path/to/file/from/the/package"
+        """
+        self._shell = shell
+
+    def for_package(self, package_name, package_version="INSTALLED") -> dict:
+        """
+        Returns a dict of filepath => md5sum (as recorded in a package's
+        md5sums control file).
+        As we cannot trust md5sums files stored in /var/lib/dpkg/info, we do
+        not use debsums and instead this code fetches md5sums control file from
+        a package in an apt repository.
+        """
+        if package_version == "INSTALLED":
+            package_version = self._shell(
+                f"dpkg-query -W -f='${{Version}}' {package_name}", capture_output=True
+            ).stdout
+
+        oldpwd = os.getcwd()
+
+        with tempfile.TemporaryDirectory(delete=False) as td:
+            uid, _ = self._shell.user
+            chown(td, uid)
+
+            os.chdir(td)
+
+            self._shell(f"apt-get download {package_name}={package_version}")
+            self._shell(f"dpkg-deb --control {package_name}*.deb")
+
+            checksums = {
+                f"/{path}": md5
+                for line in open("DEBIAN/md5sums")
+                for md5, path in [line.strip().split()]
+            }
+
+            os.chdir(oldpwd)
+
+        return checksums
+
+    def is_matching_with_installed(self, package_checksums, file_on_disk_path) -> bool:
+        """
+        Compares an md5 checksum of a file on disk with the one from package's
+        md5sums control file.
+
+        usedforsecurity=False is needed to run in a FIPS environment
+        """
+        with open(file_on_disk_path, "rb") as f:
+            real_checksum = hashlib.md5(f.read(), usedforsecurity=False).hexdigest()
+            return real_checksum == package_checksums[file_on_disk_path]
+
+
+@pytest.fixture
+def dpkg_checksums(shell, kernel_module):
+    return DpkgChecksums(shell)

--- a/tests/plugins/file.py
+++ b/tests/plugins/file.py
@@ -1,4 +1,5 @@
 import grp
+import hashlib
 import os
 import pwd
 import stat
@@ -329,8 +330,118 @@ class File:
         """
         return self.get_user(path) == user and self.get_group(path) == group
 
+    def has_permissions(self, path: str | Path, permissions: str | int) -> bool:
+        """Check if a file has the specified permission mode.
 
-@pytest.fixture
+        This helper retrieves the current permission bits of the given path
+        and compares them with the expected permissions. The expected value
+        may be provided either as an octal **string** representation (e.g., ``"0644"``
+        or ``644``) or as a symbolic string (e.g., ``"rw-r--r--"``).
+
+        Args:
+        path: File path.
+        permissions: Expected permissions as either:
+            - an octal integer (e.g., ``644``),
+            - an octal string (e.g., ``"0644"``),
+            - a symbolic string (e.g., ``"rw-r--r--"``).
+
+        Returns:
+        bool: ``True`` if the file's permissions match the expected
+        permission mode, otherwise ``False``.
+
+        Raises:
+        FileNotFoundError: If the path does not exist.
+        PermissionError: If permission to access the path is denied.
+        ValueError: If the permission specification is invalid.
+        """
+        actual_mode = stat.S_IMODE(Path(path).stat().st_mode)
+        expected_mode = self._normalize_permissions(permissions)
+        return actual_mode == expected_mode
+
+    def _normalize_permissions(self, permissions: str | int) -> int:
+        """Normalize a permission specification to a numeric mode.
+
+        Converts a permission representation into the integer mode used by
+        the operating system.
+
+        Supported formats include:
+        - integer permission modes (e.g., ``644``), which are returned unchanged,
+        - octal strings (e.g., ``"0644"``),
+        - symbolic POSIX permission strings (e.g., ``"rwxr-x---"``).
+
+        Args:
+            permissions: Permission representation to normalize.
+
+        Returns:
+            int: Numeric permission mode suitable for comparison with
+            values returned by ``stat.S_IMODE``.
+
+        Raises:
+            ValueError: If the provided permission format is invalid or
+            contains unsupported characters.
+        """
+        if isinstance(permissions, int):
+            return permissions
+
+        if not isinstance(permissions, str):
+            raise ValueError("Permissions must be int or string")
+
+        permissions = permissions.strip()
+
+        if permissions.isdigit():
+            return int(permissions, 8)
+
+        if len(permissions) != 9:
+            raise ValueError(
+                "Symbolic permissions must be 9 characters (e.g., 'rwxr-x---')"
+            )
+
+        perm_map = {"r": 4, "w": 2, "x": 1, "-": 0}
+
+        mode = 0
+        special = 0
+
+        for idx in range(3):
+            chunk = permissions[idx * 3 : (idx + 1) * 3]
+            value = 0
+
+            for pos, char in enumerate(chunk):
+                if char in perm_map:
+                    value += perm_map[char]
+
+                elif pos == 2:
+                    if idx == 0 and char in ("s", "S"):
+                        special |= stat.S_ISUID
+                        if char == "s":
+                            value += 1
+
+                    elif idx == 1 and char in ("s", "S"):
+                        special |= stat.S_ISGID
+                        if char == "s":
+                            value += 1
+
+                    elif idx == 2 and char in ("t", "T"):
+                        special |= stat.S_ISVTX
+                        if char == "t":
+                            value += 1
+
+                    else:
+                        raise ValueError(f"Invalid permission character: {char}")
+
+                else:
+                    raise ValueError(f"Invalid permission character: {char}")
+
+            mode = (mode << 3) | value
+
+        return special | mode
+
+    def checksum(self, file_path):
+        with open(file_path, "rb") as fd:
+            md5sum = hashlib.md5(fd.read(), usedforsecurity=False).hexdigest()
+        return md5sum
+
+
+@pytest.fixture(scope="session")
 def file() -> File:
     """Fixture providing the ``File`` helper for file metadata operations."""
     return File()

--- a/tests/plugins/find.py
+++ b/tests/plugins/find.py
@@ -1,5 +1,6 @@
+import fnmatch
 import os
-from typing import Iterator, Union
+from typing import Iterator, Optional, Union
 
 import pytest
 
@@ -20,10 +21,13 @@ class Find:
                 If a list is provided, all paths will be searched.
             entry_type (str):
                 Specifies the type of entries to search for (files, directories, or both).
+            pattern (str):
+                Specifies the pattern to search for. If None, all files and directories will be searched.
         """
         self.same_mnt_only: bool = False
         self.root_paths: Union[str, list[str]] = "/"
         self.entry_type: str = FIND_RESULT_TYPE_FILE
+        self.pattern: Optional[str] = None
 
     def __iter__(self) -> Iterator[str]:
         return iter(list(self._find()))
@@ -43,6 +47,9 @@ class Find:
                     FIND_RESULT_TYPE_FILE_AND_DIR,
                 ):
                     for dirname in dirnames:
+                        # Apply pattern matching if pattern is specified
+                        if self.pattern and not fnmatch.fnmatch(dirname, self.pattern):
+                            continue
                         full_path = os.path.join(dirpath, dirname)
                         if self.same_mnt_only:
                             try:
@@ -58,6 +65,9 @@ class Find:
                     FIND_RESULT_TYPE_FILE_AND_DIR,
                 ):
                     for filename in filenames:
+                        # Apply pattern matching if pattern is specified
+                        if self.pattern and not fnmatch.fnmatch(filename, self.pattern):
+                            continue
                         full_path = os.path.join(dirpath, filename)
                         if self.same_mnt_only:
                             try:

--- a/tests/plugins/initrd.py
+++ b/tests/plugins/initrd.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import subprocess
 import tempfile
 from typing import List, Optional
 
@@ -8,7 +9,6 @@ import pefile
 import pytest
 
 from .kernel_versions import KernelVersions
-from .shell import ShellRunner
 from .utils import get_cname_from_os_release
 
 logger = logging.getLogger(__name__)
@@ -17,16 +17,78 @@ logger = logging.getLogger(__name__)
 class Initrd:
     """Inspect initrd contents using lsinitrd (dracut)."""
 
-    def __init__(self, shell: ShellRunner, kernel_versions: KernelVersions):
-        self._shell = shell
+    @staticmethod
+    def _execute_lsinitrd(initrd_path: str) -> tuple[list[str], list[str]]:
+        """Execute lsinitrd and return parsed results."""
+        logger.info(f"Executing lsinitrd -v {initrd_path}")
+
+        result = subprocess.run(
+            ["lsinitrd", "-v", initrd_path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if result.returncode != 0:
+            logger.error(f"lsinitrd failed with exit code {result.returncode}")
+            if result.stderr:
+                logger.error(f"lsinitrd stderr: {result.stderr}")
+            raise RuntimeError(
+                f"lsinitrd failed for {initrd_path} with exit code {result.returncode}"
+            )
+
+        # Log raw output at DEBUG level for troubleshooting
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Raw lsinitrd output:\n{result.stdout}")
+
+        # Parse the output to extract both file contents and dracut modules
+        lines = result.stdout.split("\n")
+        contents = []
+        dracut_modules = []
+        in_dracut_modules_section = False
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Check if we're entering the dracut modules section
+            if line == "dracut modules:":
+                in_dracut_modules_section = True
+                continue
+
+            # Check if we're leaving the dracut modules section
+            if in_dracut_modules_section and (
+                line.startswith("====") or (line and line[0].isupper() and ":" in line)
+            ):
+                in_dracut_modules_section = False
+
+            if in_dracut_modules_section:
+                dracut_modules.append(line)
+            else:
+                contents.append(line)
+
+        logger.info(
+            f"lsinitrd output: {len(contents)} files and {len(dracut_modules)} dracut modules"
+        )
+
+        return (contents, dracut_modules)
+
+    def __init__(self, kernel_versions: KernelVersions):
         installed = kernel_versions.get_installed()
         if not installed:
             self._kernel_version = None
             self._contents: List[str] = []
+            self._dracut_modules: List[str] = []
             return
 
         self._kernel_version = installed[0].version
-        self._contents = self._load_initrd_contents(self._kernel_version)
+        self._contents, self._dracut_modules = self._load_initrd_contents(
+            self._kernel_version
+        )
+        # Lazy-built indexes for faster lookups on the default kernel version
+        self._file_index = None
+        self._dracut_module_set = None
 
     def _get_efi_path(self) -> Optional[str]:
         """Get the path to the EFI file based on CNAME from os-release.
@@ -145,7 +207,7 @@ class Initrd:
             )
             return None
 
-    def _load_initrd_contents(self, kernel_version: str) -> List[str]:
+    def _load_initrd_contents(self, kernel_version: str) -> tuple[List[str], List[str]]:
         """Load initrd contents for the given kernel version.
 
         Tries EFI file first (for trustedboot/USI flavors), then falls back to
@@ -155,7 +217,7 @@ class Initrd:
             kernel_version: Kernel version string.
 
         Returns:
-            List of file paths found in the initrd.
+            Tuple of (file contents list, dracut modules list).
 
         Raises:
             RuntimeError: If neither EFI initrd nor legacy initrd can be found.
@@ -184,29 +246,7 @@ class Initrd:
             )
 
         try:
-            logger.debug(f"Executing: lsinitrd {initrd_path}")
-            result = self._shell(
-                f"lsinitrd {initrd_path}",
-                capture_output=True,
-                ignore_exit_code=True,
-            )
-
-            if result.returncode == 0:
-                contents = [
-                    line.strip() for line in result.stdout.split("\n") if line.strip()
-                ]
-                logger.debug(f"lsinitrd output for {initrd_path}:\n{result.stdout}")
-                logger.info(f"Found {len(contents)} files in initrd {initrd_path}")
-                return contents
-
-            logger.warning(
-                f"lsinitrd failed for {initrd_path} with exit code {result.returncode}"
-            )
-            if result.stderr:
-                logger.warning(f"lsinitrd stderr: {result.stderr}")
-            raise RuntimeError(
-                f"lsinitrd failed for {initrd_path} with exit code {result.returncode}"
-            )
+            return Initrd._execute_lsinitrd(initrd_path)
         finally:
             # Clean up extracted temporary file
             if extracted_path and os.path.exists(extracted_path):
@@ -231,7 +271,24 @@ class Initrd:
             return self._contents
         else:
             # Load contents for a different kernel version
-            return self._load_initrd_contents(kernel_version)
+            contents, _ = self._load_initrd_contents(kernel_version)
+            return contents
+
+    def _get_dracut_modules(self, kernel_version: Optional[str] = None) -> List[str]:
+        """Get all dracut modules in the initrd.
+
+        Args:
+            kernel_version: Kernel version string. If None, uses the first installed kernel.
+
+        Returns:
+            List of dracut module names found in the initrd.
+        """
+        if kernel_version is None:
+            return self._dracut_modules
+        else:
+            # Load contents for a different kernel version
+            _, dracut_modules = self._load_initrd_contents(kernel_version)
+            return dracut_modules
 
     def contains_module(
         self, module_name: str, kernel_version: Optional[str] = None
@@ -263,6 +320,26 @@ class Initrd:
         )
         return any(pattern.search(entry) for entry in contents)
 
+    def contains_dracut_module(
+        self, module_name: str, kernel_version: Optional[str] = None
+    ) -> bool:
+        """Check if a dracut module is present in the initrd.
+
+        Args:
+            module_name: Name of the dracut module to check (e.g., "ignition", "gardenlinux-live").
+            kernel_version: Kernel version string. If None, uses the first installed kernel.
+
+        Returns:
+            True if the dracut module is found in the initrd.
+        """
+        if kernel_version is None:
+            if self._dracut_module_set is None:
+                self._dracut_module_set = set(self._get_dracut_modules())
+            return module_name in self._dracut_module_set
+        else:
+            dracut_modules = self._get_dracut_modules(kernel_version)
+            return module_name in dracut_modules
+
     def contains_file(
         self, file_path: str, kernel_version: Optional[str] = None
     ) -> bool:
@@ -276,11 +353,42 @@ class Initrd:
             True if the file is found in the initrd.
         """
         if kernel_version is None:
-            kernel_version = self._kernel_version
+            # Use an index for the default kernel version to speed up repeated lookups
+            if self._file_index is None:
+                self._file_index = set()
+                contents = self._get_contents()
+                # lsinitrd outputs in ls -l format, so entries may include metadata before the path
+                for entry in contents:
+                    parts = entry.split()
+                    if not parts:
+                        continue
+                    if "->" in entry:
+                        path_part = entry.split("->")[0].strip()
+                        actual_path = path_part.split()[-1]
+                    else:
+                        actual_path = parts[-1]
+                    self._file_index.add(actual_path)
+
+            if file_path in self._file_index:
+                return True
+            # Fallback: allow matching on trailing segment as before
+            return any(p.endswith("/" + file_path) for p in self._file_index)
+
+        # For non-default kernel versions, fall back to direct scan
         contents = self._get_contents(kernel_version)
-        return file_path in contents or any(
-            entry.endswith(file_path) for entry in contents
-        )
+        for entry in contents:
+            parts = entry.split()
+            if not parts:
+                continue
+            if file_path in entry:
+                if "->" in entry:
+                    path_part = entry.split("->")[0].strip()
+                    actual_path = path_part.split()[-1]
+                else:
+                    actual_path = parts[-1]
+                if actual_path == file_path or actual_path.endswith("/" + file_path):
+                    return True
+        return False
 
     def list_modules(self, kernel_version: Optional[str] = None) -> List[str]:
         """List all kernel modules present in the initrd.
@@ -311,7 +419,7 @@ class Initrd:
         return modules
 
 
-@pytest.fixture
-def initrd(shell: ShellRunner, kernel_versions: KernelVersions) -> Initrd:
+@pytest.fixture(scope="session")
+def initrd(kernel_versions: KernelVersions) -> Initrd:
     """Fixture providing access to initrd inspection functionality."""
-    return Initrd(shell, kernel_versions)
+    return Initrd(kernel_versions)

--- a/tests/plugins/kernel_versions.py
+++ b/tests/plugins/kernel_versions.py
@@ -49,7 +49,7 @@ class KernelVersions:
         )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def kernel_versions() -> KernelVersions:
     """Fixture providing access to installed and running kernel versions."""
     return KernelVersions()

--- a/tests/plugins/mount.py
+++ b/tests/plugins/mount.py
@@ -1,0 +1,31 @@
+from os.path import ismount
+
+import pytest
+
+
+class Mount:
+    def __init__(self, shell):
+        self._shell = shell
+        self._options = set()
+
+    def __call__(self, path):
+        if not ismount(path):
+            raise ValueError(f"{path} is not a filesystem mount")
+
+        self._path = path
+        return self
+
+    @property
+    def options(self):
+        if not self._options:
+            result = self._shell(
+                f"findmnt -n -o 'OPTIONS' {self._path}", capture_output=True
+            )
+            if result.stdout:
+                self._options = set(result.stdout.split(","))
+        return self._options
+
+
+@pytest.fixture
+def mount(shell):
+    return Mount(shell)

--- a/tests/plugins/parse.py
+++ b/tests/plugins/parse.py
@@ -98,12 +98,21 @@ class Lines:
     def _check_string_literal(self, pattern: str) -> bool:
         """Check if a string literal exists in lines (with comment filtering)."""
         comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+        # Normalize the pattern as well to match normalized lines
+        normalized_pattern = re.sub(r"\s+", " ", pattern)
+
+        # Check if pattern starts with a comment character - if so, don't strip comments
+        pattern_is_comment = any(
+            pattern.lstrip().startswith(char) for char in comment_chars
+        )
 
         for line in self.content.splitlines():
-            line = _strip_comments_from_line(line, comment_chars)
+            # Only strip comments if the pattern itself is not a comment
+            if not pattern_is_comment:
+                line = _strip_comments_from_line(line, comment_chars)
             line = line.rstrip()
-            normalized = re.sub(r"\s+", " ", line)
-            if normalized.find(pattern) != -1:
+            normalized_line = re.sub(r"\s+", " ", line)
+            if normalized_line.find(normalized_pattern) != -1:
                 return True
         return False
 
@@ -165,6 +174,54 @@ class Lines:
                 f"Expected str, re.Pattern, or list of str."
             )
 
+    def __eq__(self, other: object) -> bool:
+        """Check if Lines content matches a list of expected lines exactly.
+
+        Args:
+            other: List of expected lines to compare against.
+
+        Returns:
+            bool: True if all lines match in order, False otherwise.
+        """
+        if not isinstance(other, list):
+            return NotImplemented
+
+        comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+
+        # Get actual lines from content, stripping full-line comments but keeping inline comments
+        actual_lines = []
+        for line in self.content.splitlines():
+            line = line.rstrip()
+            if not line:  # Skip empty lines
+                continue
+            # Skip lines that are purely comments (start with comment char after whitespace)
+            stripped = line.lstrip()
+            if comment_chars and any(
+                stripped.startswith(char) for char in comment_chars
+            ):
+                continue
+            actual_lines.append(line)
+
+        return actual_lines == other
+
+    def __repr__(self) -> str:
+        """Return representation of Lines for debugging."""
+        comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+
+        actual_lines = []
+        for line in self.content.splitlines():
+            line = line.rstrip()
+            if not line:  # Skip empty lines
+                continue
+            # Skip lines that are purely comments
+            stripped = line.lstrip()
+            if comment_chars and any(
+                stripped.startswith(char) for char in comment_chars
+            ):
+                continue
+            actual_lines.append(line)
+        return repr(actual_lines)
+
 
 @dataclass
 class Parse:
@@ -208,12 +265,16 @@ class Parse:
         """
         return cls(content, label)
 
-    def _parse_keyval(self, content: str) -> Dict[str, str]:
-        cfg = configparser.ConfigParser(allow_no_value=True)
-        cfg.optionxform = lambda optionstr: optionstr
+    def _parse_keyval(
+        self, content: str, forbid_duplicates: bool = False
+    ) -> Dict[str, str]:
+        cfg = configparser.ConfigParser(allow_no_value=True, strict=forbid_duplicates)
+        cfg.optionxform = lambda optionstr: optionstr  # type: ignore[assignment]
         wrapped = "[default]\n" + content
         cfg.read_file(StringIO(wrapped))
-        return dict(cfg.items("default")) if "default" in cfg else {}
+        result = dict(cfg.items("default")) if "default" in cfg else {}
+        # Strip quotes from values (both single and double quotes)
+        return {k: v.strip('"').strip("'") if v else v for k, v in result.items()}
 
     def _parse_spacedelim(self, content: str) -> Dict[str, str]:
         result = {}
@@ -229,6 +290,7 @@ class Parse:
 
     def _parse_ini(self, content: str) -> Dict[str, Any]:
         cfg = configparser.ConfigParser()
+        cfg.optionxform = str  # type: ignore[method-assign] # Preserve case of option names
         cfg.read_file(StringIO(content))
         return {section: dict(cfg[section]) for section in cfg.sections()}
 
@@ -255,11 +317,13 @@ class Parse:
             )
         return tomllib.loads(content)
 
-    def _parse_content(self, format: str, ignore_comments: bool = True) -> Any:
+    def _parse_content(
+        self, format: str, ignore_comments: bool = True, forbid_duplicates: bool = True
+    ) -> Any:
         fmt = format.lower()
         match fmt:
             case "keyval":
-                return self._parse_keyval(self.content)
+                return self._parse_keyval(self.content, forbid_duplicates)
             case "spacedelim":
                 return self._parse_spacedelim(self.content)
             case "ini":
@@ -276,13 +340,16 @@ class Parse:
                     f"Supported formats: {', '.join(SUPPORTED_FORMATS)}."
                 )
 
-    def parse(self, format: str, ignore_comments: bool = True) -> Any:
+    def parse(
+        self, format: str, ignore_comments: bool = True, forbid_duplicates: bool = True
+    ) -> Any:
         """Parse content and return data structure based on format.
 
 
         Args:
             format: One of the supported format identifiers (json, yaml, toml, ini, keyval).
             ignore_comments: (optional, default=True) If True, strip comments where applicable.
+            forbid_duplicates: If False, won't raise an exception if duplicate key (where applicable) is found.
 
         Returns:
             Parsed data structure (dict, list, etc.) based on format.
@@ -294,7 +361,7 @@ class Parse:
             >>> assert config["database"]["port"] == 5432
             >>> assert "missing" not in config["database"]
         """
-        return self._parse_content(format, ignore_comments)
+        return self._parse_content(format, ignore_comments, forbid_duplicates)
 
     def lines(
         self,

--- a/tests/plugins/parse_file.py
+++ b/tests/plugins/parse_file.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union, overload
+from typing import Any, List, Literal, Optional, Union, overload
 
 import pytest
 
@@ -155,7 +155,7 @@ class ParseFile:
         parser = self._get_parser(
             path,
             ignore_missing,
-            error_context=f"Cannot parse file.",
+            error_context="Cannot parse file.",
         )
         if parser is None:
             return None
@@ -229,7 +229,7 @@ class ParseFile:
         parser = self._get_parser(
             path,
             ignore_missing,
-            error_context=f"Cannot get lines container.",
+            error_context="Cannot get lines container.",
         )
         if parser is None:
             return None
@@ -244,7 +244,7 @@ class ParseFile:
         )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def parse_file() -> ParseFile:
     """Fixture providing the ``ParseFile`` helper for checking file contents."""
     return ParseFile()

--- a/tests/plugins/setting_ids.py
+++ b/tests/plugins/setting_ids.py
@@ -1,0 +1,13 @@
+"""
+Plugin to register custom pytest marker for Garden Linux setting IDs.
+"""
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config):
+    """Register custom marker for Garden Linux setting IDs."""
+    config.addinivalue_line(
+        "markers",
+        "testcov(ids): Mark tests with Garden Linux setting IDs for traceability",
+    )

--- a/tests/plugins/setuid_binaries.py
+++ b/tests/plugins/setuid_binaries.py
@@ -1,0 +1,29 @@
+import os
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def exposed_setuid_binaries():
+    """
+    Returns a set of pathnames of root-owned binaries with setuid bit which are
+    also "others"-executable (i.e. binaries that give root privileges to every
+    user).
+    """
+    dirs = [
+        "/usr/sbin",
+        "/usr/bin",
+        "/usr/libexec",
+        "/usr/local/sbin",
+        "/usr/local/bin",
+    ]
+    return {
+        str(p)
+        for d in dirs
+        for root, _, files in os.walk(d)
+        for p in map(lambda n: pathlib.Path(root) / n, files)
+        if p.stat().st_uid == 0  # file belongs to root
+        and (m := p.stat().st_mode) & 0o4000  # set‑uid bit present
+        and ((m >> 3) & 0o111)  # “others” execute bit set
+    }

--- a/tests/plugins/sysdiff.py
+++ b/tests/plugins/sysdiff.py
@@ -11,10 +11,13 @@ Provides snapshot and comparison capabilities for:
 
 import difflib
 import gzip
+import hashlib
 import json
+import logging
 import os
 import re
 import shutil
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from fnmatch import fnmatch
@@ -31,6 +34,8 @@ from .kernel_versions import KernelVersions
 from .shell import ShellRunner
 from .sysctl import Sysctl, SysctlParam
 from .systemd import Systemd, SystemdUnit
+
+logger = logging.getLogger(__name__)
 
 STATE_DIR = "/tmp/sysdiff"
 
@@ -64,7 +69,23 @@ IGNORED_SYSTEMD_PATTERNS = [
     "user-runtime-dir@*.service",
     "user@*.service",
     "user-*.slice",
+    # runs periodically
+    "gce-workload-cert-refresh.service",
+    "gce-workload-cert-refresh.timer",
+    # _trustedboot: pcrlogin activates dynamically during boot/test session
+    "systemd-pcrlogin@*.service",
+    "system-systemd*pcrlogin.slice",
 ]
+
+# Units to wait for before taking a snapshot (unit_name: expected_sub_state)
+# This prevents race conditions where socket-activated services are still settling
+WAIT_FOR_SETTLED_UNITS = {
+    "libvirtd.socket": "listening",
+    "libvirtd-ro.socket": "listening",
+    "libvirtd-tcp.socket": "listening",
+    "libvirtd-admin.socket": "listening",
+}
+
 IGNORED_KERNEL_MODULES = []
 IGNORED_SYSCTL_PARAMS = {
     # File system dynamic parameters
@@ -172,7 +193,7 @@ class FileCollector:
                         existing_paths.append(path)
                         seen.add(path)
                 except Exception as e:
-                    print(f"Error normalizing paths: {e}")
+                    logger.error(f"Error normalizing paths: {e}")
 
         return existing_paths
 
@@ -189,7 +210,7 @@ class FileCollector:
                     if line and not line.startswith("#"):
                         patterns.append(line)
         except Exception as e:
-            print(f"Error loading ignore patterns from {ignore_file}: {e}")
+            logger.error(f"Error loading ignore patterns from {ignore_file}: {e}")
 
         return patterns
 
@@ -217,7 +238,7 @@ class FileCollector:
         try:
             root_dev = os.stat(root).st_dev
         except (OSError, IOError) as e:
-            print(f"Warning: Cannot access {root}: {e}")
+            logger.warning(f"Warning: Cannot access {root}: {e}")
             return
 
         for dirpath, dirnames, filenames in os.walk(
@@ -241,13 +262,12 @@ class FileCollector:
         self, filepath: str, verbose: bool = False
     ) -> Optional[str]:
         """Calculate SHA256 hash for a single file"""
-        import hashlib
 
         # Check if file exists before trying to read it
         try:
             if not os.path.exists(filepath):
                 if verbose:
-                    print(f"Warning: File not found: {filepath}")
+                    logger.warning(f"Warning: File not found: {filepath}")
                 return None
         except (OSError, IOError):
             # If we can't even check existence, skip silently
@@ -266,11 +286,11 @@ class FileCollector:
         except FileNotFoundError:
             # This shouldn't happen after the exists check, but handle it gracefully
             if verbose:
-                print(f"Warning: File disappeared: {filepath}")
+                logger.warning(f"Warning: File disappeared: {filepath}")
             return None
         except (OSError, IOError, PermissionError) as e:
             # Less common errors - always warn
-            print(f"Warning: Cannot read {filepath}: {e}")
+            logger.warning(f"Warning: Cannot read {filepath}: {e}")
             return None
 
     def collect_file_hashes(
@@ -290,7 +310,6 @@ class FileCollector:
         Returns:
             Dictionary mapping file paths to their SHA256 hashes
         """
-        import hashlib
 
         if ignore_patterns is None:
             ignore_patterns = []
@@ -307,7 +326,7 @@ class FileCollector:
                     files_in_path = list(self._walk_files_recursive(path))
                     all_files.extend(files_in_path)
                 except Exception as e:
-                    print(f"Warning: Error scanning {path}: {e}")
+                    logger.warning(f"Warning: Error scanning {path}: {e}")
                     continue
 
             filtered_files = [
@@ -322,7 +341,7 @@ class FileCollector:
                     file_hashes[filepath] = hash_value
 
         except Exception as e:
-            print(f"Error collecting file hashes: {e}")
+            logger.error(f"Error collecting file hashes: {e}")
 
         return file_hashes
 
@@ -333,6 +352,58 @@ class SnapshotManager:
     def __init__(self, state_dir: Path | None = None):
         self.state_dir = state_dir or Path(STATE_DIR)
         self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def _wait_for_units_settled(
+        self,
+        systemd: Systemd,
+        max_wait_seconds: int = 120,
+        poll_interval: float = 0.5,
+    ) -> None:
+        """
+        Wait for configured units to reach their expected sub-states.
+
+        This prevents race conditions when taking snapshots while socket-activated
+        services like libvirtd are still settling into their stable state.
+
+        Args:
+            systemd: Systemd instance for checking unit states
+            max_wait_seconds: Maximum time to wait for units to settle
+            poll_interval: Time between polls in seconds
+        """
+        if not WAIT_FOR_SETTLED_UNITS:
+            return
+
+        start_time = time.time()
+        units_to_check = set(WAIT_FOR_SETTLED_UNITS.keys())
+
+        while units_to_check and (time.time() - start_time) < max_wait_seconds:
+            current_units = systemd.list_units()
+            unit_states = {unit.unit: unit.sub for unit in current_units}
+
+            settled_units = set()
+            for unit_name in units_to_check:
+                expected_sub = WAIT_FOR_SETTLED_UNITS[unit_name]
+                current_sub = unit_states.get(unit_name)
+
+                logger.debug(
+                    f"Debug: Unit {unit_name} current state: {current_sub}, expected: {expected_sub}"
+                )
+
+                if current_sub == expected_sub:
+                    settled_units.add(unit_name)
+
+            units_to_check -= settled_units
+
+            if units_to_check:
+                time.sleep(poll_interval)
+
+        # Log if any units didn't settle (but don't fail the snapshot)
+        if units_to_check:
+            elapsed = time.time() - start_time
+            logger.warning(
+                f"Warning: Units did not settle within {max_wait_seconds}s (elapsed: {elapsed:.1f}s): "
+                f"{', '.join(units_to_check)}"
+            )
 
     def create_snapshot(
         self,
@@ -372,8 +443,14 @@ class SnapshotManager:
         sysctl_collector = Sysctl(shell)
         kernel_versions = KernelVersions()
         kernel_module = KernelModule(Find(), shell, kernel_versions)
-
         packages = dpkg.collect_installed_packages().packages
+
+        # Make sure no systemd services and sockets are still transitioning
+        systemd_wait = systemd.wait_is_system_running()
+        logger.debug(
+            f"Systemd settle returned state {systemd_wait.state} and took {systemd_wait.elapsed_time:.1f}s to complete"
+        )
+        self._wait_for_units_settled(systemd)
 
         systemd_units = systemd.list_units()
 

--- a/tests/plugins/systemd.py
+++ b/tests/plugins/systemd.py
@@ -2,12 +2,12 @@ import json
 import re
 import time
 from dataclasses import dataclass
-from os import system
 from typing import Tuple
 
 import pytest
 
 from .modify import allow_system_modifications
+from .parse import Parse
 from .shell import ShellRunner
 
 
@@ -143,6 +143,81 @@ class Systemd:
 
         return active
 
+    def is_inactive(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-active {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        inactive = result.stdout.strip() == "inactive"
+        if not inactive:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return inactive
+
+    def is_enabled(self, unit_name: str) -> bool:
+        """Check if a system-level systemd unit is enabled.
+
+        Note: This also returns True for 'static' units (units without [Install] section
+        that are enabled by default or pulled in by other units).
+        """
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        state = result.stdout.strip()
+        enabled = state in ("enabled", "static")
+        if not enabled:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return enabled
+
+    def is_disabled(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        disabled = result.stdout.strip() == "disabled"
+        if not disabled:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return disabled
+
+    def is_masked(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        state = result.stdout.strip()
+        masked = state in ("masked")
+        if not masked:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return masked
+
     def start_unit(self, unit_name: str):
         if not allow_system_modifications():
             pytest.skip(
@@ -192,6 +267,19 @@ class Systemd:
         )
         elapsed = time.time() - start_time
         return SystemRunningState(result.stdout.strip(), result.returncode, elapsed)
+
+    def get_unit_properties(self, service_name) -> dict:
+        result = self._shell(
+            cmd=f"systemctl show {service_name}.service",
+            capture_output=True,
+        )
+        return Parse.from_str(result.stdout).parse("keyval", forbid_duplicates=False)
+
+    def get_config(self, config_path) -> dict:
+        result = self._shell(
+            f"systemd-analyze cat-config {config_path}", capture_output=True
+        )
+        return Parse.from_str(result.stdout).parse("keyval", forbid_duplicates=False)
 
 
 @pytest.fixture

--- a/tests/plugins/tests/test_file.py
+++ b/tests/plugins/tests/test_file.py
@@ -3,7 +3,6 @@
 import grp
 import os
 import pwd
-import stat
 from pathlib import Path
 
 import pytest

--- a/tests/plugins/utils.py
+++ b/tests/plugins/utils.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
-from typing import Dict, List, Optional, TypeVar
+import os
+from typing import List, Optional, TypeVar
 
 # Various utility functions to make tests more readable
 # This should not contain test-assertions, but only abstract details that make tests harder to read
@@ -21,12 +21,24 @@ def is_set(obj) -> bool:
     return isinstance(obj, set)
 
 
+def tree(path: str) -> set[str]:
+    """Returns all subpaths of `path`, like the find command"""
+    tree = {path}
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            tree.add(f"{root}/{file}")
+        for dir in dirs:
+            tree.add(f"{root}/{dir}")
+
+    return tree
+
+
 T = TypeVar("T")
 
 
 def check_for_duplicates(entries: List[T]) -> List[T]:
     """
-    checks for duplicates, to change equality comparision, add a compare field to the dataclass.
+    checks for duplicates, to change equality comparison, add a compare field to the dataclass.
     """
     duplicates = list[T]()
     visited_entries = list[T]()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+disa_stig_version = General Purpose Operating System STIG V3R2

--- a/tests/util/sysdiff.py
+++ b/tests/util/sysdiff.py
@@ -26,15 +26,14 @@ podman run -it --rm \
 """
 
 import argparse
-import os
 import sys
 from pathlib import Path
 
 # Add tests to Python path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from plugins.shell import ShellRunner
-from plugins.sysdiff import Sysdiff
+from plugins.shell import ShellRunner  # noqa: E402
+from plugins.sysdiff import Sysdiff  # noqa: E402
 
 
 def list_snapshots(sysdiff: Sysdiff, verbose: bool = False):
@@ -69,7 +68,7 @@ def diff_snapshots(
 ):
     """Compare two snapshots and show differences"""
     try:
-        print(f"Comparing snapshots:")
+        print("Comparing snapshots:")
         print(f"  snapshot_a: {snapshot1_name}")
         print(f"  snapshot_b: {snapshot2_name}")
         print()
@@ -204,7 +203,7 @@ Examples:
             )
 
             print(f"✓ Snapshot created successfully: {snapshot.name}")
-            print(f"  Location: {sysdiff.manager.state_dir / snapshot.name}.json.gz")
+            print(f"  Location: {sysdiff.manager.state_dir}/{snapshot.name}.json.gz")
             print(f"  Packages: {len(snapshot.packages)}")
             print(f"  Files: {len(snapshot.files)}")
             print(f"  Sysctl params: {len(snapshot.sysctl_params)}")
@@ -212,7 +211,7 @@ Examples:
             print(f"  Systemd units: {len(snapshot.systemd_units)}")
 
             if args.verbose:
-                print(f"\nDetailed information:")
+                print("\nDetailed information:")
                 print(f"  Created at: {snapshot.metadata.created_at}")
                 print(f"  Paths scanned: {snapshot.metadata.paths}")
                 print(f"  Ignore file used: {snapshot.metadata.ignore_file}")


### PR DESCRIPTION
## Summary

- Backports `tests/integration/security/compliance/test_disastig_NNNNN.py` (114 files) from `main` to `rel-2150`
- Backports the full `tests/integration/` directory tree (171 Python files) to align `rel-2150` with `main`'s test structure
- Backports new plugins: `audit`, `docstring`, `dpkg_checksums`, `mount`, `setting_ids`, `setuid_binaries`
- Backports new handlers: `audit_user`, `pip`
- Updates existing plugins: `file`, `parse`, `parse_file`, `systemd`
- Adds `pytest.ini` with `disa_stig_version` configuration

## Problem

The stable `2150.x.0` test containers (built from `rel-2150`) produced **0 STIG rules executed** when the diki compliance scanner ran against them. The root cause: `test_disastig_*.py` files only existed on `main` (nightly `2324.x.x` builds) and were never backported to `rel-2150`.

The diki team needs to use `ghcr.io/gardenlinux/test:rel-2150-latest` (stable, reviewed images) rather than the nightly `2324.x.x` container to avoid unreviewed CVE noise. Without this backport, those stable containers cannot run any STIG compliance checks.


## Split PR series (cross-reference)

This monolithic PR has been split into 5 focused PRs for easier review:

| PR | Scope | Files |
|----|-------|-------|
| #5296 | 1/5 — Plugins + handlers + config | 24 — **merge first** |
| #5297 | 2/5 — Boot + kernel + infrastructure tests | 15 |
| #5298 | 3/5 — Core + runtime tests | 26 |
| #5299 | 4/5 — Security tests (non-compliance) | 12 |
| #5300 | 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests | 118 ← primary goal |

> Prefer merging the split PRs. This PR (#5290) can be closed once all 5 are merged.