### PR TITLE
backport: core and runtime integration tests to rel-2150 (3/5)

### DIFF
--- a/tests/integration/core/test_autologin.py
+++ b/tests/integration/core/test_autologin.py
@@ -1,0 +1,24 @@
+import re
+
+import pytest
+from plugins.parse_file import ParseFile
+
+CONFIG_FILES = [
+    "/etc/systemd/system/serial-getty@.service.d/autologin.conf",
+    "/etc/systemd/system/getty@tty1.service.d/autologin.conf",
+]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_iso-service-getty-tty1-autologin",
+        "GL-TESTCOV-_iso-service-serial-getty-autologin",
+    ]
+)
+@pytest.mark.parametrize("config_file", CONFIG_FILES)
+@pytest.mark.feature(
+    "server and (_dev or _iso) and not _autoinstall", reason="needs systemd"
+)
+def test_autologin(config_file, parse_file: ParseFile):
+    lines = parse_file.lines(config_file)
+    assert re.compile(r"ExecStart.*autologin") in lines

--- a/tests/integration/core/test_base.py
+++ b/tests/integration/core/test_base.py
@@ -1,0 +1,522 @@
+import re
+
+import pytest
+from plugins.file import File
+from plugins.kernel_configs import KernelConfigs
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+from plugins.sysctl import Sysctl
+from plugins.systemd import Systemd
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-config-machine-id"])
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_machine_id_is_initialized(parse_file: ParseFile):
+    lines = parse_file.lines("/etc/machine-id")
+    assert re.compile(r"^[0-9a-f]{32}$") in lines
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-os-release"])
+def test_gl_is_support_distro(parse_file: ParseFile):
+    lines = parse_file.lines("/etc/os-release")
+    assert (
+        "ID=gardenlinux" in lines
+    ), "/etc/os-release does not contain gardenlinux vendor field"
+
+
+@pytest.mark.parametrize(
+    "dir",
+    [
+        "/boot",
+        "/dev",
+        "/etc",
+        "/home",
+        "/mnt",
+        "/opt",
+        "/proc",
+        "/root",
+        "/run",
+        "/srv",
+        "/sys",
+        "/tmp",
+        "/usr",
+        "/var",
+    ],
+)
+def test_fhs_directories(file: File, dir: str):
+    assert file.is_dir(f"{dir}"), f"expected FHS directory {dir} does not exist"
+
+
+@pytest.mark.parametrize(
+    "link,target",
+    [
+        ("/bin", "/usr/bin"),
+        ("/lib", "/usr/lib"),
+        ("/sbin", "/usr/sbin"),
+    ],
+)
+def test_fhs_symlinks(file: File, link: str, target: str):
+    assert file.is_symlink(
+        link, target=target
+    ), f"expected FHS symlink {link} does not exist"
+
+
+@pytest.mark.arch("amd64", reason="links only present on amd64")
+@pytest.mark.parametrize(
+    "link,target",
+    [
+        ("/lib64", "/usr/lib64"),
+    ],
+)
+def test_fhs_symlinks_amd64(file: File, link: str, target: str):
+    assert file.is_symlink(
+        link, target=target
+    ), f"expected FHS symlink {link} does not exist"
+
+
+@pytest.mark.booted(
+    reason="We can only measure startup time if we actually boot the system"
+)
+@pytest.mark.performance_metric
+def test_startup_time(systemd: Systemd):
+    tolerated_kernel = 60.0
+    tolerated_userspace = 60.0
+
+    firmware, loader, kernel, initrd, userspace = systemd.analyze()
+    kernel_total = kernel + initrd
+
+    assert kernel_total < tolerated_kernel, (
+        f"Kernel+initrd startup too slow: {kernel_total:.1f}s "
+        f"(tolerated {tolerated_kernel}s)"
+    )
+    assert userspace < tolerated_userspace, (
+        f"Userspace startup too slow: {userspace:.1f}s "
+        f"(tolerated {tolerated_userspace}s)"
+    )
+
+
+@pytest.mark.booted(reason="Kernel test makes sense only on booted system")
+def test_kernel_not_tainted():
+    with open("/proc/sys/kernel/tainted", "r") as f:
+        tainted = f.read().strip()
+    assert tainted == "0", f"Kernel is tainted (value: {tainted})"
+
+
+@pytest.mark.feature(
+    "not gcp and not metal and not openstack",
+    reason="Not compatible, usually because of missing external backends",
+)
+@pytest.mark.root(reason="Required for journalctl in case of errors")
+@pytest.mark.booted(reason="Systemctl needs a booted system")
+def test_no_failed_units(systemd: Systemd, shell: ShellRunner):
+    system_run_state = systemd.wait_is_system_running()
+    print(
+        f"Waiting for systemd to report the system is running took {system_run_state.elapsed_time:.2f} seconds, with state '{system_run_state.state}' and return code '{system_run_state.returncode}'."
+    )
+    failed_systemd_units = systemd.list_failed_units()
+    for u in failed_systemd_units:
+        print(f"FAILED UNIT: {u}")
+        shell(f"journalctl --unit {u.unit}")
+    assert (
+        not failed_systemd_units
+    ), f"{len(failed_systemd_units)} systemd units failed to load"
+
+
+def test_kernel_configs_sysrq_not_set_cloud(
+    parse_file: ParseFile, kernel_configs: KernelConfigs
+):
+    """Test that the kernel config does not set magic sysrq."""
+    for config in kernel_configs.get_installed():
+        line = "# CONFIG_MAGIC_SYSRQ is not set"
+        lines = parse_file.lines(
+            config.path,
+            comment_char=[],  # Disable comment filtering for kernel config files
+        )
+        assert line in lines, f"Could not find line {line} in {config.path}."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-sysctl-sysrq-disable"])
+@pytest.mark.booted(reason="Requires running system")
+def test_sysctl_sysrq_not_set(sysctl: Sysctl):
+    """Test that sysctl sysrq parameter is not available."""
+    assert "kernel.sysrq" not in sysctl
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-sysctl-sysrq-disable"])
+@pytest.mark.booted(reason="Requires running system")
+def test_magic_sysrq_trigger_not_exists(file: File):
+    """Test that sysrq trigger does not exist."""
+    assert not file.exists("/proc/sysrq-trigger")
+
+
+# =============================================================================
+# base Feature - APT Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-apt-no-recommends",
+        "GL-TESTCOV-base-config-apt-no-suggests",
+        "GL-TESTCOV-base-config-apt-no-languages",
+        "GL-TESTCOV-base-config-apt-gzip-indexes",
+        "GL-TESTCOV-base-config-apt-autoclean",
+        "GL-TESTCOV-base-config-apt-no-caches",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_apt_configs_exist(file: File):
+    """Test that APT configuration files exist"""
+    apt_configs = [
+        "/etc/apt/apt.conf.d/no-recommends",
+        "/etc/apt/apt.conf.d/no-suggests",
+        "/etc/apt/apt.conf.d/no-languages",
+        "/etc/apt/apt.conf.d/gzip-indexes",
+        "/etc/apt/apt.conf.d/autoclean",
+        "/etc/apt/apt.conf.d/no-caches",
+    ]
+
+    missing = [cfg for cfg in apt_configs if not file.exists(cfg)]
+    assert not missing, f"Missing APT configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-apt-preferences-gardenlinux"])
+@pytest.mark.feature("base")
+def test_base_apt_preferences_gardenlinux_exists(file: File):
+    """Test that APT preferences for Garden Linux exist"""
+    assert file.is_regular_file("/etc/apt/preferences.d/gardenlinux")
+
+
+# =============================================================================
+# base Feature - DPKG Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-dpkg-origins",
+        "GL-TESTCOV-base-config-dpkg-origins-gardenlinux",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_dpkg_origins_exist(file: File):
+    """Test that DPKG origins files exist"""
+    origins = [
+        "/etc/dpkg/origins/debian",
+        "/etc/dpkg/origins/gardenlinux",
+    ]
+
+    missing = [orig for orig in origins if not file.exists(orig)]
+    assert not missing, f"Missing DPKG origins: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-dpkg-speedup",
+        "GL-TESTCOV-base-config-dpkg-forceold",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_dpkg_configs_exist(file: File):
+    """Test that DPKG configuration files exist"""
+    dpkg_configs = [
+        "/etc/dpkg/dpkg.cfg.d/speedup",
+        "/etc/dpkg/dpkg.cfg.d/forceold",
+    ]
+
+    missing = [cfg for cfg in dpkg_configs if not file.exists(cfg)]
+    assert not missing, f"Missing DPKG configs: {', '.join(missing)}"
+
+
+# =============================================================================
+# base Feature - System Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-hosts"])
+@pytest.mark.feature(
+    "base and not container", reason="Container does not have default hosts file"
+)
+def test_base_hosts_file_exists(file: File):
+    """Test that /etc/hosts exists"""
+    assert file.is_regular_file("/etc/hosts")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-hosts"])
+@pytest.mark.feature(
+    "base and not (container or aws or azure)",
+    reason="Container, Azure, AWS write their own hosts file",
+)
+def test_base_hosts_file_contains_localhost_and_garden(parse_file: ParseFile):
+    """Test that /etc/hosts contains localhost and garden"""
+    lines = parse_file.lines("/etc/hosts")
+    assert "127.0.0.1 localhost" in lines, "localhost should be in /etc/hosts"
+    assert "127.0.1.1 garden" in lines, "garden should be in /etc/hosts"
+    assert (
+        "::1 localhost ip6-localhost ip6-loopback" in lines
+    ), "localhost should be in /etc/hosts"
+    assert "ff02::1 ip6-allnodes" in lines, "ip6-allnodes should be in /etc/hosts"
+    assert "ff02::2 ip6-allrouters" in lines, "ip6-allrouters should be in /etc/hosts"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolv-conf"])
+@pytest.mark.feature("base")
+@pytest.mark.booted(reason="Resolv.conf does not exist in chroot")
+def test_base_resolv_conf_file_exists(file: File):
+    """Test that /etc/resolv.conf exists"""
+    assert file.exists("/etc/resolv.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolv-conf"])
+@pytest.mark.feature("base")
+@pytest.mark.hypervisor("not qemu", reason="Qemu sets own nameservers")
+def test_base_resolv_conf_file_contains_nameservers(parse_file: ParseFile):
+    """Test that /etc/resolv.conf contains nameservers"""
+    lines = parse_file.lines("/etc/resolv.conf")
+    assert (
+        "nameserver 8.8.8.8" in lines
+    ), "nameserver 8.8.8.8 should be in /etc/resolv.conf"
+    assert (
+        "nameserver 8.8.4.4" in lines
+    ), "nameserver 8.8.4.4 should be in /etc/resolv.conf"
+    assert (
+        "nameserver 2001:4860:4860::8888" in lines
+    ), "nameserver 2001:4860:4860::8888 should be in /etc/resolv.conf"
+    assert (
+        "nameserver 2001:4860:4860::8844" in lines
+    ), "nameserver 2001:4860:4860::8844 should be in /etc/resolv.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolved-no-backup"])
+@pytest.mark.feature("base")
+def test_base_resolved_no_backup_file_exists(file: File):
+    """Test that /etc/.resolv.conf.systemd-resolved.bak does not exist"""
+    assert not file.exists(
+        "/etc/.resolv.conf.systemd-resolved.bak"
+    ), "/etc/.resolv.conf.systemd-resolved.bak should not exist in base image"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-ucf"])
+@pytest.mark.feature("base")
+def test_base_ucf_conf_exists(file: File):
+    """Test that UCF configuration exists"""
+    assert file.is_regular_file("/etc/ucf.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-ucf"])
+@pytest.mark.feature("base")
+def test_base_ucf_conf_contains_defaults(parse_file: ParseFile):
+    """Test that UCF configuration contains defaults"""
+    lines = parse_file.lines("/etc/ucf.conf")
+    assert (
+        "conf_force_conffold=YES" in lines
+    ), "conf_force_conffold=YES should be in /etc/ucf.conf"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-veritytab"])
+@pytest.mark.feature("base")
+def test_base_veritytab_exists(file: File):
+    """Test that veritytab exists"""
+    assert file.is_regular_file("/etc/veritytab")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-www-gitignore"])
+@pytest.mark.feature("base")
+def test_base_www_gitignore_exists(file: File):
+    """Test that /var/www/.gitignore exists"""
+    assert file.is_regular_file("/var/www/.gitignore")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-www-gitignore"])
+@pytest.mark.feature("base")
+def test_base_www_gitignore_contains_defaults(parse_file: ParseFile):
+    """Test that /var/www/.gitignore contains defaults"""
+    lines = parse_file.lines("/var/www/.gitignore", comment_char=[])
+    assert lines == [
+        "#nothing",
+        "# Ignore everything in this directory",
+        "*",
+        "# Except this file",
+        "!.gitignore",
+    ]
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-no-external-installation-planner-logs",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_no_installation_planner_logs(file: File):
+    """Test that base does not have external installation planner logs"""
+    log_paths = [
+        "/var/log/installer",
+        "/var/log/debian-installer",
+    ]
+    existing = [path for path in log_paths if file.exists(path)]
+    assert (
+        not existing
+    ), f"Base should not have installation planner logs: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-security-mount-no-sbit",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_mount_no_sbit_security(file: File):
+    """Test that base has mount security without sbit"""
+    # This is typically configured in fstab
+    if file.exists("/etc/fstab"):
+        assert True, "Base mount configuration exists in fstab"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-update-motd-logo",
+        "GL-TESTCOV-_fips-config-update-motd-logo",
+    ]
+)
+@pytest.mark.feature("server or _fips")
+def test_base_update_motd_logo(file: File):
+    """Test that base has update-motd logo script"""
+    assert file.has_mode(
+        "/etc/update-motd.d/05-logo", "0755"
+    ), "Base update-motd logo script should have 0755 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-base-config-user-home-nonexistent",
+    ]
+)
+@pytest.mark.feature("base")
+def test_base_user_home_nonexistent(file: File):
+    """Test that base system users have /nonexistent as home"""
+    # Check that /nonexistent exists as a marker for system users
+    # This is a soft check - system users should have nonexistent homes
+    assert True, "Base system user home directories configured"
+
+
+# =============================================================================
+# _usi Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-no-root-home"])
+@pytest.mark.feature("_usi")
+def test_usi_empty_root_home_directory(file: File):
+    """Test that root home directory does not exist"""
+    assert not file.exists("/root/*"), "The root home directory should be empty"
+    assert not file.exists(
+        "/root/.*"
+    ), "The root home directory should not contain any hidden files"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_usi-config-no-udev-rules-image-dissect"])
+@pytest.mark.feature("_usi")
+def test_usi_no_udev_rules_image_dissect(file: File):
+    """Test that udev rules for image dissect do not exist"""
+    assert not file.exists("/usr/lib/udev/rules.d/90-image-dissect.rules")
+
+
+# =============================================================================
+# cisPartition Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisPartition-config-mount-tmp"])
+@pytest.mark.feature("cisPartition")
+def test_cispartition_mount_files_exists(file: File):
+    """Test that mount files exist"""
+    paths = [
+        "/etc/systemd/system/tmp.mount",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisPartition-config-mount-tmp-enable"])
+@pytest.mark.feature("cisPartition")
+@pytest.mark.booted(reason="Requires systemd")
+def test_cispartition_mount_units_enabled(systemd: Systemd):
+    """Test that mount units are enabled"""
+    paths = [
+        "tmp.mount",
+    ]
+
+    missing = [path for path in paths if not systemd.is_enabled(path)]
+
+
+# =============================================================================
+# _slim Feature
+# =============================================================================
+
+
+# TODO: enable after fixing https://github.com/gardenlinux/gardenlinux/issues/4387
+# @pytest.mark.testcov(["GL-TESTCOV-_slim-config-no-docs-except-copyrights", "GL-TESTCOV-_slim-config-no-docs-empty-directories"])
+# @pytest.mark.feature("_slim")
+# def test_slim_no_usr_share_docs_except_copyrights(find):
+#     """Test that /usr/share/doc has no subdirectories"""
+#     dir = "/usr/share/doc"
+#     find.root_paths = dir
+#     find.entry_type = "files"
+#     only_find = "copyright"
+#     missing = [found for found in find if not (found.endswith(only_find))]
+#     assert not missing, f"The following files were found in {dir} that are not {only_find}: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_slim-config-no-docs-directories"])
+@pytest.mark.feature("_slim")
+def test_slim_no_usr_share_docs_dirs_exist(file: File):
+    """Test that /usr/share/man and other directories do not exist"""
+    paths = [
+        "/usr/share/man",
+        "/usr/share/locale",
+        "/usr/share/groff",
+        "/usr/share/lintian",
+        "/usr/share/linda",
+    ]
+    missing = [path for path in paths if file.exists(path)]
+    assert (
+        not missing
+    ), f"The following directories do exist: {', '.join(missing)} but should not"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_slim-config-no-docs-directories"])
+@pytest.mark.feature("_slim")
+def test_no_man(shell: ShellRunner):
+    result = shell("man ls", capture_output=True, ignore_exit_code=True)
+    assert result.returncode == 127 and (
+        "not found" in result.stderr or "Permission denied" in result.stderr
+    ), f"man ls did not fail as expected, got: {result.stderr}"
+
+
+# =============================================================================
+# ali Feature - Resolved Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-config-resolved"])
+@pytest.mark.feature("ali")
+def test_ali_resolved_config_exists(file: File):
+    """Test that Alibaba Cloud systemd-resolved configuration exists"""
+    assert file.is_regular_file("/etc/systemd/resolved.conf.d/00-gardenlinux-ali.conf")
+
+
+# =============================================================================
+# aws Feature - Resolved Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-resolved"])
+@pytest.mark.feature("aws")
+def test_aws_resolved_config_exists(file: File):
+    """Test that AWS systemd-resolved configuration exists"""
+    assert file.is_regular_file("/etc/systemd/resolved.conf.d/00-gardenlinux-aws.conf")

--- a/tests/integration/core/test_codedump.py
+++ b/tests/integration/core/test_codedump.py
@@ -1,0 +1,92 @@
+import pytest
+from plugins.file import File
+from plugins.shell import ShellRunner
+from plugins.sysctl import Sysctl
+
+# =============================================================================
+# _prod Feature - Codedump
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-security-limits-disable-core-dumps",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_security_limits_no_core_dumps(file: File):
+    """Test that production has security limits disabling core dumps"""
+    assert file.exists(
+        "/etc/security/limits.conf"
+    ), "Production should have core dump limits"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-security-limits-disable-core-dumps",
+    ]
+)
+@pytest.mark.booted(reason="ulimit needs a booted system")
+@pytest.mark.feature("_prod")
+def test_prod_security_limits_no_core_dumps_check(shell: ShellRunner):
+    """Test that production has security limits disabling core dumps"""
+    result = shell("ulimit -Sc", capture_output=True)
+    assert (
+        result.stdout.strip() == "0"
+    ), "Production should have core dump limits set to 0"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-sysctl-coredump-disable",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_sysctl_coredump_disable(file: File):
+    """Test that production has sysctl disabling core dumps"""
+    assert file.exists(
+        "/etc/sysctl.d/99-disable-core-dump.conf"
+    ), "Production should have sysctl coredump disable"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-sysctl-coredump-disable",
+    ]
+)
+@pytest.mark.feature("_prod")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_prod_sysctl_coredump_disable_check(sysctl: Sysctl):
+    """Test that production has sysctl disabling core dumps"""
+    assert (
+        sysctl["fs.suid_dumpable"] == 0
+    ), "Production should have sysctl coredump disable"
+    assert (
+        sysctl["kernel.core_pattern"] == "|/bin/false"
+    ), "Production should have sysctl coredump pattern set to /bin/false"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-_prod-config-systemd-coredump-disable",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_systemd_coredump_disable(file: File):
+    """Test that production has systemd coredump configuration"""
+    assert file.exists(
+        "/etc/systemd/coredump.conf.d/disable_coredump.conf"
+    ), "Production should have systemd coredump disable config"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-service-systemd-coredump-no-override",
+    ]
+)
+@pytest.mark.feature("_prod")
+def test_prod_no_systemd_coredump_service_override(file: File):
+    """Test that production does not have systemd-coredump service override"""
+    assert not file.exists(
+        "/etc/systemd/system/systemd-coredump.service.d/override.conf"
+    ), "Production should not have systemd-coredump service override"

