### PR TITLE
backport: plugins, handlers and test config to rel-2150 (1/5)

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+    "typeCheckingMode": "basic",
+    "reportUnusedImport": "error",
+    "exclude": [
+        "tests/test_*.py"
+    ]
+}

--- a/tests/handlers/audit_user.py
+++ b/tests/handlers/audit_user.py
@@ -1,0 +1,16 @@
+import pytest
+from plugins.shell import ShellRunner
+
+TEST_USER = "audit_test_user"
+
+
+@pytest.fixture
+def audit_user(shell: ShellRunner):
+    shell(f"id {TEST_USER} || useradd -m -s /bin/sh {TEST_USER}")
+    yield TEST_USER
+    shell(f"pkill -9 -u {TEST_USER}", ignore_exit_code=True)
+    shell("sleep 1")
+    shell(f"userdel -r {TEST_USER}", ignore_exit_code=True)
+    shell(
+        "rm -f /etc/group- /etc/gshadow- /etc/passwd- /etc/shadow- /etc/subgid- /etc/subuid-"
+    )

--- a/tests/handlers/pip.py
+++ b/tests/handlers/pip.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+
+import pytest
+from plugins.shell import ShellRunner
+
+
+@pytest.fixture
+def pip_requests(shell: ShellRunner):
+    out = shell(
+        '/bin/python3 -c "import site; print(site.getsitepackages()[0])"',
+        capture_output=True,
+    )
+    package_dir = out.stdout.strip("\n")
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_before_install")
+
+    restore_backup = False
+    if os.path.isdir(package_dir):
+        restore_backup = True
+        shutil.move(package_dir, package_dir + ".backup")
+
+    os.mkdir(package_dir)
+
+    shell(
+        "/bin/pip3 install --break-system-packages --no-cache-dir --root-user-action=ignore requests"
+    )
+    shell("/bin/pip3 freeze >> /tmp/pip_freeze_after_install")
+
+    yield package_dir
+
+    shell(
+        "for dep in $(cat /tmp/pip_freeze_after_install); do grep -q $dep /tmp/pip_freeze_before_install || /bin/pip3 uninstall -y --break-system-packages $dep; done"
+    )
+    shell("rm /tmp/pip_freeze_before_install /tmp/pip_freeze_after_install")
+    shutil.rmtree(package_dir)
+    if restore_backup:
+        shutil.move(package_dir + ".backup", package_dir)

--- a/tests/plugins/audit.py
+++ b/tests/plugins/audit.py
@@ -1,0 +1,179 @@
+import itertools
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+from plugins.dpkg import Dpkg
+
+logger = logging.getLogger(__name__)
+
+
+class AuditRule:
+    def __init__(self):
+        if not Dpkg().package_is_installed("auditd"):
+            raise RuntimeError("auditd is not installed")
+        try:
+            result = subprocess.run(
+                ["auditctl", "-l"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except FileNotFoundError:
+            raise RuntimeError("auditctl not found in PATH")
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"auditctl failed (exit {exc.returncode})\n"
+                f"stderr: {exc.stderr.strip()}"
+            )
+        self.rules = self._parse(result.stdout.splitlines())
+
+    def _parse(self, auditctl_lines):
+        return [self._parse_line(line) for line in auditctl_lines]
+
+    def _parse_line(self, auditctl_line):
+        """
+        Split a line looking like this
+
+        -a exit,always -S open,unlink,rmdir -S truncate -F dir=/etc -F success=0
+
+        into a dict like this
+
+        {'-a': ['exit', 'always'],
+         '-S': ['open', 'unlink', 'rmdir', 'truncate'],
+         '-F': ['dir=/etc', 'success=0']}
+        """
+        result = {}
+        for key, value in itertools.batched(auditctl_line.split(), 2):
+            result.setdefault(key, []).extend(value.split(","))
+        return result
+
+    def _extract_paths(self, auditd_rule):
+        """
+        Return a list of file paths referred by -F path= or -F dir= arguments in the auditd rule.
+        """
+        return [
+            field.split("=")[1]
+            for field in auditd_rule["-F"]
+            if "path=" in field or "dir=" in field
+        ]
+
+    def _filter_by_rule_fields(self, rules, rule_fields):
+        if not rule_fields:
+            return rules
+        return [
+            rule
+            for rule_field in rule_fields
+            for rule in rules
+            if "-F" in rule.keys()
+            if rule_field in rule["-F"]
+        ]
+
+    def file_path_audit_rule(self, fs_watch_path, access_types):
+        logger.debug(
+            f"File path audit rule for {fs_watch_path} with access {access_types}"
+        )
+        file_path_rules = [
+            rule
+            for rule in self.rules
+            if "-w" in rule.keys()
+            if Path(fs_watch_path).is_relative_to(rule["-w"][0])  # pyright: ignore
+            if set(access_types).issubset(rule["-p"][0])
+        ]
+        if file_path_rules:
+            logger.debug(f"Matched file path rules: {file_path_rules}")
+            return True
+
+        file_syscall_rules = [
+            rule
+            for rule in self.rules
+            if "-F" in rule
+            if "path=" in rule["-F"] or "dir=" in rule["-F"]
+        ]
+        matching_file_syscall_rules = [
+            rule
+            for rule in file_syscall_rules
+            for path in self._extract_paths(rule)
+            if Path(fs_watch_path).is_relative_to(path)  # pyright: ignore
+            if set(access_types).issubset(rule["-p"][0])
+        ]
+        if matching_file_syscall_rules:
+            logger.debug(f"Matched file syscall rules: {matching_file_syscall_rules}")
+            return True
+        return False
+
+    def syscall_audit_rule(self, syscall, rule_fields):
+        logger.debug(f"Syscall audit rule for {syscall}")
+        matched_rules = [
+            rule for rule in self.rules if "-S" in rule.keys() if syscall in rule["-S"]
+        ]
+
+        filtered_rules = self._filter_by_rule_fields(matched_rules, rule_fields)
+
+        if filtered_rules:
+            logger.debug(f"Matched syscall rules: {filtered_rules}")
+            return True
+        return False
+
+    def binary_call_audit_rule(self, binary_path, rule_fields):
+        logger.debug(f"Binary call audit rule for {binary_path} | {rule_fields=}")
+        matched_rules = [
+            rule
+            for rule in self.rules
+            if "-S" in rule.keys()
+            if "-F" in rule.keys()
+            if "execve" in rule["-S"]
+            if f"exe={binary_path}" in rule["-F"]
+        ]
+
+        filtered_rules = self._filter_by_rule_fields(matched_rules, rule_fields)
+
+        if filtered_rules:
+            logger.debug(f"Matched binary call rules: {filtered_rules}")
+            return True
+        return False
+
+    def __call__(
+        self,
+        syscall=None,
+        access_types=None,
+        fs_watch_path=None,
+        binary_call=None,
+        rule_fields=[],
+    ):
+        logger.debug("In AuditRule.__call__")
+        if fs_watch_path and access_types:
+            return self.file_path_audit_rule(fs_watch_path, access_types)
+        if syscall:
+            return self.syscall_audit_rule(syscall, rule_fields)
+        if binary_call:
+            return self.binary_call_audit_rule(binary_call, rule_fields)
+
+
+@pytest.fixture
+def audit_rule():
+    """
+    Returns an object that, when called, returns an audit rule lookup function.
+    Said object calls a file path audit rule lookup function
+    if fs_watch_path and access_type arguments are not empty
+    or a syscall audit rule lookup function if syscall argument is not empty.
+
+    For a file path audit rule the lookup is successful (function return True)
+    if and only if there is at least one auditd rule that covers the provided fs_watch_path
+    and access_types' values. Given that auditd file path rules are recursive, a lookup for /etc/passwd
+    will be successful if there's a rule for /etc with matching access_types.
+
+    For a syscall audit rule the lookup is successful
+    if there is at least one auditd rule that concerns the syscall parameter's value.
+
+    For an audit rule that tracks when a certain binary is executed the lookup is successful
+    if a rule with 'execve' syscall and the provided binary path (binary_call argument) is found.
+
+    Examples:
+
+    assert audit_rule(fs_watch_path="/etc/passwd", access_types="wa")
+    assert audit_rule(syscall="setcap", rule_fields=["auid>=1000", "auid!=-1"])
+    assert audit_rule(binary_call="/usr/bin/passwd")
+    """
+    return AuditRule()

--- a/tests/plugins/booted.py
+++ b/tests/plugins/booted.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import List
 
 import pytest
 
@@ -19,7 +19,7 @@ def pytest_addoption(parser: pytest.Parser):
 
 def pytest_configure(config: pytest.Config):
     global system_booted
-    system_booted = config.getoption("--system-booted")
+    system_booted = bool(config.getoption("--system-booted"))
 
     config.addinivalue_line(
         "markers",

--- a/tests/plugins/containerd.py
+++ b/tests/plugins/containerd.py
@@ -2,7 +2,6 @@ import pytest
 import validators
 
 from .shell import ShellRunner
-from .systemd import Systemd
 
 
 class CtrRunner:

--- a/tests/plugins/docstring.py
+++ b/tests/plugins/docstring.py
@@ -1,0 +1,17 @@
+import inspect
+from typing import List
+
+import pytest
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]):
+    for item in items:
+        module = getattr(item, "module", None)
+        func = getattr(item, "function", None)
+
+        module_doc = inspect.getdoc(module) if module is not None else None
+        func_doc = inspect.getdoc(func) if func is not None else None
+
+        parts = [d for d in (module_doc, func_doc) if d]
+        if parts:
+            item.user_properties.append(("docstring", "\n\n".join(parts)))

