### PR TITLE
backport: security integration tests (non-compliance) to rel-2150 (4/5)

### DIFF
--- a/tests/integration/security/test_aide.py
+++ b/tests/integration/security/test_aide.py
@@ -1,0 +1,126 @@
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.systemd import Systemd
+
+# =============================================================================
+# aide Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-unit"])
+@pytest.mark.feature("aide")
+def test_aide_check_unit_exists(file):
+    """Test that aide-check.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/aide-check.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-unit"])
+@pytest.mark.feature("aide")
+def test_aide_init_unit_exists(file):
+    """Test that aide-init.service unit file exists"""
+    assert file.is_regular_file("/etc/systemd/system/aide-init.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_aide_init_service_enabled(systemd: Systemd):
+    """Test that aide-init.service is enabled"""
+    assert systemd.is_enabled("aide-init.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-init-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_aide_init_service_active(systemd: Systemd):
+    """Test that aide-init.service is active"""
+    assert systemd.is_active("aide-init.service")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_timer_aide_check_service_enabled(systemd: Systemd):
+    """Test that aide-check.timer is enabled"""
+    assert systemd.is_enabled("aide-check.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer-enable"])
+@pytest.mark.feature("aide")
+@pytest.mark.booted(reason="Requires systemd")
+def test_aide_timer_aide_check_service_active(systemd: Systemd):
+    """Test that aide-check.timer is active"""
+    assert systemd.is_active("aide-check.timer")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-script-aide-init-onboot"])
+@pytest.mark.feature("aide")
+def test_aide_init_onboot_script_exists(file: File):
+    """Test that AIDE initialization script exists"""
+    assert file.is_regular_file("/usr/local/sbin/aide-init-onboot.sh")
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_exists(systemd: Systemd):
+    """Verify that the AIDE timer unit exists."""
+    timer = "aide-check.timer"
+    units = systemd.list_units()
+    matches = [u for u in units if u.unit == timer]
+    assert matches, f"AIDE timer '{timer}' not found — CIS requirement failed"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_loaded(systemd: Systemd):
+    """Verify that the AIDE timer unit is loaded."""
+    timer = "aide-check.timer"
+    units = systemd.list_units()
+    matches = [u for u in units if u.unit == timer]
+    assert (
+        matches[0].load == "loaded"
+    ), f"AIDE timer must be loaded but is {matches[0].load}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_active(systemd: Systemd):
+    """Verify that the AIDE timer unit is active."""
+    timer = "aide-check.timer"
+    assert systemd.is_active(timer), f"AIDE timer '{timer}' exists but is not active."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-aide-service-aide-check-timer"])
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to query systemd units")
+@pytest.mark.booted(reason="systemd timers are expected to be configured at runtime")
+def test_aide_timer_state(systemd: Systemd):
+    """Verify that the AIDE timer is in 'waiting' or 'running' state."""
+    timer = "aide-check.timer"
+    units = systemd.list_units()
+    matches = [u for u in units if u.unit == timer]
+    unit = matches[0]
+    assert unit.sub in (
+        "waiting",
+        "running",
+    ), f"AIDE timer scheduling state unexpected (sub={unit.sub})"
+
+
+@pytest.mark.feature("aide")
+@pytest.mark.root(reason="Required to read AIDE configuration")
+@pytest.mark.booted(reason="AIDE configuration must exist at runtime")
+def test_aide_conf_contains_faillog_entry(parse_file: ParseFile):
+    """Ensure that AIDE configuration exists and includes '/var/log/faillog Full'"""
+    conf_path = "/etc/aide/aide.conf"
+    lines = parse_file.lines(conf_path)
+    expected_line = "/var/log/faillog Full"
+    assert (
+        expected_line in lines
+    ), f"Expected '{expected_line}' not found in {conf_path}. "

--- a/tests/integration/security/test_capabilities.py
+++ b/tests/integration/security/test_capabilities.py
@@ -1,0 +1,25 @@
+import pytest
+from plugins.capabilities import Capabilities
+
+# =============================================================================
+# Misc tests not tied to any specific feature
+# =============================================================================
+
+# There are two debian packages that provide an 'arping' binary
+# https://packages.debian.org/search?searchon=contents&keywords=arping&mode=path&suite=stable&arch=any
+# /usr/bin/arping is provided by iputils-arping
+# /usr/sbin/arping is provided by arping
+# We only use iputils-arping
+capabilities_allowlist = {"/usr/bin/arping cap_net_raw=ep"}
+
+
+@pytest.mark.root(reason="Need to read files not readable by unprivileged user")
+def test_only_expected_capabilities_are_set(capabilities: Capabilities):
+    actual_capabilities = capabilities.get()
+
+    unexpected = actual_capabilities - capabilities_allowlist
+
+    assert not unexpected, (
+        f"Unexpected capabilities found: {unexpected}. "
+        f"Allowed: {capabilities_allowlist}"
+    )

--- a/tests/integration/security/test_firewall.py
+++ b/tests/integration/security/test_firewall.py
@@ -1,0 +1,40 @@
+import pytest
+from plugins.file import File
+from plugins.nft import Nft
+
+# =============================================================================
+# firewall Feature
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-firewall-config-nft-default",  # exact: tests nftables firewall configuration
+    ]
+)
+@pytest.mark.root(reason="nft is only accessible by root")
+@pytest.mark.booted(reason="Firewall needs booted system")
+@pytest.mark.feature("firewall")
+def test_nft_config(nft: Nft):
+    matching_policies = [
+        chain
+        for chain in nft.list_table_inet_filter()
+        if chain.type == "filter"
+        and chain.hook == "input"
+        and chain.prio == 0
+        and chain.policy == "drop"
+    ]
+    assert len(matching_policies) == 1, "input has policy drop not as default"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-firewall-config-nftables-include",
+    ]
+)
+@pytest.mark.feature("firewall")
+def test_firewall_nft_default_config_exists(file: File):
+    """Test that firewall nft default configuration exists"""
+    assert file.exists(
+        "/etc/nft.d/default.conf"
+    ), "Firewall nft default configuration should exist"

--- a/tests/integration/security/test_lsm.py
+++ b/tests/integration/security/test_lsm.py
@@ -1,0 +1,74 @@
+from typing import List
+
+import pytest
+from plugins.file import File
+
+# =============================================================================
+# _selinux Feature
+# =============================================================================
+
+
+# SELinux
+@pytest.mark.testcov(["GL-TESTCOV-_selinux-config-kernel-cmdline-lsm"])
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires a running kernel to read /proc/cmdline")
+def test_selinux_cmdline(kernel_cmdline: List[str]):
+    assert "security=selinux" in kernel_cmdline
+
+
+@pytest.mark.feature("_selinux")
+@pytest.mark.booted(reason="requires a running kernel to access sysfs")
+def test_selinux_enabled(file: File):
+    assert file.exists("/sys/fs/selinux/enforce"), "SELinux not enabled"
+
+
+# TODO: enable after fixing https://github.com/gardenlinux/gardenlinux/issues/4315
+# @pytest.mark.testcov(["GL-TESTCOV-_selinux-config-selinux-contexts"])
+# @pytest.mark.feature("_selinux")
+# @pytest.mark.booted(reason="requires SELinux to be running")
+# @pytest.mark.root(reason="restorecon requires root privileges")
+# def test_selinux_no_relabeling_needed(shell):
+#     result = shell("restorecon -Rnv /", capture_output=True, ignore_exit_code=True)
+#     assert (
+#         result.stdout.strip() == ""
+#     ), f"SELinux relabeling is needed. Files requiring relabeling:\n{result.stdout}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-_selinux-config-kernel-cmdline-lsm"])
+@pytest.mark.booted
+@pytest.mark.feature("_selinux")
+def test_lsm_selinux(lsm):
+    assert "selinux" in lsm
+    assert "apparmor" not in lsm
+
+
+# =============================================================================
+# gardener Feature enables Apparmor
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-kernel-cmdline-lsm"])
+@pytest.mark.feature("gardener")
+@pytest.mark.booted(reason="requires a running kernel to read /proc/cmdline")
+def test_apparmor_cmdline(kernel_cmdline: List[str]):
+    assert "security=apparmor" in kernel_cmdline
+
+
+@pytest.mark.testcov(["GL-TESTCOV-gardener-config-kernel-cmdline-lsm"])
+@pytest.mark.booted
+@pytest.mark.feature("gardener")
+def test_lsm_gardener(lsm):
+    assert "apparmor" in lsm
+    assert "selinux" not in lsm
+
+
+# =============================================================================
+# Common tests for all LSMs
+# =============================================================================
+
+
+@pytest.mark.booted
+def test_lsm_common(lsm):
+    required = {"landlock", "lockdown", "capability", "yama"}
+    missing = required - set(lsm)
+    assert not missing, f"missing lsm(s): {', '.join(sorted(missing))}"

--- a/tests/integration/security/test_pam.py
+++ b/tests/integration/security/test_pam.py
@@ -1,0 +1,103 @@
+import pytest
+
+# =============================================================================
+# server Feature - PAM Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+        "GL-TESTCOV-server-config-pam-garden-extra",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-auth"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+@pytest.mark.feature("not cis", reason="CIS handles auth_pam by itself")
+def test_common_auth_pam_faillock(pam_config):
+
+    results = pam_config.find_entries(
+        type_="auth",
+        control_contains="required",
+        module_contains="pam_faillock.so",
+        arg_contains=["preauth", "silent", "audit", "deny=5", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Logins should be blocked for 15 minutes after 5 failed attempts (preauth check configured)"
+
+    pam_config.find_entries(
+        type_="auth",
+        control_contains="default=die",
+        module_contains="pam_faillock.so",
+        arg_contains=["authfail", "silent", "audit", "deny=5", "unlock_time=900"],
+    )
+    assert (
+        len(results) == 1
+    ), "Control value of PAM Module pam_faillock.so must be set to required (postauth action configured)"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-account"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+@pytest.mark.feature("not cis", reason="CIS handles auth_pam by itself")
+def test_common_account_pam_faillock(pam_config):
+    results = pam_config.find_entries(
+        type_="account", control_contains="required", module_contains="pam_faillock.so"
+    )
+    assert (
+        len(results) == 1
+    ), "User account should be validated for its lock status before session starts"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+def test_common_password_passwdqc_pam_faillock(pam_config):
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_passwdqc.so",
+        arg_contains=[
+            "min=disabled,disabled,12,8,8",
+            "passphrase=4",
+            "similar=deny",
+            "retry=5",
+        ],
+    )
+    assert (
+        len(results) == 1
+    ), "User password should conform to password strength requirements"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-server-config-pam-garden",
+    ]
+)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+@pytest.mark.feature("server")
+def test_common_password_pwhistory_pam_faillock(pam_config):
+    results = pam_config.find_entries(
+        type_="password",
+        control_contains="required",
+        module_contains="pam_pwhistory.so",
+        arg_contains=["use_authtok", "remember=5", "retry=5"],
+    )
+    assert len(results) == 1, "Last 5 user passwords should not be reused"

--- a/tests/integration/security/test_password_hashes.py
+++ b/tests/integration/security/test_password_hashes.py
@@ -1,0 +1,56 @@
+import pytest
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.security_id(325)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+def test_password_entry_present(pam_config):
+    """
+    Ensure that exactly one password entry with [success=... default=ignore]
+    exists in PAM config.
+    """
+    candidates = pam_config.find_entries(
+        type_="password",
+        control_contains={"success": "*", "default": "ignore"},
+        match_all=True,
+    )
+    assert (
+        len(candidates) == 1
+    ), f"Expected exactly one password entry, found {len(candidates)}: {candidates}"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-stig-config-pam-garden-stig"])
+@pytest.mark.security_id(325)
+@pytest.mark.parametrize(
+    "pam_config", ["/etc/pam.d/common-password"], indirect=["pam_config"]
+)
+def test_password_entry_uses_strong_hash(pam_config):
+    """
+    Ensure that the password entry uses a strong hash algorithm (yescrypt or sha512).
+    """
+    candidates = pam_config.find_entries(
+        type_="password",
+        control_contains={"success": "*", "default": "ignore"},
+        match_all=True,
+    )
+
+    # Validate that this is only defined a single time
+    # to ensure no feature has appended different options
+    # multiple times
+    assert (
+        len(candidates) == 1
+    ), f"Expected exactly one 'password ... [success=... default=ignore] ...' entry, found {len(candidates)}: {candidates}"
+    entry = candidates[0]
+
+    # Validate the entry for 'sha512' or 'yescrypt'
+    # We're using YESCRYPT instead of sha512 because it offers more
+    # resistance to offline attacks.
+    # https://www.openwall.com/yescrypt/
+    assert (
+        "yescrypt" in entry.options or "sha512" in entry.options
+    ), f"Weak or unknown hash algorithm used: {entry.options}"

--- a/tests/integration/security/test_password_shadow.py
+++ b/tests/integration/security/test_password_shadow.py
@@ -1,0 +1,45 @@
+from typing import List
+
+import pytest
+from plugins.linux_etc_files import Passwd, Shadow
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "not cis and not disaSTIGmedium",
+    reason="CIS and disaSTIGmedium handle shadow_entries by themselves",
+)
+def test_shadow_passwords_are_locked(shadow_entries: List[Shadow]):
+    """No user in shadow should have a valid password entry and all users are locked."""
+    for entry in shadow_entries:
+        # Assert that the password field for the given entry is not empty (not invalid)
+        assert (
+            entry.encrypted_password
+        ), f"Empty password field in shadow for {entry.login_name}"
+
+        # Assert whether the first character is a '!' or '*' marking the user as locked.
+        assert entry.encrypted_password[0] in [
+            "!",
+            "*",
+        ], f"Unexpected password hash in shadow for {entry.login_name}: {entry.encrypted_password}"
+
+
+def test_passwd_password_field_is_valid(passwd_entries: List[Passwd]):
+    """All passwd entries must use 'x' or '*' in the password field."""
+    for entry in passwd_entries:
+        assert entry.password in [
+            "*",
+            "x",
+        ], f"Malformed passwd entry for {entry.name}: {entry}"
+
+
+@pytest.mark.root
+@pytest.mark.parametrize("command", ["pwck -r", "grpck -r"])
+def test_system_integrity_tools(shell, command):
+    """System tools must confirm consistency of passwd and group files."""
+    result = shell(command, capture_output=True, ignore_exit_code=True)
+    assert result.returncode == 0, f"{command} failed: {result.stderr}"
+    assert result.stdout.strip() == "", f"{command} produced unexpected output"

--- a/tests/integration/security/test_sgx.py
+++ b/tests/integration/security/test_sgx.py
@@ -1,0 +1,21 @@
+import pytest
+from plugins.kernel_configs import KernelConfigs
+from plugins.parse_file import ParseFile
+
+# =============================================================================
+# cloud or metal Feature - SGX Configuration
+# =============================================================================
+
+
+@pytest.mark.feature("cloud or metal")
+@pytest.mark.arch("amd64", reason="SGX is an amd64 option")
+def test_kernel_configs_sgx(parse_file: ParseFile, kernel_configs: KernelConfigs):
+    """Test that all kernel configs have SGX enabled for amd64."""
+    for config in kernel_configs.get_installed():
+        parsed_config = parse_file.parse(config.path, format="keyval")
+        assert (
+            parsed_config["CONFIG_X86_SGX"] == "y"
+        ), f"CONFIG_X86_SGX not set to 'y' in {config.path}"
+        assert (
+            parsed_config["CONFIG_X86_SGX_KVM"] == "y"
+        ), f"CONFIG_X86_SGX_KVM not set to 'y' in {config.path}"

--- a/tests/integration/security/test_ssh.py
+++ b/tests/integration/security/test_ssh.py
@@ -1,0 +1,333 @@
+import os
+import pwd
+
+import pytest
+from plugins.file import File
+from plugins.parse_file import ParseFile
+from plugins.sshd import Sshd
+from plugins.systemd import Systemd
+from plugins.utils import equals_ignore_case, get_normalized_sets, is_set
+
+# =============================================================================
+# ssh Feature - SSH Configuration (not _fips and cis)
+# =============================================================================
+
+required_sshd_config = {
+    "HostKey": {
+        "/etc/ssh/ssh_host_ed25519_key",
+        "/etc/ssh/ssh_host_rsa_key",
+    },
+    "KexAlgorithms": {
+        "sntrup761x25519-sha512",
+        "sntrup761x25519-sha512@openssh.com",
+        "mlkem768x25519-sha256",
+        "curve25519-sha256",
+        "curve25519-sha256@libssh.org",
+        "ecdh-sha2-nistp256",
+        "ecdh-sha2-nistp384",
+        "ecdh-sha2-nistp521",
+    },
+    "Ciphers": {
+        "chacha20-poly1305@openssh.com",
+        "aes128-ctr",
+        "aes192-ctr",
+        "aes256-ctr",
+        "aes128-gcm@openssh.com",
+        "aes256-gcm@openssh.com",
+    },
+    "MACs": {
+        "umac-64-etm@openssh.com",
+        "umac-128-etm@openssh.com",
+        "hmac-sha2-256-etm@openssh.com",
+        "hmac-sha2-512-etm@openssh.com",
+        "hmac-sha1-etm@openssh.com",
+        "umac-64@openssh.com",
+        "umac-128@openssh.com",
+        "hmac-sha2-256",
+        "hmac-sha2-512",
+        "hmac-sha1",
+    },
+    "AuthenticationMethods": "publickey",
+    "LogLevel": "VERBOSE",
+    "Subsystem": "sftp /usr/lib/openssh/sftp-server -f AUTHPRIV -l INFO",
+    "PermitRootLogin": "No",
+    "X11Forwarding": "no",
+    "UsePAM": "yes",
+}
+
+
+FIPS_REASON = "FIPS uses different values for the KEX and Cipher."
+
+
+@pytest.mark.testcov(["GL-TESTCOV-ssh-config-ssh-sshd-config"])
+@pytest.mark.booted(reason="Calling sshd -T requires a booted system")
+@pytest.mark.root(reason="Calling sshd -T requires root")
+@pytest.mark.feature("ssh")
+@pytest.mark.parametrize("sshd_config_item", required_sshd_config)
+@pytest.mark.feature("not _fips", reason=FIPS_REASON)
+@pytest.mark.feature("not cis", reason="CIS has specific KEX and MACs")
+@pytest.mark.feature(
+    "not disaSTIGmedium", reason="disaSTIGmedium enforces STIG-specific SSH algorithms"
+)
+def test_sshd_has_required_config(sshd_config_item: str, sshd: Sshd):
+    actual_value = sshd.get_config_section(sshd_config_item)
+    expected_value = required_sshd_config[sshd_config_item]
+    if is_set(expected_value):
+        if actual_value is None:
+            actual_value = set()
+        elif not is_set(actual_value):
+            actual_value = set(str(actual_value).split(","))
+        # Ensure actual_value is a set at this point
+        assert isinstance(
+            actual_value, set
+        ), f"actual_value should be a set, got {type(actual_value)}"
+        actual_set, expected_set = get_normalized_sets(actual_value, expected_value)
+        assert expected_set.issubset(
+            actual_set
+        ), f"{sshd_config_item}: missing values {expected_set - actual_set}"
+    else:
+        assert equals_ignore_case(
+            str(actual_value or ""), str(expected_value)
+        ), f"{sshd_config_item}: expected {expected_value}, got {actual_value}"
+
+
+# =============================================================================
+# ssh Feature - SSH Extended Configuration (not ali, aws, azure or openstack)
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "ssh and not (ali or aws or azure or openstack)",
+    reason="We want no authorized_keys for unmanaged users",
+)
+def test_users_have_no_authorized_keys(expected_users, file: File):
+    skip_users = {"nologin", "sync"}
+    skip_shells = {"/bin/false"}
+    files_to_check = ["authorized_keys", "authorized_keys2"]
+
+    for entry in pwd.getpwall():
+        if any(
+            [
+                entry.pw_name in skip_users,
+                entry.pw_shell in skip_shells,
+                entry.pw_name in expected_users,
+            ]
+        ):
+            continue
+
+        ssh_dir = os.path.join(entry.pw_dir, ".ssh")
+        for filename in files_to_check:
+            key_path = os.path.join(ssh_dir, filename)
+            assert not file.exists(
+                key_path
+            ), f"user '{entry.pw_name}' should not have an authorized_keys file: {key_path}"
+
+
+# =============================================================================
+# ssh Feature - SSH Extended Configuration (ali, aws, azure or openstack)
+# =============================================================================
+
+
+@pytest.mark.feature(
+    "ssh and (ali or aws or azure or openstack)",
+    reason="ALI, AWS, Azure and OpenStack auto generate authorized_keys for root with a hint to use another user",
+)
+def test_users_have_only_root_authorized_keys_cloud(
+    expected_users, file, parse_file: ParseFile
+):
+    skip_users = {"nologin", "sync"}
+    skip_shells = {"/bin/false"}
+    files_to_check = ["authorized_keys", "authorized_keys2"]
+
+    for entry in pwd.getpwall():
+        if any(
+            [
+                entry.pw_name in skip_users,
+                entry.pw_shell in skip_shells,
+                entry.pw_name in expected_users,
+            ]
+        ):
+            continue
+        ssh_dir = os.path.join(entry.pw_dir, ".ssh")
+        for filename in files_to_check:
+            key_path = os.path.join(ssh_dir, filename)
+            if file.exists(key_path):
+                if entry.pw_name != "root":
+                    assert (
+                        False
+                    ), f"user '{entry.pw_name}' should not have an authorized_keys file: {key_path}"
+                else:
+                    # Check if the file contains only the specific restricted root key
+                    lines = parse_file.lines(key_path)
+                    if not lines.content.strip():
+                        # Allow empty authorized_keys for root on cloud images
+                        continue
+                    expected_patterns = [
+                        f'command="echo \'Please login as the user \\"{user}\\" rather than the user \\"root\\".\''
+                        for user in expected_users
+                    ]
+                    # Check that at least one expected pattern exists in the file
+                    # (The file should only contain authorized keys with redirect commands)
+                    if not any(pattern in lines for pattern in expected_patterns):
+                        assert (
+                            False
+                        ), f"user '{entry.pw_name}' has unauthorized SSH key in file: {key_path}"
+
+
+# =============================================================================
+# ssh Feature - SSH Service
+# =============================================================================
+
+
+@pytest.mark.booted(reason="Starting the unit requires a booted system")
+@pytest.mark.modify(reason="Starting the unit modifies the system state")
+@pytest.mark.root(reason="Starting the unit requires root")
+@pytest.mark.feature("ssh")
+def test_ssh_service_running(systemd: Systemd, service_ssh):
+    assert systemd.is_active(
+        "ssh"
+    ), "Required systemd unit for ssh.service is not running"
+
+
+# =============================================================================
+# ssh Feature - SSH Extended Configuration
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-no-init-ssh",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_no_init_script(file: File):
+    """Test that SSH does not have init script"""
+    assert not file.exists(
+        "/etc/init.d/ssh"
+    ), "SSH should not have init.d script (using systemd)"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-ssh-ssh-config",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_client_config_exists(file: File):
+    """Test that SSH client configuration exists"""
+    assert file.exists("/etc/ssh/ssh_config"), "SSH client configuration should exist"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-ssh-ssh-config",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_client_config_content(parse_file: ParseFile):
+    """Test that SSH client configuration exists"""
+    lines = parse_file.lines("/etc/ssh/ssh_config")
+    lines_expected = [
+        "Include /etc/ssh/ssh_config.d/*.conf",
+        "Host *",
+        "Protocol 2",
+        "ForwardAgent no",
+        "ForwardX11 no",
+        "HostbasedAuthentication no",
+        "StrictHostKeyChecking no",
+        "Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr",
+        "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com",
+        "KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256",
+        "Tunnel no",
+        "ServerAliveInterval 420",
+    ]
+    assert (
+        lines == lines_expected
+    ), "SSH client configuration should contain the expected content"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-config-sudoers-wheel-permissions",
+    ]
+)
+@pytest.mark.feature("ssh")
+def test_ssh_sudoers_wheel_permissions(file: File):
+    """Test that sudoers wheel file has correct permissions"""
+    assert file.has_mode(
+        "/etc/sudoers.d/wheel", "0440"
+    ), "Sudoers wheel file should have 0440 permissions"
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-sshguard-nftables-configure",
+    ]
+)
+@pytest.mark.feature(
+    "ssh and firewall", reason="nftables package is installed on firewall"
+)
+def test_ssh_sshguard_nftables_configured(parse_file: ParseFile):
+    """Test that sshguard nftables is configured"""
+
+    content = parse_file.lines("/etc/systemd/system/sshguard.service.d/override.conf")
+    assert (
+        "Requires=nftables.service" in content
+    ), "SSHGuard systemd service override configuration should require nftables.service"
+    assert (
+        "PartOf=nftables.service" in content
+    ), "SSHGuard systemd service override configuration should part of nftables.service"
+    assert (
+        "WantedBy=multi-user.target nftables.service" in content
+    ), "SSHGuard systemd service override configuration should want to be started by multi-user.target and nftables.service"
+
+
+# =============================================================================
+# ssh Feature - SSH Guard Configuration (iptables)
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-sshguard-iptables-configure",
+    ]
+)
+@pytest.mark.feature("ssh and server", reason="iptables package is installed on server")
+@pytest.mark.feature("not firewall", reason="iptables package is installed on server")
+def test_ssh_sshguard_iptables_configured(parse_file: ParseFile):
+    """Test that sshguard iptables is configured"""
+
+    content = parse_file.lines("/etc/systemd/system/sshguard.service.d/override.conf")
+    assert (
+        "ExecStartPre=-/sbin/iptables -N sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStartPre=-/sbin/iptables -N sshguard"
+    assert (
+        "ExecStartPre=-/sbin/ip6tables -N sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStartPre=-/sbin/ip6tables -N sshguard"
+    assert (
+        "ExecStopPost=-/sbin/iptables -X sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStopPost=-/sbin/iptables -X sshguard"
+    assert (
+        "ExecStopPost=-/sbin/ip6tables -X sshguard" in content
+    ), "SSHGuard systemd service override configuration should have ExecStopPost=-/sbin/ip6tables -X sshguard"
+
+
+# =============================================================================
+# ssh Feature - SSH Guard Configuration (nftables)
+# =============================================================================
+
+
+@pytest.mark.testcov(
+    [
+        "GL-TESTCOV-ssh-service-sshguard-iptables-configure",
+    ]
+)
+@pytest.mark.feature("ssh and server", reason="iptables package is installed on server")
+@pytest.mark.feature("not firewall", reason="iptables package is installed on server")
+def test_ssh_sshguard_iptables_backend_configured(parse_file: ParseFile):
+    """Test that sshguard iptables backend is configured"""
+
+    content = parse_file.parse("/etc/sshguard/sshguard.conf", format="keyval")
+    assert (
+        content["BACKEND"] == "/usr/libexec/sshguard/sshg-fw-iptables"
+    ), "SSHGuard configuration should reference iptables backend"

--- a/tests/integration/security/test_su.py
+++ b/tests/integration/security/test_su.py
@@ -1,0 +1,38 @@
+import pytest
+from plugins.pam import PamConfig
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-server-config-pam-su-wheel"])
+@pytest.mark.security_id(166)
+@pytest.mark.root
+@pytest.mark.feature("not container")
+@pytest.mark.parametrize("pam_config", ["/etc/pam.d/su"], indirect=["pam_config"])
+@pytest.mark.feature("not cis", reason="CIS handles pam_config on its own")
+def test_pam_wheel_is_required(pam_config: PamConfig):
+    """
+    Validate that we have access to su restircted by default.  The test will
+    read the file from `/etc/pam.d/su` and check if it has the configuration
+    parameter we expect.
+
+    A user needs to be configured to be admitted to use `su`. By default, this
+    is realized by a specify group, the `wheel` group. We have to ensure that
+    this behavior is enabled.
+
+    This line should be defined:
+
+        auth       required pam_wheel.so
+
+    """
+    pam_config.find_entries()
+
+    candidates = pam_config.find_entries(
+        type_="auth", control_contains="required", module_contains="pam_wheel.so"
+    )
+
+    assert (
+        len(candidates) == 1
+    ), "Control value of PAM Module pam_wheel.so must be set to required"

--- a/tests/integration/security/test_umask.py
+++ b/tests/integration/security/test_umask.py
@@ -1,0 +1,27 @@
+import pytest
+from plugins.parse_file import ParseFile
+from plugins.shell import ShellRunner
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-login-defs"])
+@pytest.mark.feature(
+    "not disaSTIGmedium", reason="disaSTIGmedium intentionally sets UMASK to 077"
+)
+def test_umask_file(parse_file: ParseFile):
+    config = parse_file.parse("/etc/login.defs", format="spacedelim")
+    assert config["UMASK"] == "027"
+
+
+@pytest.mark.testcov(["GL-TESTCOV-base-config-login-defs"])
+@pytest.mark.feature(
+    "not disaSTIGmedium", reason="disaSTIGmedium intentionally sets UMASK to 077"
+)
+@pytest.mark.root
+def test_umask_cmd(shell: ShellRunner):
+    result = shell("su --login --command 'umask'", capture_output=True)
+    assert result.returncode == 0, f"Could not execute umask cmd: {result.stderr}"
+    assert result.stdout == "0027\n", "umask is not set to 0027"

--- a/tests/integration/security/test_wireguard.py
+++ b/tests/integration/security/test_wireguard.py
@@ -1,0 +1,16 @@
+import pytest
+from plugins.kernel_module import KernelModule
+
+# =============================================================================
+# Miscellaneous tests not tied to any specific feature
+# =============================================================================
+
+
+@pytest.mark.booted(reason="Modules can only be loaded on booted system")
+def test_kernel_module_wireguard_available(kernel_module: KernelModule):
+    """Test that the wireguard kernel module is available as loadable module."""
+    kernel_modules = ["wireguard"]
+    for module in kernel_modules:
+        assert kernel_module.is_module_available(
+            module
+        ), f"{module} kernel module is not available."


### PR DESCRIPTION
## Part 4 of 5 — Security integration tests (non-compliance)

> **Depends on:** #5296 (plugins + handlers) must merge first.

### What
Adds `tests/integration/security/` (non-compliance) to `rel-2150` (12 files):

`aide`, `capabilities`, `firewall`, `lsm`, `pam`, `password_hashes`, `password_shadow`, `sgx`, `ssh`, `su`, `umask`, `wireguard`

### Part of series
- 1/5 — Plugins + handlers + config (#5296) ← merge first
- 2/5 — Boot + kernel + infrastructure tests
- 3/5 — Core + runtime tests
- **4/5** — Security tests (non-compliance, this PR)
- 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests

## Split PR series (cross-reference)

| PR | Scope | Files |
|----|-------|-------|
| #5296 | 1/5 — Plugins + handlers + config | 24 — **merge first** |
| #5297 | 2/5 — Boot + kernel + infrastructure tests | 15 |
| #5298 | 3/5 — Core + runtime tests | 26 |
| #5299 | 4/5 — Security tests (non-compliance) | 12 |
| #5300 | 5/5 — STIG/CIS/FIPS/FedRAMP compliance tests | 118 ← primary goal |

> Original monolithic PR: #5290