--- a/tests/integration/core/test_deny_packages.py
+++ b/tests/integration/core/test_deny_packages.py
@@ -1,0 +1,28 @@
+import pytest
+from plugins.dpkg import Dpkg
+
+denylist = [
+    "rlogin",
+    "rsh",
+    "rcp",
+    "telnet",
+    "libdb5.3",
+    "libssl1.1",
+]
+
+
+@pytest.mark.parametrize("denied_package", denylist)
+def test_no_denylisted_packages(denied_package: str, dpkg: Dpkg):
+    assert not dpkg.package_is_installed(
+        denied_package
+    ), f"Denylisted package {denied_package} is installed"
+
+
+@pytest.mark.feature(
+    "gcp",
+    reason="To ensure high performance network and disk capability, disable or remove the irqbalance daemon. This daemon does not correctly balance IRQ requests for the guest operating systems on virtual machine (VM) instances.",
+)  # https://docs.cloud.google.com/compute/docs/import/configuring-imported-images
+def test_package_irqbalance_not_installed_on_gcp(dpkg: Dpkg):
+    assert not dpkg.package_is_installed(
+        "irqbalance"
+    ), "Denylisted package irqbalance is installed on gcp"

--- a/tests/integration/core/test_dmesg.py
+++ b/tests/integration/core/test_dmesg.py
@@ -1,0 +1,126 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# server and gardener Feature - dmesg
+# =============================================================================
+
+# server adds /etc/sysctl.d/40-restrict-dmesg.conf, gardener excludes it
+#    and adds /etc/sysctl.d/40-allow-nonroot-dmesg.conf instead
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-sysctl-allow-nonroot-dmesg"])
+@pytest.mark.feature("gardener")
+def test_dmesg_gardener_sysctl_no_restrictions_on_accessing_dmesg(parse_file):
+    file_path = "/etc/sysctl.d/40-allow-nonroot-dmesg.conf"
+    config = parse_file.parse(file_path, format="keyval")
+    assert config["kernel.dmesg_restrict"] == "0"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("server and not gardener")
+def test_dmesg_server_sysctl_restrictions_on_accessing_dmesg(parse_file):
+    file_path = "/etc/sysctl.d/40-restrict-dmesg.conf"
+    config = parse_file.parse(file_path, format="keyval")
+    assert config["kernel.dmesg_restrict"] == "1"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-stig-config-sysctl-stig"])
+@pytest.mark.feature("stig")
+def test_dmesg_stig_sysctl_restrictions_on_accessing_dmesg(parse_file):
+    file_path = "/etc/sysctl.d/99-stig.conf"
+    config = parse_file.parse(file_path, format="keyval")
+    assert config["kernel.dmesg_restrict"] == "1"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-sysctl-no-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_sysctl_no_restrict_dmesg(file: File):
+    """Test that gardener does not restrict dmesg (allows non-root access)"""
+    # Check that allow-nonroot-dmesg config exists (covered elsewhere)
+    # or that restrict-dmesg config doesn't exist
+    assert not file.exists(
+        "/etc/sysctl.d/40-restrict-dmesg.conf"
+    ), "Gardener should not restrict dmesg access"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-sysctl-allow-nonroot-dmesg",
+    ]
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_dmesg_gardener_no_restrictions_sysctl_runtime(sysctl):
+    assert sysctl["kernel.dmesg_restrict"] == 0
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("server and not gardener")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_dmesg_server_restrictions_sysctl_runtime(sysctl):
+    assert sysctl["kernel.dmesg_restrict"] == 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-sysctl-allow-nonroot-dmesg",
+    ]
+)
+@pytest.mark.booted(reason="needs a booted system with dmesg restrictions loaded")
+@pytest.mark.feature("gardener")
+def test_dmesg_gardener_call_by_unprivileged_user_allowed(shell):
+    res = shell("dmesg", capture_output=True, ignore_exit_code=True)
+    assert res.returncode == 0
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sysctl-restrict-dmesg",
+    ]
+)
+@pytest.mark.feature("server and not gardener")
+@pytest.mark.booted(reason="needs a booted system with dmesg restrictions loaded")
+def test_dmesg_server_call_by_unprivileged_user_forbidden(shell):
+    res = shell("dmesg", capture_output=True, ignore_exit_code=True)
+    assert res.returncode == 1
+
+
+# =============================================================================
+# stig Feature - dmesg
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-stig-config-sysctl-stig",
+    ]
+)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="sysctl needs a booted system")
+def test_dmesg_stig_restrictions_sysctl_runtime(sysctl):
+    assert sysctl["kernel.dmesg_restrict"] == 1
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-stig-config-sysctl-stig",
+    ]
+)
+@pytest.mark.feature("stig")
+@pytest.mark.booted(reason="needs a booted system with dmesg restrictions loaded")
+def test_dmesg_stig_call_by_unprivileged_user_forbidden(shell):
+    res = shell("dmesg", capture_output=True, ignore_exit_code=True)
+    assert res.returncode == 1

--- a/tests/integration/core/test_history.py
+++ b/tests/integration/core/test_history.py
@@ -1,0 +1,35 @@
+import pytest
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# server Feature - History
+# =============================================================================
+
+CONFIG_FILE = "/etc/profile.d/50-nohistory.sh"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-script-profile-nohistory",
+    ]
+)
+@pytest.mark.feature("server")
+def test_history_profile_d_contains_required_configuration(parse_file: ParseFile):
+    sorted_lines = parse_file.lines(CONFIG_FILE, ordered=True)
+    assert [
+        "HISTFILE=/dev/null",
+        "readonly HISTFILE",
+        "export HISTFILE",
+    ] in sorted_lines
+
+
+@pytest.mark.feature("server")
+def test_histfile_env_var_is_readonly(shell):
+    res = shell(
+        ". /etc/profile.d/50-nohistory.sh && HISTFILE=/tmp/owned",
+        capture_output=True,
+        ignore_exit_code=True,
+    )
+
+    assert res.returncode == 2
+    assert "HISTFILE: is read only" in res.stderr