--- a/tests/plugins/dpkg.py
+++ b/tests/plugins/dpkg.py
@@ -1,11 +1,7 @@
-import json
-from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import List
 
 import pytest
 from debian import deb822
-
-from .shell import ShellRunner
 
 
 class InstalledPackages:

--- a/tests/plugins/dpkg_checksums.py
+++ b/tests/plugins/dpkg_checksums.py
@@ -1,0 +1,81 @@
+import hashlib
+import os
+import tempfile
+from shutil import chown
+
+import pytest
+
+
+class DpkgChecksums:
+    def __init__(self, shell):
+        """
+        This plugin can be used to compare recorded checksums of files in a deb
+        package to checksums of the actual files on disk in order to check if
+        package contents was tampered.
+
+        How to use:
+        -----------
+
+        1. pass the dpkg_checksums fixture to your unit test
+        def test_something(dpkg_checksums):
+
+        2. collect md5sums for a package you're interested in:
+        ideal_checksums = dpkg_checksums.for_package("somepackage")
+
+        3. ideal_checksums is a dict with file paths from the package as keys
+
+        4. you can compare a checksum from ideal_checksums to a checksum of a
+        file on a disk:
+        dpkg_checksums.is_matching_with_installed(ideal_checksums, "/path/to/file/from/the/package"
+        """
+        self._shell = shell
+
+    def for_package(self, package_name, package_version="INSTALLED") -> dict:
+        """
+        Returns a dict of filepath => md5sum (as recorded in a package's
+        md5sums control file).
+        As we cannot trust md5sums files stored in /var/lib/dpkg/info, we do
+        not use debsums and instead this code fetches md5sums control file from
+        a package in an apt repository.
+        """
+        if package_version == "INSTALLED":
+            package_version = self._shell(
+                f"dpkg-query -W -f='${{Version}}' {package_name}", capture_output=True
+            ).stdout
+
+        oldpwd = os.getcwd()
+
+        with tempfile.TemporaryDirectory(delete=False) as td:
+            uid, _ = self._shell.user
+            chown(td, uid)
+
+            os.chdir(td)
+
+            self._shell(f"apt-get download {package_name}={package_version}")
+            self._shell(f"dpkg-deb --control {package_name}*.deb")
+
+            checksums = {
+                f"/{path}": md5
+                for line in open("DEBIAN/md5sums")
+                for md5, path in [line.strip().split()]
+            }
+
+            os.chdir(oldpwd)
+
+        return checksums
+
+    def is_matching_with_installed(self, package_checksums, file_on_disk_path) -> bool:
+        """
+        Compares an md5 checksum of a file on disk with the one from package's
+        md5sums control file.
+
+        usedforsecurity=False is needed to run in a FIPS environment
+        """
+        with open(file_on_disk_path, "rb") as f:
+            real_checksum = hashlib.md5(f.read(), usedforsecurity=False).hexdigest()
+            return real_checksum == package_checksums[file_on_disk_path]
+
+
+@pytest.fixture
+def dpkg_checksums(shell, kernel_module):
+    return DpkgChecksums(shell)