--- a/tests/integration/core/test_logging.py
+++ b/tests/integration/core/test_logging.py
@@ -1,0 +1,280 @@
+import pytest
+from plugins.file import File
+from plugins.find import Find
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# log Feature - Audit Rules Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-permissions",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_directory_permissions(find: Find, file: File):
+    """Test that audit directory has correct permissions"""
+    find.root_paths = "/etc/audit/rules.d"
+    find.entry_type = "files"
+    find.pattern = "*.rules"
+    missing = [file_path for file_path in find if not file.has_mode(file_path, "0640")]
+    assert (
+        not missing
+    ), f"Audit rules files should have permissions 0640, but these do not: {missing}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-README",
+        "GL-TESTCOV-log-config-audit-rules-base-config",
+        "GL-TESTCOV-log-config-audit-rules-cont-fail",
+        "GL-TESTCOV-log-config-audit-rules-ignore-error",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rules_files_exist(file: File):
+    """Test that audit rules configuration files exist"""
+    audit_rules = [
+        "/etc/audit/rules.d/README",
+        "/etc/audit/rules.d/10-base-config.rules",
+        "/etc/audit/rules.d/12-cont-fail.rules",
+        "/etc/audit/rules.d/12-ignore-error.rules",
+    ]
+    missing = [rule for rule in audit_rules if not file.exists(rule)]
+    assert not missing, f"Missing audit rules files: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-base-config",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rule_base_config_content(parse_file: ParseFile):
+    """Test that audit rules configuration files contain the correct content"""
+    lines = parse_file.lines("/etc/audit/rules.d/10-base-config.rules")
+    assert lines == [
+        "-D",
+        "-b 8192",
+        "--backlog_wait_time 60000",
+        "-f 1",
+    ], "Audit rules base configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-cont-fail",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rule_cont_fail_content(parse_file: ParseFile):
+    """Test that audit rules configuration files contain the correct content"""
+    lines = parse_file.lines("/etc/audit/rules.d/12-cont-fail.rules")
+    assert lines == [
+        "-c",
+    ], "Audit rules cont fail configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-audit-rules-ignore-error",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_audit_rule_ignore_error_content(parse_file: ParseFile):
+    """Test that audit rules configuration files contain the correct content"""
+    lines = parse_file.lines("/etc/audit/rules.d/12-ignore-error.rules")
+    assert lines == [
+        "-i",
+    ], "Audit rules ignore error configuration should contain the correct content"
+
+
+# =============================================================================
+# log Feature - Journald Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-minimum",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_minimum_config_exists(file: File):
+    """Test that journald minimum configuration exists"""
+    assert file.exists(
+        "/etc/systemd/journald.conf.d/10-minimum.conf"
+    ), "Journald minimum configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-minimum",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_minimum_config_content(parse_file: ParseFile):
+    """Test that journald minimum configuration contains the correct content"""
+    lines = parse_file.lines("/etc/systemd/journald.conf.d/10-minimum.conf")
+    assert lines == [
+        "[Journal]",
+        "Seal=yes",
+        "ReadKMsg=yes",
+        "Audit=yes",
+    ], "Journald minimum configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-rsyslog",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_rsyslog_config_exists(file: File):
+    """Test that journald rsyslog integration configuration exists"""
+    assert file.exists(
+        "/etc/systemd/journald.conf.d/20-rsyslog.conf"
+    ), "Journald rsyslog configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-journald-rsyslog",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_journald_rsyslog_config_content(parse_file: ParseFile):
+    """Test that journald rsyslog integration configuration contains the correct content"""
+    lines = parse_file.lines("/etc/systemd/journald.conf.d/20-rsyslog.conf")
+    assert lines == [
+        "[Journal]",
+        "ForwardToSyslog=yes",
+        "MaxLevelSyslog=info",
+    ], "Journald rsyslog integration configuration should contain the correct content"
+
+
+# =============================================================================
+# log Feature - Rsyslog Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_main_config_exists(file: File):
+    """Test that main rsyslog configuration exists"""
+    assert file.is_regular_file(
+        "/etc/rsyslog.conf"
+    ), "Main rsyslog configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_main_config_content(parse_file: ParseFile):
+    """Test that main rsyslog configuration contains the correct content"""
+    lines = parse_file.lines("/etc/rsyslog.conf")
+    assert lines == [
+        "$FileOwner root",
+        "$FileGroup adm",
+        "$FileCreateMode 0640",
+        "$DirCreateMode 0755",
+        "$Umask 0022",
+        "$WorkDirectory /var/spool/rsyslog",
+        "$IncludeConfig /etc/rsyslog.d/*.conf",
+    ], "Main rsyslog configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-input-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_input_configs_exist(file: File):
+    """Test that rsyslog input configurations exist"""
+    input_configs = [
+        "/etc/rsyslog.d/20-input.conf",
+    ]
+    missing = [cfg for cfg in input_configs if not file.exists(cfg)]
+    assert not missing, f"Missing rsyslog input configs: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-log-config-rsyslog-input-conf",
+    ]
+)
+@pytest.mark.feature("log")
+def test_log_rsyslog_input_config_content(parse_file: ParseFile):
+    """Test that rsyslog input configuration contains the correct content"""
+    lines = parse_file.lines("/etc/rsyslog.d/20-input.conf")
+    assert (
+        'module(load="imuxsock")' in lines
+    ), "Rsyslog input configuration should contain the correct content"
+
+
+# =============================================================================
+# log Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-log-service-auditd-enable", "GL-TESTCOV-ssh-service-auditd-enable"]
+)
+@pytest.mark.feature("log or ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_auditd_service_enabled(systemd: Systemd):
+    """Test that auditd.service is enabled"""
+    assert systemd.is_enabled("auditd.service")
+
+
+@pytest.mark.testcov(
+    ["GL-TESTCOV-log-service-auditd-enable", "GL-TESTCOV-ssh-service-auditd-enable"]
+)
+@pytest.mark.feature("log or ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_auditd_service_active(systemd: Systemd):
+    """Test that auditd.service is active"""
+    assert systemd.is_active("auditd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-rsyslog-preset-disable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_rsyslog_service_disabled(systemd: Systemd):
+    """Test that rsyslog.service is disabled by preset"""
+    assert systemd.is_disabled("rsyslog.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-rsyslog-preset-disable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_rsyslog_service_inactive(systemd: Systemd):
+    """Test that rsyslog.service is inactive"""
+    assert systemd.is_inactive("rsyslog.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-systemd-journald-audit-socket-enable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_systemd_journald_audit_socket_service_enabled(systemd: Systemd):
+    """Test that systemd-journald-audit.socket is enabled"""
+    assert systemd.is_enabled("systemd-journald-audit.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-log-service-systemd-journald-audit-socket-enable"])
+@pytest.mark.feature("log")
+@pytest.mark.booted(reason="Requires systemd")
+def test_log_systemd_journald_audit_socket_service_active(systemd: Systemd):
+    """Test that systemd-journald-audit.socket is active"""
+    assert systemd.is_active("systemd-journald-audit.socket")

--- a/tests/integration/core/test_network.py
+++ b/tests/integration/core/test_network.py
@@ -1,0 +1,156 @@
+import datetime
+import socket
+
+import pytest
+from plugins.file import File
+from plugins.network import has_ipv6
+from plugins.systemd import Systemd
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+# Test parameters. IPv6 skipped if not supported.
+LOCAL_TEST_PARAMS = [
+    pytest.param(socket.AF_INET, "127.0.0.1"),
+    pytest.param(
+        socket.AF_INET6,
+        "::1",
+        marks=pytest.mark.skipif(not has_ipv6(), reason="IPv6 not available"),
+    ),
+]
+
+
+@pytest.mark.booted(reason="ping requires full network stack")
+def test_loopback_interface(shell):
+    """Assert loopback device present."""
+    result = shell("ping -c 1 127.0.0.1", capture_output=True)
+    assert result.returncode == 0
+    assert "1 received" in result.stdout
+
+
+@pytest.mark.parametrize("ip_version, loopback", LOCAL_TEST_PARAMS)
+def test_local_tcp_stack(ip_version, loopback, tcp_echo_server):
+    """
+    Test if local TCP stack is functional by creating a new
+    listening socket on the loopback device and connecting to it.
+    """
+    # Arrange
+    msg = b"Hello, TCP!"
+    result, done = tcp_echo_server(ip_version, loopback, msg)
+
+    # Wait until the server bound to a port
+    while "port" not in result:
+        pass
+
+    # Act
+    with socket.create_connection((loopback, result["port"]), timeout=2) as conn:
+        conn.sendall(msg)
+
+    # Assert
+    done.wait(timeout=2)
+    assert result.get("data") == msg
+
+
+@pytest.mark.parametrize("ip_version,loopback", LOCAL_TEST_PARAMS)
+def test_local_udp_stack(ip_version, loopback, udp_echo_server):
+    """
+    Test if local UDP stack is functional by creating a new listening
+    socket on the loopback device and sending data to it.
+    """
+    # Arrange
+    msg = b"ping"
+    result = udp_echo_server(ip_version, loopback)
+
+    # Wait until the server bound to a port
+    while "port" not in result:
+        pass
+
+    # Act
+    with socket.socket(ip_version, socket.SOCK_DGRAM) as client:
+        client.sendto(msg, (result["addr"], result["port"]))
+        reply_data, _ = client.recvfrom(1024)
+
+        # Assert
+        assert result.get("data") == msg
+        assert reply_data == b"pong"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-resolv-conf"])
+@pytest.mark.booted
+def test_resolv_conf_exists(file: File):
+    """Test if local DNS config is available."""
+    # Arrange
+    path = "/etc/resolv.conf"
+
+    # Act / Assert
+    assert file.exists(path), f"'{path}' does not exist"
+    assert file.get_size(path) > 0, f"'{path}' is empty"
+
+
+@pytest.mark.booted
+def test_no_default_drop_policy(shell):
+    result = shell(
+        "iptables -S | grep 'DROP'", capture_output=True, ignore_exit_code=True
+    )
+    assert "DROP" not in result.stdout, "Default DROP policy detected"
+
+
+# =============================================================================
+# azure Feature - Network
+# =============================================================================
+
+
+@pytest.mark.booted(reason="nslookup requires fully booted system")
+@pytest.mark.feature("azure")
+def test_hostname_azure(shell):
+    """Test if hostname is resolvable in Azure DNS."""
+    # Arrange / Act
+    start_time = datetime.datetime.now()
+    result = shell("nslookup $(hostname)", capture_output=True, ignore_exit_code=True)
+    end_time = datetime.datetime.now()
+
+    # Assert
+    assert result.returncode == 0, f"nslookup failed: {result.stderr}"
+
+    execution_time = round((end_time - start_time).total_seconds())
+    assert (
+        execution_time <= 10
+    ), f"nslookup should not run into timeout: {result.stderr}"
+
+
+# =============================================================================
+# DISA Stig related features - Network
+# =============================================================================
+
+
+@pytest.mark.security_id(1127)
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="firewall service check requires booted system")
+@pytest.mark.feature(
+    "not gardener and not lima and not metal and not azure and not aws and not gcp and not gdch and not ali"
+)
+def test_that_nftables_firewall_service_is_running(systemd: Systemd):
+    """
+    As per DISA STIG requirement, either nftables or iptables firewall service should be active
+    for firewall compliance. This test checks that nftables is active for marked image types.
+    Ref: SRG-OS-000480-GPOS-00232
+    """
+    assert systemd.is_active(
+        "nftables"
+    ), "nftables should be active for firewall compliance"
+
+
+@pytest.mark.security_id(1127)
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="firewall service check requires booted system")
+@pytest.mark.feature("lima and gardener and server and ssh")
+def test_that_iptables_firewall_service_is_running(systemd: Systemd):
+    """
+    As per DISA STIG requirement, either iptables or nftables firewall service should be active
+    for firewall compliance. This test checks that iptables is active for marked image types.
+    Ref: SRG-OS-000480-GPOS-00232
+    """
+    assert systemd.is_active(
+        "iptables"
+    ), "iptables should be active for firewall compliance"

--- a/tests/integration/core/test_proc.py
+++ b/tests/integration/core/test_proc.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.root
+@pytest.mark.booted
+def test_image_proc_is_empty(remounted_root):
+    """
+    Test for an empty /proc within the given rootfs tarball. Since /proc is mounted
+    we remount / temporarily. This allows to check if the image comes with an empty
+    proc directory.
+    """
+    temp_proc = os.path.join(remounted_root, "proc")
+
+    # We need the clean /proc directory in the chroot
+    assert os.path.ismount(temp_proc) == False, f"{temp_proc} must not be mounted"
+
+    # Execute local file listing (this does not need to be
+    # performed within a platform itself) since "/proc"
+    # will never be empty on a running/used system.
+    proc_files: list[str] = os.listdir(temp_proc)
+
+    # Within temporary "/proc" no files or directories should be found.
+    assert len(proc_files) == 0, f"{temp_proc} is not empty."
+
+
+@pytest.mark.root
+@pytest.mark.booted
+def test_running_proc_is_not_empty():
+    """
+    negative test as mounted proc should contain expected files
+    """
+    root_proc = "/proc"
+    root_proc_files: list[str] = os.listdir(root_proc)
+    assert len(root_proc_files) >= 0, f"{root_proc} should contain files."
+    assert all(
+        expected_procfile in root_proc_files
+        for expected_procfile in ["version", "uptime"]
+    ), f"{root_proc} does not contain the usual files."

--- a/tests/integration/core/test_profile.py
+++ b/tests/integration/core/test_profile.py
@@ -1,0 +1,179 @@
+import re
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# cloud or (openstack and metal) Feature - Profile
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cloud-script-profile-autologout"])
+@pytest.mark.feature("cloud", reason="enabled in cloud feature")
+def test_profile_autologout_cloud(parse_file: ParseFile):
+    """Test that the autologout profile is set correctly."""
+    file = "/etc/profile.d/50-autologout.sh"
+    lines_list = [
+        "TMOUT=900",
+        "readonly TMOUT",
+        "export TMOUT",
+    ]
+    sorted_lines = parse_file.lines(file, ordered=True)
+    assert (
+        lines_list in sorted_lines
+    ), f"Could not find expected lines in order in {file}: {lines_list}"
+
+
+TMOUT_FILE_CLOUD = "/etc/profile.d/50-autologout.sh"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_file_exists_cloud(file: File):
+    """
+    As per DISA STIG requirement, this test validates that the shell inactivity
+    timeout configuration file exists.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert file.exists(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: shell inactivity timeout configuration file is missing"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_is_configured_cloud(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT variable is configured.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"TMOUT\s*=\s*\d+") in parse_file.lines(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: TMOUT is not configured"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_is_readonly_cloud(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is marked ReadOnly.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"readonly\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: TMOUT is not marked as readonly"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("cloud or (openstack and metal)")
+def test_shell_tmout_is_exported_cloud(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is
+    exported to subshells
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"export\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_CLOUD
+    ), "stigcompliance: TMOUT is not exported"
+
+
+# =============================================================================
+# openstackMetal Feature - Profile
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-script-profile-autologout"])
+@pytest.mark.feature(
+    "openstack and metal", reason="enabled in openstack on metal feature"
+)
+def test_profile_autologout_openstack_metal(parse_file: ParseFile):
+    """Test that the autologout profile is set correctly."""
+    file = "/etc/profile.d/50-autologout.sh"
+    lines_list = [
+        "TMOUT=900",
+        "readonly TMOUT",
+        "export TMOUT",
+    ]
+    sorted_lines = parse_file.lines(file, ordered=True)
+    assert (
+        lines_list in sorted_lines
+    ), f"Could not find expected lines in order in {file}: {lines_list}"
+
+
+# =============================================================================
+# disaSTIG Feature - Profile
+# =============================================================================
+
+
+# TODO: decide if "disaSTIGmedium" feature shall get more setting/test
+@pytest.mark.feature("disaSTIGmedium", reason="enabled in disaSTIGmedium feature")
+def test_profile_autologout_stig(parse_file: ParseFile):
+    """Test that the autologout profile is set correctly."""
+    file = "/etc/profile.d/99-terminal_tmout.sh"
+    lines_list = [
+        "TMOUT=900",
+        "readonly TMOUT",
+        "export TMOUT",
+    ]
+    sorted_lines = parse_file.lines(file, ordered=True)
+    assert (
+        lines_list in sorted_lines
+    ), f"Could not find expected lines in order in {file}: {lines_list}"
+
+
+# =============================================================================
+# disaSTIG Feature - Profile
+# =============================================================================
+
+TMOUT_FILE_STIG = "/etc/profile.d/99-terminal_tmout.sh"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_file_exists_stig(file: File):
+    """
+    As per DISA STIG requirement, this test validates that the shell inactivity
+    timeout configuration file exists.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert file.exists(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: shell inactivity timeout configuration file is missing"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_is_configured_stig(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT variable is configured.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"TMOUT\s*=\s*\d+") in parse_file.lines(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: TMOUT is not configured"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_is_readonly_stig(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is marked ReadOnly.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"readonly\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: TMOUT is not marked as readonly"
+
+
+@pytest.mark.security_id(485)
+@pytest.mark.feature("disaSTIGmedium")
+def test_shell_tmout_is_exported_stig(parse_file: ParseFile):
+    """
+    As per DISA STIG requirement, this test verifies that TMOUT is
+    exported to subshells.
+    Ref: SRG-OS-000755-GPOS-00220
+    """
+    assert re.compile(r"export\s+TMOUT") in parse_file.lines(
+        TMOUT_FILE_STIG
+    ), "stigcompliance: TMOUT is not exported"

--- a/tests/integration/core/test_server.py
+++ b/tests/integration/core/test_server.py
@@ -1,0 +1,610 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# server Feature - MOTD Scripts
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-update-motd-hostname",
+        "GL-TESTCOV-server-config-update-motd-line-001",
+        "GL-TESTCOV-server-config-update-motd-uname",
+        "GL-TESTCOV-server-config-update-motd-load",
+        "GL-TESTCOV-server-config-update-motd-free",
+        "GL-TESTCOV-server-config-update-motd-network",
+        "GL-TESTCOV-server-config-update-motd-line-002",
+        "GL-TESTCOV-server-config-update-motd-logo",
+        "GL-TESTCOV-server-config-update-motd-needrestart",
+        "GL-TESTCOV-server-config-update-motd-unattended-upgrades",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_motd_scripts_exist(file: File):
+    """Test that MOTD scripts exist"""
+    motd_scripts = [
+        "/etc/update-motd.d/05-logo",
+        "/etc/update-motd.d/10-hostname",
+        "/etc/update-motd.d/20-uname",
+        "/etc/update-motd.d/30-load",
+        "/etc/update-motd.d/40-free",
+        "/etc/update-motd.d/45-line",
+        "/etc/update-motd.d/50-network",
+        "/etc/update-motd.d/55-line",
+        "/etc/update-motd.d/92-unattended-upgrades",
+        "/etc/update-motd.d/95-needrestart",
+    ]
+
+    missing = [script for script in motd_scripts if not file.exists(script)]
+    assert not missing, f"Missing MOTD scripts: {', '.join(missing)}"
+
+
+# =============================================================================
+# server Feature - Filesystem overrides
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-growfs-override",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_growfs_override_exists(file: File):
+    """Test that systemd-growfs service override exists"""
+    # The growfs service might be in different paths
+    paths = [
+        "/etc/systemd/system/systemd-growfs@.service.d/override.conf",
+        "/etc/systemd/system/systemd-growfs-root.service.d/override.conf",
+    ]
+    exists = any(file.exists(path) for path in paths)
+    assert exists, f"systemd-growfs override not found in any of: {', '.join(paths)}"
+
+
+# =============================================================================
+# server Feature - Network & Resolved Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-networkd-wait-online-any",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_networkd_wait_online_override_exists(file: File):
+    """Test that systemd-networkd-wait-online service override exists"""
+    assert file.exists(
+        "/etc/systemd/system/systemd-networkd-wait-online.service.d/any.conf"
+    )
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-resolved-wait-for-networkd",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_networkd_dependency_exists(file: File):
+    """Test that systemd-resolved has networkd dependency override"""
+    assert file.exists(
+        "/etc/systemd/system/systemd-resolved.service.d/wait-for-networkd.conf"
+    )
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-llmnr-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_llmn_config_exists(file: File):
+    """Test that systemd-resolved LLMNR configuration exists"""
+    assert file.exists(
+        "/etc/systemd/resolved.conf.d/00-disable-llmnr.conf"
+    ), "systemd-resolved LLMNR configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-llmnr-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_llmnr_disabled(parse_file: ParseFile):
+    """Test that LLMNR is disabled in systemd-resolved"""
+
+    lines = parse_file.lines("/etc/systemd/resolved.conf.d/00-disable-llmnr.conf")
+    assert "LLMNR=no" in lines, "LLMNR should be disabled in systemd-resolved"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-mdns-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_mdns_config_exists(file: File):
+    """Test that systemd-resolved mDNS configuration exists"""
+    assert file.exists(
+        "/etc/systemd/resolved.conf.d/01-disable-mdns.conf"
+    ), "systemd-resolved mDNS configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolved-mdns-disable",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_resolved_mdns_disabled(parse_file: ParseFile):
+    """Test that mDNS is disabled in systemd-resolved"""
+    lines = parse_file.lines("/etc/systemd/resolved.conf.d/01-disable-mdns.conf")
+    assert (
+        "MulticastDNS=no" in lines
+    ), "MulticastDNS should be disabled in systemd-resolved"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-network-server",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_networkd_server_config_exists(parse_file: ParseFile):
+    """Test that Foreign Routing is disabled in Networkd configuration"""
+    lines = parse_file.lines("/etc/systemd/networkd.conf.d/00-gardenlinux-server.conf")
+    assert (
+        "ManageForeignRoutingPolicyRules=no" in lines
+    ), "Foreign Routing Policy Rules should be disabled in Networkd"
+    assert (
+        "ManageForeignRoutes=no" in lines
+    ), "Foreign Routes should be disabled in Networkd"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-network-server",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_networkd_foreign_routing_disabled(parse_file: ParseFile):
+    """Test that Foreign Routing is disabled in Networkd configuration"""
+    lines = parse_file.lines("/etc/systemd/networkd.conf.d/00-gardenlinux-server.conf")
+    assert (
+        "ManageForeignRoutingPolicyRules=no" in lines
+    ), "Foreign Routing Policy Rules should be disabled in Networkd"
+    assert (
+        "ManageForeignRoutes=no" in lines
+    ), "Foreign Routes should be disabled in Networkd"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-resolv-conf-link",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Resolv.conf does not exist in chroot")
+def test_server_resolv_conf_stub_link(file: File):
+    """Test that resolv.conf is a symlink to stub-resolv.conf"""
+    assert file.is_symlink(
+        "/etc/resolv.conf", "/run/systemd/resolve/resolv.conf"
+    ), "/etc/resolv.conf should be a symlink to /run/systemd/resolve/resolv.conf"
+
+
+# =============================================================================
+# server Feature - System Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-hosts-permissions",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_hosts_file_permissions(file: File):
+    """Test that /etc/hosts has correct permissions"""
+    assert file.has_mode(
+        "/etc/hosts", "0644"
+    ), "/etc/hosts should have 0644 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-wheel",
+    ]
+)
+@pytest.mark.feature("server and not disaSTIGmedium")
+def test_server_sudoers_wheel_exists(file: File):
+    """Test that sudoers wheel configuration exists"""
+    assert file.exists("/etc/sudoers.d/wheel"), "/etc/sudoers.d/wheel should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-wheel",
+    ]
+)
+@pytest.mark.feature("server and not disaSTIGmedium")
+def test_server_sudoers_wheel_content(parse_file: ParseFile):
+    """Test that sudoers wheel configuration contains the correct content"""
+    lines = parse_file.lines("/etc/sudoers.d/wheel")
+    assert (
+        "%wheel  ALL=(ALL:ALL) NOPASSWD: ALL" in lines
+    ), "sudoers wheel configuration should contain the correct content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-keepssh",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_sudoers_keepssh_exists(file: File):
+    """Test that sudoers keepssh configuration exists"""
+    assert file.exists("/etc/sudoers.d/keepssh"), "/etc/sudoers.d/keepssh should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-sudoers-keepssh",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_sudoers_keepssh_content(parse_file: ParseFile):
+    """Test that sudoers keepssh configuration contains the correct content"""
+    lines = parse_file.lines("/etc/sudoers.d/keepssh")
+    assert (
+        "Defaults env_keep+=SSH_AUTH_SOCK" in lines
+    ), "sudoers keepssh configuration should contain the correct content"
+
+
+@pytest.mark.feature("server")
+@pytest.mark.root
+def test_sudo_secure_path_is_set(parse_file: ParseFile):
+    lines = parse_file.lines("/etc/sudoers")
+    assert "Defaults secure_path" in lines
+
+
+# =============================================================================
+# server Feature - Additional System Files
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_locale_conf_exists(file: File):
+    """Test that locale.conf exists"""
+    assert file.is_regular_file("/etc/locale.conf"), "/etc/locale.conf should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_locale_conf_content(parse_file: ParseFile):
+    """Test that locale.conf contains the correct content"""
+    lines = parse_file.parse("/etc/locale.conf", format="keyval")
+    assert lines["LANG"] == "C.UTF-8", "LANG should be C.UTF-8"
+    assert lines["LANGUAGE"] == "en_US:en", "LANGUAGE should be en_US:en"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-init-auditd",
+        "GL-TESTCOV-server-config-no-init-dbus",
+        "GL-TESTCOV-server-config-no-init-kexec",
+        "GL-TESTCOV-server-config-no-init-kexec-load",
+        "GL-TESTCOV-server-config-no-init-sudo",
+        "GL-TESTCOV-server-config-no-init-sysstat",
+        "GL-TESTCOV-server-config-no-init-udev",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_init_scripts(file: File):
+    """Test that server does not have unnecessary init scripts"""
+    init_scripts = [
+        "/etc/init.d/auditd",
+        "/etc/init.d/dbus",
+        "/etc/init.d/kexec",
+        "/etc/init.d/kexec-load",
+        "/etc/init.d/sudo",
+        "/etc/init.d/sysstat",
+        "/etc/init.d/udev",
+    ]
+    existing = [script for script in init_scripts if file.exists(script)]
+    assert not existing, f"Unexpected init scripts found: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-games",
+        "GL-TESTCOV-server-config-no-monit",
+        "GL-TESTCOV-server-config-no-pycache",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_unnecessary_dirs(file: File):
+    """Test that server does not have unnecessary directories"""
+    dirs = [
+        "/usr/games",
+        "/etc/monit",
+        "/usr/lib/python*/__pycache__",  # Pattern
+    ]
+    missing = [dir for dir in dirs if not file.is_dir(dir)]
+    assert missing, f"Unnecessary directories found: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-runit",
+        "GL-TESTCOV-server-config-no-runit-log",
+        "GL-TESTCOV-server-config-no-sv",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_runit_files(file: File):
+    """Test that server does not have runit service manager files"""
+    runit_paths = [
+        "/etc/runit",
+        "/etc/runit/1",
+        "/var/log/runit",
+        "/etc/sv",
+    ]
+    existing = [path for path in runit_paths if file.exists(path)]
+    assert not existing, f"Unexpected runit files found: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-ufw",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_ufw(file: File):
+    """Test that server does not have UFW firewall"""
+    assert not file.exists("/etc/ufw"), "UFW should not be present"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-kvm-config-no-vmlinuz",
+        "GL-TESTCOV-kvm-config-no-vmlinuz-old",
+        "GL-TESTCOV-server-config-no-vmlinuz",
+        "GL-TESTCOV-server-config-no-vmlinuz-old",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_vmlinuz_in_root(file: File):
+    """Test that server does not have vmlinuz files in root directory"""
+    vmlinuz_files = [
+        "/vmlinuz",
+        "/vmlinuz.old",
+    ]
+    existing = [f for f in vmlinuz_files if file.exists(f)]
+    assert not existing, f"vmlinuz files should not be in root: {', '.join(existing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-no-dbus-machine-id",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_dbus_machine_id(file: File):
+    """Test that server does not have static dbus machine-id"""
+    # machine-id should be a symlink to /etc/machine-id, not a static file
+    if file.exists("/var/lib/dbus/machine-id"):
+        assert file.is_symlink(
+            "/var/lib/dbus/machine-id"
+        ), "/var/lib/dbus/machine-id should be a symlink, not a static file"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-mount-tmp",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_mount_tmp_exists(file: File):
+    """Test that server has tmp mount configuration"""
+    assert file.exists("/etc/systemd/system/tmp.mount")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-mount-tmp-enable",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_mount_tmp_enabled(systemd: Systemd):
+    """Test that server tmp mount is enabled"""
+    assert systemd.is_enabled("tmp.mount")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-mount-tmp-enable",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="No mounts available in chroot")
+def test_server_mount_tmp_active(systemd: Systemd):
+    """Test that server tmp mount is active"""
+    assert systemd.is_active("tmp.mount")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-network-default",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_network_default_config_exists(file: File):
+    """Test that server has network default configuration"""
+    assert file.exists("/etc/systemd/network/99-default.network")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-cron-no-e2scrub_all",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_e2scrub_all_cron(file: File):
+    """Test that server does not have e2scrub_all cron job"""
+    assert not file.exists(
+        "/etc/cron.d/e2scrub_all"
+    ), "e2scrub_all cron job should not exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-kernel-img-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_kernel_img_conf_exists(file: File):
+    """Test that server kernel-img.conf exists"""
+    assert file.exists("/etc/kernel-img.conf"), "Server kernel-img.conf should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-kernel-img-conf",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_kernel_img_do_symlinks(parse_file: ParseFile):
+    """Test that server kernel-img.conf does disable do_symlinks"""
+    config = parse_file.parse("/etc/kernel-img.conf", format="keyval")
+    assert (
+        config["do_symlinks"] == "no"
+    ), "Server kernel-img.conf should have do_symlinks disabled"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-conf-permissions",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_locale_conf_permissions(file: File):
+    """Test that server locale.conf has correct permissions"""
+    assert file.has_mode(
+        "/etc/locale.conf", "0644"
+    ), "locale.conf should have 0644 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-locale-link",
+    ]
+)
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="set in exec.config, which is not run in chroot")
+def test_server_locale_link(file: File):
+    """Test that server locale configuration is properly linked"""
+    assert file.is_symlink(
+        "/etc/default/locale", "/etc/locale.conf"
+    ), "Locale configuration should be a symlink"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-nsswitch-no-nis",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_nsswitch_no_nis(parse_file: ParseFile):
+    """Test that server nsswitch does not use NIS"""
+    lines = parse_file.lines("/etc/nsswitch.conf")
+    assert "netgroup:" not in lines, "netgroup should not be in nsswitch.conf"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-skel-bash-permissions",
+        "GL-TESTCOV-server-config-skel-profile-permissions",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_skel_file_permissions(file: File):
+    """Test that server skel files have correct permissions"""
+    skel_files = {
+        "/etc/skel/.bashrc": "0640",
+        "/etc/skel/.profile": "0640",
+    }
+    missing = [
+        filepath
+        for filepath, expected_mode in skel_files.items()
+        if not file.has_mode(filepath, expected_mode)
+    ]
+    assert (
+        not missing
+    ), f"Skel files should have correct permissions: {', '.join(missing)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-systemd-system-conf-server",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_system_conf(file: File):
+    """Test that server systemd system.conf exists"""
+    assert file.exists(
+        "/etc/systemd/system.conf.d/00-gardenlinux-server.conf"
+    ), "Server systemd system.conf should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-systemd-system-dbus-socket",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_dbus_socket(file: File):
+    """Test that server has dbus.socket systemd unit"""
+    assert file.exists(
+        "/usr/lib/systemd/system/dbus.socket"
+    ), "Server dbus.socket should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-systemd-system-dbus-socket",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_systemd_dbus_socket_content(parse_file: ParseFile):
+    """Test that server has dbus.socket systemd unit"""
+    config = parse_file.parse("/usr/lib/systemd/system/dbus.socket", format="ini")
+    assert (
+        config["Socket"]["ListenStream"] == "/run/dbus/system_bus_socket"
+    ), "Server dbus.socket should listen on /run/dbus/system_bus_socket"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-update-motd-no-uname",
+    ]
+)
+@pytest.mark.feature("server")
+def test_server_no_uname_motd_script(file: File):
+    """Test that server does not have uname update-motd script"""
+    assert not file.exists(
+        "/etc/update-motd.d/10-uname"
+    ), "uname motd script should not exist"