--- a/tests/plugins/file.py
+++ b/tests/plugins/file.py
@@ -1,4 +1,5 @@
 import grp
+import hashlib
 import os
 import pwd
 import stat
@@ -329,8 +330,118 @@ class File:
         """
         return self.get_user(path) == user and self.get_group(path) == group
 
+    def has_permissions(self, path: str | Path, permissions: str | int) -> bool:
+        """Check if a file has the specified permission mode.
 
-@pytest.fixture
+        This helper retrieves the current permission bits of the given path
+        and compares them with the expected permissions. The expected value
+        may be provided either as an octal **string** representation (e.g., ``"0644"``
+        or ``644``) or as a symbolic string (e.g., ``"rw-r--r--"``).
+
+        Args:
+        path: File path.
+        permissions: Expected permissions as either:
+            - an octal integer (e.g., ``644``),
+            - an octal string (e.g., ``"0644"``),
+            - a symbolic string (e.g., ``"rw-r--r--"``).
+
+        Returns:
+        bool: ``True`` if the file's permissions match the expected
+        permission mode, otherwise ``False``.
+
+        Raises:
+        FileNotFoundError: If the path does not exist.
+        PermissionError: If permission to access the path is denied.
+        ValueError: If the permission specification is invalid.
+        """
+        actual_mode = stat.S_IMODE(Path(path).stat().st_mode)
+        expected_mode = self._normalize_permissions(permissions)
+        return actual_mode == expected_mode
+
+    def _normalize_permissions(self, permissions: str | int) -> int:
+        """Normalize a permission specification to a numeric mode.
+
+        Converts a permission representation into the integer mode used by
+        the operating system.
+
+        Supported formats include:
+        - integer permission modes (e.g., ``644``), which are returned unchanged,
+        - octal strings (e.g., ``"0644"``),
+        - symbolic POSIX permission strings (e.g., ``"rwxr-x---"``).
+
+        Args:
+            permissions: Permission representation to normalize.
+
+        Returns:
+            int: Numeric permission mode suitable for comparison with
+            values returned by ``stat.S_IMODE``.
+
+        Raises:
+            ValueError: If the provided permission format is invalid or
+            contains unsupported characters.
+        """
+        if isinstance(permissions, int):
+            return permissions
+
+        if not isinstance(permissions, str):
+            raise ValueError("Permissions must be int or string")
+
+        permissions = permissions.strip()
+
+        if permissions.isdigit():
+            return int(permissions, 8)
+
+        if len(permissions) != 9:
+            raise ValueError(
+                "Symbolic permissions must be 9 characters (e.g., 'rwxr-x---')"
+            )
+
+        perm_map = {"r": 4, "w": 2, "x": 1, "-": 0}
+
+        mode = 0
+        special = 0
+
+        for idx in range(3):
+            chunk = permissions[idx * 3 : (idx + 1) * 3]
+            value = 0
+
+            for pos, char in enumerate(chunk):
+                if char in perm_map:
+                    value += perm_map[char]
+
+                elif pos == 2:
+                    if idx == 0 and char in ("s", "S"):
+                        special |= stat.S_ISUID
+                        if char == "s":
+                            value += 1
+
+                    elif idx == 1 and char in ("s", "S"):
+                        special |= stat.S_ISGID
+                        if char == "s":
+                            value += 1
+
+                    elif idx == 2 and char in ("t", "T"):
+                        special |= stat.S_ISVTX
+                        if char == "t":
+                            value += 1
+
+                    else:
+                        raise ValueError(f"Invalid permission character: {char}")
+
+                else:
+                    raise ValueError(f"Invalid permission character: {char}")
+
+            mode = (mode << 3) | value
+
+        return special | mode
+
+    def checksum(self, file_path):
+        with open(file_path, "rb") as fd:
+            md5sum = hashlib.md5(fd.read(), usedforsecurity=False).hexdigest()
+        return md5sum
+
+
+@pytest.fixture(scope="session")
 def file() -> File:
     """Fixture providing the ``File`` helper for file metadata operations."""
     return File()

--- a/tests/plugins/find.py
+++ b/tests/plugins/find.py
@@ -1,5 +1,6 @@
+import fnmatch
 import os
-from typing import Iterator, Union
+from typing import Iterator, Optional, Union
 
 import pytest
 
@@ -20,10 +21,13 @@ class Find:
                 If a list is provided, all paths will be searched.
             entry_type (str):
                 Specifies the type of entries to search for (files, directories, or both).
+            pattern (str):
+                Specifies the pattern to search for. If None, all files and directories will be searched.
         """
         self.same_mnt_only: bool = False
         self.root_paths: Union[str, list[str]] = "/"
         self.entry_type: str = FIND_RESULT_TYPE_FILE
+        self.pattern: Optional[str] = None
 
     def __iter__(self) -> Iterator[str]:
         return iter(list(self._find()))
@@ -43,6 +47,9 @@ class Find:
                     FIND_RESULT_TYPE_FILE_AND_DIR,
                 ):
                     for dirname in dirnames:
+                        # Apply pattern matching if pattern is specified
+                        if self.pattern and not fnmatch.fnmatch(dirname, self.pattern):
+                            continue
                         full_path = os.path.join(dirpath, dirname)
                         if self.same_mnt_only:
                             try:
@@ -58,6 +65,9 @@ class Find:
                     FIND_RESULT_TYPE_FILE_AND_DIR,
                 ):
                     for filename in filenames:
+                        # Apply pattern matching if pattern is specified
+                        if self.pattern and not fnmatch.fnmatch(filename, self.pattern):
+                            continue
                         full_path = os.path.join(dirpath, filename)
                         if self.same_mnt_only:
                             try:

--- a/tests/plugins/initrd.py
+++ b/tests/plugins/initrd.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import subprocess
 import tempfile
 from typing import List, Optional
 
@@ -8,7 +9,6 @@ import pefile
 import pytest
 
 from .kernel_versions import KernelVersions
-from .shell import ShellRunner
 from .utils import get_cname_from_os_release
 
 logger = logging.getLogger(__name__)
@@ -17,16 +17,78 @@ logger = logging.getLogger(__name__)
 class Initrd:
     """Inspect initrd contents using lsinitrd (dracut)."""
 
-    def __init__(self, shell: ShellRunner, kernel_versions: KernelVersions):
-        self._shell = shell
+    @staticmethod
+    def _execute_lsinitrd(initrd_path: str) -> tuple[list[str], list[str]]:
+        """Execute lsinitrd and return parsed results."""
+        logger.info(f"Executing lsinitrd -v {initrd_path}")
+
+        result = subprocess.run(
+            ["lsinitrd", "-v", initrd_path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if result.returncode != 0:
+            logger.error(f"lsinitrd failed with exit code {result.returncode}")
+            if result.stderr:
+                logger.error(f"lsinitrd stderr: {result.stderr}")
+            raise RuntimeError(
+                f"lsinitrd failed for {initrd_path} with exit code {result.returncode}"
+            )
+
+        # Log raw output at DEBUG level for troubleshooting
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Raw lsinitrd output:\n{result.stdout}")
+
+        # Parse the output to extract both file contents and dracut modules
+        lines = result.stdout.split("\n")
+        contents = []
+        dracut_modules = []
+        in_dracut_modules_section = False
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Check if we're entering the dracut modules section
+            if line == "dracut modules:":
+                in_dracut_modules_section = True
+                continue
+
+            # Check if we're leaving the dracut modules section
+            if in_dracut_modules_section and (
+                line.startswith("====") or (line and line[0].isupper() and ":" in line)
+            ):
+                in_dracut_modules_section = False
+
+            if in_dracut_modules_section:
+                dracut_modules.append(line)
+            else:
+                contents.append(line)
+
+        logger.info(
+            f"lsinitrd output: {len(contents)} files and {len(dracut_modules)} dracut modules"
+        )
+
+        return (contents, dracut_modules)
+
+    def __init__(self, kernel_versions: KernelVersions):
         installed = kernel_versions.get_installed()
         if not installed:
             self._kernel_version = None
             self._contents: List[str] = []
+            self._dracut_modules: List[str] = []
             return
 
         self._kernel_version = installed[0].version
-        self._contents = self._load_initrd_contents(self._kernel_version)
+        self._contents, self._dracut_modules = self._load_initrd_contents(
+            self._kernel_version
+        )
+        # Lazy-built indexes for faster lookups on the default kernel version
+        self._file_index = None
+        self._dracut_module_set = None
 
     def _get_efi_path(self) -> Optional[str]:
         """Get the path to the EFI file based on CNAME from os-release.
@@ -145,7 +207,7 @@ class Initrd:
             )
             return None
 
-    def _load_initrd_contents(self, kernel_version: str) -> List[str]:
+    def _load_initrd_contents(self, kernel_version: str) -> tuple[List[str], List[str]]:
         """Load initrd contents for the given kernel version.
 
         Tries EFI file first (for trustedboot/USI flavors), then falls back to
@@ -155,7 +217,7 @@ class Initrd:
             kernel_version: Kernel version string.
 
         Returns:
-            List of file paths found in the initrd.
+            Tuple of (file contents list, dracut modules list).
 
         Raises:
             RuntimeError: If neither EFI initrd nor legacy initrd can be found.
@@ -184,29 +246,7 @@ class Initrd:
             )
 
         try:
-            logger.debug(f"Executing: lsinitrd {initrd_path}")
-            result = self._shell(
-                f"lsinitrd {initrd_path}",
-                capture_output=True,
-                ignore_exit_code=True,
-            )
-
-            if result.returncode == 0:
-                contents = [
-                    line.strip() for line in result.stdout.split("\n") if line.strip()
-                ]
-                logger.debug(f"lsinitrd output for {initrd_path}:\n{result.stdout}")
-                logger.info(f"Found {len(contents)} files in initrd {initrd_path}")
-                return contents
-
-            logger.warning(
-                f"lsinitrd failed for {initrd_path} with exit code {result.returncode}"
-            )
-            if result.stderr:
-                logger.warning(f"lsinitrd stderr: {result.stderr}")
-            raise RuntimeError(
-                f"lsinitrd failed for {initrd_path} with exit code {result.returncode}"
-            )
+            return Initrd._execute_lsinitrd(initrd_path)
         finally:
             # Clean up extracted temporary file
             if extracted_path and os.path.exists(extracted_path):
@@ -231,7 +271,24 @@ class Initrd:
             return self._contents
         else:
             # Load contents for a different kernel version
-            return self._load_initrd_contents(kernel_version)
+            contents, _ = self._load_initrd_contents(kernel_version)
+            return contents
+
+    def _get_dracut_modules(self, kernel_version: Optional[str] = None) -> List[str]:
+        """Get all dracut modules in the initrd.
+
+        Args:
+            kernel_version: Kernel version string. If None, uses the first installed kernel.
+
+        Returns:
+            List of dracut module names found in the initrd.
+        """
+        if kernel_version is None:
+            return self._dracut_modules
+        else:
+            # Load contents for a different kernel version
+            _, dracut_modules = self._load_initrd_contents(kernel_version)
+            return dracut_modules
 
     def contains_module(
         self, module_name: str, kernel_version: Optional[str] = None
@@ -263,6 +320,26 @@ class Initrd:
         )
         return any(pattern.search(entry) for entry in contents)
 
+    def contains_dracut_module(
+        self, module_name: str, kernel_version: Optional[str] = None
+    ) -> bool:
+        """Check if a dracut module is present in the initrd.
+
+        Args:
+            module_name: Name of the dracut module to check (e.g., "ignition", "gardenlinux-live").
+            kernel_version: Kernel version string. If None, uses the first installed kernel.
+
+        Returns:
+            True if the dracut module is found in the initrd.
+        """
+        if kernel_version is None:
+            if self._dracut_module_set is None:
+                self._dracut_module_set = set(self._get_dracut_modules())
+            return module_name in self._dracut_module_set
+        else:
+            dracut_modules = self._get_dracut_modules(kernel_version)
+            return module_name in dracut_modules
+
     def contains_file(
         self, file_path: str, kernel_version: Optional[str] = None
     ) -> bool:
@@ -276,11 +353,42 @@ class Initrd:
             True if the file is found in the initrd.
         """
         if kernel_version is None:
-            kernel_version = self._kernel_version
+            # Use an index for the default kernel version to speed up repeated lookups
+            if self._file_index is None:
+                self._file_index = set()
+                contents = self._get_contents()
+                # lsinitrd outputs in ls -l format, so entries may include metadata before the path
+                for entry in contents:
+                    parts = entry.split()
+                    if not parts:
+                        continue
+                    if "->" in entry:
+                        path_part = entry.split("->")[0].strip()
+                        actual_path = path_part.split()[-1]
+                    else:
+                        actual_path = parts[-1]
+                    self._file_index.add(actual_path)
+
+            if file_path in self._file_index:
+                return True
+            # Fallback: allow matching on trailing segment as before
+            return any(p.endswith("/" + file_path) for p in self._file_index)
+
+        # For non-default kernel versions, fall back to direct scan
         contents = self._get_contents(kernel_version)
-        return file_path in contents or any(
-            entry.endswith(file_path) for entry in contents
-        )
+        for entry in contents:
+            parts = entry.split()
+            if not parts:
+                continue
+            if file_path in entry:
+                if "->" in entry:
+                    path_part = entry.split("->")[0].strip()
+                    actual_path = path_part.split()[-1]
+                else:
+                    actual_path = parts[-1]
+                if actual_path == file_path or actual_path.endswith("/" + file_path):
+                    return True
+        return False
 
     def list_modules(self, kernel_version: Optional[str] = None) -> List[str]:
         """List all kernel modules present in the initrd.
@@ -311,7 +419,7 @@ class Initrd:
         return modules
 
 
-@pytest.fixture
-def initrd(shell: ShellRunner, kernel_versions: KernelVersions) -> Initrd:
+@pytest.fixture(scope="session")
+def initrd(kernel_versions: KernelVersions) -> Initrd:
     """Fixture providing access to initrd inspection functionality."""
-    return Initrd(shell, kernel_versions)
+    return Initrd(kernel_versions)

--- a/tests/plugins/kernel_versions.py
+++ b/tests/plugins/kernel_versions.py
@@ -49,7 +49,7 @@ class KernelVersions:
         )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def kernel_versions() -> KernelVersions:
     """Fixture providing access to installed and running kernel versions."""
     return KernelVersions()