--- a/tests/integration/core/test_services.py
+++ b/tests/integration/core/test_services.py
@@ -1,0 +1,887 @@
+"""
+Test systemd services for enabled/disabled, active/inactive states across all Garden Linux features.
+"""
+
+import pytest
+from plugins.file import File
+from plugins.kernel_versions import KernelVersions
+from plugins.systemd import Systemd
+
+# =============================================================================
+# _fwcfg Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-service-qemu-fw_cfg-script-unit"])
+@pytest.mark.feature("_fwcfg")
+def test_fwcfg_qemu_fw_cfg_script_unit_exists(file):
+    """Test that qemu-fw_cfg-script.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/qemu-fw_cfg-script.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-service-qemu-fw_cfg-script-enable"])
+@pytest.mark.feature("_fwcfg")
+@pytest.mark.booted(reason="Requires systemd")
+def test__fwcfg_qemu_fw_cfg_script_service_enabled(systemd: Systemd):
+    """Test that qemu-fw_cfg-script.service is enabled"""
+    assert systemd.is_enabled("qemu-fw_cfg-script.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_fwcfg-service-qemu-fw_cfg-script-enable"])
+@pytest.mark.feature("_fwcfg")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor("qemu", reason="qemu-fw_cfg-script only works on Qemu")
+def test__fwcfg_qemu_fw_cfg_script_service_active(systemd: Systemd):
+    """Test that qemu-fw_cfg-script.service is active"""
+    assert systemd.is_active("qemu-fw_cfg-script.service")
+
+
+# =============================================================================
+# _kdump Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_kdump-service-kdump-tools-enable"])
+@pytest.mark.feature("_kdump")
+@pytest.mark.booted(reason="Requires systemd")
+def test__kdump_kdump_tools_service_enabled(systemd: Systemd):
+    """Test that kdump-tools.service is enabled"""
+    assert systemd.is_enabled("kdump-tools.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_kdump-service-kdump-tools-enable"])
+@pytest.mark.feature("_kdump")
+@pytest.mark.booted(reason="Requires systemd")
+def test__kdump_kdump_tools_service_active(systemd: Systemd):
+    """Test that kdump-tools.service is active"""
+    assert systemd.is_active("kdump-tools.service")
+
+
+# =============================================================================
+# _prod Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_prod-service-no-systemd-coredump"])
+@pytest.mark.feature("_prod")
+@pytest.mark.booted(reason="Requires systemd")
+def test__prod_no_systemd_coredump_service(systemd: Systemd):
+    """Test that systemd-coredump.service is not installed"""
+    assert not any(
+        u.unit == "systemd-coredump.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# aws Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-aws-clocksource-unit"])
+@pytest.mark.feature("aws")
+def test_aws_clocksource_unit_exists(file):
+    """Test that aws-clocksource.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/aws-clocksource.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-aws-clocksource-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aws_aws_clocksource_service_enabled(systemd: Systemd):
+    """Test that aws-clocksource.service is enabled"""
+    assert systemd.is_enabled("aws-clocksource.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-service-aws-clocksource-enable"])
+@pytest.mark.feature("aws")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aws_aws_clocksource_service_inactive(systemd: Systemd):
+    """Test that aws-clocksource.service is inactive (oneshot service)"""
+    assert systemd.is_inactive("aws-clocksource.service")
+
+
+# =============================================================================
+# checkbox Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-generate-report-unit"])
+@pytest.mark.feature("checkbox")
+def test_checkbox_generate_report_unit_exists(file):
+    """Test that generate-report.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/generate-report.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-getty-tty1-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_getty_tty1_service_disabled(systemd: Systemd):
+    """Test that getty@tty1.service is disabled"""
+    assert systemd.is_disabled("getty@tty1.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-getty-tty1-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_getty_tty1_service_inactive(systemd: Systemd):
+    """Test that getty@tty1.service is inactive"""
+    assert systemd.is_inactive("getty@tty1.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-getty-tty1-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_serial_getty_service_disabled(systemd: Systemd):
+    """Test that serial-getty@.service is disabled"""
+    assert systemd.is_disabled("serial-getty@.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-serial-getty-disable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_serial_getty_service_inactive(systemd: Systemd):
+    """Test that serial-getty@.service is inactive"""
+    assert systemd.is_inactive("serial-getty@.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-nginx-enable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_nginx_service_enabled(systemd: Systemd):
+    """Test that nginx.service is enabled"""
+    assert systemd.is_enabled("nginx.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-checkbox-service-nginx-enable"])
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="Requires systemd")
+def test_checkbox_nginx_service_active(systemd: Systemd):
+    """Test that nginx.service is active"""
+    assert systemd.is_active("nginx.service")
+
+
+# =============================================================================
+# chost Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-apparmor-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-apparmor-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-containerd-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_containerd_service_enabled(systemd: Systemd):
+    """Test that containerd.service is enabled"""
+    assert systemd.is_enabled("containerd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-chost-service-containerd-enable"])
+@pytest.mark.feature("chost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_chost_containerd_service_active(systemd: Systemd):
+    """Test that containerd.service is active"""
+    assert systemd.is_active("containerd.service")
+
+
+# TODO: Add tests for user-level systemd units
+# @pytest.mark.testcov(["GL-TESTCOV-chost-service-user-dbus-socket-enable"])
+# @pytest.mark.feature("chost")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_chost_dbus_socket_user_service_enabled(systemd: Systemd):
+#     """Test that user service for dbus.socket is enabled"""
+#     assert systemd.is_enabled_user("dbus.socket")
+#
+#
+# @pytest.mark.testcov(["GL-TESTCOV-chost-service-user-dbus-socket-enable"])
+# @pytest.mark.feature("chost")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_chost_dbus_socket_user_service_active(systemd: Systemd):
+#     """Test that user service for dbus.socket is active"""
+#     assert systemd.is_active_user("dbus.socket")
+
+
+# -----------------------------------------------------------------------------
+# cisSshd Feature Unit Files
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-service-gardenlinux-fw-ipv4-unit"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_fw_ipv4_unit_exists(file):
+    """Test that gardenlinux-fw-ipv4.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-cisSshd-service-gardenlinux-fw-ipv6-unit"])
+@pytest.mark.feature("cisSshd")
+def test_cissshd_fw_ipv6_unit_exists(file):
+    """Test that gardenlinux-fw-ipv6.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv6.service")
+
+
+# =============================================================================
+# clamav Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-clamav-service-clamav-enable"])
+@pytest.mark.feature("clamav")
+@pytest.mark.booted(reason="Requires systemd")
+def test_clamav_clamav_daemon_service_enabled(systemd: Systemd):
+    """Test that clamav-daemon.service is enabled"""
+    assert systemd.is_enabled("clamav-daemon.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-clamav-service-clamav-enable"])
+@pytest.mark.feature("clamav")
+@pytest.mark.booted(reason="Requires systemd")
+def test_clamav_clamav_daemon_service_active(systemd: Systemd):
+    """Test that clamav-daemon.service is active"""
+    assert systemd.is_active("clamav-daemon.service")
+
+
+# =============================================================================
+# fedramp Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv4-unit"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_fw_ipv4_unit_exists(file):
+    """Test that gardenlinux-fw-ipv4.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv6-unit"])
+@pytest.mark.feature("fedramp")
+def test_fedramp_fw_ipv6_unit_exists(file):
+    """Test that gardenlinux-fw-ipv6.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/gardenlinux-fw-ipv6.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-apparmor-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-apparmor-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv4-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv4_service_enabled(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv4.service is enabled"""
+    assert systemd.is_enabled("gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv4-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv4_service_active(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv4.service is active"""
+    assert systemd.is_active("gardenlinux-fw-ipv4.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv6-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv6_service_enabled(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv6.service is enabled"""
+    assert systemd.is_enabled("gardenlinux-fw-ipv6.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-gardenlinux-fw-ipv6-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_gardenlinux_fw_ipv6_service_active(systemd: Systemd):
+    """Test that gardenlinux-fw-ipv6.service is active"""
+    assert systemd.is_active("gardenlinux-fw-ipv6.service")
+
+
+# =============================================================================
+# firewall Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-firewall-service-nftables-enable"])
+@pytest.mark.feature("firewall")
+@pytest.mark.booted(reason="Requires systemd")
+def test_firewall_nftables_service_enabled(systemd: Systemd):
+    """Test that nftables.service is enabled"""
+    assert systemd.is_enabled("nftables.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-firewall-service-nftables-enable"])
+@pytest.mark.feature("firewall")
+@pytest.mark.booted(reason="Requires systemd")
+def test_firewall_nftables_service_active(systemd: Systemd):
+    """Test that nftables.service is active"""
+    assert systemd.is_active("nftables.service")
+
+
+# =============================================================================
+# gcp Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-google-guest-agent-enable"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gcp_google_guest_agent_service_enabled(systemd: Systemd):
+    """Test that google-guest-agent.service is enabled"""
+    assert systemd.is_enabled("google-guest-agent.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-google-guest-agent-enable"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="google-guest-agent.service crashes if run in qemu"
+)
+def test_gcp_google_guest_agent_service_active(systemd: Systemd):
+    """Test that google-guest-agent.service is active"""
+    assert systemd.is_active("google-guest-agent.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-service-no-irqbalance"])
+@pytest.mark.feature("gcp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gcp_no_irqbalance_service(systemd: Systemd):
+    """Test that irqbalance.service is not installed"""
+    assert not any(
+        u.unit == "irqbalance.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# gdch Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-no-irqbalance"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_no_irqbalance_service(systemd: Systemd):
+    """Test that irqbalance.service is not installed"""
+    assert not any(
+        u.unit == "irqbalance.service" for u in systemd.list_installed_units()
+    )
+
+
+# =============================================================================
+# iscsi Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-iscsi-service-iscsi-initiatorname-unit",
+    ]
+)
+@pytest.mark.feature("iscsi")
+def test_iscsi_initiatorname_template_exists(file: File):
+    """Test that iSCSI initiator name template exists"""
+    assert file.exists(
+        "/etc/systemd/system/iscsi-initiatorname.service"
+    ), "iSCSI initiator name service template should exist"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-iscsi-initiatorname-unit"])
+@pytest.mark.feature("iscsi")
+def test_iscsi_initiatorname_unit_exists(file):
+    """Test that iscsi-initiatorname.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/iscsi-initiatorname.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-iscsid-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_iscsid_service_enabled(systemd: Systemd):
+    """Test that iscsid.service is enabled"""
+    assert systemd.is_enabled("iscsid.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-iscsid-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_iscsid_service_active(systemd: Systemd):
+    """Test that iscsid.service is active"""
+    assert systemd.is_active("iscsid.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-tgt-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_tgt_service_enabled(systemd: Systemd):
+    """Test that tgt.service is enabled"""
+    assert systemd.is_enabled("tgt.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-iscsi-service-tgt-enable"])
+@pytest.mark.feature("iscsi")
+@pytest.mark.booted(reason="Requires systemd")
+def test_iscsi_tgt_service_active(systemd: Systemd):
+    """Test that tgt.service is active"""
+    assert systemd.is_active("tgt.service")
+
+
+# =============================================================================
+# khost Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-khost-service-apparmor-enable"])
+@pytest.mark.feature("khost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_khost_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-khost-service-apparmor-enable"])
+@pytest.mark.feature("khost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_khost_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+# =============================================================================
+# lima Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-service-sshd-enable"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="Requires systemd")
+def test_lima_ssh_service_enabled(systemd: Systemd):
+    """Test that ssh.service is enabled"""
+    assert systemd.is_enabled("ssh.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-lima-service-sshd-enable"])
+@pytest.mark.feature("lima")
+@pytest.mark.booted(reason="Requires systemd")
+def test_lima_ssh_service_active(systemd: Systemd):
+    """Test that ssh.service is active"""
+    assert systemd.is_active("ssh.service")
+
+
+# =============================================================================
+# metal Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-ipmievd-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+def test_metal_ipmievd_service_enabled(systemd: Systemd):
+    """Test that ipmievd.service is enabled"""
+    assert systemd.is_enabled("ipmievd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-ipmievd-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="IPMI device is not available on QEMU and service will fail"
+)
+def test_metal_ipmievd_service_active(systemd: Systemd):
+    """Test that ipmievd.service is active"""
+    assert systemd.is_active("ipmievd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-mdmonitor-oneshot-timer-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+def test_metal_mdmonitor_oneshot_timer_enabled(systemd: Systemd):
+    """Test that mdadm.service is enabled"""
+    assert systemd.is_enabled("mdmonitor-oneshot.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-mdmonitor-oneshot-timer-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+def test_metal_mdmonitor_oneshot_timer_inactive(systemd: Systemd):
+    """Test that mdmonitor-oneshot.timer is inactive"""
+    assert systemd.is_inactive("mdmonitor-oneshot.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-smartmontools-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu",
+    reason="unit will has condition to not be enabled/started on virtualization",
+)
+def test_metal_smartd_service_enabled(systemd: Systemd):
+    """Test that smartd.service is enabled"""
+    assert systemd.is_enabled("smartd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-metal-service-smartmontools-enable"])
+@pytest.mark.feature("metal")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu",
+    reason="unit will has condition to not be enabled/started on virtualization",
+)
+def test_metal_smartd_service_active(systemd: Systemd):
+    """Test that smartd.service is active"""
+    assert systemd.is_active("smartd.service")
+
+
+# =============================================================================
+# multipath Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-multipath-service-multipathd-enable"])
+@pytest.mark.feature("multipath")
+@pytest.mark.booted(reason="Requires systemd")
+def test_multipath_multipathd_service_enabled(systemd: Systemd):
+    """Test that multipathd.service is enabled"""
+    assert systemd.is_enabled("multipathd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-multipath-service-multipathd-enable"])
+@pytest.mark.feature("multipath")
+@pytest.mark.booted(reason="Requires systemd")
+def test_multipath_multipathd_service_active(systemd: Systemd):
+    """Test that multipathd.service is active"""
+    assert systemd.is_active("multipathd.service")
+
+
+# -----------------------------------------------------------------------------
+# nvme Feature Unit Files
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.testcov(["GL-TESTCOV-nvme-service-nvme-hostid-unit"])
+@pytest.mark.feature("nvme")
+def test_nvme_hostid_unit_exists(file):
+    """Test that nvme-hostid.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/nvme-hostid.service")
+
+
+# =============================================================================
+# openstackMetal Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-service-netplan-enable"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="Requires systemd")
+def test_openstackMetal_systemd_networkd_service_enabled(systemd: Systemd):
+    """Test that systemd-networkd.service is enabled"""
+    assert systemd.is_enabled("systemd-networkd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-openstackMetal-service-netplan-enable"])
+@pytest.mark.feature("openstack")
+@pytest.mark.booted(reason="Requires systemd")
+def test_openstackMetal_systemd_networkd_service_active(systemd: Systemd):
+    """Test that systemd-networkd.service is active"""
+    assert systemd.is_active("systemd-networkd.service")
+
+
+# =============================================================================
+# sap Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-sap-service-auditd-enable"])
+@pytest.mark.feature("sap")
+@pytest.mark.booted(reason="Requires systemd")
+def test_sap_auditd_service_enabled(systemd: Systemd):
+    """Test that auditd.service is enabled"""
+    assert systemd.is_enabled("auditd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-sap-service-auditd-enable"])
+@pytest.mark.feature("sap")
+@pytest.mark.booted(reason="Requires systemd")
+def test_sap_auditd_service_active(systemd: Systemd):
+    """Test that auditd.service is active"""
+    assert systemd.is_active("auditd.service")
+
+
+# =============================================================================
+# server Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-coredump-override",
+    ]
+)
+@pytest.mark.feature("server and not _prod")
+def test_server_systemd_coredump_override_exists(file: File):
+    """Test that systemd-coredump service override exists"""
+    assert file.exists("/etc/systemd/system/systemd-coredump@.service.d/override.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-coredump-enable"])
+@pytest.mark.feature("server and not _prod")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_coredump_socket_active(systemd: Systemd):
+    """Test that systemd-coredump.socket is enabled"""
+    assert systemd.is_active("systemd-coredump.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-kexec-load-unit"])
+@pytest.mark.feature("server")
+def test_server_kexec_load_unit_exists(file):
+    """Test that kexec-load@.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/kexec-load@.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-cron-update-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_cron_update_service_inactive(systemd: Systemd):
+    """Test that cron-update.service is inactive (oneshot service)"""
+    assert systemd.is_inactive("cron-update.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-kexec-load-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_kexec_load_service_enabled(
+    systemd: Systemd, kernel_versions: KernelVersions
+):
+    kernel_version = kernel_versions.get_running().version
+    """Test that kexec-load@{kernel_version}.service is enabled"""
+    assert systemd.is_enabled(f"kexec-load@{kernel_version}.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-kexec-load-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_kexec_load_service_inactive(
+    systemd: Systemd, kernel_versions: KernelVersions
+):
+    kernel_version = kernel_versions.get_running().version
+    """Test that kexec-load@{kernel_version}.service is inactive (oneshot service)"""
+    assert systemd.is_inactive(f"kexec-load@{kernel_version}.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-sysstat-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_sysstat_service_enabled(systemd: Systemd):
+    """Test that sysstat.service is enabled"""
+    assert systemd.is_enabled("sysstat.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-sysstat-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_sysstat_service_active(systemd: Systemd):
+    """Test that sysstat.service is active"""
+    assert systemd.is_active("sysstat.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-networkd-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_networkd_service_enabled(systemd: Systemd):
+    """Test that systemd-networkd.service is enabled"""
+    assert systemd.is_enabled("systemd-networkd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-networkd-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_networkd_service_active(systemd: Systemd):
+    """Test that systemd-networkd.service is active"""
+    assert systemd.is_active("systemd-networkd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-repart-socket-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_repart_socket_active(systemd: Systemd):
+    """Test that systemd-repart.socket is enabled"""
+    assert systemd.is_active("systemd-repart.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-resolved-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_resolved_service_enabled(systemd: Systemd):
+    """Test that systemd-resolved.service is enabled"""
+    assert systemd.is_enabled("systemd-resolved.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-resolved-enable"])
+@pytest.mark.feature("server")
+@pytest.mark.booted(reason="Requires systemd")
+def test_server_systemd_resolved_service_active(systemd: Systemd):
+    """Test that systemd-resolved.service is active"""
+    assert systemd.is_active("systemd-resolved.service")
+
+
+# =============================================================================
+# ssh Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-keygen-unit"])
+@pytest.mark.feature("ssh")
+def test_ssh_keygen_unit_exists(file):
+    """Test that ssh-keygen.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/ssh-keygen.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-moduli-unit"])
+@pytest.mark.feature("ssh")
+def test_ssh_moduli_unit_exists(file):
+    """Test that ssh-moduli.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/ssh-moduli.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-ssh-enable",
+        "GL-TESTCOV-ssh-service-ssh-socket-preset-disable",
+    ]
+)
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_socket_disabled(systemd: Systemd):
+    """Test that ssh.socket is disabled by preset"""
+    assert systemd.is_disabled("ssh.socket")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-ssh-enable",
+        "GL-TESTCOV-ssh-service-ssh-socket-preset-disable",
+    ]
+)
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_socket_inactive(systemd: Systemd):
+    """Test that ssh.service is inactive"""
+    assert systemd.is_inactive("ssh.socket")
+
+
+# TODO: enable if nftables or iptables is not available
+# see: features/ssh/exec.config
+# @pytest.mark.testcov([
+#     "GL-TESTCOV-ssh-service-sshguard-enable",
+#     "GL-TESTCOV-ssh-service-sshguard-preset-disable"
+#     ])
+# @pytest.mark.feature("ssh")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_ssh_sshguard_service_disabled(systemd: Systemd):
+#     """Test that sshguard.service is disabled by preset"""
+#     assert systemd.is_disabled("sshguard.service")
+#
+#
+# @pytest.mark.testcov([
+#     "GL-TESTCOV-ssh-service-sshguard-enable",
+#     "GL-TESTCOV-ssh-service-sshguard-preset-disable"
+#     ])
+# @pytest.mark.feature("ssh")
+# @pytest.mark.booted(reason="Requires systemd")
+# def test_ssh_sshguard_service_inactive(systemd: Systemd):
+#     """Test that sshguard.service is inactive"""
+#     assert systemd.is_inactive("sshguard.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-keygen-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_keygen_service_enabled(systemd: Systemd):
+    """Test that ssh-keygen.service is enabled"""
+    assert systemd.is_enabled("ssh-keygen.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-ssh-keygen-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_ssh_keygen_service_active(systemd: Systemd):
+    """Test that ssh-keygen.service is active"""
+    assert systemd.is_active("ssh-keygen.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-sshguard-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+def test_ssh_sshguard_service_enabled(systemd: Systemd):
+    """Test that sshguard.service is enabled"""
+    assert systemd.is_enabled("sshguard.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-service-sshguard-enable"])
+@pytest.mark.feature("ssh")
+@pytest.mark.booted(reason="Requires systemd")
+@pytest.mark.hypervisor(
+    "not qemu", reason="a started sshguard prevents running the testsuite"
+)
+def test_ssh_sshguard_service_active(systemd: Systemd):
+    """Test that sshguard.service is active"""
+    assert systemd.is_active("sshguard.service")
+
+
+# =============================================================================
+# vhost Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-socket-enable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_socket_service_enabled(systemd: Systemd):
+    """Test that libvirtd.socket is enabled"""
+    assert systemd.is_enabled("libvirtd.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-socket-enable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_socket_service_active(systemd: Systemd):
+    """Test that libvirtd.socket is active"""
+    assert systemd.is_active("libvirtd.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-tls-socket-preset-disable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_tls_socket_service_disabled(systemd: Systemd):
+    """Test that libvirtd-tls.socket is disabled by preset"""
+    assert systemd.is_disabled("libvirtd-tls.socket")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-vhost-service-libvirtd-tls-socket-preset-disable"])
+@pytest.mark.feature("vhost")
+@pytest.mark.booted(reason="Requires systemd")
+def test_vhost_libvirtd_tls_socket_service_inactive(systemd: Systemd):
+    """Test that libvirtd-tls.socket is inactive"""
+    assert systemd.is_inactive("libvirtd-tls.socket")

--- a/tests/integration/core/test_sysdiff.py
+++ b/tests/integration/core/test_sysdiff.py
@@ -1,0 +1,73 @@
+import logging
+import sys
+
+import pytest
+from plugins.sysdiff import Sysdiff
+
+logger = logging.getLogger(__name__)
+
+before_suffix = "before-tests"
+after_suffix = "after-tests"
+
+
+@pytest.mark.order("first")
+@pytest.mark.root(reason="Sysdiff needs to read all files.")
+def test_sysdiff_before_tests(sysdiff: Sysdiff):
+    """
+    Verifies no system changes were detected during the test run.
+    This test runs before all other tests and creates the before-tests snapshot.
+    """
+    try:
+        snapshot = sysdiff.create_snapshot(before_suffix)
+        assert before_suffix in snapshot.name
+
+    except Exception as e:
+        pytest.fail(f"Error creating {before_suffix} snapshot: {e}")
+
+
+@pytest.mark.order("last")
+@pytest.mark.root(reason="Sysdiff needs to read all files.")
+@pytest.mark.feature("not cis", reason="CIS handles sysdiff by itself")
+def test_sysdiff_after_tests(sysdiff: Sysdiff):
+    """
+    Verifies no system changes were detected during the test run.
+    This test runs after all other tests, creates the after-tests snapshot and performs the sysdiff comparison.
+    """
+    before_snapshot = None
+    after_snapshot = None
+    try:
+        snapshots = sysdiff.manager.list_snapshots()
+        before_snapshot = next(
+            (s for s in reversed(snapshots) if s.endswith(f"-{before_suffix}")),
+            None,
+        )
+        assert (
+            before_snapshot is not None
+        ), f"{before_suffix} snapshot not found. Make sure test_sysdiff_before_tests ran first."
+
+        after_snapshot = sysdiff.create_snapshot(after_suffix).name
+
+        diff_result = sysdiff.compare_snapshots(before_snapshot, after_snapshot)
+        if diff_result.has_changes:
+            diff_output = sysdiff.diff_engine.generate_diff(
+                diff_result, before_snapshot, after_snapshot
+            )
+            print(
+                "System changes detected - detailed diff:\n" + diff_output,
+                file=sys.stderr,
+            )
+            pytest.fail(
+                "System changes were detected during the test run. See stderr output for details."
+            )
+
+    except Exception as e:
+        pytest.fail(f"Error during sysdiff comparison: {e}")
+
+    finally:
+        cleanup_names = []
+        if before_snapshot:
+            cleanup_names.append(before_snapshot)
+        if after_snapshot:
+            cleanup_names.append(after_snapshot)
+        if cleanup_names:
+            sysdiff.cleanup_snapshots(cleanup_names)

--- a/tests/integration/core/test_time.py
+++ b/tests/integration/core/test_time.py
@@ -1,0 +1,420 @@
+import os
+from datetime import datetime
+from time import time
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+from plugins.systemd import Systemd
+from plugins.systemd_detect_virt import Hypervisor
+from plugins.timedatectl import TimeDateCtl
+
+# =============================================================================
+# clock skew test
+# =============================================================================
+
+
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+def test_clock(shell: ShellRunner):
+    """Test clock skew"""
+    local_seconds = int(time())
+    output = shell(cmd="date '+%s'", capture_output=True)
+    remote_seconds = int(output.stdout)
+
+    assert (
+        abs(local_seconds - remote_seconds) < 5
+    ), f"clock skew should be less than 5 seconds. Local time is {local_seconds} and remote time is {remote_seconds}"
+
+
+# =============================================================================
+# ALI NTP server configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ali-config-timesyncd"])
+@pytest.mark.feature("ali")
+def test_ali_timesyncd_config_exists(file: File):
+    """Test that Alibaba Cloud systemd-timesyncd configuration exists"""
+    assert file.is_regular_file("/etc/systemd/timesyncd.conf.d/00-gardenlinux-ali.conf")
+
+
+# ================================
+# AWS NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-timesyncd"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("aws")
+@pytest.mark.hypervisor(
+    "amazon",
+    reason="Only works on real AWS infrastructure due to NTP server access requirements.",
+)
+def test_correct_ntp_on_aws(timedatectl: TimeDateCtl):
+    ntp_ip = timedatectl.get_ntpserver().ip
+    assert (
+        ntp_ip == "169.254.169.123"
+    ), f"ntp server is invalid. Expected '169.254.169.123' got '{ntp_ip}'."
+
+
+# ================================
+# Azure NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-after-ptp-device"])
+@pytest.mark.feature("azure")
+def test_azure_chrony_service_after_ptp_exists(file: File):
+    """Test that Azure chrony device service configuration exists"""
+    assert file.exists(
+        "/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf"
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-after-ptp-device"])
+@pytest.mark.feature("azure")
+def test_azure_chrony_service_after_ptp_content(parse_file: ParseFile):
+    """Test that Azure chrony device service configuration content is correct"""
+    config = parse_file.parse(
+        "/etc/systemd/system/chronyd.service.d/10-after_dev-ptp_hyperv.device.conf",
+        format="ini",
+    )
+    assert config["Unit"]["BindsTo"] == "dev-ptp_hyperv.device"
+    assert config["Unit"]["After"] == "dev-ptp_hyperv.device"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-no-systemd-timesyncd-override"])
+@pytest.mark.feature("azure")
+def test_azure_no_timesyncd_override(file: File):
+    """Test that Azure does not have systemd-timesyncd override"""
+    assert not file.exists(
+        "/etc/systemd/system/systemd-timesyncd.service.d/override.conf"
+    ), "Azure should not have timesyncd override (uses chrony instead)"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-chrony"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor("microsoft")
+def test_chrony_azure(
+    chrony_config_file: str,
+    ptp_hyperv_dev: str,
+    systemd_detect_virt: Hypervisor,
+    parse_file: ParseFile,
+):
+    """
+    Check Chrony configuration for expected content according to https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
+
+    Gets skipped for QEMU tests as these do not start chrony.
+    """
+    expected_config = f"refclock PHC {ptp_hyperv_dev} poll 3 dpoll -2 offset 0"
+    lines = parse_file.lines(chrony_config_file)
+    assert expected_config in lines, "chrony config for ptp expected but not found"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_wait_service_disabled(systemd: Systemd):
+    """Test that chrony-wait.service is disabled by preset"""
+    assert systemd.is_disabled("chrony-wait.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_wait_service_inactive(systemd: Systemd):
+    """Test that chrony-wait.service is inactive"""
+    assert systemd.is_inactive("chrony-wait.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_restricted_service_disabled(systemd: Systemd):
+    """Test that chronyd-restricted.service is disabled by preset"""
+    assert systemd.is_disabled("chronyd-restricted.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-preset-disable"])
+@pytest.mark.feature("azure")
+@pytest.mark.booted(reason="Requires systemd")
+def test_azure_chrony_restricted_service_inactive(systemd: Systemd):
+    """Test that chronyd-restricted.service is inactive"""
+    assert systemd.is_inactive("chronyd-restricted.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-config-udev-rules-hyperv-ptp"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor("microsoft")
+def test_azure_ptp_symlink(ptp_hyperv_dev: str, systemd_detect_virt: Hypervisor):
+    """
+    Ensure /dev/ptp_hyperv exists and is a symlink on real Azure VMs.
+
+    Skips for QEMU only provides a generic virtualized clock.
+    """
+    assert os.path.islink(
+        ptp_hyperv_dev
+    ), f"{ptp_hyperv_dev} should always be a symlink."
+
+
+# ================================
+# GCP NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gcp-config-timesyncd"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("gcp")
+@pytest.mark.hypervisor(
+    "google", reason="Only works on real google cloud because of metadata access."
+)
+def test_correct_ntp_on_gcp(timedatectl: TimeDateCtl):
+    ntp_ip = timedatectl.get_ntpserver().ip
+    assert (
+        ntp_ip == "169.254.169.254"  # gcp metadata service
+    ), f"ntp server is invalid. Expected '169.254.169.254' got '{ntp_ip}'."
+
+
+# ================================
+# GDCH NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-no-systemd-timesyncd"])
+@pytest.mark.feature("ghdc")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_no_systemd_timesyncd_service(systemd: Systemd):
+    """Test that systemd-timesyncd.service is not installed"""
+    assert not any(
+        u.unit == "systemd-timesyncd.service" for u in systemd.list_installed_units()
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gdch-service-chrony-enable"])
+@pytest.mark.feature("gdch")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gdch_chrony_service_enabled(systemd: Systemd):
+    """Test that chrony.service is enabled"""
+    assert systemd.is_enabled("chrony.service")
+
+
+# ================================
+# FedRAMP NTP server configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-no-systemd-timesyncd"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_no_systemd_timesyncd_service(systemd: Systemd):
+    """Test that systemd-timesyncd.service is not installed"""
+    assert not any(
+        u.unit == "systemd-timesyncd.service" for u in systemd.list_installed_units()
+    )
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-chrony-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_chrony_service_enabled(systemd: Systemd):
+    """Test that chrony.service is enabled"""
+    assert systemd.is_enabled("chrony.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-fedramp-service-chrony-enable"])
+@pytest.mark.feature("fedramp")
+@pytest.mark.booted(reason="Requires systemd")
+def test_fedramp_chrony_service_active(systemd: Systemd):
+    """Test that chrony.service is active"""
+    assert systemd.is_active("chrony.service")
+
+
+# ================================
+# Timesyncd service configuration
+# ================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-service-systemd-timesyncd-override",
+    ]
+)
+@pytest.mark.feature("server and not azure")
+def test_server_systemd_timesyncd_override_exists(file: File):
+    """Test that systemd-timesyncd service override exists"""
+    assert file.exists("/etc/systemd/system/systemd-timesyncd.service.d/override.conf")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-service-systemd-timesyncd-enable"])
+@pytest.mark.flaky(reruns=10, reruns_delay=30, only_rerun="AssertionError")
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("not azure and not aws and not gcp and not gdch")
+def test_ntp(timedatectl: TimeDateCtl):
+    """
+    Validate that systemd-timesyncd is installed and active.
+    """
+    # Verify image configuration
+    assert (
+        timedatectl.has_timesync_installed()
+    ), "systemd-timesyncd.service should be present on the image."
+
+    # Check activity and sync when present
+    if timedatectl.is_timesyncd_active():
+        status = timedatectl.get_timesync_status()
+        assert status.ntp, "NTP should be enabled"
+        assert status.ntp_synchronized, "NTP should be synchronized"
+    else:
+        pytest.skip("systemd-timesyncd installed but not active in this environment")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-no-systemd-timesyncd"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor("microsoft")
+def test_systemd_timesyncd_disabled_on_azure(systemd: Systemd):
+    assert (
+        systemd.is_active("systemd-timesyncd") == False
+    ), "Chrony instead of systemd-timesyncd should be active on Azure."
+
+
+# ================================
+# Chrony service configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-enable"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor(
+    "microsoft", "chrony only loaded and running in real Azure environment."
+)
+def test_chrony_on_azure(systemd: Systemd):
+    """
+    Test for chrony as active time sync service on Azure.
+    See: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#chrony
+    """
+    assert systemd.is_active("chrony"), "Chrony should be active on Azure."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-azure-service-chrony-enable"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("azure")
+@pytest.mark.hypervisor(
+    "qemu",
+    "Test only asserts presence of chrony unit file in cases the testsuite runs in QEMU.",
+)
+def test_chrony_installed_for_azure_image(systemd: Systemd):
+    """
+    Test for chrony service installed on Azure image when running in QEMU.
+    (no Hyper-V clock available -> chrony is disabled and not loaded)
+    """
+    units = systemd.list_installed_units()
+    chrony_unit = next(
+        (unit for unit in units if unit.unit == "chrony.service"),
+        None,
+    )
+
+    assert chrony_unit is not None, "chrony.service should be present in Azure images."
+    assert chrony_unit.load in (
+        "enabled",
+        "disabled",
+    ), f"Unexpected chrony.service state: {chrony_unit.load!r}"
+
+
+# ================================
+# Clock source configuration
+# ================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-script-clocksource-setup"])
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("not azure and not container")
+@pytest.mark.arch("amd64")
+def test_clocksource_amd64(systemd_detect_virt: Hypervisor, clocksource: str):
+    match systemd_detect_virt:
+        case Hypervisor.xen | Hypervisor.qemu:
+            expected_clocksource = "tsc"
+        case Hypervisor.kvm | Hypervisor.amazon | Hypervisor.google:
+            expected_clocksource = "kvm-clock"
+        case _:
+            assert False, f"unknown hypervisor {systemd_detect_virt}"
+
+    assert clocksource, expected_clocksource
+
+
+@pytest.mark.booted(reason="NTP server configuration is read at runtime")
+@pytest.mark.feature("not azure and not container")
+@pytest.mark.arch("amd64", "aarch64")
+def test_clocksource_arm64_aarch64(systemd_detect_virt: Hypervisor, clocksource: str):
+    match systemd_detect_virt:
+        case Hypervisor.kvm | Hypervisor.qemu | Hypervisor.amazon | Hypervisor.google:
+            expected_clocksource = "arch_sys_counter"
+        case _:
+            assert False, f"unknown hypervisor {systemd_detect_virt}"
+
+    assert clocksource, expected_clocksource
+
+
+# ================================
+# File timestamps validation
+# ================================
+
+
+@pytest.mark.feature(
+    "not container", reason="Filesystem not mounted in container tests"
+)
+@pytest.mark.parametrize("dir", ["/bin", "/etc/ssh"])
+def test_files_not_in_future(find, dir: str):
+    """
+    Validate that all files in the image have a timestamp in the past.
+    """
+    now = datetime.now()
+
+    find.root_paths = dir
+    find.entry_type = "files"
+
+    for file_path in find:
+        try:
+            mod_time = datetime.fromtimestamp(os.path.getmtime(file_path))
+        except FileNotFoundError:
+            continue
+
+        assert mod_time <= now, (
+            f"Timestamp of {file_path} is in the future " f"{mod_time} (now={now})"
+        )
+
+
+@pytest.mark.feature("container")
+def test_files_not_in_future_container(find):
+    """
+    Validate that all files in container images have timestamps in the past.
+    """
+    find.root_paths = ["/bin"]
+    now = datetime.now()
+    for file_path in find:
+        modification = datetime.fromtimestamp(os.path.getmtime(file_path))
+        assert (
+            modification <= now
+        ), f"timestamp of {file_path} is in the future ({modification} > {now})"
+
+
+# ================================
+# Timezone configuration
+# ================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gcp-config-timezone-utc",
+        "GL-TESTCOV-gdch-config-timezone-utc",
+    ]
+)
+@pytest.mark.feature("gcp or gdch")
+def test_gcp_or_gdch_timezone_utc(file: File):
+    """Test that GCP or GDCH has UTC timezone configured"""
+    assert file.is_symlink(
+        "/usr/share/zoneinfo/localtime", "/etc/localtime"
+    ), "GCP or GDCH timezone should be set to UTC"

--- a/tests/integration/core/test_users_groups.py
+++ b/tests/integration/core/test_users_groups.py
@@ -1,0 +1,150 @@
+import os
+import pwd
+from typing import List, Set
+
+import pytest
+from plugins.file import File
+from plugins.linux_etc_files import Group, Passwd
+from plugins.users import User
+from plugins.utils import check_for_duplicates
+
+# =============================================================================
+# Misc settings not tied to any specific feature
+# =============================================================================
+
+
+def test_service_accounts_have_nologin_shell(regular_user_uid_range):
+    for entry in pwd.getpwall():
+        if entry.pw_uid in regular_user_uid_range:
+            continue
+        if entry.pw_name in {"root", "sync"}:
+            continue
+        assert entry.pw_shell in [
+            "/usr/sbin/nologin",
+            "/sbin/nologin",
+            "/bin/false",
+        ], f"User {entry.pw_name} has unexpected shell: {entry.pw_shell}"
+
+
+def test_root_home_permissions(file: File):
+    assert file.has_mode("/root", "0700"), "/root has incorrect permissions"
+
+
+@pytest.mark.feature("not _dev")
+def test_no_extra_home_directories(expected_users, file: File):
+    if file.is_symlink("/home"):
+        return
+    entries = os.listdir("/home")
+    unexpected = [e for e in entries if e not in expected_users]
+    assert not unexpected, f"Unexpected entries in /home: {entries}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aws-config-cloud-user-sudo"])
+@pytest.mark.booted
+@pytest.mark.root(reason="Using sudo command to check the access")
+def test_users_sudo_capability(get_all_users, expected_users, user: User):
+    users_with_sudo_capabilities = set(
+        [u for u in get_all_users if user.is_user_sudo(u)]
+    )
+    allowed_sudo_users = set(expected_users) | {"root", "dev"}
+    unexpected_sudo_users = users_with_sudo_capabilities - allowed_sudo_users
+
+    assert (
+        not unexpected_sudo_users
+    ), f"Unexpected sudo capability {unexpected_sudo_users}"
+
+
+def test_available_regular_users(get_regular_users, expected_users):
+    allowed_users = ["dev", "nobody"] + list(expected_users)
+    unexpected_user = [user for user in get_regular_users if user not in allowed_users]
+
+    assert (
+        not unexpected_user
+    ), f"Unexpected user account found in /etc/passwd, {unexpected_user}"
+
+
+def test_duplicate_uids(passwd_entries: List[Passwd]):
+    """
+    Check if any duplicate userids are defined in /etc/passwd.
+    """
+    duplicates = check_for_duplicates(entries=passwd_entries)
+    assert (
+        len(duplicates) == 0
+    ), "uids {} are used multiple times in /etc/passwd".format(duplicates)
+
+
+def test_duplicate_uids_detection(passwd_entries: List[Passwd]):
+    """
+    Appending an existing entry to the list to check if the duplication check finds this.
+    """
+    expected_duplicate = passwd_entries[0]
+    passwd_entries.append(expected_duplicate)
+
+    duplicates = check_for_duplicates(entries=passwd_entries)
+    assert len(duplicates) == 1, "duplicate entry is not found successfully"
+    assert expected_duplicate == duplicates[0]
+
+
+def test_groups_are_unique(group_entries: List[Group]):
+    """
+    Check if there are any duplicate groups in /etc/group.
+    """
+    duplicates = check_for_duplicates(group_entries)
+    assert (
+        len(duplicates) == 0
+    ), f"Groups from /etc/group should not have duplicates: {duplicates}"
+
+
+def test_groups_find_duplicate(group_entries: List[Group]):
+    """
+    Check if duplication check works by adding a duplicate.
+    """
+    duplicate_group = group_entries[0]
+    group_entries.append(duplicate_group)
+
+    duplicates = check_for_duplicates(group_entries)
+    assert (
+        len(duplicates) == 1
+    ), f"Group #{duplicate_group.groupname} should be found as duplicate, but was not."
+
+
+@pytest.mark.feature("not _dev and not pythonDev")
+def test_group_root_has_no_users(group_entries: List[Group]):
+    """
+    Check if parameterized groups have the expected users.
+    """
+    group_list = [group for group in group_entries if group.groupname == "root"]
+    group = group_list[0] if group_list else None
+
+    assert group, "Group root is not present."
+
+    assert (
+        len(group.user_list) == 0
+    ), f"user group root is not empty as expected. Was: {group.user_list}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-group-wheel",
+    ]
+)
+@pytest.mark.feature("not _dev and not pythonDev and not container")
+def test_group_wheel_has_no_unexpected_users(
+    group_entries: List[Group], expected_users: Set[str]
+):
+    """
+    Check if parameterized groups have the expected users.
+    """
+    group_list = [group for group in group_entries if group.groupname == "wheel"]
+    group = group_list[0] if group_list else None
+
+    assert group, "Group wheel is not present."
+
+    # remove expected users from group as we want to check for unexpected users
+    expected_user_list = [
+        user for user in group.user_list if user not in expected_users
+    ]
+
+    assert (
+        len(expected_user_list) == 0
+    ), f"user group wheel is not empty as expected. Was: {expected_user_list}"

--- a/tests/integration/runtime/test_checkbox.py
+++ b/tests/integration/runtime/test_checkbox.py
@@ -1,0 +1,255 @@
+from typing import List
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# checkbox Feature - Hardware Testing Framework
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-test-plan",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_test_plan_exists(file: File):
+    """Test that checkbox test plan exists"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/test-plan.pxu"
+    ), "Checkbox test plan should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-units-category",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_units_category_exists(file: File):
+    """Test that checkbox category units exist"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/category.pxu"
+    ), "Checkbox category units should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-units-jobs",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_units_jobs_exists(file: File):
+    """Test that checkbox job units exist"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/jobs.pxu"
+    ), "Checkbox job units should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-checkbox-units-manifest",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_units_manifest_exists(file: File):
+    """Test that checkbox manifest units exist"""
+    assert file.exists(
+        "/usr/share/checkbox-provider-base/units/gardenlinux/manifest.pxu"
+    ), "Checkbox manifest units should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_banner_exists(file: File):
+    """Test that checkbox has issue banner file"""
+    assert file.exists("/etc/issue"), "Checkbox issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_banner_content(parse_file: ParseFile):
+    """Test that checkbox has issue banner file"""
+    expected_lines = ["Welcome to Garden Linux HW Testing Image"]
+    assert expected_lines in parse_file.lines(
+        "/etc/issue"
+    ), "Checkbox issue banner should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue-net",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_net_banner_exists(file: File):
+    """Test that checkbox has network issue banner file"""
+    assert file.exists("/etc/issue.net"), "Checkbox network issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-issue-net",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_issue_net_banner_empty(file: File):
+    """Test that checkbox has empty network issue banner file"""
+    size = file.get_size("/etc/issue.net")
+    assert size == 0, "Checkbox network issue.net banner should be empty"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-motd",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_motd_exists(file: File):
+    """Test that checkbox has message of the day file"""
+    assert file.exists("/etc/motd"), "Checkbox motd should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-motd",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_motd_empty(file: File):
+    """Test that checkbox has empty message of the day file"""
+    size = file.get_size("/etc/motd")
+    assert size == 0, "Checkbox motd should be empty"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-journald-10-logs",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_journald_logs_config_exists(file: File):
+    """Test that checkbox has journald logs configuration"""
+    assert file.exists(
+        "/etc/systemd/journald.conf.d/10-logs.conf"
+    ), "Checkbox journald logs configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-journald-10-logs",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_journald_logs_config_content(parse_file: ParseFile):
+    """Test that checkbox has journald logs configuration"""
+    config = parse_file.parse("/etc/systemd/journald.conf.d/10-logs.conf", format="ini")
+    assert (
+        config["Journal"]["ForwardToConsole"] == "no"
+    ), "Checkbox journald logs configuration ForwardToConsole should be correct"
+    assert (
+        config["Journal"]["ForwardToWall"] == "no"
+    ), "Checkbox journald logs configuration ForwardToWall should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-kernel-cmdline-iso",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_kernel_cmdline_iso_exists(file: File):
+    """Test that checkbox has kernel cmdline ISO configuration"""
+    assert file.exists(
+        "/etc/kernel/cmdline.iso"
+    ), "Checkbox kernel cmdline ISO configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-config-kernel-cmdline-iso",
+    ]
+)
+@pytest.mark.feature("checkbox")
+@pytest.mark.booted(reason="kernel cmdline needs a booted system")
+def test_checkbox_kernel_cmdline_iso_content(kernel_cmdline: List[str]):
+    """Verify kernel cmdline ISO configuration parameters are present in the running kernel command line for checkbox."""
+    assert (
+        "console=tty0 rd.live.squashimg=squashfs.img root=live:CDLABEL=GardenlinuxISO rd.live.overlay.overlayfs rd.live.dir=live rd.live.ram quiet"
+        in kernel_cmdline
+    ), "Kernel cmdline ISO configuration should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-dmesg_colored",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_dmesg_colored_script_exists(file: File):
+    """Test that checkbox has dmesg colored script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/dmesg_colored.sh"
+    ), "Checkbox dmesg colored script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-generate-report",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_generate_report_script_exists(file: File):
+    """Test that checkbox has generate report script"""
+    assert file.exists(
+        "/usr/local/bin/generate-report.sh"
+    ), "Checkbox generate report script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-hw_encrypt_check",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_hw_encrypt_check_script_exists(file: File):
+    """Test that checkbox has hardware encryption check script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/hw_encrypt_check.sh"
+    ), "Checkbox hardware encryption check script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-tpm_check",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_tpm_check_script_exists(file: File):
+    """Test that checkbox has TPM check script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/tpm_check.sh"
+    ), "Checkbox TPM check script should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-checkbox-script-virtualization_disabled",
+    ]
+)
+@pytest.mark.feature("checkbox")
+def test_checkbox_virtualization_disabled_script_exists(file: File):
+    """Test that checkbox has virtualization disabled check script"""
+    assert file.exists(
+        "/usr/lib/checkbox-provider-base/bin/virtualization_disabled.sh"
+    ), "Checkbox virtualization disabled script should exist"

--- a/tests/integration/runtime/test_chost.py
+++ b/tests/integration/runtime/test_chost.py
@@ -1,0 +1,119 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# chost Feature - Container Host Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-containerd-config",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_containerd_config_exists(file: File):
+    """Test that containerd configuration exists"""
+    assert file.is_regular_file(
+        "/etc/containerd/config.toml"
+    ), "Containerd configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-containerd-config",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_containerd_config_content(parse_file: ParseFile):
+    """Test that containerd configuration contains the correct content"""
+    config = parse_file.parse("/etc/containerd/config.toml")
+    assert config["version"] == 2, "Containerd configuration should be version 2"
+    assert (
+        config["plugins"]["io.containerd.grpc.v1.cri"]["cni"]["bin_dir"]
+        == "/var/lib/containerd/io.containerd.grpc.v1.cri.cni"
+    ), "Containerd CNI bin directory should be /var/lib/containerd/io.containerd.grpc.v1.cri.cni"
+    assert (
+        config["plugins"]["io.containerd.grpc.v1.cri"]["containerd"]["runtimes"][
+            "runc"
+        ]["runtime_type"]
+        == "io.containerd.runc.v2"
+    ), "Containerd runc runtime type should be io.containerd.runc.v2"
+    assert (
+        config["plugins"]["io.containerd.grpc.v1.cri"]["containerd"]["runtimes"][
+            "runc"
+        ]["options"]["SystemdCgroup"]
+        == True
+    ), "Containerd runc runtime options should include SystemdCgroup"
+    assert (
+        config["plugins"]["io.containerd.internal.v1.opt"]["path"]
+        == "/var/lib/containerd/io.containerd.internal.v1.opt"
+    ), "Containerd internal opt path should be /var/lib/containerd/io.containerd.internal.v1.opt"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-crictl-yaml",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_crictl_config_exists(file: File):
+    """Test that crictl configuration exists"""
+    assert file.is_regular_file("/etc/crictl.yaml"), "Crictl configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-crictl-yaml",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_crictl_config_content(parse_file: ParseFile):
+    """Test that crictl configuration contains the correct content"""
+    config = parse_file.parse("/etc/crictl.yaml")
+    assert (
+        config["runtime-endpoint"] == "unix:///run/containerd/containerd.sock"
+    ), "Crictl runtime endpoint should be unix:///run/containerd/containerd.sock"
+    assert (
+        config["image-endpoint"] == "unix:///run/containerd/containerd.sock"
+    ), "Crictl image endpoint should be unix:///run/containerd/containerd.sock"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-service-containerd-override",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_containerd_service_override_exists(file: File):
+    """Test that containerd service override exists"""
+    assert file.exists(
+        "/etc/systemd/system/containerd.service.d/override.conf"
+    ), "Containerd service override should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-no-initd-apparmor",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_no_apparmor_init(file: File):
+    """Test that chost does not have AppArmor init script"""
+    assert not file.exists(
+        "/etc/init.d/apparmor"
+    ), "Container host should not have AppArmor init script"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-chost-config-no-var-lib-containerd-opt",
+    ]
+)
+@pytest.mark.feature("chost")
+def test_chost_no_containerd_opt_directory(file: File):
+    """Test that chost does not have containerd opt directory"""
+    assert not file.exists(
+        "/var/lib/containerd/opt"
+    ), "Container host should not have containerd opt directory"

--- a/tests/integration/runtime/test_clamav.py
+++ b/tests/integration/runtime/test_clamav.py
@@ -1,0 +1,38 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# clamav Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-clamav-config-cron-root",
+    ]
+)
+@pytest.mark.feature("clamav")
+def test_clamav_cron_exists(file: File):
+    """Test that clamav cron job exists"""
+    cron_locations = [
+        "/var/spool/cron/crontabs/root",
+    ]
+    exists = any(file.exists(loc) for loc in cron_locations)
+    assert (
+        exists
+    ), f"Clamav cron job should exist in one of: {', '.join(cron_locations)}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-clamav-config-cron-root",
+    ]
+)
+@pytest.mark.feature("clamav")
+def test_clamav_cron_content(parse_file: ParseFile):
+    """Test that clamav cron job contains the correct content"""
+    lines = parse_file.lines("/var/spool/cron/crontabs/root")
+    assert lines == [
+        "0 30 * * * root /usr/bin/clamscan -ri / >> /var/log/clamav/clamd.log",
+    ], "Clamav cron job should contain the correct content"

--- a/tests/integration/runtime/test_containers.py
+++ b/tests/integration/runtime/test_containers.py
@@ -1,0 +1,24 @@
+import pytest
+from plugins.containerd import CtrRunner
+
+TEST_IMAGES = [
+    "docker.io/library/busybox:latest",  # Docker Hub, https://hub.docker.com/_/busybox
+    "public.ecr.aws/docker/library/busybox:unstable-uclibc",  # AWS ECR, https://gallery.ecr.aws/docker/library/busybox
+]
+
+
+@pytest.mark.skip(
+    reason="Skip until https://github.com/gardenlinux/gardenlinux/issues/3567 is resolved to avoid false negative results"
+)
+@pytest.mark.booted(reason="Container tests require systemd")
+@pytest.mark.root(reason="Needs to start containerd")
+@pytest.mark.feature(
+    "(gardener or chost or _debug) and not _pxe",
+    reason="containerd is not installed, pxe has tmpfs for /",
+)
+@pytest.mark.parametrize("uri", TEST_IMAGES)
+def test_basic_container_functionality(
+    service_containerd, container_image_setup, uri: str, ctr: CtrRunner
+):
+    out = ctr.run(uri, "uname", capture_output=True, ignore_exit_code=True)
+    assert "Linux" in out.stdout, f"Command failed: {out.stderr}"

--- a/tests/integration/runtime/test_gardener.py
+++ b/tests/integration/runtime/test_gardener.py
@@ -1,0 +1,195 @@
+import pytest
+from plugins.file import File
+from plugins.modify import allow_system_modifications
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# gardener Feature - Gardener Kubernetes Extended
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-containerd-no-config",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_no_containerd_default_config(file: File):
+    """Test that gardener does not have default containerd config"""
+    assert not file.exists(
+        "/etc/containerd/config.toml"
+    ), "Gardener should not have default containerd config"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-iptables-legacy",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_iptables_legacy_alternative(file: File):
+    """Test that gardener has iptables legacy alternative configured"""
+    symlinks = [
+        {"path": "/etc/alternatives/iptables", "target": "/usr/sbin/iptables-legacy"},
+        {"path": "/etc/alternatives/ip6tables", "target": "/usr/sbin/ip6tables-legacy"},
+        {"path": "/etc/alternatives/arptables", "target": "/usr/sbin/arptables-legacy"},
+        {"path": "/etc/alternatives/ebtables", "target": "/usr/sbin/ebtables-legacy"},
+    ]
+    missing = [
+        symlink
+        for symlink in symlinks
+        if not file.is_symlink(symlink["path"], symlink["target"])
+    ]
+    assert (
+        not missing
+    ), f"Gardener iptables alternatives should be symlinks to iptables-legacy, but are {missing}: {', '.join([symlink['path'] for symlink in missing])}"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-security-mount-no-sbit",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_mount_no_sbit_security(file: File):
+    """Test that gardener has mount security without sbit"""
+    files = [
+        "/sbin/mount.nfs",
+        "/sbin/mount.cifs",
+    ]
+    missing = [file_path for file_path in files if not file.has_mode(file_path, "0755")]
+    assert (
+        not missing
+    ), f"Gardener mount security should be without sbit, but are {missing}: {', '.join([file_path for file_path in missing])}"
+
+
+# =============================================================================
+# gardener Feature Services
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-apparmor-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_apparmor_service_enabled(systemd: Systemd):
+    """Test that apparmor.service is enabled"""
+    assert systemd.is_enabled("apparmor.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-apparmor-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_apparmor_service_active(systemd: Systemd):
+    """Test that apparmor.service is active"""
+    assert systemd.is_active("apparmor.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-service-containerd-enable",
+        "GL-TESTCOV-gardener-service-containerd-disable",
+    ]
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_containerd_service_disabled(systemd: Systemd):
+    """Test that containerd.service is disabled"""
+    assert systemd.is_disabled("containerd.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-service-containerd-enable",
+        "GL-TESTCOV-gardener-service-containerd-disable",
+    ]
+)
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_containerd_service_inactive(systemd: Systemd):
+    """Test that containerd.service is inactive"""
+    assert systemd.is_inactive("containerd.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-logrotate-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_logrotate_timer_service_enabled(systemd: Systemd):
+    """Test that logrotate.timer is enabled"""
+    assert systemd.is_enabled("logrotate.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-logrotate-enable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_logrotate_timer_service_active(systemd: Systemd):
+    """Test that logrotate.timer is active"""
+    assert systemd.is_active("logrotate.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-ssh-disable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_ssh_service_disabled(systemd: Systemd):
+    """Test that ssh.service is disabled"""
+    # TODO: find better way to exclude this
+    if allow_system_modifications():
+        pytest.skip("ssh.service is enabled to connect to test instances")
+    else:
+        assert systemd.is_disabled("ssh.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-ssh-disable"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="Requires systemd")
+def test_gardener_ssh_service_inactive(systemd: Systemd):
+    """Test that ssh.service is inactive"""
+    # TODO: find better way to exclude this
+    if allow_system_modifications():
+        pytest.skip("ssh.service is enabled to connect to test instances")
+    else:
+        assert systemd.is_inactive("ssh.service")
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-containerd-override",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_containerd_override_exists(file: File):
+    """Test that gardener containerd service override exists"""
+    assert file.exists(
+        "/etc/systemd/system/containerd.service.d/override.conf"
+    ), "Gardener containerd service override should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-gardener-config-containerd-override",
+    ]
+)
+@pytest.mark.feature("gardener")
+def test_gardener_containerd_override_content(parse_file: ParseFile):
+    """Test that gardener containerd service override contains the correct content"""
+    config = parse_file.parse(
+        "/etc/systemd/system/containerd.service.d/override.conf", format="ini"
+    )
+    assert (
+        config["Service"]["LimitMEMLOCK"] == "67108864"
+    ), "Gardener containerd service override should include correct LimitMEMLOCK value"
+    assert (
+        config["Service"]["LimitNOFILE"] == "1048576"
+    ), "Gardener containerd service override should include correct LimitNOFILE value"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-service-containerd-disable"])
+@pytest.mark.booted(reason="Test runs systemd")
+@pytest.mark.root(reason="To start the systemd service")
+@pytest.mark.modify(reason="Starts systemd service")
+@pytest.mark.feature("gardener or chost")
+def test_gardener_containerd_can_be_started(systemd: Systemd, service_containerd):
+    """Test that containerd.service can be started. It will be started and stopped by the service fixture."""
+    assert systemd.is_active(
+        "containerd.service"
+    ), "containerd.service is still running"

--- a/tests/integration/runtime/test_glvd.py
+++ b/tests/integration/runtime/test_glvd.py
@@ -1,0 +1,18 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# glvd Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-glvd-script-update-motd-glvd"])
+@pytest.mark.feature("glvd")
+def test_glvd_motd_scripts_exists(file: File):
+    """Test that GLVD MOTD script exists"""
+    paths = [
+        "/etc/update-motd.d/99-glvd",
+    ]
+
+    missing = [path for path in paths if not file.exists(path)]
+    assert not missing, f"The following files were not found: {', '.join(missing)}"

--- a/tests/integration/runtime/test_khost.py
+++ b/tests/integration/runtime/test_khost.py
@@ -1,0 +1,19 @@
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# khost Feature - Kubernetes Host Extended
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-khost-config-security-no-apparmor-init",
+    ]
+)
+@pytest.mark.feature("khost")
+def test_khost_no_apparmor_init(file: File):
+    """Test that khost does not have AppArmor init script"""
+    assert not file.exists(
+        "/etc/init.d/apparmor"
+    ), "Kubernetes host should not have AppArmor init script"

--- a/tests/integration/runtime/test_nodejs.py
+++ b/tests/integration/runtime/test_nodejs.py
@@ -1,0 +1,22 @@
+import pytest
+from plugins.dpkg import Dpkg
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# nodejs Feature
+# =============================================================================
+
+
+@pytest.mark.feature("nodejs")
+def test_nodejs_is_installed(shell: ShellRunner):
+    dpkg = Dpkg(shell)
+    assert dpkg.package_is_installed("nodejs"), "nodejs package is not installed"
+
+
+@pytest.mark.feature("nodejs")
+def test_node_can_run_script(shell: ShellRunner):
+    out = shell(
+        "node --eval 'const foo = (x,y) => x + y; console.log(foo(1,2))'",
+        capture_output=True,
+    )
+    assert out.stdout == "3\n", "Expected node to run script"

--- a/tests/integration/runtime/test_pythonDev.py
+++ b/tests/integration/runtime/test_pythonDev.py
@@ -1,0 +1,65 @@
+import os
+import shutil
+
+import pytest
+from plugins.dpkg import Dpkg
+from plugins.shell import ShellRunner
+from plugins.utils import tree
+
+
+@pytest.mark.feature("pythonDev")
+def test_python_environment_is_installed(shell: ShellRunner):
+    dpkg = Dpkg(shell)
+
+    assert dpkg.package_is_installed("python3"), "python3 package is not installed"
+    assert dpkg.package_is_installed(
+        "python3-pip"
+    ), "python3-pip package is not installed"
+    assert dpkg.package_is_installed(
+        "python3.14-venv"
+    ), "python3.14-venv package is not installed"
+
+
+dependencies = {
+    "arm64": {
+        "/required_libs_test",
+        "/required_libs_test/usr",
+        "/required_libs_test/usr/lib",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/libpthread.so.0",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/libc.so.6",
+        "/required_libs_test/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
+    },
+    "amd64": {
+        "/required_libs_test",
+        "/required_libs_test/usr",
+        "/required_libs_test/usr/lib",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/libpthread.so.0",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/libc.so.6",
+        "/required_libs_test/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2",
+    },
+}
+
+
+@pytest.mark.feature("pythonDev")
+@pytest.mark.root(reason="Installs pip packages")
+@pytest.mark.modify(reason="Installs pip packages")
+def test_python_export_libs(shell: ShellRunner, pip_requests):
+    dpkg = Dpkg(shell)
+    arch = dpkg.architecture_native()
+
+    # Check if requests is installed
+    shell("/bin/python3 -c 'import requests'")
+
+    shell(
+        f"exportLibs.py --package-dir {pip_requests} --output-dir /required_libs_test"
+    )
+
+    assert os.path.isdir("/required_libs_test"), "/required_libs_test was not created"
+
+    assert (
+        tree("/required_libs_test") == dependencies[arch]
+    ), "required_libs content differs"
+
+    shutil.rmtree("/required_libs_test")

--- a/tests/integration/runtime/test_sap.py
+++ b/tests/integration/runtime/test_sap.py
@@ -1,0 +1,301 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# sap Feature - SAP Compliance Requirements
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privilege-escalaction-permissions",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_privilege_escalation_permissions(file: File):
+    """Test that SAP has privilege escalation audit rules permissions"""
+    assert file.has_mode(
+        "/etc/audit/rules.d/70-privilege-escalation.rules", "0640"
+    ), "SAP privilege escalation audit rules should have 0640 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privilege-escalaction",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_privilege_escalation(parse_file: ParseFile):
+    """Test that SAP has privilege escalation audit rules"""
+    expected_lines = [
+        "-a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+        "-a exit,always -F arch=b32 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+        "-a exit,always -F arch=b64 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+        "-a exit,always -F arch=b32 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-privilege-escalation.rules"
+    ), "SAP privilege escalation audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privileged-special-permissions",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_privilege_escalation_special_permissions(file: File):
+    """Test that SAP has privilege escalation audit rules special permissions"""
+    assert file.has_mode(
+        "/etc/audit/rules.d/70-privileged-special.rules", "0640"
+    ), "SAP privilege escalation audit rules special should have 0640 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privileged-special-amd64",
+    ]
+)
+@pytest.mark.feature("sap")
+@pytest.mark.arch("amd64")
+def test_sap_audit_privilege_escalation_special_amd64(parse_file: ParseFile):
+    """Test that SAP has AMD64-specific privilege escalation audit rules"""
+    expected_lines = [
+        "-a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+        "-a exit,always -F arch=b32 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-privileged-special.rules"
+    ), "SAP AMD64 privilege escalation audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-privileged-special-arm64",
+    ]
+)
+@pytest.mark.feature("sap")
+@pytest.mark.arch("arm64")
+def test_sap_audit_privilege_escalation_special_arm64(parse_file: ParseFile):
+    """Test that SAP has ARM64-specific privilege escalation audit rules"""
+    expected_lines = [
+        "-a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+        "-a exit,always -F arch=b32 -S mount -S mount_setattr -S umount2 -S mknodat -S chroot -F auid!=-1 -F key=privileged_special",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-privileged-special.rules"
+    ), "SAP ARM64 privilege escalation audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-system-integrity-permissions",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_system_integrity_permissions(file: File):
+    """Test that SAP has system integrity audit rules with correct permissions"""
+    assert file.has_mode(
+        "/etc/audit/rules.d/70-system-integrity.rules", "0640"
+    ), "SAP system integrity audit rules should have 0640 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-audit-rules-system-integrity",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_audit_system_integrity(parse_file: ParseFile):
+    """Test that SAP has system integrity audit rules"""
+    expected_lines = [
+        "-a exit,always -F dir=/boot -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/etc -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/bin -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/sbin -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/usr -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/opt -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/root -F perm=wa -F key=system_integrity",
+        "-a exit,always -F dir=/lib -F perm=wa -F key=system_integrity",
+        "#-a exit,always -F dir=/lib64 -F perm=wa -F key=system_integrity",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/audit/rules.d/70-system-integrity.rules"
+    ), "SAP system integrity audit rules should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_banner_exists(file: File):
+    """Test that SAP has issue banner file"""
+    assert file.exists("/etc/issue"), "SAP issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_banner_content(parse_file: ParseFile):
+    """Test that SAP has issue banner file"""
+    expected_lines = [
+        "You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted."
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/issue"
+    ), "SAP issue banner should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue-net",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_net_banner_exists(file: File):
+    """Test that SAP has network issue banner file"""
+    assert file.exists("/etc/issue.net"), "SAP network issue banner should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-issue-net",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_issue_net_banner_content(parse_file: ParseFile):
+    """Test that SAP has network issue banner file"""
+    expected_lines = [
+        "You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted."
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/issue.net"
+    ), "SAP network issue banner should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-motd",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_motd_exists(file: File):
+    """Test that SAP has message of the day file"""
+    assert file.exists("/etc/motd"), "SAP motd should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-motd",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_motd_content(parse_file: ParseFile):
+    """Test that SAP has message of the day file"""
+    expected_lines = [
+        "You are accessing SAP computer systems and network through which you may have access to business sensitive information (“SAP Systems”). SAP Systems are intended for legitimate business use by authorized users of SAP only. Personal use of the SAP Systems you are about to access is not permitted."
+    ]
+    assert expected_lines in parse_file.lines("/etc/motd"), "SAP motd should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-tmpfiles-legacy",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_tmpfiles_legacy_exists(file: File):
+    """Test that SAP has tmpfiles legacy configuration"""
+    assert file.exists(
+        "/etc/tmpfiles.d/legacy.conf"
+    ), "SAP tmpfiles legacy configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-tmpfiles-legacy",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_tmpfiles_legacy_content(parse_file: ParseFile):
+    """Test that SAP has tmpfiles legacy configuration"""
+    expected_lines = [
+        "L /var/lock - - - - ../run/lock",
+        "d /run/lock/subsys 0755 root root -",
+        "r! /forcefsck",
+        "r! /fastboot",
+        "r! /forcequotacheck",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/etc/tmpfiles.d/legacy.conf"
+    ), "SAP tmpfiles legacy configuration should be correct"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-security-sap-global-root-ca",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_global_root_ca_exists(file: File):
+    """Test that SAP Global Root CA certificate exists"""
+    assert file.exists(
+        "/usr/local/share/ca-certificates/SAP_Global_Root_CA.crt"
+    ), "SAP Global Root CA certificate should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-sap-config-security-sap-global-root-ca",
+    ]
+)
+@pytest.mark.feature("sap")
+def test_sap_global_root_ca_content(parse_file: ParseFile):
+    """Test that SAP Global Root CA certificate content is correct"""
+    expected_lines = [
+        "-----BEGIN CERTIFICATE-----",
+        "MIIGTDCCBDSgAwIBAgIQXQPZPTFhXY9Iizlwx48bmTANBgkqhkiG9w0BAQsFADBO",
+        "MQswCQYDVQQGEwJERTERMA8GA1UEBwwIV2FsbGRvcmYxDzANBgNVBAoMBlNBUCBB",
+        "RzEbMBkGA1UEAwwSU0FQIEdsb2JhbCBSb290IENBMB4XDTEyMDQyNjE1NDE1NVoX",
+        "DTMyMDQyNjE1NDYyN1owTjELMAkGA1UEBhMCREUxETAPBgNVBAcMCFdhbGxkb3Jm",
+        "MQ8wDQYDVQQKDAZTQVAgQUcxGzAZBgNVBAMMElNBUCBHbG9iYWwgUm9vdCBDQTCC",
+        "AiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAOrxJKFFA1eTrZg1Ux8ax6n/",
+        "LQRHZlgLc2FZpfyAgwvkt71wLkPLiTOaRb3Bd1dyydpKcwJLy0dzGkunzNkPRSFz",
+        "bKy2IPS0RS45hUCCPzhGnqQM6TcDYWeWpSUvygqujgb/cAG0mSJpvzAD3SMDQ+VJ",
+        "Az5Ryq4IrP7LkfCb63LKZxLsHEkEcNKoGPsSsd4LTwuEIyM3ZHcCoA97m6hvgLWV",
+        "GLzLIQMEblkswqX29z7JZH+zJopoqZB6eEogE2YpExkw52PufytEslDY3dyVubjp",
+        "GlvD4T03F2zm6CYleMwgWbATLVYvk2I9WfqPAP+ln2IU9DZzegSMTWHCE+jizaiq",
+        "b5f5s7m8f+cz7ndHSrz8KD/S9iNdWpuSlknHDrh+3lFTX/uWNBRs5mC/cdejcqS1",
+        "v6erflyIfqPWWO6PxhIs49NL9Lix3ou6opJo+m8K757T5uP/rQ9KYALIXvl2uFP7",
+        "0CqI+VGfossMlSXa1keagraW8qfplz6ffeSJQWO/+zifbfsf0tzUAC72zBuO0qvN",
+        "E7rSbqAfpav/o010nKP132gbkb4uOkUfZwCuvZjA8ddsQ4udIBRj0hQlqnPLJOR1",
+        "PImrAFC3PW3NgaDEo9QAJBEp5jEJmQghNvEsmzXgABebwLdI9u0VrDz4mSb6TYQC",
+        "XTUaSnH3zvwAv8oMx7q7AgMBAAGjggEkMIIBIDAOBgNVHQ8BAf8EBAMCAQYwEgYD",
+        "VR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUg8dB/Q4mTynBuHmOhnrhv7XXagMw",
+        "gdoGA1UdIASB0jCBzzCBzAYKKwYBBAGFNgRkATCBvTAmBggrBgEFBQcCARYaaHR0",
+        "cDovL3d3dy5wa2kuY28uc2FwLmNvbS8wgZIGCCsGAQUFBwICMIGFHoGCAEMAZQBy",
+        "AHQAaQBmAGkAYwBhAHQAZQAgAFAAbwBsAGkAYwB5ACAAYQBuAGQAIABDAGUAcgB0",
+        "AGkAZgBpAGMAYQB0AGkAbwBuACAAUAByAGEAYwB0AGkAYwBlACAAUwB0AGEAdABl",
+        "AG0AZQBuAHQAIABvAGYAIABTAEEAUAAgAEEARzANBgkqhkiG9w0BAQsFAAOCAgEA",
+        "0HpCIaC36me6ShB3oHDexA2a3UFcU149nZTABPKT+yUCnCQPzvK/6nJUc5I4xPfv",
+        "2Q8cIlJjPNRoh9vNSF7OZGRmWQOFFrPWeqX5JA7HQPsRVURjJMeYgZWMpy4t1Tof",
+        "lF13u6OY6xV6A5kQZIISFj/dOYLT3+O7wME5SItL+YsNh6BToNU0xAZt71Z8JNdY",
+        "VJb2xSPMzn6bNXY8ioGzHlVxfEvzMqebV0KY7BTXR3y/Mh+v/RjXGmvZU6L/gnU7",
+        "8mTRPgekYKY8JX2CXTqgfuW6QSnJ+88bHHMhMP7nPwv+YkPcsvCPBSY08ykzFATw",
+        "SNoKP1/QFtERVUwrUXt3Cufz9huVysiy23dEyfAglgCCRWA+ZlaaXfieKkUWCJaE",
+        "Kw/2Jqz02HDc7uXkFLS1BMYjr3WjShg1a+ulYvrBhNtseRoZT833SStlS/jzZ8Bi",
+        "c1dt7UOiIZCGUIODfcZhO8l4mtjh034hdARLF0sUZhkVlosHPml5rlxh+qn8yJiJ",
+        "GJ7CUQtNCDBVGksVlwew/+XnesITxrDjUMu+2297at7wjBwCnO93zr1/wsx1e2Um",
+        "Xn+IfM6K/pbDar/y6uI9rHlyWu4iJ6cg7DAPJ2CCklw/YHJXhDHGwheO/qSrKtgz",
+        "PGHZoN9jcvvvWDLUGtJkEotMgdFpEA2XWR83H4fVFVc=",
+        "-----END CERTIFICATE-----",
+    ]
+    assert expected_lines in parse_file.lines(
+        "/usr/local/share/ca-certificates/SAP_Global_Root_CA.crt"
+    ), "SAP Global Root CA certificate content should be correct"

--- a/tests/integration/runtime/test_sapmachine.py
+++ b/tests/integration/runtime/test_sapmachine.py
@@ -1,0 +1,36 @@
+import pytest
+from plugins.apt import Apt
+from plugins.dpkg import Dpkg
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# sapmachine Feature
+# =============================================================================
+
+
+@pytest.mark.feature("sapmachine")
+def test_sapmachine_is_installed(dpkg: Dpkg):
+    assert dpkg.package_is_installed(
+        "sapmachine-25-jre-headless"
+    ), "sapmachine-25-jre-headless package is not installed"
+
+
+@pytest.mark.feature("sapmachine")
+def test_java_version_command(shell: ShellRunner):
+    out = shell("java -version", capture_output=True)
+    assert "SapMachine" in out.stderr, "Expected jvm to be installed is SapMachine"
+
+
+@pytest.mark.feature("sapmachine")
+def test_sapmachine_apt_repo_is_installed(apt: Apt):
+    repos = apt.list_repos()
+    assert any(
+        "sapmachine" in repo for repo in repos
+    ), "No apt repo containing 'sapmachine' found"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-sapmachine-config-apt-keyrings-sapmachine"])
+@pytest.mark.feature("sapmachine")
+def test_sapmachine_apt_keyring_exists(file):
+    """Test that SapMachine APT keyring exists"""
+    assert file.is_regular_file("/etc/apt/keyrings/sapmachine-apt-keyring.gpg")


### PR DESCRIPTION
## Part 3 of 5 — Core / runtime integration tests

> **Depends on:** #5296 (plugins + handlers) must merge first.

### What
Adds `tests/integration/{core,runtime}/` to `rel-2150` (26 files):

| Dir | Tests |
|-----|-------|
| `core/` | autologin, base, codedump, deny_packages, dmesg, history, logging, network, proc, profile, server, services, sysdiff, time, users_groups |
| `runtime/` | checkbox, chost, clamav, containers, gardener, glvd, khost, nodejs, pythonDev, sap, sapmachine |

### Part of series
- 1/5 — Plugins + handlers + config (#5296) ← merge first
- 2/5 — Boot + kernel + infrastructure tests
- **3/5** — Core + runtime tests (this PR)
- 4/5 — Security tests (non-compliance)
- 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests

## Split PR series (cross-reference)

| PR | Scope | Files |
|----|-------|-------|
| #5296 | 1/5 — Plugins + handlers + config | 24 — **merge first** |
| #5297 | 2/5 — Boot + kernel + infrastructure tests | 15 |
| #5298 | 3/5 — Core + runtime tests | 26 |
| #5299 | 4/5 — Security tests (non-compliance) | 12 |
| #5300 | 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests | 118 ← primary goal |

> Original monolithic PR: #5290