--- a/tests/plugins/mount.py
+++ b/tests/plugins/mount.py
@@ -1,0 +1,31 @@
+from os.path import ismount
+
+import pytest
+
+
+class Mount:
+    def __init__(self, shell):
+        self._shell = shell
+        self._options = set()
+
+    def __call__(self, path):
+        if not ismount(path):
+            raise ValueError(f"{path} is not a filesystem mount")
+
+        self._path = path
+        return self
+
+    @property
+    def options(self):
+        if not self._options:
+            result = self._shell(
+                f"findmnt -n -o 'OPTIONS' {self._path}", capture_output=True
+            )
+            if result.stdout:
+                self._options = set(result.stdout.split(","))
+        return self._options
+
+
+@pytest.fixture
+def mount(shell):
+    return Mount(shell)

--- a/tests/plugins/parse.py
+++ b/tests/plugins/parse.py
@@ -98,12 +98,21 @@ class Lines:
     def _check_string_literal(self, pattern: str) -> bool:
         """Check if a string literal exists in lines (with comment filtering)."""
         comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+        # Normalize the pattern as well to match normalized lines
+        normalized_pattern = re.sub(r"\s+", " ", pattern)
+
+        # Check if pattern starts with a comment character - if so, don't strip comments
+        pattern_is_comment = any(
+            pattern.lstrip().startswith(char) for char in comment_chars
+        )
 
         for line in self.content.splitlines():
-            line = _strip_comments_from_line(line, comment_chars)
+            # Only strip comments if the pattern itself is not a comment
+            if not pattern_is_comment:
+                line = _strip_comments_from_line(line, comment_chars)
             line = line.rstrip()
-            normalized = re.sub(r"\s+", " ", line)
-            if normalized.find(pattern) != -1:
+            normalized_line = re.sub(r"\s+", " ", line)
+            if normalized_line.find(normalized_pattern) != -1:
                 return True
         return False
 
@@ -165,6 +174,54 @@ class Lines:
                 f"Expected str, re.Pattern, or list of str."
             )
 
+    def __eq__(self, other: object) -> bool:
+        """Check if Lines content matches a list of expected lines exactly.
+
+        Args:
+            other: List of expected lines to compare against.
+
+        Returns:
+            bool: True if all lines match in order, False otherwise.
+        """
+        if not isinstance(other, list):
+            return NotImplemented
+
+        comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+
+        # Get actual lines from content, stripping full-line comments but keeping inline comments
+        actual_lines = []
+        for line in self.content.splitlines():
+            line = line.rstrip()
+            if not line:  # Skip empty lines
+                continue
+            # Skip lines that are purely comments (start with comment char after whitespace)
+            stripped = line.lstrip()
+            if comment_chars and any(
+                stripped.startswith(char) for char in comment_chars
+            ):
+                continue
+            actual_lines.append(line)
+
+        return actual_lines == other
+
+    def __repr__(self) -> str:
+        """Return representation of Lines for debugging."""
+        comment_chars = _resolve_comment_chars(self.format, self.comment_char)
+
+        actual_lines = []
+        for line in self.content.splitlines():
+            line = line.rstrip()
+            if not line:  # Skip empty lines
+                continue
+            # Skip lines that are purely comments
+            stripped = line.lstrip()
+            if comment_chars and any(
+                stripped.startswith(char) for char in comment_chars
+            ):
+                continue
+            actual_lines.append(line)
+        return repr(actual_lines)
+
 
 @dataclass
 class Parse:
@@ -208,12 +265,16 @@ class Parse:
         """
         return cls(content, label)
 
-    def _parse_keyval(self, content: str) -> Dict[str, str]:
-        cfg = configparser.ConfigParser(allow_no_value=True)
-        cfg.optionxform = lambda optionstr: optionstr
+    def _parse_keyval(
+        self, content: str, forbid_duplicates: bool = False
+    ) -> Dict[str, str]:
+        cfg = configparser.ConfigParser(allow_no_value=True, strict=forbid_duplicates)
+        cfg.optionxform = lambda optionstr: optionstr  # type: ignore[assignment]
         wrapped = "[default]\n" + content
         cfg.read_file(StringIO(wrapped))
-        return dict(cfg.items("default")) if "default" in cfg else {}
+        result = dict(cfg.items("default")) if "default" in cfg else {}
+        # Strip quotes from values (both single and double quotes)
+        return {k: v.strip('"').strip("'") if v else v for k, v in result.items()}
 
     def _parse_spacedelim(self, content: str) -> Dict[str, str]:
         result = {}
@@ -229,6 +290,7 @@ class Parse:
 
     def _parse_ini(self, content: str) -> Dict[str, Any]:
         cfg = configparser.ConfigParser()
+        cfg.optionxform = str  # type: ignore[method-assign] # Preserve case of option names
         cfg.read_file(StringIO(content))
         return {section: dict(cfg[section]) for section in cfg.sections()}
 
@@ -255,11 +317,13 @@ class Parse:
             )
         return tomllib.loads(content)
 
-    def _parse_content(self, format: str, ignore_comments: bool = True) -> Any:
+    def _parse_content(
+        self, format: str, ignore_comments: bool = True, forbid_duplicates: bool = True
+    ) -> Any:
         fmt = format.lower()
         match fmt:
             case "keyval":
-                return self._parse_keyval(self.content)
+                return self._parse_keyval(self.content, forbid_duplicates)
             case "spacedelim":
                 return self._parse_spacedelim(self.content)
             case "ini":
@@ -276,13 +340,16 @@ class Parse:
                     f"Supported formats: {', '.join(SUPPORTED_FORMATS)}."
                 )
 
-    def parse(self, format: str, ignore_comments: bool = True) -> Any:
+    def parse(
+        self, format: str, ignore_comments: bool = True, forbid_duplicates: bool = True
+    ) -> Any:
         """Parse content and return data structure based on format.
 
 
         Args:
             format: One of the supported format identifiers (json, yaml, toml, ini, keyval).
             ignore_comments: (optional, default=True) If True, strip comments where applicable.
+            forbid_duplicates: If False, won't raise an exception if duplicate key (where applicable) is found.
 
         Returns:
             Parsed data structure (dict, list, etc.) based on format.
@@ -294,7 +361,7 @@ class Parse:
             >>> assert config["database"]["port"] == 5432
             >>> assert "missing" not in config["database"]
         """
-        return self._parse_content(format, ignore_comments)
+        return self._parse_content(format, ignore_comments, forbid_duplicates)
 
     def lines(
         self,

--- a/tests/plugins/parse_file.py
+++ b/tests/plugins/parse_file.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union, overload
+from typing import Any, List, Literal, Optional, Union, overload
 
 import pytest
 
@@ -155,7 +155,7 @@ class ParseFile:
         parser = self._get_parser(
             path,
             ignore_missing,
-            error_context=f"Cannot parse file.",
+            error_context="Cannot parse file.",
         )
         if parser is None:
             return None
@@ -229,7 +229,7 @@ class ParseFile:
         parser = self._get_parser(
             path,
             ignore_missing,
-            error_context=f"Cannot get lines container.",
+            error_context="Cannot get lines container.",
         )
         if parser is None:
             return None
@@ -244,7 +244,7 @@ class ParseFile:
         )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def parse_file() -> ParseFile:
     """Fixture providing the ``ParseFile`` helper for checking file contents."""
     return ParseFile()

--- a/tests/plugins/setting_ids.py
+++ b/tests/plugins/setting_ids.py
@@ -1,0 +1,13 @@
+"""
+Plugin to register custom pytest marker for Garden Linux setting IDs.
+"""
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config):
+    """Register custom marker for Garden Linux setting IDs."""
+    config.addinivalue_line(
+        "markers",
+        "testcov(ids): Mark tests with Garden Linux setting IDs for traceability",
+    )

--- a/tests/plugins/setuid_binaries.py
+++ b/tests/plugins/setuid_binaries.py
@@ -1,0 +1,29 @@
+import os
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def exposed_setuid_binaries():
+    """
+    Returns a set of pathnames of root-owned binaries with setuid bit which are
+    also "others"-executable (i.e. binaries that give root privileges to every
+    user).
+    """
+    dirs = [
+        "/usr/sbin",
+        "/usr/bin",
+        "/usr/libexec",
+        "/usr/local/sbin",
+        "/usr/local/bin",
+    ]
+    return {
+        str(p)
+        for d in dirs
+        for root, _, files in os.walk(d)
+        for p in map(lambda n: pathlib.Path(root) / n, files)
+        if p.stat().st_uid == 0  # file belongs to root
+        and (m := p.stat().st_mode) & 0o4000  # set‑uid bit present
+        and ((m >> 3) & 0o111)  # “others” execute bit set
+    }

--- a/tests/plugins/sysdiff.py
+++ b/tests/plugins/sysdiff.py
@@ -11,10 +11,13 @@ Provides snapshot and comparison capabilities for:
 
 import difflib
 import gzip
+import hashlib
 import json
+import logging
 import os
 import re
 import shutil
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from fnmatch import fnmatch
@@ -31,6 +34,8 @@ from .kernel_versions import KernelVersions
 from .shell import ShellRunner
 from .sysctl import Sysctl, SysctlParam
 from .systemd import Systemd, SystemdUnit
+
+logger = logging.getLogger(__name__)
 
 STATE_DIR = "/tmp/sysdiff"
 
@@ -64,7 +69,23 @@ IGNORED_SYSTEMD_PATTERNS = [
     "user-runtime-dir@*.service",
     "user@*.service",
     "user-*.slice",
+    # runs periodically
+    "gce-workload-cert-refresh.service",
+    "gce-workload-cert-refresh.timer",
+    # _trustedboot: pcrlogin activates dynamically during boot/test session
+    "systemd-pcrlogin@*.service",
+    "system-systemd*pcrlogin.slice",
 ]
+
+# Units to wait for before taking a snapshot (unit_name: expected_sub_state)
+# This prevents race conditions where socket-activated services are still settling
+WAIT_FOR_SETTLED_UNITS = {
+    "libvirtd.socket": "listening",
+    "libvirtd-ro.socket": "listening",
+    "libvirtd-tcp.socket": "listening",
+    "libvirtd-admin.socket": "listening",
+}
+
 IGNORED_KERNEL_MODULES = []
 IGNORED_SYSCTL_PARAMS = {
     # File system dynamic parameters
@@ -172,7 +193,7 @@ class FileCollector:
                         existing_paths.append(path)
                         seen.add(path)
                 except Exception as e:
-                    print(f"Error normalizing paths: {e}")
+                    logger.error(f"Error normalizing paths: {e}")
 
         return existing_paths
 
@@ -189,7 +210,7 @@ class FileCollector:
                     if line and not line.startswith("#"):
                         patterns.append(line)
         except Exception as e:
-            print(f"Error loading ignore patterns from {ignore_file}: {e}")
+            logger.error(f"Error loading ignore patterns from {ignore_file}: {e}")
 
         return patterns
 
@@ -217,7 +238,7 @@ class FileCollector:
         try:
             root_dev = os.stat(root).st_dev
         except (OSError, IOError) as e:
-            print(f"Warning: Cannot access {root}: {e}")
+            logger.warning(f"Warning: Cannot access {root}: {e}")
             return
 
         for dirpath, dirnames, filenames in os.walk(
@@ -241,13 +262,12 @@ class FileCollector:
         self, filepath: str, verbose: bool = False
     ) -> Optional[str]:
         """Calculate SHA256 hash for a single file"""
-        import hashlib
 
         # Check if file exists before trying to read it
         try:
             if not os.path.exists(filepath):
                 if verbose:
-                    print(f"Warning: File not found: {filepath}")
+                    logger.warning(f"Warning: File not found: {filepath}")
                 return None
         except (OSError, IOError):
             # If we can't even check existence, skip silently
@@ -266,11 +286,11 @@ class FileCollector:
         except FileNotFoundError:
             # This shouldn't happen after the exists check, but handle it gracefully
             if verbose:
-                print(f"Warning: File disappeared: {filepath}")
+                logger.warning(f"Warning: File disappeared: {filepath}")
             return None
         except (OSError, IOError, PermissionError) as e:
             # Less common errors - always warn
-            print(f"Warning: Cannot read {filepath}: {e}")
+            logger.warning(f"Warning: Cannot read {filepath}: {e}")
             return None
 
     def collect_file_hashes(
@@ -290,7 +310,6 @@ class FileCollector:
         Returns:
             Dictionary mapping file paths to their SHA256 hashes
         """
-        import hashlib
 
         if ignore_patterns is None:
             ignore_patterns = []
@@ -307,7 +326,7 @@ class FileCollector:
                     files_in_path = list(self._walk_files_recursive(path))
                     all_files.extend(files_in_path)
                 except Exception as e:
-                    print(f"Warning: Error scanning {path}: {e}")
+                    logger.warning(f"Warning: Error scanning {path}: {e}")
                     continue
 
             filtered_files = [
@@ -322,7 +341,7 @@ class FileCollector:
                     file_hashes[filepath] = hash_value
 
         except Exception as e:
-            print(f"Error collecting file hashes: {e}")
+            logger.error(f"Error collecting file hashes: {e}")
 
         return file_hashes
 
@@ -333,6 +352,58 @@ class SnapshotManager:
     def __init__(self, state_dir: Path | None = None):
         self.state_dir = state_dir or Path(STATE_DIR)
         self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def _wait_for_units_settled(
+        self,
+        systemd: Systemd,
+        max_wait_seconds: int = 120,
+        poll_interval: float = 0.5,
+    ) -> None:
+        """
+        Wait for configured units to reach their expected sub-states.
+
+        This prevents race conditions when taking snapshots while socket-activated
+        services like libvirtd are still settling into their stable state.
+
+        Args:
+            systemd: Systemd instance for checking unit states
+            max_wait_seconds: Maximum time to wait for units to settle
+            poll_interval: Time between polls in seconds
+        """
+        if not WAIT_FOR_SETTLED_UNITS:
+            return
+
+        start_time = time.time()
+        units_to_check = set(WAIT_FOR_SETTLED_UNITS.keys())
+
+        while units_to_check and (time.time() - start_time) < max_wait_seconds:
+            current_units = systemd.list_units()
+            unit_states = {unit.unit: unit.sub for unit in current_units}
+
+            settled_units = set()
+            for unit_name in units_to_check:
+                expected_sub = WAIT_FOR_SETTLED_UNITS[unit_name]
+                current_sub = unit_states.get(unit_name)
+
+                logger.debug(
+                    f"Debug: Unit {unit_name} current state: {current_sub}, expected: {expected_sub}"
+                )
+
+                if current_sub == expected_sub:
+                    settled_units.add(unit_name)
+
+            units_to_check -= settled_units
+
+            if units_to_check:
+                time.sleep(poll_interval)
+
+        # Log if any units didn't settle (but don't fail the snapshot)
+        if units_to_check:
+            elapsed = time.time() - start_time
+            logger.warning(
+                f"Warning: Units did not settle within {max_wait_seconds}s (elapsed: {elapsed:.1f}s): "
+                f"{', '.join(units_to_check)}"
+            )
 
     def create_snapshot(
         self,
@@ -372,8 +443,14 @@ class SnapshotManager:
         sysctl_collector = Sysctl(shell)
         kernel_versions = KernelVersions()
         kernel_module = KernelModule(Find(), shell, kernel_versions)
-
         packages = dpkg.collect_installed_packages().packages
+
+        # Make sure no systemd services and sockets are still transitioning
+        systemd_wait = systemd.wait_is_system_running()
+        logger.debug(
+            f"Systemd settle returned state {systemd_wait.state} and took {systemd_wait.elapsed_time:.1f}s to complete"
+        )
+        self._wait_for_units_settled(systemd)
 
         systemd_units = systemd.list_units()
 

--- a/tests/plugins/systemd.py
+++ b/tests/plugins/systemd.py
@@ -2,12 +2,12 @@ import json
 import re
 import time
 from dataclasses import dataclass
-from os import system
 from typing import Tuple
 
 import pytest
 
 from .modify import allow_system_modifications
+from .parse import Parse
 from .shell import ShellRunner
 
 
@@ -143,6 +143,81 @@ class Systemd:
 
         return active
 
+    def is_inactive(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-active {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        inactive = result.stdout.strip() == "inactive"
+        if not inactive:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return inactive
+
+    def is_enabled(self, unit_name: str) -> bool:
+        """Check if a system-level systemd unit is enabled.
+
+        Note: This also returns True for 'static' units (units without [Install] section
+        that are enabled by default or pulled in by other units).
+        """
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        state = result.stdout.strip()
+        enabled = state in ("enabled", "static")
+        if not enabled:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return enabled
+
+    def is_disabled(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        disabled = result.stdout.strip() == "disabled"
+        if not disabled:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return disabled
+
+    def is_masked(self, unit_name: str) -> bool:
+        result = self._shell(
+            f"{self._systemctl} is-enabled {unit_name}",
+            capture_output=True,
+            ignore_exit_code=True,
+        )
+        state = result.stdout.strip()
+        masked = state in ("masked")
+        if not masked:
+            result_status = self._shell(
+                f"{self._systemctl} status {unit_name}",
+                capture_output=True,
+                ignore_exit_code=True,
+            )
+            print(result_status.stdout)
+
+        return masked
+
     def start_unit(self, unit_name: str):
         if not allow_system_modifications():
             pytest.skip(
@@ -192,6 +267,19 @@ class Systemd:
         )
         elapsed = time.time() - start_time
         return SystemRunningState(result.stdout.strip(), result.returncode, elapsed)
+
+    def get_unit_properties(self, service_name) -> dict:
+        result = self._shell(
+            cmd=f"systemctl show {service_name}.service",
+            capture_output=True,
+        )
+        return Parse.from_str(result.stdout).parse("keyval", forbid_duplicates=False)
+
+    def get_config(self, config_path) -> dict:
+        result = self._shell(
+            f"systemd-analyze cat-config {config_path}", capture_output=True
+        )
+        return Parse.from_str(result.stdout).parse("keyval", forbid_duplicates=False)
 
 
 @pytest.fixture

--- a/tests/plugins/tests/test_file.py
+++ b/tests/plugins/tests/test_file.py
@@ -3,7 +3,6 @@
 import grp
 import os
 import pwd
-import stat
 from pathlib import Path
 
 import pytest

--- a/tests/plugins/utils.py
+++ b/tests/plugins/utils.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
-from typing import Dict, List, Optional, TypeVar
+import os
+from typing import List, Optional, TypeVar
 
 # Various utility functions to make tests more readable
 # This should not contain test-assertions, but only abstract details that make tests harder to read
@@ -21,12 +21,24 @@ def is_set(obj) -> bool:
     return isinstance(obj, set)
 
 
+def tree(path: str) -> set[str]:
+    """Returns all subpaths of `path`, like the find command"""
+    tree = {path}
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            tree.add(f"{root}/{file}")
+        for dir in dirs:
+            tree.add(f"{root}/{dir}")
+
+    return tree
+
+
 T = TypeVar("T")
 
 
 def check_for_duplicates(entries: List[T]) -> List[T]:
     """
-    checks for duplicates, to change equality comparision, add a compare field to the dataclass.
+    checks for duplicates, to change equality comparison, add a compare field to the dataclass.
     """
     duplicates = list[T]()
     visited_entries = list[T]()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+disa_stig_version = General Purpose Operating System STIG V3R2

--- a/tests/util/sysdiff.py
+++ b/tests/util/sysdiff.py
@@ -26,15 +26,14 @@ podman run -it --rm \
 """
 
 import argparse
-import os
 import sys
 from pathlib import Path
 
 # Add tests to Python path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from plugins.shell import ShellRunner
-from plugins.sysdiff import Sysdiff
+from plugins.shell import ShellRunner  # noqa: E402
+from plugins.sysdiff import Sysdiff  # noqa: E402
 
 
 def list_snapshots(sysdiff: Sysdiff, verbose: bool = False):
@@ -69,7 +68,7 @@ def diff_snapshots(
 ):
     """Compare two snapshots and show differences"""
     try:
-        print(f"Comparing snapshots:")
+        print("Comparing snapshots:")
         print(f"  snapshot_a: {snapshot1_name}")
         print(f"  snapshot_b: {snapshot2_name}")
         print()
@@ -204,7 +203,7 @@ Examples:
             )
 
             print(f"✓ Snapshot created successfully: {snapshot.name}")
-            print(f"  Location: {sysdiff.manager.state_dir / snapshot.name}.json.gz")
+            print(f"  Location: {sysdiff.manager.state_dir}/{snapshot.name}.json.gz")
             print(f"  Packages: {len(snapshot.packages)}")
             print(f"  Files: {len(snapshot.files)}")
             print(f"  Sysctl params: {len(snapshot.sysctl_params)}")
@@ -212,7 +211,7 @@ Examples:
             print(f"  Systemd units: {len(snapshot.systemd_units)}")
 
             if args.verbose:
-                print(f"\nDetailed information:")
+                print("\nDetailed information:")
                 print(f"  Created at: {snapshot.metadata.created_at}")
                 print(f"  Paths scanned: {snapshot.metadata.paths}")
                 print(f"  Ignore file used: {snapshot.metadata.ignore_file}")


### PR DESCRIPTION
## Part 1 of 5 — Foundation (plugins, handlers, config)

> **Merge order:** This PR must merge before the other 4 parts.

### What
Backports updated/new test infrastructure from `main` to `rel-2150`:

**New plugins** (6): `audit`, `docstring`, `dpkg_checksums`, `mount`, `setting_ids`, `setuid_binaries`
**Updated plugins** (12): `booted`, `containerd`, `dpkg`, `file`, `find`, `initrd`, `kernel_versions`, `parse_file`, `parse`, `sysdiff`, `systemd`, `utils`
**New handlers** (2): `audit_user`, `pip`
**Config**: `pyrightconfig.json` (`typeCheckingMode=basic`), `tests/pytest.ini`

### Why
These are the shared fixtures and helpers that all 4 test PRs (parts 2–5) depend on. Separating them allows reviewing infrastructure changes independently of the test logic.

### Part of series
- **1/5** — Plugins + handlers + config (this PR) ← merge first
- 2/5 — Boot + kernel + infrastructure tests
- 3/5 — Core + runtime tests
- 4/5 — Security tests (non-compliance)
- 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests ← primary goal

## Split PR series (cross-reference)

| PR | Scope | Files |
|----|-------|-------|
| #5296 | 1/5 — Plugins + handlers + config | 24 — **merge first** |
| #5297 | 2/5 — Boot + kernel + infrastructure tests | 15 |
| #5298 | 3/5 — Core + runtime tests | 26 |
| #5299 | 4/5 — Security tests (non-compliance) | 12 |
| #5300 | 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests | 118 ← primary goal |

> Original monolithic PR: #5290